### PR TITLE
fix(cli): use writeSync(1, ...) so large stdout isn't truncated at process.exit (closes #12)

### DIFF
--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -14,8 +14,9 @@
 // { status: "terminal", verdict, run_dir_path } at terminal.
 // Exit 0 on success, non-zero on schema/validation failure.
 
-import { readFileSync, writeSync } from "node:fs";
+import { readFileSync } from "node:fs";
 
+import { emitJson } from "./lib/emit.mjs";
 import {
   readLock,
   readManifest,
@@ -58,15 +59,10 @@ function parseArgs(argv) {
   return args;
 }
 
-function emit(payload) {
-  // writeSync to fd 1 (stdout) — a blocking POSIX write that does NOT
-  // queue in Node's userspace stream buffer. The previous shape
-  // (`process.stdout.write(...)` followed by `process.exit(...)`)
-  // truncated payloads larger than the kernel pipe buffer (~64KB on
-  // macOS) because the userspace queue was dropped at exit before it
-  // could drain. Issue #12.
-  writeSync(1, `${JSON.stringify(payload, null, 2)}\n`);
-}
+// Delegates to ./lib/emit.mjs which loops fs.writeSync until the full
+// payload is written (single writeSync may partial-write) and swallows
+// EPIPE when the reader closes early. Issue #12.
+const emit = emitJson;
 
 function fail(error, code = 1) {
   process.stderr.write(`fsm-commit: ${error}\n`);

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -14,7 +14,7 @@
 // { status: "terminal", verdict, run_dir_path } at terminal.
 // Exit 0 on success, non-zero on schema/validation failure.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeSync } from "node:fs";
 
 import {
   readLock,
@@ -59,7 +59,13 @@ function parseArgs(argv) {
 }
 
 function emit(payload) {
-  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  // writeSync to fd 1 (stdout) — a blocking POSIX write that does NOT
+  // queue in Node's userspace stream buffer. The previous shape
+  // (`process.stdout.write(...)` followed by `process.exit(...)`)
+  // truncated payloads larger than the kernel pipe buffer (~64KB on
+  // macOS) because the userspace queue was dropped at exit before it
+  // could drain. Issue #12.
+  writeSync(1, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
 function fail(error, code = 1) {

--- a/scripts/fsm-inspect.mjs
+++ b/scripts/fsm-inspect.mjs
@@ -6,9 +6,9 @@
 //
 // Output: JSON with manifest + lock state + ordered list of trace records.
 
-import { writeSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { emitJson } from "./lib/emit.mjs";
 import {
   readLock,
   readManifest,
@@ -34,15 +34,10 @@ function parseArgs(argv) {
   return args;
 }
 
-function emit(payload) {
-  // writeSync to fd 1 (stdout) — a blocking POSIX write that does NOT
-  // queue in Node's userspace stream buffer. The previous shape
-  // (`process.stdout.write(...)` followed by `process.exit(...)`)
-  // truncated payloads larger than the kernel pipe buffer (~64KB on
-  // macOS) because the userspace queue was dropped at exit before it
-  // could drain. Issue #12.
-  writeSync(1, `${JSON.stringify(payload, null, 2)}\n`);
-}
+// Delegates to ./lib/emit.mjs which loops fs.writeSync until the full
+// payload is written (single writeSync may partial-write) and swallows
+// EPIPE when the reader closes early. Issue #12.
+const emit = emitJson;
 
 let parsed;
 try {

--- a/scripts/fsm-inspect.mjs
+++ b/scripts/fsm-inspect.mjs
@@ -6,6 +6,7 @@
 //
 // Output: JSON with manifest + lock state + ordered list of trace records.
 
+import { writeSync } from "node:fs";
 import { resolve } from "node:path";
 
 import {
@@ -34,7 +35,13 @@ function parseArgs(argv) {
 }
 
 function emit(payload) {
-  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  // writeSync to fd 1 (stdout) — a blocking POSIX write that does NOT
+  // queue in Node's userspace stream buffer. The previous shape
+  // (`process.stdout.write(...)` followed by `process.exit(...)`)
+  // truncated payloads larger than the kernel pipe buffer (~64KB on
+  // macOS) because the userspace queue was dropped at exit before it
+  // could drain. Issue #12.
+  writeSync(1, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
 let parsed;

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -19,7 +19,7 @@
 // Output: JSON brief on stdout. Exit 0 success; non-zero on lock conflict,
 // run-not-found, or fsm_yaml_changed.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeSync } from "node:fs";
 
 import {
   acquireLock,
@@ -59,7 +59,13 @@ function parseArgs(argv) {
 }
 
 function emit(payload) {
-  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  // writeSync to fd 1 (stdout) — a blocking POSIX write that does NOT
+  // queue in Node's userspace stream buffer. The previous shape
+  // (`process.stdout.write(...)` followed by `process.exit(...)`)
+  // truncated payloads larger than the kernel pipe buffer (~64KB on
+  // macOS) because the userspace queue was dropped at exit before it
+  // could drain. Issue #12.
+  writeSync(1, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
 function fail(error, code = 1) {

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -19,7 +19,9 @@
 // Output: JSON brief on stdout. Exit 0 success; non-zero on lock conflict,
 // run-not-found, or fsm_yaml_changed.
 
-import { readFileSync, writeSync } from "node:fs";
+import { readFileSync } from "node:fs";
+
+import { emitJson } from "./lib/emit.mjs";
 
 import {
   acquireLock,
@@ -58,15 +60,10 @@ function parseArgs(argv) {
   return args;
 }
 
-function emit(payload) {
-  // writeSync to fd 1 (stdout) — a blocking POSIX write that does NOT
-  // queue in Node's userspace stream buffer. The previous shape
-  // (`process.stdout.write(...)` followed by `process.exit(...)`)
-  // truncated payloads larger than the kernel pipe buffer (~64KB on
-  // macOS) because the userspace queue was dropped at exit before it
-  // could drain. Issue #12.
-  writeSync(1, `${JSON.stringify(payload, null, 2)}\n`);
-}
+// Delegates to ./lib/emit.mjs which loops fs.writeSync until the full
+// payload is written (single writeSync may partial-write) and swallows
+// EPIPE when the reader closes early. Issue #12.
+const emit = emitJson;
 
 function fail(error, code = 1) {
   process.stderr.write(`fsm-next: ${error}\n`);

--- a/scripts/fsm-validate-static.mjs
+++ b/scripts/fsm-validate-static.mjs
@@ -7,10 +7,11 @@
 // Exits 0 on clean, 1 on any validation failure.
 // Prints a structured JSON report to stdout.
 
-import { readFileSync, existsSync, writeSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 
+import { emitJson } from "./lib/emit.mjs";
 import {
   validateFsmSchema,
   validateFsmStatic,
@@ -80,9 +81,8 @@ const summary = {
   total_errors: totalErrors,
   files: reports,
 };
-// writeSync to fd 1 — see fsm-commit.mjs's emit() comment. process.exit
-// after process.stdout.write truncates large payloads at the kernel pipe
-// buffer (~64KB on macOS); writeSync is a blocking POSIX write that
-// drains synchronously. Issue #12.
-writeSync(1, `${JSON.stringify(summary, null, 2)}\n`);
+// Delegates to ./lib/emit.mjs — loops fs.writeSync until the full
+// payload is written (single writeSync may partial-write) and swallows
+// EPIPE when the reader closes early. Issue #12.
+emitJson(summary);
 process.exit(totalErrors === 0 ? 0 : 1);

--- a/scripts/fsm-validate-static.mjs
+++ b/scripts/fsm-validate-static.mjs
@@ -7,7 +7,7 @@
 // Exits 0 on clean, 1 on any validation failure.
 // Prints a structured JSON report to stdout.
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, writeSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 
@@ -80,5 +80,9 @@ const summary = {
   total_errors: totalErrors,
   files: reports,
 };
-process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+// writeSync to fd 1 — see fsm-commit.mjs's emit() comment. process.exit
+// after process.stdout.write truncates large payloads at the kernel pipe
+// buffer (~64KB on macOS); writeSync is a blocking POSIX write that
+// drains synchronously. Issue #12.
+writeSync(1, `${JSON.stringify(summary, null, 2)}\n`);
 process.exit(totalErrors === 0 ? 0 : 1);

--- a/scripts/lib/emit.mjs
+++ b/scripts/lib/emit.mjs
@@ -34,19 +34,14 @@ export function emitJson(payload) {
     }
     if (typeof n !== "number" || n <= 0) {
       // Defensive: writeSync should always advance or throw. A zero-byte
-      // advance would otherwise spin forever; we exit the loop loudly
-      // instead of silently truncating. The error reaches stderr (so it
-      // appears in spawnSync's `result.stderr` rather than in the stdout
-      // JSON the parent is trying to parse) and exits non-zero so the
-      // caller's status check fires.
-      try {
-        process.stderr.write(
-          `emitJson: writeSync did not advance (returned ${n}); aborting to avoid infinite loop\n`,
-        );
-      } catch {
-        // stderr unwritable too; nothing useful we can do.
-      }
-      process.exit(2);
+      // advance would otherwise spin forever. Throw a labeled error
+      // instead of silently truncating; each CLI's top-level error
+      // handler decides how to surface it (stderr message + non-zero
+      // exit). The helper itself stays side-effect-free apart from the
+      // intended write, so it remains reusable and testable.
+      throw new Error(
+        `emitJson: writeSync did not advance (returned ${n}); pipe state is unrecoverable`,
+      );
     }
     written += n;
   }

--- a/scripts/lib/emit.mjs
+++ b/scripts/lib/emit.mjs
@@ -33,9 +33,20 @@ export function emitJson(payload) {
       throw err;
     }
     if (typeof n !== "number" || n <= 0) {
-      // Defensive: writeSync should always advance or throw; treat a
-      // zero-byte advance as a fatal pipe state to avoid an infinite loop.
-      return;
+      // Defensive: writeSync should always advance or throw. A zero-byte
+      // advance would otherwise spin forever; we exit the loop loudly
+      // instead of silently truncating. The error reaches stderr (so it
+      // appears in spawnSync's `result.stderr` rather than in the stdout
+      // JSON the parent is trying to parse) and exits non-zero so the
+      // caller's status check fires.
+      try {
+        process.stderr.write(
+          `emitJson: writeSync did not advance (returned ${n}); aborting to avoid infinite loop\n`,
+        );
+      } catch {
+        // stderr unwritable too; nothing useful we can do.
+      }
+      process.exit(2);
     }
     written += n;
   }

--- a/scripts/lib/emit.mjs
+++ b/scripts/lib/emit.mjs
@@ -1,0 +1,42 @@
+// Shared emit() helper for the FSM CLIs.
+//
+// Each CLI (fsm-commit, fsm-next, fsm-inspect, fsm-validate-static) needs
+// to write a JSON document to stdout and immediately exit. The naive
+// shape — `process.stdout.write(text); process.exit(...)` — truncates
+// payloads larger than the kernel pipe buffer (~64 KB on macOS) because
+// process.stdout.write is async on a pipe and process.exit terminates
+// the process before the userspace queue drains. Issue #12.
+//
+// fs.writeSync(1, buffer) is a blocking POSIX write to fd 1, but it can
+// legally perform a partial write (returns bytes written, not a
+// guarantee of full delivery). The loop below retries until the full
+// payload reaches the kernel.
+//
+// EPIPE handling: when the parent reader closes the pipe early, writeSync
+// throws EPIPE. We swallow it intentionally — there's no consumer left
+// to receive the error, and propagating would mask the (more useful)
+// upstream cause that closed the pipe.
+
+import { writeSync } from "node:fs";
+import { Buffer } from "node:buffer";
+
+export function emitJson(payload) {
+  const text = `${JSON.stringify(payload, null, 2)}\n`;
+  const buf = Buffer.from(text, "utf8");
+  let written = 0;
+  while (written < buf.length) {
+    let n;
+    try {
+      n = writeSync(1, buf, written, buf.length - written);
+    } catch (err) {
+      if (err && err.code === "EPIPE") return;
+      throw err;
+    }
+    if (typeof n !== "number" || n <= 0) {
+      // Defensive: writeSync should always advance or throw; treat a
+      // zero-byte advance as a fatal pipe state to avoid an infinite loop.
+      return;
+    }
+    written += n;
+  }
+}

--- a/tests/unit/fsm-cli-large-stdout.test.js
+++ b/tests/unit/fsm-cli-large-stdout.test.js
@@ -108,10 +108,14 @@ test("fsm-commit: large brief (>64KB) is byte-complete on stdout (issue #12)", (
     // emit the next state's brief (which threads the blob into env.blob)
     // without truncation. 200KB chosen so the brief reliably exceeds the
     // 64KB pipe buffer cap that the previous emit() shape clipped at.
+    // Pass via --outputs-file rather than --outputs to keep the test
+    // portable (some platforms cap argv length below 200KB).
     const blob = "x".repeat(200_000);
+    const outputsPath = join(tmp, "outputs.json");
+    writeFileSync(outputsPath, JSON.stringify({ blob }));
     const commitResult = runScript("fsm-commit.mjs", [
       "--run-id", newRun.run_id,
-      "--outputs", JSON.stringify({ blob }),
+      "--outputs-file", outputsPath,
       "--session-id", session,
       ...commonArgs(tmp),
     ]);

--- a/tests/unit/fsm-cli-large-stdout.test.js
+++ b/tests/unit/fsm-cli-large-stdout.test.js
@@ -1,0 +1,132 @@
+// fsm-cli-large-stdout.test.js — regression for issue #12.
+//
+// The three FSM CLIs (fsm-next, fsm-commit, fsm-inspect) used to emit JSON
+// via `process.stdout.write(...)` followed immediately by `process.exit(...)`.
+// On macOS the kernel pipe buffer caps at ~64KB; payloads larger than that
+// were queued in Node's userspace stream buffer and dropped at exit before
+// they could drain. spawnSync parents observed truncation at exactly 65536
+// bytes and JSON.parse(stdout) threw "Unterminated string in JSON".
+//
+// emit() now uses fs.writeSync(1, ...) which is a blocking POSIX write to
+// fd 1 — no userspace queue, no truncation under process.exit. This test
+// drives a payload >> 64KB through fsm-commit and asserts the parent
+// receives the full JSON byte-complete.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+);
+
+// FSM with a deeply-nested response_schema that produces a multi-hundred-KB
+// brief on the next state. The size driver is `inputs[*]` carrying a long
+// string that buildBrief threads into the next-state brief.
+function makeBigPayloadFsm() {
+  return `
+fsm:
+  id: bigpayload
+  version: 1
+  entry: a
+  states:
+    - id: a
+      purpose: "Entry; accepts a large blob output."
+      preconditions: []
+      worker:
+        role: stub
+        prompt_template: workers/stub.md
+        inputs: ["args"]
+        response_schema:
+          type: object
+          required: [blob]
+          properties:
+            blob: { type: string, minLength: 1 }
+      outputs: ["blob"]
+      transitions:
+        - to: b
+          when: always
+    - id: b
+      purpose: "Mid; consumes the blob."
+      preconditions: ["blob exists"]
+      worker:
+        role: stub
+        prompt_template: workers/stub.md
+        inputs: ["blob"]
+        response_schema:
+          type: object
+          required: [done]
+          properties:
+            done: { type: boolean }
+      outputs: ["done"]
+      transitions: []
+`;
+}
+
+function setupFixture(yamlText) {
+  const tmp = mkdtempSync(join(tmpdir(), "fsm-bigpayload-"));
+  writeFileSync(join(tmp, "fsm.yaml"), yamlText);
+  mkdirSync(join(tmp, "workers"));
+  writeFileSync(join(tmp, "workers", "stub.md"), "# stub worker\n");
+  mkdirSync(join(tmp, "store"));
+  return tmp;
+}
+
+function runScript(name, args) {
+  return spawnSync("node", [join(SCRIPT_DIR, name), ...args], { encoding: "utf8" });
+}
+
+function commonArgs(tmp) {
+  return ["--fsm-path", join(tmp, "fsm.yaml"), "--storage-root", join(tmp, "store")];
+}
+
+test("fsm-commit: large brief (>64KB) is byte-complete on stdout (issue #12)", () => {
+  const tmp = setupFixture(makeBigPayloadFsm());
+  try {
+    const session = "test-bigpayload";
+    const newRun = JSON.parse(
+      runScript("fsm-next.mjs", [
+        "--new-run", "--repo", "bigtest", "--base-sha", "aaa", "--head-sha", "bbb",
+        "--session-id", session, "--args", "{}",
+        ...commonArgs(tmp),
+      ]).stdout,
+    );
+
+    // Commit the entry state with a multi-hundred-KB blob. fsm-commit must
+    // emit the next state's brief (which threads the blob into env.blob)
+    // without truncation. 200KB chosen so the brief reliably exceeds the
+    // 64KB pipe buffer cap that the previous emit() shape clipped at.
+    const blob = "x".repeat(200_000);
+    const commitResult = runScript("fsm-commit.mjs", [
+      "--run-id", newRun.run_id,
+      "--outputs", JSON.stringify({ blob }),
+      "--session-id", session,
+      ...commonArgs(tmp),
+    ]);
+
+    assert.equal(commitResult.status, 0, `fsm-commit exit status; stderr: ${commitResult.stderr}`);
+    // The full stdout must be present and parseable. With the bug, this
+    // would truncate near 65536 bytes and JSON.parse would throw
+    // "Unterminated string in JSON".
+    assert.ok(
+      commitResult.stdout.length > 200_000,
+      `expected stdout > 200KB, got ${commitResult.stdout.length}`,
+    );
+    const brief = JSON.parse(commitResult.stdout); // would throw under the bug
+    assert.equal(brief.ok, true);
+    assert.equal(brief.advanced_from, "a");
+    assert.equal(brief.state, "b");
+    // The blob round-tripped through fsm-commit's brief output for state b.
+    assert.equal(brief.inputs.blob.length, blob.length);
+    assert.equal(brief.inputs.blob, blob);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/fsm-cli-large-stdout.test.js
+++ b/tests/unit/fsm-cli-large-stdout.test.js
@@ -91,13 +91,16 @@ test("fsm-commit: large brief (>64KB) is byte-complete on stdout (issue #12)", (
   const tmp = setupFixture(makeBigPayloadFsm());
   try {
     const session = "test-bigpayload";
-    const newRun = JSON.parse(
-      runScript("fsm-next.mjs", [
-        "--new-run", "--repo", "bigtest", "--base-sha", "aaa", "--head-sha", "bbb",
-        "--session-id", session, "--args", "{}",
-        ...commonArgs(tmp),
-      ]).stdout,
+    const newRunResult = runScript("fsm-next.mjs", [
+      "--new-run", "--repo", "bigtest", "--base-sha", "aaa", "--head-sha", "bbb",
+      "--session-id", session, "--args", "{}",
+      ...commonArgs(tmp),
+    ]);
+    assert.equal(
+      newRunResult.status, 0,
+      `fsm-next --new-run failed; stderr: ${newRunResult.stderr}`,
     );
+    const newRun = JSON.parse(newRunResult.stdout);
 
     // Commit the entry state with a multi-hundred-KB blob. fsm-commit must
     // emit the next state's brief (which threads the blob into env.blob)
@@ -126,6 +129,81 @@ test("fsm-commit: large brief (>64KB) is byte-complete on stdout (issue #12)", (
     // The blob round-tripped through fsm-commit's brief output for state b.
     assert.equal(brief.inputs.blob.length, blob.length);
     assert.equal(brief.inputs.blob, blob);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("fsm-next --new-run: large args echoed in brief (>64KB) is byte-complete (issue #12)", () => {
+  // Sibling of the fsm-commit test above. fsm-next --new-run emits the
+  // entry-state brief which carries `inputs: { args: <args> }`. Pass a
+  // 200KB args bag so the brief reliably exceeds the 64KB pipe-buffer
+  // cap. Asserts the parent receives the full JSON byte-complete.
+  const tmp = setupFixture(makeBigPayloadFsm());
+  try {
+    const session = "test-bignewrun";
+    const blob = "x".repeat(200_000);
+    const argsJson = JSON.stringify({ huge: blob });
+    // 200KB JSON arg passed via --args-file (some shells choke on long
+    // --args strings on the command line).
+    writeFileSync(join(tmp, "args.json"), argsJson);
+
+    const newRunResult = runScript("fsm-next.mjs", [
+      "--new-run", "--repo", "bigtest", "--base-sha", "aaa", "--head-sha", "bbb",
+      "--session-id", session, "--args-file", join(tmp, "args.json"),
+      ...commonArgs(tmp),
+    ]);
+    assert.equal(
+      newRunResult.status, 0,
+      `fsm-next --new-run failed; stderr: ${newRunResult.stderr}`,
+    );
+    assert.ok(
+      newRunResult.stdout.length > 200_000,
+      `expected new-run stdout > 200KB, got ${newRunResult.stdout.length}`,
+    );
+    const brief = JSON.parse(newRunResult.stdout); // would throw under the bug
+    assert.equal(brief.ok, true);
+    assert.equal(brief.state, "a");
+    assert.equal(brief.inputs.args.huge.length, blob.length);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("fsm-validate-static: large summary is byte-complete on stdout (issue #12)", () => {
+  // fsm-validate-static reports per-file results. To exercise the
+  // large-stdout path, write enough invalid FSM files that the cumulative
+  // JSON summary exceeds the 64KB pipe-buffer cap.
+  const tmp = mkdtempSync(join(tmpdir(), "fsm-static-large-"));
+  try {
+    // Each invalid FSM contributes ~150 bytes to the JSON report. 600
+    // files cross the 64KB cap with margin (~90KB).
+    const filenames = [];
+    for (let i = 0; i < 600; i++) {
+      const name = `bad-${String(i).padStart(4, "0")}.yaml`;
+      writeFileSync(
+        join(tmp, name),
+        `fsm:\n  id: x\n  version: 1\n  entry: missing_state_${i}\n  states:\n    - id: a\n      purpose: "."\n      preconditions: []\n      outputs: []\n      transitions: []\n`,
+      );
+      filenames.push(name);
+    }
+
+    const result = spawnSync(
+      "node",
+      [join(SCRIPT_DIR, "fsm-validate-static.mjs"), ...filenames],
+      { encoding: "utf8", cwd: tmp },
+    );
+
+    // Exit 1 expected (every file is invalid). Stdout must still be
+    // a complete JSON document.
+    assert.equal(result.status, 1, `expected exit 1; stderr: ${result.stderr}`);
+    assert.ok(
+      result.stdout.length > 64 * 1024,
+      `expected stdout > 64KB to exercise the truncation path; got ${result.stdout.length}`,
+    );
+    const summary = JSON.parse(result.stdout); // would throw under the bug
+    assert.equal(summary.ok, false);
+    assert.equal(summary.files.length, 600);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/tests/unit/fsm-cli-large-stdout.test.js
+++ b/tests/unit/fsm-cli-large-stdout.test.js
@@ -1,16 +1,18 @@
-// fsm-cli-large-stdout.test.js — regression for issue #12.
+// fsm-cli-large-stdout.test.js — regressions for issue #12.
 //
-// The three FSM CLIs (fsm-next, fsm-commit, fsm-inspect) used to emit JSON
-// via `process.stdout.write(...)` followed immediately by `process.exit(...)`.
-// On macOS the kernel pipe buffer caps at ~64KB; payloads larger than that
-// were queued in Node's userspace stream buffer and dropped at exit before
-// they could drain. spawnSync parents observed truncation at exactly 65536
-// bytes and JSON.parse(stdout) threw "Unterminated string in JSON".
+// All four FSM CLIs (fsm-next, fsm-commit, fsm-inspect, fsm-validate-static)
+// used to emit JSON via `process.stdout.write(...)` followed immediately by
+// `process.exit(...)`. On macOS the kernel pipe buffer caps at ~64KB;
+// payloads larger than that were queued in Node's userspace stream buffer
+// and dropped at exit before they could drain. spawnSync parents observed
+// truncation at exactly 65536 bytes and JSON.parse(stdout) threw
+// "Unterminated string in JSON".
 //
-// emit() now uses fs.writeSync(1, ...) which is a blocking POSIX write to
-// fd 1 — no userspace queue, no truncation under process.exit. This test
-// drives a payload >> 64KB through fsm-commit and asserts the parent
-// receives the full JSON byte-complete.
+// emit() now delegates to scripts/lib/emit.mjs::emitJson which loops
+// fs.writeSync(1, ...) until the full buffer is delivered. Three tests
+// drive byte-complete-stdout assertions through the three end-user CLIs
+// (fsm-commit, fsm-next, fsm-validate-static); fsm-inspect uses the same
+// shared helper and therefore inherits the fix.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";


### PR DESCRIPTION
## Summary

- All four FSM CLIs (\`fsm-commit\`, \`fsm-next\`, \`fsm-inspect\`, \`fsm-validate-static\`) now use \`fs.writeSync(1, ...)\` in their \`emit()\` helper instead of \`process.stdout.write(...)\`.
- New regression test \`tests/unit/fsm-cli-large-stdout.test.js\` drives a 200 KB blob through fsm-commit and asserts byte-complete stdout reaches the parent.

## Why

\`process.stdout.write(text)\` is async on a pipe. When the kernel pipe buffer (~64 KB on macOS) fills, the remainder is queued in Node's userspace stream buffer. \`process.exit(...)\` terminates the process before the userspace queue drains, dropping the remaining bytes. spawnSync parents see exactly 65536 bytes and \`JSON.parse(stdout)\` throws "Unterminated string in JSON at position 65534".

\`fs.writeSync(1, text)\` is a blocking POSIX write to fd 1 — no userspace queue, no truncation at exit. Empirically verified:

\`\`\`
process.stdout.write + process.exit → 65536 bytes (truncated)
fs.writeSync(1, ...) + process.exit → 100017 bytes (full)
\`\`\`

## Surface

skill-code-review's [PR #88](https://github.com/ctxr-dev/skill-code-review/pull/88) (now merged) made \`activate_leaves\` briefs reliably exceed 64 KB on real diffs (264 KB observed in one run), faulting every review of a non-trivial change set with the exact \`Unterminated string in JSON at position 65534\` error this PR fixes.

Closes #12.

## Test plan

- [x] New: \`tests/unit/fsm-cli-large-stdout.test.js\` — 200 KB blob through fsm-commit, asserts \`stdout.length > 200_000\` and \`JSON.parse(stdout)\` succeeds. Fails on main, passes here.
- [x] All 89 existing tests pass (\`npm test\`).
- [x] Lint clean (\`npm run lint\`).

## Out of scope

- Stress-testing other consumers of the FSM CLIs. The fix is universal: any spawnSync caller that previously truncated >64 KB now sees byte-complete stdout.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>