### PR TITLE
feat(lib): reusable worker-dispatch prompt fragments (A6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "./schema": "./scripts/lib/fsm-schema.mjs",
     "./predicates": "./scripts/lib/fsm-predicates.mjs",
     "./engine": "./scripts/lib/fsm-engine.mjs",
-    "./aggregator": "./scripts/lib/fsm-aggregator.mjs"
+    "./aggregator": "./scripts/lib/fsm-aggregator.mjs",
+    "./prompt-fragments": "./scripts/lib/prompt-fragments.mjs"
   },
   "bin": {
     "fsm-next": "scripts/fsm-next.mjs",

--- a/scripts/lib/prompt-fragments.mjs
+++ b/scripts/lib/prompt-fragments.mjs
@@ -1,0 +1,177 @@
+// prompt-fragments.mjs - reusable text fragments for FSM worker-dispatch
+// prompts.
+//
+// Skill runners that dispatch a worker for a given FSM state assemble the
+// worker's prompt from a fixed set of building blocks: a greeting that names
+// the role and the run, the brief itself, an output contract that pins down
+// where the worker must write its JSON and what shape that JSON must take,
+// and a notice about forbidden write paths. This module factors those four
+// pieces out of every per-skill runner so the dispatch wording stays
+// consistent across the substrate and the per-skill runners stay short.
+//
+// The fragments are intentionally tool-agnostic - they never name a specific
+// MCP server, CLI, or orchestrator harness. The output is plain Markdown so
+// any worker (LLM or otherwise) can consume it. Each fragment validates its
+// inputs and throws synchronously on misuse so callers fail fast at compose
+// time rather than at dispatch time.
+//
+// Composition is the caller's job: assemble the fragments in whatever order
+// suits the skill, joined by blank lines. A typical sequence is
+//   specialistHeader -> briefBlock -> outputContractBlock -> forbiddenPathsNotice
+// but the fragments themselves do not assume any ordering.
+
+// ─── Input validation helpers ──────────────────────────────────────────
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${label} must be a non-empty string`);
+  }
+}
+
+function requireOptions(opts, label) {
+  if (!opts || typeof opts !== "object" || Array.isArray(opts)) {
+    throw new TypeError(`${label} requires an options object`);
+  }
+}
+
+// ─── specialistHeader ──────────────────────────────────────────────────
+
+/**
+ * Standard opening text for a specialist worker prompt.
+ *
+ * @param {object} opts
+ * @param {string} opts.role     - the worker role identifier (e.g. "lens-gap").
+ * @param {string} opts.run_id   - the FSM run id this dispatch belongs to.
+ * @param {string} opts.state_id - the FSM state id that is dispatching this worker.
+ * @returns {string} Markdown header block addressed to the worker.
+ */
+export function specialistHeader(opts) {
+  requireOptions(opts, "specialistHeader");
+  const { role, run_id, state_id } = opts;
+  requireNonEmptyString(role, "specialistHeader.role");
+  requireNonEmptyString(run_id, "specialistHeader.run_id");
+  requireNonEmptyString(state_id, "specialistHeader.state_id");
+
+  return [
+    `# Specialist dispatch: ${role}`,
+    "",
+    `You are the **${role}** specialist for FSM run \`${run_id}\`, state \`${state_id}\`.`,
+    "",
+    "Work strictly within the contract below. Do not improvise outputs, do",
+    "not invent fields, and do not narrate your reasoning outside the",
+    "structured output file.",
+  ].join("\n");
+}
+
+// ─── outputContractBlock ───────────────────────────────────────────────
+
+/**
+ * Output-contract block instructing the worker to write a single JSON
+ * object to `outputs_path` that matches `response_schema`. The JSON Schema
+ * is pretty-printed inside a fenced code block so the worker can read it
+ * directly.
+ *
+ * @param {object} opts
+ * @param {string} opts.outputs_path    - absolute path the worker must write its JSON to.
+ * @param {object} opts.response_schema - JSON Schema (Draft-07) the output must satisfy.
+ * @returns {string} Markdown output-contract block.
+ */
+export function outputContractBlock(opts) {
+  requireOptions(opts, "outputContractBlock");
+  const { outputs_path, response_schema } = opts;
+  requireNonEmptyString(outputs_path, "outputContractBlock.outputs_path");
+  if (
+    !response_schema ||
+    typeof response_schema !== "object" ||
+    Array.isArray(response_schema)
+  ) {
+    throw new TypeError(
+      "outputContractBlock.response_schema must be a JSON Schema object",
+    );
+  }
+
+  const prettySchema = JSON.stringify(response_schema, null, 2);
+
+  return [
+    "## Output contract",
+    "",
+    `Write **one** JSON object to:`,
+    "",
+    `    ${outputs_path}`,
+    "",
+    "The object MUST validate against the JSON Schema below. Do not write",
+    "any other file. Do not print the JSON to stdout. Do not wrap the JSON",
+    "in code fences inside the output file.",
+    "",
+    "```json",
+    prettySchema,
+    "```",
+  ].join("\n");
+}
+
+// ─── forbiddenPathsNotice ──────────────────────────────────────────────
+
+/**
+ * Standard notice forbidding writes outside `<run_dir>/workers/`.
+ *
+ * @param {object} opts
+ * @param {string} opts.run_dir - absolute path to the FSM run directory.
+ * @returns {string} Markdown notice block.
+ */
+export function forbiddenPathsNotice(opts) {
+  requireOptions(opts, "forbiddenPathsNotice");
+  const { run_dir } = opts;
+  requireNonEmptyString(run_dir, "forbiddenPathsNotice.run_dir");
+
+  const workersDir = `${run_dir.replace(/\/+$/, "")}/workers/`;
+
+  return [
+    "## Forbidden write paths",
+    "",
+    `Never write anywhere outside \`${workersDir}\`. In particular:`,
+    "",
+    "- Do not modify any file under the project source tree.",
+    "- Do not create files in `/tmp`, the home directory, or any system path.",
+    "- Do not append to files outside the run directory.",
+    "",
+    "If you believe you need to write elsewhere, stop and surface the need",
+    "in your structured output instead of writing the file.",
+  ].join("\n");
+}
+
+// ─── briefBlock ────────────────────────────────────────────────────────
+
+/**
+ * Labelled brief section. The brief may be a plain string or a JSON-
+ * serialisable object; objects are pretty-printed inside a fenced JSON
+ * block so workers receive a stable, parseable representation.
+ *
+ * @param {object} opts
+ * @param {string|object} opts.brief - the brief payload for this worker.
+ * @returns {string} Markdown brief block.
+ */
+export function briefBlock(opts) {
+  requireOptions(opts, "briefBlock");
+  const { brief } = opts;
+  if (brief === undefined || brief === null) {
+    throw new TypeError("briefBlock.brief is required");
+  }
+
+  let body;
+  if (typeof brief === "string") {
+    if (brief.length === 0) {
+      throw new TypeError("briefBlock.brief must be a non-empty string");
+    }
+    body = brief;
+  } else if (typeof brief === "object" && !Array.isArray(brief)) {
+    body = ["```json", JSON.stringify(brief, null, 2), "```"].join("\n");
+  } else if (Array.isArray(brief)) {
+    body = ["```json", JSON.stringify(brief, null, 2), "```"].join("\n");
+  } else {
+    throw new TypeError(
+      "briefBlock.brief must be a string, array, or plain object",
+    );
+  }
+
+  return ["## Brief", "", body].join("\n");
+}

--- a/tests/unit/prompt-fragments.test.js
+++ b/tests/unit/prompt-fragments.test.js
@@ -1,0 +1,243 @@
+// prompt-fragments.test.js - unit coverage for the reusable worker-dispatch
+// prompt fragments. Each fragment is exercised for happy-path content, input
+// validation, and tool-agnostic wording. A final composition test asserts the
+// fragments chain into a coherent prompt.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  briefBlock,
+  forbiddenPathsNotice,
+  outputContractBlock,
+  specialistHeader,
+} from "../../scripts/lib/prompt-fragments.mjs";
+
+// ─── specialistHeader ──────────────────────────────────────────────────
+
+test("specialistHeader includes role, run_id, and state_id verbatim", () => {
+  const text = specialistHeader({
+    role: "lens-gap",
+    run_id: "run-2026-05-29-abcd",
+    state_id: "dispatch_lens_specialists",
+  });
+  assert.match(text, /Specialist dispatch: lens-gap/);
+  assert.match(text, /run-2026-05-29-abcd/);
+  assert.match(text, /dispatch_lens_specialists/);
+  assert.match(text, /\*\*lens-gap\*\*/);
+});
+
+test("specialistHeader rejects missing fields", () => {
+  assert.throws(() => specialistHeader(), /requires an options object/);
+  assert.throws(
+    () => specialistHeader({ run_id: "r", state_id: "s" }),
+    /role must be a non-empty string/,
+  );
+  assert.throws(
+    () => specialistHeader({ role: "r", state_id: "s" }),
+    /run_id must be a non-empty string/,
+  );
+  assert.throws(
+    () => specialistHeader({ role: "r", run_id: "r" }),
+    /state_id must be a non-empty string/,
+  );
+});
+
+test("specialistHeader rejects wrong-type fields", () => {
+  assert.throws(
+    () => specialistHeader({ role: 1, run_id: "r", state_id: "s" }),
+    /role must be a non-empty string/,
+  );
+  assert.throws(
+    () => specialistHeader({ role: "", run_id: "r", state_id: "s" }),
+    /role must be a non-empty string/,
+  );
+});
+
+// ─── outputContractBlock ───────────────────────────────────────────────
+
+test("outputContractBlock embeds outputs_path and pretty-printed schema", () => {
+  const schema = {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "object",
+    required: ["findings"],
+    properties: {
+      findings: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" } },
+        },
+      },
+    },
+  };
+  const text = outputContractBlock({
+    outputs_path: "/tmp/run-xyz/workers/lens-gap.out.json",
+    response_schema: schema,
+  });
+
+  // Path appears verbatim.
+  assert.match(text, /\/tmp\/run-xyz\/workers\/lens-gap\.out\.json/);
+  // The fenced code block is present.
+  assert.match(text, /```json\n[\s\S]+\n```/);
+  // Schema is pretty-printed (two-space indentation, line per field).
+  const pretty = JSON.stringify(schema, null, 2);
+  assert.ok(text.includes(pretty), "pretty-printed schema is embedded verbatim");
+  // The wording emphasises "one" JSON object and JSON Schema compliance.
+  assert.match(text, /one/i);
+  assert.match(text, /Output contract/);
+});
+
+test("outputContractBlock rejects missing or wrong-type inputs", () => {
+  const schema = { type: "object" };
+  assert.throws(
+    () => outputContractBlock({ response_schema: schema }),
+    /outputs_path must be a non-empty string/,
+  );
+  assert.throws(
+    () => outputContractBlock({ outputs_path: "/x" }),
+    /response_schema must be a JSON Schema object/,
+  );
+  assert.throws(
+    () => outputContractBlock({ outputs_path: "/x", response_schema: "schema" }),
+    /response_schema must be a JSON Schema object/,
+  );
+  assert.throws(
+    () => outputContractBlock({ outputs_path: "/x", response_schema: [1, 2] }),
+    /response_schema must be a JSON Schema object/,
+  );
+});
+
+// ─── forbiddenPathsNotice ──────────────────────────────────────────────
+
+test("forbiddenPathsNotice references run_dir/workers/ exactly", () => {
+  const text = forbiddenPathsNotice({ run_dir: "/var/runs/run-42" });
+  assert.match(text, /\/var\/runs\/run-42\/workers\//);
+  assert.match(text, /Forbidden write paths/);
+  assert.match(text, /Never write anywhere outside/);
+});
+
+test("forbiddenPathsNotice normalises a trailing slash on run_dir", () => {
+  const text = forbiddenPathsNotice({ run_dir: "/var/runs/run-42/" });
+  // Should not produce `//workers/`.
+  assert.doesNotMatch(text, /run-42\/\/workers\//);
+  assert.match(text, /\/var\/runs\/run-42\/workers\//);
+});
+
+test("forbiddenPathsNotice rejects missing run_dir", () => {
+  assert.throws(() => forbiddenPathsNotice({}), /run_dir must be a non-empty string/);
+  assert.throws(() => forbiddenPathsNotice(), /requires an options object/);
+});
+
+// ─── briefBlock ────────────────────────────────────────────────────────
+
+test("briefBlock renders a string brief verbatim under a Brief heading", () => {
+  const text = briefBlock({ brief: "Review the plan at /tmp/plan.md against the lens." });
+  assert.match(text, /## Brief/);
+  assert.match(text, /Review the plan at \/tmp\/plan\.md against the lens\./);
+});
+
+test("briefBlock pretty-prints an object brief inside a fenced JSON block", () => {
+  const briefObj = { plan_path: "/tmp/plan.md", lens: "gap" };
+  const text = briefBlock({ brief: briefObj });
+  const pretty = JSON.stringify(briefObj, null, 2);
+  assert.ok(text.includes(pretty), "object brief is pretty-printed");
+  assert.match(text, /```json/);
+  assert.match(text, /```$/m);
+});
+
+test("briefBlock pretty-prints an array brief", () => {
+  const briefArr = [{ id: "c1" }, { id: "c2" }];
+  const text = briefBlock({ brief: briefArr });
+  assert.ok(text.includes(JSON.stringify(briefArr, null, 2)));
+});
+
+test("briefBlock rejects empty / nullish / wrong-type briefs", () => {
+  assert.throws(() => briefBlock({}), /brief is required/);
+  assert.throws(() => briefBlock({ brief: null }), /brief is required/);
+  assert.throws(() => briefBlock({ brief: "" }), /non-empty string/);
+  assert.throws(() => briefBlock({ brief: 42 }), /string, array, or plain object/);
+  assert.throws(() => briefBlock({ brief: true }), /string, array, or plain object/);
+});
+
+// ─── Tool-agnostic wording ─────────────────────────────────────────────
+
+test("fragments do not name any specific MCP server, CLI, or harness", () => {
+  const composed = [
+    specialistHeader({ role: "lens-gap", run_id: "r1", state_id: "s1" }),
+    briefBlock({ brief: "do the thing" }),
+    outputContractBlock({
+      outputs_path: "/x.json",
+      response_schema: { type: "object" },
+    }),
+    forbiddenPathsNotice({ run_dir: "/x" }),
+  ].join("\n\n");
+
+  // Sample of forbidden brand / harness names. The fragments must stay
+  // generic so any worker can consume them.
+  const forbiddenTerms = [
+    "Claude Code",
+    "Anthropic",
+    "ChatGPT",
+    "OpenAI",
+    "Cursor",
+    "Aider",
+    "gh CLI",
+    "MCP server",
+  ];
+  for (const term of forbiddenTerms) {
+    assert.ok(
+      !composed.includes(term),
+      `composed prompt must not name "${term}"`,
+    );
+  }
+});
+
+// ─── Composition ───────────────────────────────────────────────────────
+
+test("fragments compose into a coherent worker-dispatch prompt", () => {
+  const schema = {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "object",
+    required: ["findings"],
+    properties: {
+      findings: { type: "array", items: { type: "object" } },
+    },
+  };
+  const prompt = [
+    specialistHeader({
+      role: "lens-gap",
+      run_id: "run-2026-05-29-coherence",
+      state_id: "dispatch_lens_specialists",
+    }),
+    briefBlock({ brief: { plan_path: "/tmp/plan.md", lens: "gap" } }),
+    outputContractBlock({
+      outputs_path: "/tmp/run-2026-05-29-coherence/workers/lens-gap.out.json",
+      response_schema: schema,
+    }),
+    forbiddenPathsNotice({ run_dir: "/tmp/run-2026-05-29-coherence" }),
+  ].join("\n\n");
+
+  // Every key element survives composition.
+  assert.match(prompt, /Specialist dispatch: lens-gap/);
+  assert.match(prompt, /run-2026-05-29-coherence/);
+  assert.match(prompt, /## Brief/);
+  assert.match(prompt, /plan_path/);
+  assert.match(prompt, /## Output contract/);
+  assert.match(prompt, /lens-gap\.out\.json/);
+  assert.match(prompt, /## Forbidden write paths/);
+  assert.match(prompt, /run-2026-05-29-coherence\/workers\//);
+
+  // The four section headings appear in the order the caller composed them.
+  const headerIdx = prompt.indexOf("# Specialist dispatch");
+  const briefIdx = prompt.indexOf("## Brief");
+  const contractIdx = prompt.indexOf("## Output contract");
+  const forbiddenIdx = prompt.indexOf("## Forbidden write paths");
+  assert.ok(headerIdx >= 0 && briefIdx > headerIdx, "brief follows header");
+  assert.ok(contractIdx > briefIdx, "contract follows brief");
+  assert.ok(forbiddenIdx > contractIdx, "forbidden notice follows contract");
+
+  // The pretty-printed schema survives composition unchanged.
+  assert.ok(prompt.includes(JSON.stringify(schema, null, 2)));
+});


### PR DESCRIPTION
Adds `scripts/lib/prompt-fragments.mjs` with composable fragments (`specialistHeader`, `outputContractBlock`, `forbiddenPathsNotice`, `briefBlock`) and a tool-agnostic test suite. Per plan A6. +14 tests, all green. `package.json` exports `./prompt-fragments`.