### PR TITLE
feat(engine,cli,aggregator): loop state primitive + aggregator (A1+A2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "./storage": "./scripts/lib/fsm-storage.mjs",
     "./schema": "./scripts/lib/fsm-schema.mjs",
     "./predicates": "./scripts/lib/fsm-predicates.mjs",
-    "./engine": "./scripts/lib/fsm-engine.mjs"
+    "./engine": "./scripts/lib/fsm-engine.mjs",
+    "./aggregator": "./scripts/lib/fsm-aggregator.mjs"
   },
   "bin": {
     "fsm-next": "scripts/fsm-next.mjs",

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -175,6 +175,16 @@ if (state.loop) {
   );
   const decision = runLoopDecision(state, parsed.outputs, iterationN);
   if (!decision.terminate) {
+    // Bump the manifest's last_update_at on every loop iteration so
+    // run-health and stale-run signals still tick over while the loop
+    // is making progress. current_state is reaffirmed defensively (it
+    // is unchanged for a continuing loop, but this keeps the patch
+    // self-explanatory and survives manifest schema drift).
+    updateManifest(
+      parsed.runId,
+      { current_state: state.id },
+      { storageRoot: settings.storageRoot },
+    );
     const envSoFar = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
     const continueBrief = buildBrief({
       doc: fsm.doc,

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -18,6 +18,7 @@ import { readFileSync } from "node:fs";
 
 import { emitJson } from "./lib/emit.mjs";
 import {
+  appendTraceFile,
   readLock,
   readManifest,
   releaseLock,
@@ -25,9 +26,11 @@ import {
 } from "./lib/fsm-storage.mjs";
 import {
   buildBrief,
+  countLoopIterations,
   loadFsm,
   resolveTransition,
   runEnv,
+  runLoopDecision,
   runPostValidations,
   stateById,
   updateManifest,
@@ -36,6 +39,7 @@ import {
   writeExitTrace,
   writeFaultTrace,
 } from "./lib/fsm-engine.mjs";
+import { aggregateLoopOutputs } from "./lib/fsm-aggregator.mjs";
 import { resolveSettings } from "./lib/fsm-config.mjs";
 
 function parseArgs(argv) {
@@ -153,10 +157,56 @@ if (!validationResult.valid) {
   process.exit(1);
 }
 
+// Loop-state branch: write the iter trace and either re-emit the next
+// loop brief (continue) or aggregate + fall through to the regular
+// exit-trace + transition path (terminate).
+let outputsForFlow = parsed.outputs;
+if (state.loop) {
+  const iterationN =
+    countLoopIterations(parsed.runId, state.id, { storageRoot: settings.storageRoot }) + 1;
+  appendTraceFile(
+    parsed.runId,
+    {
+      phase: "iter",
+      state: state.id,
+      data: { iteration_n: iterationN, outputs: parsed.outputs },
+    },
+    { storageRoot: settings.storageRoot },
+  );
+  const decision = runLoopDecision(state, parsed.outputs, iterationN);
+  if (!decision.terminate) {
+    const envSoFar = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
+    const continueBrief = buildBrief({
+      doc: fsm.doc,
+      state,
+      env: envSoFar,
+      runId: parsed.runId,
+      opts: { storageRoot: settings.storageRoot },
+    });
+    emit({
+      ok: true,
+      loop_continued: true,
+      ...continueBrief,
+    });
+    process.exit(0);
+  }
+  // Terminating: aggregate iter outputs into one canonical record and use
+  // that as the loop state's outputs for the rest of the commit flow.
+  const runDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
+  const agg = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
+  outputsForFlow = {
+    [`aggregated_${state.id}`]: agg.aggregated_path,
+    iteration_meta_path: agg.iteration_meta_path,
+    total_iterations: agg.iteration_count,
+    merged_length: agg.merged_length,
+    terminated_by: decision.reason,
+  };
+}
+
 const postValidations = runPostValidations(state);
 
 const env = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
-const envWithCommit = { ...env, ...parsed.outputs };
+const envWithCommit = { ...env, ...outputsForFlow };
 const { transition, evaluations } = resolveTransition(state, envWithCommit, {
   judgementPick: parsed.judgementPick,
 });
@@ -165,7 +215,7 @@ writeExitTrace(
   parsed.runId,
   {
     state,
-    outputs: parsed.outputs,
+    outputs: outputsForFlow,
     postValidations: postValidations.results,
     transitionEvals: evaluations,
     chosenTransition: transition?.to ?? null,
@@ -245,6 +295,12 @@ updateManifest(
   },
   { storageRoot: settings.storageRoot },
 );
-const brief = buildBrief({ doc: fsm.doc, state: nextState, env: envWithCommit, runId: parsed.runId });
+const brief = buildBrief({
+  doc: fsm.doc,
+  state: nextState,
+  env: envWithCommit,
+  runId: parsed.runId,
+  opts: { storageRoot: settings.storageRoot },
+});
 emit({ ok: true, advanced_from: state.id, ...brief });
 process.exit(0);

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -202,12 +202,20 @@ if (state.loop) {
   }
   // Terminating: aggregate iter outputs into one canonical record and use
   // that as the loop state's outputs for the rest of the commit flow.
+  // `total_iterations` is the COMMITTED iteration count (taken from
+  // iterationN, the trace-driven counter), NOT agg.iteration_count
+  // which only counts iter-N.json files the aggregator could parse
+  // and schema-validate. Otherwise tolerated invalid iters would make
+  // the manifest's iteration count disagree with max_iterations
+  // bookkeeping and the trace.
   const runDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
   const agg = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
   outputsForFlow = {
     [`aggregated_${state.id}`]: agg.aggregated_path,
     iteration_meta_path: agg.iteration_meta_path,
-    total_iterations: agg.iteration_count,
+    total_iterations: iterationN,
+    aggregated_iteration_count: agg.iteration_count,
+    aggregator_validation_errors: agg.validation_errors,
     merged_length: agg.merged_length,
     terminated_by: decision.reason,
   };

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -277,10 +277,16 @@ if (!transition) {
 }
 
 const nextState = stateById(fsm.doc, transition.to);
-const nextInputs = nextState.worker?.inputs?.reduce((acc, name) => {
+// Loop states declare their worker under state.loop.worker; falling back
+// here keeps the entry trace's recorded inputs consistent with what
+// buildBrief will pass to the worker dispatch (otherwise the trace shows
+// no inputs for a loop-entry state, which is misleading on inspection).
+const nextInputsDecl =
+  nextState.worker?.inputs ?? nextState.loop?.worker?.inputs ?? [];
+const nextInputs = nextInputsDecl.reduce((acc, name) => {
   acc[name] = envWithCommit[name];
   return acc;
-}, {}) ?? {};
+}, {});
 writeEntryTrace(
   parsed.runId,
   { state: nextState, inputs: nextInputs },

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -127,10 +127,16 @@ if (parsed.newRun) {
   });
   const entryState = stateById(fsm.doc, fsm.doc.fsm.entry);
   const env = { args: parsed.args ?? {} };
-  const inputs = entryState.worker?.inputs?.reduce((acc, name) => {
+  // A loop state declares its worker under state.loop.worker; reading
+  // only state.worker.inputs would silently drop `args` (and any other
+  // declared input) from the entry trace, which runEnv on resume reads
+  // back as `env.args`. Fall through to loop.worker.inputs if present.
+  const entryInputsDecl =
+    entryState.worker?.inputs ?? entryState.loop?.worker?.inputs ?? [];
+  const inputs = entryInputsDecl.reduce((acc, name) => {
     acc[name] = env[name];
     return acc;
-  }, {}) ?? {};
+  }, {});
   writeEntryTrace(
     runId,
     { state: entryState, inputs },

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -141,7 +141,13 @@ if (parsed.newRun) {
     { current_state: entryState.id, next_state: null },
     { storageRoot: settings.storageRoot },
   );
-  const brief = buildBrief({ doc: fsm.doc, state: entryState, env, runId });
+  const brief = buildBrief({
+    doc: fsm.doc,
+    state: entryState,
+    env,
+    runId,
+    opts: { storageRoot: settings.storageRoot },
+  });
   emit({ ok: true, ...brief });
   process.exit(0);
 }
@@ -181,6 +187,12 @@ if (!lock.acquired) {
 const env = runEnv(runId, { storageRoot: settings.storageRoot });
 const stateId = manifest.current_state ?? fsm.doc.fsm.entry;
 const state = stateById(fsm.doc, stateId);
-const brief = buildBrief({ doc: fsm.doc, state, env, runId });
+const brief = buildBrief({
+  doc: fsm.doc,
+  state,
+  env,
+  runId,
+  opts: { storageRoot: settings.storageRoot },
+});
 emit({ ok: true, resumed: true, ...brief });
 process.exit(0);

--- a/scripts/lib/fsm-aggregator.mjs
+++ b/scripts/lib/fsm-aggregator.mjs
@@ -124,9 +124,21 @@ export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } 
   for (const { n, payload } of iters) {
     const arr = Array.isArray(payload?.[mergeField]) ? payload[mergeField] : [];
     for (const item of arr) merged.push(item);
-    const meta = { iteration_n: n };
+    // Use a null-prototype object so worker-controlled keys (e.g. a
+    // payload that intentionally or accidentally carries `__proto__`,
+    // `constructor`, or `prototype`) cannot mutate Object.prototype
+    // when copied in below. JSON.stringify on a null-prototype object
+    // serialises the same as a regular literal.
+    const meta = Object.assign(Object.create(null), { iteration_n: n });
     for (const key of Object.keys(payload ?? {})) {
       if (key === mergeField) continue;
+      // Defensive: skip the well-known prototype-pollution keys
+      // explicitly even with the null-prototype object, since some
+      // downstream consumers may later spread `meta` into a normal
+      // object literal.
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        continue;
+      }
       meta[key] = payload[key];
     }
     iterationMeta.push(meta);

--- a/scripts/lib/fsm-aggregator.mjs
+++ b/scripts/lib/fsm-aggregator.mjs
@@ -1,0 +1,109 @@
+// fsm-aggregator.mjs — loop-state output aggregator.
+//
+// Loop states write per-iteration JSON outputs to
+// <run_dir>/workers/<state.loop.iteration_outputs_dir>/iter-<N>.json.
+// When the loop terminates, this helper reads every iter-*.json file in
+// sequence order, validates each against the loop worker's response_schema,
+// concatenates the per-iteration `findings[]` (or any configured mergeField)
+// arrays, and atomic-writes a single aggregated output file under
+// <run_dir>/workers/. A sibling meta file captures per-iteration metadata
+// (strategy, ruled_out, rationale, done) so the manifest can summarise the
+// loop without re-reading every iter file.
+//
+// All filesystem operations are atomic; re-running the aggregator on the
+// same run_dir is idempotent. The aggregator never mutates iter files.
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { atomicWriteJson } from "./fsm-storage.mjs";
+import { validateWorkerResponse } from "./fsm-schema.mjs";
+
+// aggregateLoopOutputs reads per-iteration JSON files for a loop state
+// and produces a unified aggregated array. `runDir` is the absolute path
+// to the run's directory (the parent of `workers/`). `state` is the loop
+// state object from the FSM YAML (used for response_schema + iteration
+// outputs_dir). `mergeField` is the top-level array field whose values
+// are concatenated (default "findings"). Returns:
+//   {
+//     aggregated_path: "workers/<state-id>-aggregated.json",
+//     iteration_meta_path: "workers/<state-id>-iteration-meta.json",
+//     iteration_count: <n>,
+//     merged_length: <n>,
+//     validation_errors: [],
+//   }
+// On schema-violation in any iter file, the path appears in validation_errors
+// but aggregation still proceeds with the remaining valid files.
+export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } = {}) {
+  if (!state?.loop) {
+    throw new Error("aggregateLoopOutputs: state is not a loop state");
+  }
+  if (!runDir || typeof runDir !== "string") {
+    throw new TypeError("aggregateLoopOutputs: runDir must be a non-empty string path");
+  }
+  const stateId = state.id;
+  const loop = state.loop;
+  const iterSubdir = (loop.iteration_outputs_dir ?? `${stateId}-iters/`).replace(/^\/+/, "").replace(/\/+$/, "");
+  const iterDir = join(runDir, "workers", iterSubdir);
+  const schema = loop.worker?.response_schema;
+
+  const iters = [];
+  const validationErrors = [];
+
+  if (existsSync(iterDir)) {
+    const entries = readdirSync(iterDir).filter((n) => /^iter-\d+\.json$/.test(n));
+    const numbered = entries
+      .map((name) => ({ name, n: Number.parseInt(name.match(/^iter-(\d+)\.json$/)[1], 10) }))
+      .sort((a, b) => a.n - b.n);
+    for (const { name, n } of numbered) {
+      const filePath = join(iterDir, name);
+      let payload;
+      try {
+        payload = JSON.parse(readFileSync(filePath, "utf8"));
+      } catch (err) {
+        validationErrors.push({ path: filePath, error: `parse_error: ${err.message}` });
+        continue;
+      }
+      if (schema) {
+        const result = validateWorkerResponse(schema, payload);
+        if (!result.valid) {
+          validationErrors.push({ path: filePath, error: `schema: ${result.errors.join("; ")}` });
+          continue;
+        }
+      }
+      iters.push({ n, payload });
+    }
+  }
+
+  const merged = [];
+  const iterationMeta = [];
+  for (const { n, payload } of iters) {
+    const arr = Array.isArray(payload?.[mergeField]) ? payload[mergeField] : [];
+    for (const item of arr) merged.push(item);
+    const meta = { iteration_n: n };
+    for (const key of Object.keys(payload ?? {})) {
+      if (key === mergeField) continue;
+      meta[key] = payload[key];
+    }
+    iterationMeta.push(meta);
+  }
+
+  const aggregatedRel = join("workers", `${stateId}-aggregated.json`);
+  const metaRel = join("workers", `${stateId}-iteration-meta.json`);
+  mkdirSync(join(runDir, "workers"), { recursive: true });
+  atomicWriteJson(join(runDir, aggregatedRel), { state: stateId, merge_field: mergeField, items: merged });
+  atomicWriteJson(join(runDir, metaRel), { state: stateId, iterations: iterationMeta });
+
+  return {
+    aggregated_path: aggregatedRel,
+    iteration_meta_path: metaRel,
+    iteration_count: iters.length,
+    merged_length: merged.length,
+    validation_errors: validationErrors,
+  };
+}

--- a/scripts/lib/fsm-aggregator.mjs
+++ b/scripts/lib/fsm-aggregator.mjs
@@ -62,6 +62,16 @@ export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } 
   if (typeof state.id !== "string" || state.id.length === 0) {
     throw new TypeError("aggregateLoopOutputs: state.id must be a non-empty string");
   }
+  // Match the schema-layer constraint (snake_case lowercase + digits +
+  // underscore). state.id feeds directly into output filenames; a
+  // caller-supplied id like "../x" or "a/b" would either escape the
+  // workers/ subdir or split into nested dirs that nothing else
+  // expects. Validate once here so the public-surface call is safe.
+  if (!/^[a-z][a-z0-9_]*$/.test(state.id)) {
+    throw new TypeError(
+      `aggregateLoopOutputs: state.id must be snake_case (lowercase letters, digits, underscores), got "${state.id}"`,
+    );
+  }
   if (typeof mergeField !== "string" || mergeField.length === 0) {
     throw new TypeError("aggregateLoopOutputs: mergeField must be a non-empty string");
   }

--- a/scripts/lib/fsm-aggregator.mjs
+++ b/scripts/lib/fsm-aggregator.mjs
@@ -21,8 +21,21 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { sanitiseLoopOutputsDirSegment } from "./fsm-engine.mjs";
 import { atomicWriteJson } from "./fsm-storage.mjs";
 import { validateWorkerResponse } from "./fsm-schema.mjs";
+
+// Returned relative paths must be POSIX (forward slash) so consumers on
+// any platform see the same wire shape as the rest of the worker
+// contract paths under workers/. join() uses os-native separators, which
+// produces backslashes on Windows; use this helper for ANY path returned
+// to the caller.
+function posixRel(...segments) {
+  return segments
+    .filter((s) => typeof s === "string" && s.length > 0)
+    .join("/")
+    .replace(/\/{2,}/g, "/");
+}
 
 // aggregateLoopOutputs reads per-iteration JSON files for a loop state
 // and produces a unified aggregated array. `runDir` is the absolute path
@@ -46,9 +59,20 @@ export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } 
   if (!runDir || typeof runDir !== "string") {
     throw new TypeError("aggregateLoopOutputs: runDir must be a non-empty string path");
   }
+  if (typeof state.id !== "string" || state.id.length === 0) {
+    throw new TypeError("aggregateLoopOutputs: state.id must be a non-empty string");
+  }
+  if (typeof mergeField !== "string" || mergeField.length === 0) {
+    throw new TypeError("aggregateLoopOutputs: mergeField must be a non-empty string");
+  }
   const stateId = state.id;
   const loop = state.loop;
-  const iterSubdir = (loop.iteration_outputs_dir ?? `${stateId}-iters/`).replace(/^\/+/, "").replace(/\/+$/, "");
+  // Sanitise the configured iteration_outputs_dir at runtime too: the
+  // schema validates this at load time, but the aggregator is part of
+  // the public surface and may be called with a state object whose
+  // origin is not under our control. Reject leading "/" and ".." here
+  // explicitly to prevent path traversal out of <runDir>/workers/.
+  const iterSubdir = sanitiseLoopOutputsDirSegment(loop.iteration_outputs_dir, stateId);
   const iterDir = join(runDir, "workers", iterSubdir);
   const schema = loop.worker?.response_schema;
 
@@ -93,11 +117,14 @@ export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } 
     iterationMeta.push(meta);
   }
 
-  const aggregatedRel = join("workers", `${stateId}-aggregated.json`);
-  const metaRel = join("workers", `${stateId}-iteration-meta.json`);
+  // Returned relative paths use POSIX separators (the wire format the
+  // worker contract is documented in). Filesystem writes go through
+  // join() so they use OS-native separators locally.
+  const aggregatedRel = posixRel("workers", `${stateId}-aggregated.json`);
+  const metaRel = posixRel("workers", `${stateId}-iteration-meta.json`);
   mkdirSync(join(runDir, "workers"), { recursive: true });
-  atomicWriteJson(join(runDir, aggregatedRel), { state: stateId, merge_field: mergeField, items: merged });
-  atomicWriteJson(join(runDir, metaRel), { state: stateId, iterations: iterationMeta });
+  atomicWriteJson(join(runDir, "workers", `${stateId}-aggregated.json`), { state: stateId, merge_field: mergeField, items: merged });
+  atomicWriteJson(join(runDir, "workers", `${stateId}-iteration-meta.json`), { state: stateId, iterations: iterationMeta });
 
   return {
     aggregated_path: aggregatedRel,

--- a/scripts/lib/fsm-aggregator.mjs
+++ b/scripts/lib/fsm-aggregator.mjs
@@ -86,17 +86,22 @@ export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } 
       .sort((a, b) => a.n - b.n);
     for (const { name, n } of numbered) {
       const filePath = join(iterDir, name);
+      // Report paths relative to runDir with POSIX separators so the
+      // aggregator never leaks absolute filesystem paths (which would
+      // reveal local layout in logs) and matches the rest of the
+      // worker-contract path style.
+      const relPath = posixRel("workers", iterSubdir, name);
       let payload;
       try {
         payload = JSON.parse(readFileSync(filePath, "utf8"));
       } catch (err) {
-        validationErrors.push({ path: filePath, error: `parse_error: ${err.message}` });
+        validationErrors.push({ path: relPath, error: `parse_error: ${err.message}` });
         continue;
       }
       if (schema) {
         const result = validateWorkerResponse(schema, payload);
         if (!result.valid) {
-          validationErrors.push({ path: filePath, error: `schema: ${result.errors.join("; ")}` });
+          validationErrors.push({ path: relPath, error: `schema: ${result.errors.join("; ")}` });
           continue;
         }
       }

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -123,6 +123,34 @@ export function buildBrief({ doc, state, env, runId, opts = {} }) {
   return brief;
 }
 
+// sanitiseLoopOutputsDirSegment normalises a loop state's
+// iteration_outputs_dir into a single relative subpath under workers/.
+// Schema validation rejects "/"-leading and ".." segments at FSM load
+// time, but the engine is also called from contexts that may not have
+// re-validated the doc (tests, dynamic FSMs). Re-running the checks here
+// keeps the runtime defensive: a malicious or stale state cannot escape
+// <run_dir>/workers/ via path traversal.
+export function sanitiseLoopOutputsDirSegment(raw, fallbackStateId) {
+  const candidate = raw && typeof raw === "string" && raw.length > 0
+    ? raw
+    : `${fallbackStateId}-iters/`;
+  const trimmed = candidate.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (trimmed.length === 0) {
+    throw new Error(
+      "sanitiseLoopOutputsDirSegment: iteration_outputs_dir collapses to empty after trimming slashes",
+    );
+  }
+  const parts = trimmed.split("/");
+  for (const part of parts) {
+    if (part === "" || part === "." || part === "..") {
+      throw new Error(
+        `sanitiseLoopOutputsDirSegment: iteration_outputs_dir "${raw}" contains an invalid segment ("${part}")`,
+      );
+    }
+  }
+  return trimmed;
+}
+
 // buildLoopBrief composes the per-iteration brief for a loop state. The
 // orchestrator dispatches the worker with `worker.prompt_template` and is
 // expected to write the JSON output to `loop.outputs_path`. Subsequent
@@ -130,8 +158,10 @@ export function buildBrief({ doc, state, env, runId, opts = {} }) {
 export function buildLoopBrief({ doc, state, env, runId, opts = {} }) {
   const loop = state.loop;
   const max = loop.max_iterations ?? 30;
-  const dirSegment = (loop.iteration_outputs_dir ?? `${state.id}-iters/`).replace(/^\/+/, "").replace(/\/+$/, "");
+  const dirSegment = sanitiseLoopOutputsDirSegment(loop.iteration_outputs_dir, state.id);
   const iterationN = countLoopIterations(runId, state.id, opts) + 1;
+  // outputs_path is part of the worker contract and is consumed across
+  // platforms; always emit POSIX forward slashes regardless of host OS.
   const outputsPath = `workers/${dirSegment}/iter-${iterationN}.json`;
   const fakeStateForInputs = { worker: { inputs: loop.worker.inputs ?? [] } };
   return {

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -134,6 +134,16 @@ export function sanitiseLoopOutputsDirSegment(raw, fallbackStateId) {
   const candidate = raw && typeof raw === "string" && raw.length > 0
     ? raw
     : `${fallbackStateId}-iters/`;
+  // Backslashes are a path separator on Windows where `path.join`
+  // interprets them as such; allowing them through the POSIX-split
+  // check below would let `foo\..\bar` traverse out of workers/ on a
+  // Windows host. Reject the whole value up-front so the guard is
+  // platform-portable.
+  if (candidate.includes("\\")) {
+    throw new Error(
+      `sanitiseLoopOutputsDirSegment: iteration_outputs_dir "${raw}" must not contain backslashes (use forward slashes)`,
+    );
+  }
   const trimmed = candidate.replace(/^\/+/, "").replace(/\/+$/, "");
   if (trimmed.length === 0) {
     throw new Error(

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -212,21 +212,23 @@ export function buildLoopBrief({ doc, state, env, runId, opts = {} }) {
 
 // countLoopIterations returns the number of "iter" phase trace records
 // recorded so far for the given state. Returns 0 when the run dir has no
-// trace yet. Tolerant: callers in unit-test contexts without opts get 0.
+// trace yet (or no opts.storageRoot is supplied, the test-fixture case).
+// Real readTrace failures (corruption, EIO, parse errors) MUST propagate
+// so buildLoopBrief cannot silently reset to iter-1 and overwrite an
+// existing iteration output file.
 export function countLoopIterations(runId, stateId, opts = {}) {
-  try {
-    const trace = readTrace(runId, opts);
-    let n = 0;
-    for (const record of trace) {
-      const payload = record.data ?? record;
-      if (payload?.phase === "iter" && payload?.state === stateId) {
-        n++;
-      }
-    }
-    return n;
-  } catch {
+  if (!opts || typeof opts.storageRoot !== "string" || opts.storageRoot.length === 0) {
     return 0;
   }
+  const trace = readTrace(runId, opts);
+  let n = 0;
+  for (const record of trace) {
+    const payload = record.data ?? record;
+    if (payload?.phase === "iter" && payload?.state === stateId) {
+      n++;
+    }
+  }
+  return n;
 }
 
 // runLoopDecision decides whether a loop state should terminate given the

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -144,13 +144,20 @@ export function sanitiseLoopOutputsDirSegment(raw, fallbackStateId) {
       `sanitiseLoopOutputsDirSegment: iteration_outputs_dir "${raw}" must not contain backslashes (use forward slashes)`,
     );
   }
-  // Reject leading "/" explicitly rather than silently normalising it
-  // away. The schema layer rejects absolute paths at FSM load time, and
-  // the runtime helper should match (otherwise "/abs/path" would walk
-  // through as "abs/path" and disagree with the schema diagnostic).
+  // Reject leading "/" AND Windows drive-letter / colon-bearing
+  // segments. `path.join("workers", "C:/abs")` produces "workers/C:/abs"
+  // on POSIX but ends up absolute under path.win32.join, so the guard
+  // has to cover both. Disallow any ":" anywhere in the segment to keep
+  // the rule portable (a legitimate ":" inside a directory name is
+  // exotic and not worth supporting at the cost of the safety bound).
   if (candidate.startsWith("/")) {
     throw new Error(
       `sanitiseLoopOutputsDirSegment: iteration_outputs_dir "${raw}" must be relative; absolute paths are not allowed`,
+    );
+  }
+  if (/^[A-Za-z]:[\\/]/.test(candidate) || candidate.includes(":")) {
+    throw new Error(
+      `sanitiseLoopOutputsDirSegment: iteration_outputs_dir "${raw}" must not contain ":" (Windows drive letters or colon segments could escape workers/)`,
     );
   }
   const trimmed = candidate.replace(/\/+$/, "");

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -87,7 +87,18 @@ export function runEnv(runId, opts = {}) {
 // Includes the state spec + resolved inputs + transitions + the worker
 // response_schema if present. The orchestrator never reads the FSM YAML;
 // the brief is the only contract.
-export function buildBrief({ doc, state, env, runId }) {
+//
+// For loop states (state.loop present), the brief carries a `loop` section
+// with the current iteration counter and the outputs_path the worker must
+// write to. The iteration counter is derived from existing "iter" trace
+// records for this state in this run; pass runId+opts so we can read the
+// trace from disk. Callers that don't supply opts (no storageRoot) get
+// iteration_n = 1 as a safe default for non-resume flows where the count
+// is already known by the caller.
+export function buildBrief({ doc, state, env, runId, opts = {} }) {
+  if (state.loop) {
+    return buildLoopBrief({ doc, state, env, runId, opts });
+  }
   const brief = {
     run_id: runId,
     fsm_id: doc.fsm.id,
@@ -99,6 +110,7 @@ export function buildBrief({ doc, state, env, runId }) {
     post_validations: state.post_validations ?? [],
     transitions: (state.transitions ?? []).map((t) => ({ to: t.to, when: t.when })),
     has_worker: Boolean(state.worker),
+    has_loop: false,
   };
   if (state.worker) {
     brief.worker = {
@@ -109,6 +121,83 @@ export function buildBrief({ doc, state, env, runId }) {
     };
   }
   return brief;
+}
+
+// buildLoopBrief composes the per-iteration brief for a loop state. The
+// orchestrator dispatches the worker with `worker.prompt_template` and is
+// expected to write the JSON output to `loop.outputs_path`. Subsequent
+// fsm-commit + fsm-next calls advance the iteration counter or terminate.
+export function buildLoopBrief({ doc, state, env, runId, opts = {} }) {
+  const loop = state.loop;
+  const max = loop.max_iterations ?? 30;
+  const dirSegment = (loop.iteration_outputs_dir ?? `${state.id}-iters/`).replace(/^\/+/, "").replace(/\/+$/, "");
+  const iterationN = countLoopIterations(runId, state.id, opts) + 1;
+  const outputsPath = `workers/${dirSegment}/iter-${iterationN}.json`;
+  const fakeStateForInputs = { worker: { inputs: loop.worker.inputs ?? [] } };
+  return {
+    run_id: runId,
+    fsm_id: doc.fsm.id,
+    state: state.id,
+    purpose: state.purpose,
+    preconditions: state.preconditions ?? [],
+    inputs: resolveInputs(fakeStateForInputs, env),
+    outputs_expected: state.outputs ?? [],
+    post_validations: state.post_validations ?? [],
+    transitions: (state.transitions ?? []).map((t) => ({ to: t.to, when: t.when })),
+    has_worker: true,
+    has_loop: true,
+    loop: {
+      iteration_n: iterationN,
+      max_iterations: max,
+      done_field: loop.done_field,
+      outputs_path: outputsPath,
+    },
+    worker: {
+      role: loop.worker.role,
+      prompt_template: loop.worker.prompt_template,
+      inputs: loop.worker.inputs ?? [],
+      response_schema: loop.worker.response_schema,
+    },
+  };
+}
+
+// countLoopIterations returns the number of "iter" phase trace records
+// recorded so far for the given state. Returns 0 when the run dir has no
+// trace yet. Tolerant: callers in unit-test contexts without opts get 0.
+export function countLoopIterations(runId, stateId, opts = {}) {
+  try {
+    const trace = readTrace(runId, opts);
+    let n = 0;
+    for (const record of trace) {
+      const payload = record.data ?? record;
+      if (payload?.phase === "iter" && payload?.state === stateId) {
+        n++;
+      }
+    }
+    return n;
+  } catch {
+    return 0;
+  }
+}
+
+// runLoopDecision decides whether a loop state should terminate given the
+// just-committed iteration output. Returns:
+//   { isLoop: false } for non-loop states.
+//   { isLoop: true, terminate: true, reason: "done_field" | "max_iterations", iteration_n }
+//   { isLoop: true, terminate: false, iteration_n }
+export function runLoopDecision(state, outputs, iterationN) {
+  const loop = state.loop;
+  if (!loop) return { isLoop: false };
+  const max = loop.max_iterations ?? 30;
+  const doneField = loop.done_field;
+  const done = Boolean(outputs?.[doneField]);
+  if (done) {
+    return { isLoop: true, terminate: true, reason: "done_field", iteration_n: iterationN };
+  }
+  if (iterationN >= max) {
+    return { isLoop: true, terminate: true, reason: "max_iterations", iteration_n: iterationN };
+  }
+  return { isLoop: true, terminate: false, iteration_n: iterationN };
 }
 
 function resolveInputs(state, env) {
@@ -198,12 +287,14 @@ export function runPostValidations(state) {
 
 // validateOutputs runs the worker.response_schema (if any) over the
 // supplied payload. Returns { valid, errors[] }. Inline states (no worker)
-// skip schema validation and return valid=true.
+// skip schema validation and return valid=true. For loop states the
+// schema lives at state.loop.worker.response_schema.
 export function validateOutputs(state, outputs) {
-  if (!state.worker?.response_schema) {
+  const schema = state.loop?.worker?.response_schema ?? state.worker?.response_schema;
+  if (!schema) {
     return { valid: true, errors: [] };
   }
-  return validateWorkerResponse(state.worker.response_schema, outputs);
+  return validateWorkerResponse(schema, outputs);
 }
 
 // initialiseManifest writes the very first manifest.json for a new run.

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -144,7 +144,16 @@ export function sanitiseLoopOutputsDirSegment(raw, fallbackStateId) {
       `sanitiseLoopOutputsDirSegment: iteration_outputs_dir "${raw}" must not contain backslashes (use forward slashes)`,
     );
   }
-  const trimmed = candidate.replace(/^\/+/, "").replace(/\/+$/, "");
+  // Reject leading "/" explicitly rather than silently normalising it
+  // away. The schema layer rejects absolute paths at FSM load time, and
+  // the runtime helper should match (otherwise "/abs/path" would walk
+  // through as "abs/path" and disagree with the schema diagnostic).
+  if (candidate.startsWith("/")) {
+    throw new Error(
+      `sanitiseLoopOutputsDirSegment: iteration_outputs_dir "${raw}" must be relative; absolute paths are not allowed`,
+    );
+  }
+  const trimmed = candidate.replace(/\/+$/, "");
   if (trimmed.length === 0) {
     throw new Error(
       "sanitiseLoopOutputsDirSegment: iteration_outputs_dir collapses to empty after trimming slashes",

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -248,7 +248,13 @@ export function runLoopDecision(state, outputs, iterationN) {
   if (!loop) return { isLoop: false };
   const max = loop.max_iterations ?? 30;
   const doneField = loop.done_field;
-  const done = Boolean(outputs?.[doneField]);
+  // The schema requires the done field to be `boolean`; matching only
+  // the literal `true` here keeps the termination contract honest
+  // when a permissive worker schema or a caller that bypasses
+  // validation lets a non-boolean truthy value (e.g. `"false"`, `1`,
+  // `"yes"`) reach the engine. Anything other than literal `true` is
+  // treated as "continue".
+  const done = outputs?.[doneField] === true;
   if (done) {
     return { isLoop: true, terminate: true, reason: "done_field", iteration_n: iterationN };
   }

--- a/scripts/lib/fsm-schema.mjs
+++ b/scripts/lib/fsm-schema.mjs
@@ -81,6 +81,12 @@ function validateState(state, prefix, errors) {
   if (state.worker !== undefined) {
     validateWorker(state.worker, `${prefix}.worker`, errors);
   }
+  if (state.loop !== undefined) {
+    if (state.worker !== undefined) {
+      errors.push(`${prefix} may not declare both \`worker\` and \`loop\``);
+    }
+    validateLoop(state.loop, `${prefix}.loop`, errors);
+  }
   if (!Array.isArray(state.outputs)) {
     errors.push(`${prefix}.outputs must be an array (use [] for terminal states)`);
   } else {
@@ -127,6 +133,58 @@ function validateWorker(worker, prefix, errors) {
     } catch (err) {
       errors.push(`${prefix}.response_schema is not a valid JSON Schema: ${err.message}`);
     }
+  }
+}
+
+function validateLoop(loop, prefix, errors) {
+  if (!loop || typeof loop !== "object") {
+    errors.push(`${prefix} must be a mapping`);
+    return;
+  }
+  for (const field of ["worker", "done_field"]) {
+    if (!Object.prototype.hasOwnProperty.call(loop, field)) {
+      errors.push(`${prefix}.${field} is required`);
+    }
+  }
+  if (loop.worker !== undefined) {
+    validateWorker(loop.worker, `${prefix}.worker`, errors);
+  }
+  if (loop.done_field !== undefined && (typeof loop.done_field !== "string" || !loop.done_field)) {
+    errors.push(`${prefix}.done_field must be a non-empty string`);
+  }
+  if (loop.max_iterations !== undefined) {
+    if (!Number.isInteger(loop.max_iterations) || loop.max_iterations < 1) {
+      errors.push(`${prefix}.max_iterations must be a positive integer (default 30 if omitted)`);
+    }
+  }
+  if (loop.iteration_outputs_dir !== undefined) {
+    if (typeof loop.iteration_outputs_dir !== "string" || !loop.iteration_outputs_dir) {
+      errors.push(`${prefix}.iteration_outputs_dir must be a non-empty string`);
+    } else if (
+      loop.iteration_outputs_dir.startsWith("/") ||
+      loop.iteration_outputs_dir.split("/").includes("..")
+    ) {
+      errors.push(
+        `${prefix}.iteration_outputs_dir must be a relative path under workers/ (no leading "/" and no ".." segments)`,
+      );
+    }
+  }
+  // Best-effort: done_field must appear as a property in the worker's
+  // response_schema. We only check object schemas with a properties map;
+  // anything more exotic is the FSM author's problem.
+  const schema = loop.worker?.response_schema;
+  if (
+    schema &&
+    typeof schema === "object" &&
+    schema.properties &&
+    typeof schema.properties === "object" &&
+    typeof loop.done_field === "string" &&
+    loop.done_field.length > 0 &&
+    !Object.prototype.hasOwnProperty.call(schema.properties, loop.done_field)
+  ) {
+    errors.push(
+      `${prefix}.done_field "${loop.done_field}" is not a property in loop.worker.response_schema.properties`,
+    );
   }
 }
 
@@ -231,24 +289,27 @@ export function validateFsmStatic(doc, { fsmFilePath } = {}) {
   // Worker prompt template files must exist on disk. Relative paths
   // resolve against the FSM YAML's directory; absolute paths are taken
   // verbatim. Convention: paths in the YAML are local to the YAML.
+  // Covers both regular worker states and loop states (loop.worker has the
+  // same shape; the prompt is staged per-iteration but the template is one).
   if (fsmFilePath) {
     const fsmDir = dirname(fsmFilePath);
     for (const state of fsm.states) {
-      if (!state?.worker?.prompt_template) continue;
-      const tpl = state.worker.prompt_template;
+      const workerSpec = state?.worker ?? state?.loop?.worker;
+      if (!workerSpec?.prompt_template) continue;
+      const tpl = workerSpec.prompt_template;
       const candidate = isAbsolute(tpl) ? tpl : resolve(fsmDir, tpl);
       if (!existsSync(candidate)) {
+        const kind = state.loop ? "loop.worker" : "worker";
         errors.push(
-          `State "${state.id}" worker prompt_template "${tpl}" not found at ${candidate}`,
+          `State "${state.id}" ${kind} prompt_template "${tpl}" not found at ${candidate}`,
         );
       }
     }
   }
-  // Best-effort input/output flow check: each state's preconditions reference
-  // a name that is produced by some upstream state's outputs. We do this as
-  // a substring check rather than a full dataflow analysis — preconditions
-  // are free-form English sentences that often contain the variable name
-  // (e.g. "project_profile exists in run state").
+  // Best-effort input/output flow check: each state's worker (or loop.worker)
+  // declares inputs[] that must be produced by some upstream state's outputs[].
+  // We do this as a name match — preconditions are free-form English so
+  // not analysed here; inputs are precise names.
   const allOutputs = new Set();
   for (const state of fsm.states) {
     for (const o of state?.outputs ?? []) {
@@ -256,13 +317,15 @@ export function validateFsmStatic(doc, { fsmFilePath } = {}) {
     }
   }
   for (const state of fsm.states) {
-    if (!state?.worker?.inputs) continue;
-    for (const inputName of state.worker.inputs) {
+    const workerSpec = state?.worker ?? state?.loop?.worker;
+    if (!workerSpec?.inputs) continue;
+    for (const inputName of workerSpec.inputs) {
       if (inputName === "args") continue; // entry-state argument bag
       if (typeof inputName !== "string") continue;
       if (!allOutputs.has(inputName)) {
+        const kind = state.loop ? "loop.worker" : "worker";
         errors.push(
-          `State "${state.id}" worker.inputs references "${inputName}" which is not produced by any state's outputs[]`,
+          `State "${state.id}" ${kind}.inputs references "${inputName}" which is not produced by any state's outputs[]`,
         );
       }
     }

--- a/scripts/lib/fsm-schema.mjs
+++ b/scripts/lib/fsm-schema.mjs
@@ -170,6 +170,14 @@ function validateLoop(loop, prefix, errors) {
           `${prefix}.iteration_outputs_dir must not contain backslashes; use forward slashes`,
         );
       }
+      // Reject Windows drive-letter shapes (e.g. "C:/abs") and any
+      // ":" anywhere. `path.win32.join("workers", "C:/abs")` becomes
+      // an absolute path even though the leading char is not "/".
+      if (raw.includes(":")) {
+        errors.push(
+          `${prefix}.iteration_outputs_dir must not contain ":" (Windows drive letters or colon segments could escape workers/)`,
+        );
+      }
       const trimmed = raw.replace(/^\/+/, "").replace(/\/+$/, "");
       const parts = trimmed.split("/");
       if (
@@ -321,10 +329,13 @@ export function validateFsmStatic(doc, { fsmFilePath } = {}) {
       }
     }
   }
-  // Best-effort input/output flow check: each state's worker (or loop.worker)
-  // declares inputs[] that must be produced by some upstream state's outputs[].
-  // We do this as a name match — preconditions are free-form English so
-  // not analysed here; inputs are precise names.
+  // Best-effort input/output flow check: each state's worker (or
+  // loop.worker) declares inputs[] that must appear as the name of an
+  // output[] anywhere in the FSM. This is a name-set check, NOT a
+  // topological-upstream proof: a state that declares its inputs as
+  // outputs only produced downstream of itself will pass this gate
+  // and only fail at runtime in fsm-commit. Upstream-only checking is
+  // a future enhancement (would require a real DAG analysis).
   const allOutputs = new Set();
   for (const state of fsm.states) {
     for (const o of state?.outputs ?? []) {

--- a/scripts/lib/fsm-schema.mjs
+++ b/scripts/lib/fsm-schema.mjs
@@ -160,13 +160,28 @@ function validateLoop(loop, prefix, errors) {
   if (loop.iteration_outputs_dir !== undefined) {
     if (typeof loop.iteration_outputs_dir !== "string" || !loop.iteration_outputs_dir) {
       errors.push(`${prefix}.iteration_outputs_dir must be a non-empty string`);
-    } else if (
-      loop.iteration_outputs_dir.startsWith("/") ||
-      loop.iteration_outputs_dir.split("/").includes("..")
-    ) {
-      errors.push(
-        `${prefix}.iteration_outputs_dir must be a relative path under workers/ (no leading "/" and no ".." segments)`,
-      );
+    } else {
+      const raw = loop.iteration_outputs_dir;
+      // Reject backslashes outright: `path.join` treats them as
+      // separators on Windows, so `foo\..\bar` would slip past a
+      // POSIX-only split-and-check and still escape workers/.
+      if (raw.includes("\\")) {
+        errors.push(
+          `${prefix}.iteration_outputs_dir must not contain backslashes; use forward slashes`,
+        );
+      }
+      const trimmed = raw.replace(/^\/+/, "").replace(/\/+$/, "");
+      const parts = trimmed.split("/");
+      if (
+        raw.startsWith("/") ||
+        parts.includes("..") ||
+        parts.includes(".") ||
+        parts.some((p) => p === "")
+      ) {
+        errors.push(
+          `${prefix}.iteration_outputs_dir must be a relative path under workers/ (no leading "/", no "." or ".." segments, no empty segments)`,
+        );
+      }
     }
   }
   // Best-effort: done_field must appear as a property in the worker's

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -265,8 +265,8 @@ export function nextTraceSequence(runId, opts = {}) {
 }
 
 export function appendTraceFile(runId, { phase, state, data }, opts = {}) {
-  if (!["entry", "exit", "fault"].includes(phase)) {
-    throw new Error(`appendTraceFile: phase must be entry|exit|fault, got "${phase}"`);
+  if (!["entry", "exit", "fault", "iter"].includes(phase)) {
+    throw new Error(`appendTraceFile: phase must be entry|exit|fault|iter, got "${phase}"`);
   }
   if (!state || typeof state !== "string") {
     throw new Error("appendTraceFile: state must be a non-empty string");

--- a/tests/unit/fsm-aggregator.test.js
+++ b/tests/unit/fsm-aggregator.test.js
@@ -204,8 +204,12 @@ test("aggregateLoopOutputs: writes aggregated and meta files atomically (no tmp 
     assert.ok(existsSync(join(runDir, result.aggregated_path)));
     assert.ok(existsSync(join(runDir, result.iteration_meta_path)));
     const workersDir = join(runDir, "workers");
-    const tmpLeftovers = readdirSync(workersDir).filter(
-      (n) => n.endsWith(".tmp") || n.endsWith(".tmp~"),
+    // atomicWriteFile names its temp shadow `<basename>.tmp.<pid>.<ms>.<hex>`
+    // (see fsm-storage.mjs), so the leftover-detector has to match that
+    // shape directly. The old endsWith(".tmp" | ".tmp~") never matched
+    // the real pattern and would never flag a stuck atomic write.
+    const tmpLeftovers = readdirSync(workersDir).filter((n) =>
+      /\.tmp\.\d+\.\d+\.[0-9a-f]+$/.test(n),
     );
     assert.equal(tmpLeftovers.length, 0);
   } finally {

--- a/tests/unit/fsm-aggregator.test.js
+++ b/tests/unit/fsm-aggregator.test.js
@@ -1,0 +1,214 @@
+// fsm-aggregator.test.js — unit coverage for the loop-aware aggregator
+// (A2). Aggregator reads iter-N.json files from a run's workers/ subdir,
+// validates each against the loop worker's response_schema, concatenates
+// the mergeField (default "findings"), and writes a unified aggregated
+// JSON plus a per-iteration meta JSON.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { aggregateLoopOutputs } from "../../scripts/lib/fsm-aggregator.mjs";
+
+function makeRunDir() {
+  return mkdtempSync(join(tmpdir(), "fsm-agg-rd-"));
+}
+
+function loopState({ outputsDir = "explore-iters/" } = {}) {
+  return {
+    id: "explore",
+    loop: {
+      worker: {
+        role: "explorer",
+        prompt_template: "t.md",
+        inputs: [],
+        response_schema: {
+          type: "object",
+          required: ["done", "findings"],
+          properties: {
+            done: { type: "boolean" },
+            findings: { type: "array" },
+            strategy: { type: "string" },
+          },
+        },
+      },
+      max_iterations: 10,
+      done_field: "done",
+      iteration_outputs_dir: outputsDir,
+    },
+  };
+}
+
+function writeIter(runDir, outputsDir, n, payload) {
+  const dir = join(runDir, "workers", outputsDir.replace(/\/$/, ""));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `iter-${n}.json`), JSON.stringify(payload));
+}
+
+test("aggregateLoopOutputs: empty iter dir produces empty merged array", () => {
+  const runDir = makeRunDir();
+  try {
+    const state = loopState();
+    const result = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
+    assert.equal(result.iteration_count, 0);
+    assert.equal(result.merged_length, 0);
+    const aggregated = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.deepEqual(aggregated.items, []);
+    assert.equal(aggregated.state, "explore");
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateLoopOutputs: N iters concatenate findings in sequence order", () => {
+  const runDir = makeRunDir();
+  try {
+    const state = loopState();
+    writeIter(runDir, "explore-iters/", 1, {
+      done: false,
+      findings: [{ a: 1 }],
+      strategy: "symbol",
+    });
+    writeIter(runDir, "explore-iters/", 2, {
+      done: false,
+      findings: [{ a: 2 }, { a: 3 }],
+      strategy: "path",
+    });
+    writeIter(runDir, "explore-iters/", 3, {
+      done: true,
+      findings: [{ a: 4 }],
+      strategy: "doc",
+    });
+    const result = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
+    assert.equal(result.iteration_count, 3);
+    assert.equal(result.merged_length, 4);
+    const aggregated = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.deepEqual(
+      aggregated.items.map((i) => i.a),
+      [1, 2, 3, 4],
+    );
+    const meta = JSON.parse(readFileSync(join(runDir, result.iteration_meta_path), "utf8"));
+    assert.equal(meta.iterations.length, 3);
+    assert.equal(meta.iterations[0].strategy, "symbol");
+    assert.equal(meta.iterations[2].done, true);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateLoopOutputs: idempotent re-run produces identical result", () => {
+  const runDir = makeRunDir();
+  try {
+    const state = loopState();
+    writeIter(runDir, "explore-iters/", 1, { done: true, findings: [{ x: 1 }] });
+    const first = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
+    const firstBody = readFileSync(join(runDir, first.aggregated_path), "utf8");
+    const second = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
+    const secondBody = readFileSync(join(runDir, second.aggregated_path), "utf8");
+    assert.equal(first.merged_length, second.merged_length);
+    assert.equal(firstBody, secondBody);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateLoopOutputs: skips schema-invalid iters and records the error", () => {
+  const runDir = makeRunDir();
+  try {
+    const state = loopState();
+    writeIter(runDir, "explore-iters/", 1, { done: false, findings: [{ a: 1 }] });
+    writeIter(runDir, "explore-iters/", 2, { findings: [{ a: 2 }] }); // missing done
+    writeIter(runDir, "explore-iters/", 3, { done: true, findings: [{ a: 3 }] });
+    const result = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
+    assert.equal(result.iteration_count, 2); // iter-2 dropped
+    assert.equal(result.merged_length, 2);
+    assert.equal(result.validation_errors.length, 1);
+    assert.match(result.validation_errors[0].error, /schema/);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateLoopOutputs: records parse errors on malformed JSON", () => {
+  const runDir = makeRunDir();
+  try {
+    const state = loopState();
+    const dir = join(runDir, "workers", "explore-iters");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "iter-1.json"), "not json");
+    const result = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
+    assert.equal(result.iteration_count, 0);
+    assert.equal(result.validation_errors.length, 1);
+    assert.match(result.validation_errors[0].error, /parse_error/);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateLoopOutputs: throws on non-loop state input", () => {
+  const runDir = makeRunDir();
+  try {
+    assert.throws(
+      () => aggregateLoopOutputs(runDir, { id: "x", worker: {} }, {}),
+      /not a loop state/,
+    );
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateLoopOutputs: honours default outputs_dir when state omits it", () => {
+  const runDir = makeRunDir();
+  try {
+    const state = {
+      id: "explore",
+      loop: {
+        worker: {
+          role: "r",
+          prompt_template: "t",
+          inputs: [],
+          response_schema: {
+            type: "object",
+            required: ["done"],
+            properties: { done: { type: "boolean" }, findings: { type: "array" } },
+          },
+        },
+        max_iterations: 5,
+        done_field: "done",
+      },
+    };
+    writeIter(runDir, "explore-iters/", 1, { done: true, findings: [{ k: 1 }] });
+    const result = aggregateLoopOutputs(runDir, state, {});
+    assert.equal(result.merged_length, 1);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateLoopOutputs: writes aggregated and meta files atomically (no tmp leftovers)", () => {
+  const runDir = makeRunDir();
+  try {
+    const state = loopState();
+    writeIter(runDir, "explore-iters/", 1, { done: true, findings: [{ q: 1 }] });
+    const result = aggregateLoopOutputs(runDir, state, {});
+    assert.ok(existsSync(join(runDir, result.aggregated_path)));
+    assert.ok(existsSync(join(runDir, result.iteration_meta_path)));
+    const workersDir = join(runDir, "workers");
+    const tmpLeftovers = readdirSync(workersDir).filter(
+      (n) => n.endsWith(".tmp") || n.endsWith(".tmp~"),
+    );
+    assert.equal(tmpLeftovers.length, 0);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/fsm-loop.test.js
+++ b/tests/unit/fsm-loop.test.js
@@ -1,0 +1,258 @@
+// fsm-loop.test.js — unit coverage for the loop-state primitive runtime
+// helpers added in A1: buildLoopBrief, countLoopIterations,
+// runLoopDecision, plus validateOutputs delegation to loop.worker.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildBrief,
+  buildLoopBrief,
+  countLoopIterations,
+  runLoopDecision,
+  validateOutputs,
+} from "../../scripts/lib/fsm-engine.mjs";
+import {
+  appendTraceFile,
+  buildRunId,
+  ensureRunDir,
+} from "../../scripts/lib/fsm-storage.mjs";
+
+function tmpStore() {
+  return mkdtempSync(join(tmpdir(), "fsm-loop-store-"));
+}
+
+function loopFsm() {
+  return {
+    fsm: {
+      id: "loop-test",
+      version: 1,
+      entry: "explore",
+      states: [
+        {
+          id: "explore",
+          purpose: "loop test",
+          preconditions: [],
+          loop: {
+            worker: {
+              role: "explorer",
+              prompt_template: "fsm/workers/x.md",
+              inputs: ["args"],
+              response_schema: {
+                type: "object",
+                required: ["done", "findings"],
+                properties: {
+                  done: { type: "boolean" },
+                  findings: { type: "array" },
+                },
+              },
+            },
+            max_iterations: 3,
+            done_field: "done",
+            iteration_outputs_dir: "explore-iters/",
+          },
+          outputs: ["aggregated_explore"],
+          post_validations: [],
+          transitions: [{ to: "terminal", when: { kind: "always" } }],
+        },
+        {
+          id: "terminal",
+          purpose: "end",
+          preconditions: [],
+          outputs: [],
+          transitions: [],
+        },
+      ],
+    },
+  };
+}
+
+// ─── runLoopDecision ────────────────────────────────────────────────────
+
+test("runLoopDecision: non-loop state returns isLoop=false", () => {
+  const result = runLoopDecision({ id: "x", worker: {} }, { done: true }, 1);
+  assert.equal(result.isLoop, false);
+});
+
+test("runLoopDecision: terminates on done_field=true", () => {
+  const state = loopFsm().fsm.states[0];
+  const result = runLoopDecision(state, { done: true, findings: [] }, 1);
+  assert.equal(result.isLoop, true);
+  assert.equal(result.terminate, true);
+  assert.equal(result.reason, "done_field");
+  assert.equal(result.iteration_n, 1);
+});
+
+test("runLoopDecision: terminates on max_iterations cap", () => {
+  const state = loopFsm().fsm.states[0];
+  const result = runLoopDecision(state, { done: false, findings: [] }, 3);
+  assert.equal(result.terminate, true);
+  assert.equal(result.reason, "max_iterations");
+});
+
+test("runLoopDecision: continues otherwise", () => {
+  const state = loopFsm().fsm.states[0];
+  const result = runLoopDecision(state, { done: false, findings: [] }, 2);
+  assert.equal(result.terminate, false);
+  assert.equal(result.iteration_n, 2);
+});
+
+test("runLoopDecision: falsy done values continue", () => {
+  const state = loopFsm().fsm.states[0];
+  for (const v of [false, 0, null, undefined, ""]) {
+    const r = runLoopDecision(state, { done: v, findings: [] }, 1);
+    assert.equal(r.terminate, false, `expected continue for done=${JSON.stringify(v)}`);
+  }
+});
+
+test("runLoopDecision: default max_iterations is 30 when omitted", () => {
+  const state = { id: "s", loop: { worker: {}, done_field: "done" } };
+  const r29 = runLoopDecision(state, { done: false }, 29);
+  assert.equal(r29.terminate, false);
+  const r30 = runLoopDecision(state, { done: false }, 30);
+  assert.equal(r30.terminate, true);
+  assert.equal(r30.reason, "max_iterations");
+});
+
+// ─── countLoopIterations ───────────────────────────────────────────────
+
+test("countLoopIterations: returns 0 when no trace dir exists", () => {
+  const store = tmpStore();
+  try {
+    const n = countLoopIterations("20260426-143045-1234567", "explore", { storageRoot: store });
+    assert.equal(n, 0);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("countLoopIterations: counts iter records for the named state only", () => {
+  const store = tmpStore();
+  const runId = buildRunId({ repo: "ctxr-dev/fsm", baseSha: "base", headSha: "head" }).runId;
+  try {
+    ensureRunDir(runId, { storageRoot: store });
+    appendTraceFile(runId, { phase: "entry", state: "explore", data: {} }, { storageRoot: store });
+    appendTraceFile(runId, { phase: "iter", state: "explore", data: { iteration_n: 1, outputs: {} } }, { storageRoot: store });
+    appendTraceFile(runId, { phase: "iter", state: "explore", data: { iteration_n: 2, outputs: {} } }, { storageRoot: store });
+    appendTraceFile(runId, { phase: "iter", state: "other", data: { iteration_n: 1, outputs: {} } }, { storageRoot: store });
+    assert.equal(countLoopIterations(runId, "explore", { storageRoot: store }), 2);
+    assert.equal(countLoopIterations(runId, "other", { storageRoot: store }), 1);
+    assert.equal(countLoopIterations(runId, "absent", { storageRoot: store }), 0);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+// ─── buildLoopBrief / buildBrief delegation ─────────────────────────────
+
+test("buildLoopBrief: emits has_loop=true with iteration_n=1 on first call", () => {
+  const store = tmpStore();
+  const runId = buildRunId({ repo: "ctxr-dev/fsm", baseSha: "base", headSha: "head" }).runId;
+  try {
+    ensureRunDir(runId, { storageRoot: store });
+    const state = loopFsm().fsm.states[0];
+    const brief = buildLoopBrief({
+      doc: loopFsm(),
+      state,
+      env: { args: { hello: "world" } },
+      runId,
+      opts: { storageRoot: store },
+    });
+    assert.equal(brief.has_loop, true);
+    assert.equal(brief.has_worker, true);
+    assert.equal(brief.state, "explore");
+    assert.equal(brief.loop.iteration_n, 1);
+    assert.equal(brief.loop.max_iterations, 3);
+    assert.equal(brief.loop.done_field, "done");
+    assert.match(brief.loop.outputs_path, /^workers\/explore-iters\/iter-1\.json$/);
+    assert.equal(brief.worker.role, "explorer");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("buildLoopBrief: iteration_n advances with each iter trace already on disk", () => {
+  const store = tmpStore();
+  const runId = buildRunId({ repo: "ctxr-dev/fsm", baseSha: "base", headSha: "head" }).runId;
+  try {
+    ensureRunDir(runId, { storageRoot: store });
+    appendTraceFile(runId, { phase: "entry", state: "explore", data: {} }, { storageRoot: store });
+    appendTraceFile(runId, { phase: "iter", state: "explore", data: { iteration_n: 1, outputs: {} } }, { storageRoot: store });
+    appendTraceFile(runId, { phase: "iter", state: "explore", data: { iteration_n: 2, outputs: {} } }, { storageRoot: store });
+    const brief = buildLoopBrief({
+      doc: loopFsm(),
+      state: loopFsm().fsm.states[0],
+      env: { args: {} },
+      runId,
+      opts: { storageRoot: store },
+    });
+    assert.equal(brief.loop.iteration_n, 3);
+    assert.match(brief.loop.outputs_path, /iter-3\.json$/);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("buildLoopBrief: uses default iteration_outputs_dir when omitted", () => {
+  const state = {
+    id: "myloop",
+    purpose: "x",
+    preconditions: [],
+    loop: {
+      worker: {
+        role: "r",
+        prompt_template: "t",
+        inputs: [],
+        response_schema: { type: "object", properties: { done: { type: "boolean" } } },
+      },
+      max_iterations: 5,
+      done_field: "done",
+    },
+    outputs: ["aggregated_myloop"],
+    transitions: [],
+  };
+  const brief = buildLoopBrief({
+    doc: { fsm: { id: "f" } },
+    state,
+    env: {},
+    runId: "20260426-143045-abcdef0",
+  });
+  assert.match(brief.loop.outputs_path, /^workers\/myloop-iters\/iter-1\.json$/);
+});
+
+test("buildBrief: delegates to buildLoopBrief for loop states", () => {
+  const state = loopFsm().fsm.states[0];
+  const brief = buildBrief({
+    doc: loopFsm(),
+    state,
+    env: { args: {} },
+    runId: "20260426-143045-abcdef0",
+  });
+  assert.equal(brief.has_loop, true);
+  assert.equal(brief.has_worker, true);
+});
+
+test("buildBrief: non-loop states still set has_loop=false", () => {
+  const state = loopFsm().fsm.states[1]; // terminal
+  const brief = buildBrief({
+    doc: loopFsm(),
+    state,
+    env: {},
+    runId: "20260426-143045-abcdef0",
+  });
+  assert.equal(brief.has_loop, false);
+  assert.equal(brief.has_worker, false);
+});
+
+// ─── validateOutputs delegation to loop.worker.response_schema ───────────
+
+test("validateOutputs: uses loop.worker.response_schema for loop states", () => {
+  const state = loopFsm().fsm.states[0];
+  const good = validateOutputs(state, { done: true, findings: [] });
+  assert.equal(good.valid, true);
+  const bad = validateOutputs(state, { findings: [] }); // missing done
+  assert.equal(bad.valid, false);
+});

--- a/tests/unit/fsm-schema.test.js
+++ b/tests/unit/fsm-schema.test.js
@@ -225,3 +225,138 @@ test("validateWorkerResponse: schema compilation error returns valid=false", () 
   assert.equal(result.valid, false);
   assert.match(result.errors[0], /Schema compilation/);
 });
+
+// ─── loop state primitive ──────────────────────────────────────────────
+
+function validFsmWithLoop() {
+  return {
+    fsm: {
+      id: "loop-fsm",
+      version: 1,
+      entry: "explore",
+      states: [
+        {
+          id: "explore",
+          purpose: "Iterative exploration loop.",
+          preconditions: [],
+          loop: {
+            worker: {
+              role: "explorer",
+              prompt_template: "fsm/workers/explore-iter.md",
+              inputs: ["args"],
+              response_schema: {
+                type: "object",
+                required: ["done", "findings"],
+                properties: {
+                  done: { type: "boolean" },
+                  findings: { type: "array" },
+                },
+              },
+            },
+            max_iterations: 5,
+            done_field: "done",
+            iteration_outputs_dir: "explore-iters/",
+          },
+          outputs: ["aggregated_explore"],
+          post_validations: [],
+          transitions: [{ to: "done", when: { kind: "always" } }],
+        },
+        {
+          id: "done",
+          purpose: "Terminal.",
+          preconditions: ["aggregated_explore exists"],
+          outputs: [],
+          transitions: [],
+        },
+      ],
+    },
+  };
+}
+
+test("validateFsmSchema accepts a loop state", () => {
+  const { valid, errors } = validateFsmSchema(validFsmWithLoop());
+  assert.equal(valid, true, `expected valid; got errors: ${errors.join("; ")}`);
+});
+
+test("validateFsmSchema rejects a state with both worker and loop", () => {
+  const doc = validFsmWithLoop();
+  doc.fsm.states[0].worker = {
+    role: "x",
+    prompt_template: "x.md",
+    inputs: [],
+    response_schema: { type: "object" },
+  };
+  const { valid, errors } = validateFsmSchema(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /may not declare both `worker` and `loop`/);
+});
+
+test("validateFsmSchema rejects loop missing worker", () => {
+  const doc = validFsmWithLoop();
+  delete doc.fsm.states[0].loop.worker;
+  const { valid, errors } = validateFsmSchema(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /\.loop\.worker is required/);
+});
+
+test("validateFsmSchema rejects loop missing done_field", () => {
+  const doc = validFsmWithLoop();
+  delete doc.fsm.states[0].loop.done_field;
+  const { valid, errors } = validateFsmSchema(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /\.loop\.done_field is required/);
+});
+
+test("validateFsmSchema rejects loop with non-positive max_iterations", () => {
+  const doc = validFsmWithLoop();
+  doc.fsm.states[0].loop.max_iterations = 0;
+  const { valid, errors } = validateFsmSchema(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /max_iterations must be a positive integer/);
+});
+
+test("validateFsmSchema rejects loop with non-integer max_iterations", () => {
+  const doc = validFsmWithLoop();
+  doc.fsm.states[0].loop.max_iterations = 1.5;
+  const { valid, errors } = validateFsmSchema(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /max_iterations must be a positive integer/);
+});
+
+test("validateFsmSchema rejects loop with absolute iteration_outputs_dir", () => {
+  const doc = validFsmWithLoop();
+  doc.fsm.states[0].loop.iteration_outputs_dir = "/abs/path/";
+  const { valid, errors } = validateFsmSchema(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /iteration_outputs_dir must be a relative path/);
+});
+
+test("validateFsmSchema rejects loop iteration_outputs_dir with parent traversal", () => {
+  const doc = validFsmWithLoop();
+  doc.fsm.states[0].loop.iteration_outputs_dir = "../escape/";
+  const { valid, errors } = validateFsmSchema(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /iteration_outputs_dir must be a relative path/);
+});
+
+test("validateFsmSchema rejects loop where done_field is not in response_schema.properties", () => {
+  const doc = validFsmWithLoop();
+  doc.fsm.states[0].loop.done_field = "finished";
+  const { valid, errors } = validateFsmSchema(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /"finished" is not a property in loop\.worker\.response_schema/);
+});
+
+test("validateFsmStatic flags loop.worker.inputs not produced upstream", () => {
+  const doc = validFsmWithLoop();
+  doc.fsm.states[0].loop.worker.inputs = ["never_produced"];
+  const { valid, errors } = validateFsmStatic(doc);
+  assert.equal(valid, false);
+  assert.match(errors.join(" "), /loop\.worker\.inputs references "never_produced"/);
+});
+
+test("validateFsmStatic accepts loop with valid input/output flow", () => {
+  const doc = validFsmWithLoop();
+  const { valid, errors } = validateFsmStatic(doc);
+  assert.equal(valid, true, `expected valid; got errors: ${errors.join("; ")}`);
+});

--- a/tests/unit/fsm-storage.test.js
+++ b/tests/unit/fsm-storage.test.js
@@ -284,6 +284,22 @@ test("appendTraceFile: rejects invalid phase / empty state", () => {
   }
 });
 
+test("appendTraceFile: accepts the iter phase for loop iterations", () => {
+  const store = tmpStore();
+  const runId = "20260426-143045-1234567";
+  try {
+    const result = appendTraceFile(
+      runId,
+      { phase: "iter", state: "explore_loop", data: { iteration_n: 1, outputs: { done: false } } },
+      { storageRoot: store },
+    );
+    assert.equal(result.sequence, 1);
+    assert.match(result.fileName, /^0001-iter-explore_loop\.yaml$/);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
 // ─── listRecentRuns ────────────────────────────────────────────────────
 
 test("listRecentRuns: walks date-sharded folders and returns matching manifests", () => {


### PR DESCRIPTION
Closes the loop-state primitive (A1) and the loop-aware aggregator (A2) from the approved plan at `/Users/developer/.claude/plans/how-it-fits-toasty-gray.md`.

## What landed
- **Schema layer**: `validateLoop` enforces xor on `worker` vs `loop`, required `worker` + `done_field`, optional `max_iterations` (positive integer) and `iteration_outputs_dir` (relative path), and best-effort `done_field` present in `loop.worker.response_schema.properties`. Static checker resolves loop prompt templates and includes `loop.worker.inputs` in the upstream-output flow check.
- **Storage**: `appendTraceFile` phase allowlist extended with `iter`; sequence-numbered `0001-iter-<state>.yaml` files.
- **Engine**: `buildBrief` delegates to `buildLoopBrief` for loop states; `countLoopIterations`, `runLoopDecision` (terminate on `done_field=true` OR `iteration_n === max_iterations`, default 30); `validateOutputs` uses `loop.worker.response_schema` when present.
- **Aggregator** (`scripts/lib/fsm-aggregator.mjs`): `aggregateLoopOutputs(runDir, state, {mergeField})` reads iter files in sequence, validates each, concatenates `mergeField`, atomic-writes `<state>-aggregated.json` + `<state>-iteration-meta.json`; idempotent; tolerates schema + parse errors per-iter.
- **CLIs**: `fsm-next` passes opts to `buildBrief`; `fsm-commit` writes iter traces, runs the loop decision, and either re-emits the next loop brief (`loop_continued: true`) or aggregates + falls through to the regular exit + transition path with `terminated_by` + `total_iterations`.
- **package.json**: exports `./aggregator`.

## Tests
102 -> 125 (+ 23 new tests). All green.

## Backward compatibility
Existing FSM YAMLs (e.g. `skill-code-review`'s `code-reviewer.fsm.yaml`) walk through unchanged.

## Notes
- Loop `max_iterations` defaults to 30 to prevent runaway.
- A3 (cross-state aggregator) lands as a follow-up PR on top of this branch.
- A9 (CI/CD workflows) also lands on top of this branch.