### PR TITLE
feat(lint): orchestrator-shell-only lint runner (A8)

### DIFF
--- a/docs/orchestrator-discipline.md
+++ b/docs/orchestrator-discipline.md
@@ -29,7 +29,7 @@ LLM work happens inside the worker the FSM engine dispatches. If the runner itse
 The linter flags calls to the known LLM-dispatch verbs:
 
 - Anthropic SDK shapes: `messages.create`, `completions.create`, `anthropic.messages`, `client.messages`.
-- Harness-tool-shaped invocations from JS: `Task(`, `Agent(`, `Skill(`, `Bash(`, `WebFetch(`, `WebSearch(`. Legitimate orchestrator dispatches that match these shapes (e.g. an `Agent(...)` worker spawn that IS the intended pattern) suppress with `// fsm-lint:ignore`.
+- Harness-tool-shaped invocations from JS: `Task(`, `Agent(`, `Skill(`, `Bash(`, `WebFetch(`, `WebSearch(`. These are flagged whenever they appear in a JS runner because runners are supposed to shell out to `fsm-next` / `fsm-commit` rather than dispatch tools themselves; the calling LLM does the dispatching in the orchestrator harness, NOT the runner. The rule has known false positives (e.g. a helper function or variable that coincidentally happens to be named `Agent`); suppress those with `// fsm-lint:ignore`.
 
 This rule has the most false-positive risk (see below).
 

--- a/docs/orchestrator-discipline.md
+++ b/docs/orchestrator-discipline.md
@@ -1,0 +1,102 @@
+# Orchestrator-Shell Discipline
+
+`@ctxr/fsm` is designed around a strict separation of responsibilities:
+
+- The **FSM engine** parses the FSM YAML, validates worker outputs against the per-state JSON Schemas, applies transition predicates, and writes manifest + trace files.
+- The **worker** receives a staged prompt (assembled from `fsm/prompt-templates/*.md` + reusable fragments from `@ctxr/fsm/prompt-fragments`) and emits a single JSON document that conforms to the state's `response_schema`.
+- The **orchestrator (the skill runner)** is a thin shell around the FSM CLIs. It calls `fsm-next` to get the next dispatch brief, asks the harness to spawn a worker with the staged prompt, hands the worker's JSON output to `fsm-commit`, and loops until the FSM reaches a terminal state.
+
+When the runner stays a shell, the FSM is the single source of truth for control flow. When the runner starts reading YAML, calling LLM tools directly, or assembling prompts inline, control flow leaks back into the runner and the FSM's determinism guarantees erode.
+
+`fsm-lint-runner` is an **advisory** linter that scans runner files for the three most common drift modes. It never modifies files; it exits non-zero only as a signal so authors notice the drift in code review or CI.
+
+## The three rules
+
+### 1. `no-direct-fsm-yaml-read`
+
+> The orchestrator must not read `*.fsm.yaml` directly.
+
+The engine owns YAML parsing. A runner that `readFileSync`s the FSM YAML is either (a) duplicating logic the engine already does, or (b) making decisions the FSM should make. Both cases break the "FSM is the single source of truth" invariant.
+
+The linter flags any of `readFileSync`, `readFile`, `createReadStream`, `open`, `openSync` whose call argument on the same line contains the substring `.fsm.yaml`.
+
+### 2. `no-orchestrator-llm-call`
+
+> The orchestrator must not call LLM tools at orchestrator level.
+
+LLM work happens inside the worker the FSM engine dispatches. If the runner itself calls `messages.create`, `Task(...)`, `Agent(...)`, etc., the FSM cannot validate that work against a per-state schema, cannot record it in a trace file, and cannot replay it.
+
+The linter flags calls to the known LLM-dispatch verbs:
+
+- Anthropic SDK shapes: `messages.create`, `completions.create`, `anthropic.messages`, `client.messages`.
+- Harness-tool-shaped invocations from JS: `Task(`, `Agent(`, `WebFetch(`, `WebSearch(`.
+
+This rule has the most false-positive risk (see below).
+
+### 3. `no-inline-prompt-composition`
+
+> The orchestrator must not compose worker prompts inline.
+
+Prompts belong in `fsm/prompt-templates/*.md`, with reusable fragments imported from `@ctxr/fsm/prompt-fragments` (specialist header, output-contract block, forbidden-paths notice, brief block). Composing prompts inline puts the worker contract in the runner where it cannot be reviewed, reused, or diffed independently.
+
+The linter flags multi-line template literals (backtick strings spanning two or more source lines) that contain BOTH:
+
+- A role / contract marker: `You are`, `Role:`, `## Role`, `## Brief`, `Specialist:`, `Output Contract`.
+- A schema marker: `$schema`, `"type": "object"`, `"required":`, `response_schema`.
+
+A multi-line template that holds only a message string (no schema, no role header) is fine and not flagged.
+
+## How to invoke
+
+```bash
+node scripts/fsm-lint-runner.mjs <path-to-runner> [<more-runner-paths>]
+```
+
+The linter accepts one or more positional file paths. It prints one diagnostic per violation to stdout in the form:
+
+```text
+<file>:<line>: <rule>: <suggestion>
+```
+
+Exit codes:
+
+- `0` clean: every file passes every rule.
+- `1` at least one diagnostic was emitted, or a given path was not found.
+- `2` invalid CLI arguments (e.g. zero positional arguments and no `--help`).
+
+`--help` (or `-h`) prints the usage block to stdout and exits 0.
+
+The linter never writes to disk, never spawns subprocesses, and never reaches the network. It is safe to run from any pre-commit or CI step.
+
+## Suppressing a false positive
+
+Each heuristic can fire on legitimate code. Authors suppress a known false positive by appending the marker `// fsm-lint:ignore` to the offending line. For multi-line constructs (e.g. a template literal that triggers `no-inline-prompt-composition`), placing the marker on the line immediately above the opening backtick also suppresses the diagnostic.
+
+Example:
+
+```js
+// This template literal is documentation, not a worker prompt. // fsm-lint:ignore
+const docExample = `
+You are a worker.
+"type": "object"
+`;
+```
+
+Use the marker sparingly. The right fix for most flags is to move the offending code into the engine or a prompt template.
+
+## Honest limitations
+
+The linter uses simple line-based heuristics and a hand-rolled template-literal walker, not a full JavaScript parser. Known false-positive and false-negative shapes:
+
+- **`no-orchestrator-llm-call`** matches function names. A renamed import (`import { messages as msg } from "@anthropic-ai/sdk"`) will evade detection. A legitimate `Task(` call that is part of the harness's worker-dispatch protocol may also fire; suppress with `// fsm-lint:ignore`.
+- **`no-inline-prompt-composition`** matches string markers inside the literal body. A prompt that uses none of the listed role or schema markers will evade detection. Conversely, a docstring that quotes both markers as examples will fire and need suppression.
+- **`no-direct-fsm-yaml-read`** matches the literal substring `.fsm.yaml` on the same line as a read API. A two-line read where the filename is assigned to a variable on line N and passed to `readFileSync` on line N+1 will evade detection.
+- The template-literal walker is intentionally simple: it does not parse `${...}` expression blocks. Markers inside an expression block are not recognised as such, which has never mattered in practice for these heuristics.
+
+The linter is advisory because runtime enforcement of the orchestrator-shell discipline would require sandboxing the runner process (cutting off LLM SDK imports, intercepting filesystem reads). That is out of scope for `@ctxr/fsm`; this lint catches the common drift modes at code-review time, and that is enough.
+
+## Related
+
+- `docs/orchestration-design.md` for the broader hub-and-spoke architecture.
+- `docs/worker-contract.md` for what staged prompts look like.
+- `docs/state-yaml-reference.md` for the FSM YAML shape the engine consumes.

--- a/docs/orchestrator-discipline.md
+++ b/docs/orchestrator-discipline.md
@@ -3,7 +3,7 @@
 `@ctxr/fsm` is designed around a strict separation of responsibilities:
 
 - The **FSM engine** parses the FSM YAML, validates worker outputs against the per-state JSON Schemas, applies transition predicates, and writes manifest + trace files.
-- The **worker** receives a staged prompt (assembled from `fsm/prompt-templates/*.md` + reusable fragments from `@ctxr/fsm/prompt-fragments`) and emits a single JSON document that conforms to the state's `response_schema`.
+- The **worker** receives a staged prompt (assembled by the runner from the file referenced by the FSM state's `worker.prompt_template`, possibly composed with project-local prompt fragments) and emits a single JSON document that conforms to the state's `response_schema`.
 - The **orchestrator (the skill runner)** is a thin shell around the FSM CLIs. It calls `fsm-next` to get the next dispatch brief, asks the harness to spawn a worker with the staged prompt, hands the worker's JSON output to `fsm-commit`, and loops until the FSM reaches a terminal state.
 
 When the runner stays a shell, the FSM is the single source of truth for control flow. When the runner starts reading YAML, calling LLM tools directly, or assembling prompts inline, control flow leaks back into the runner and the FSM's determinism guarantees erode.
@@ -37,7 +37,7 @@ This rule has the most false-positive risk (see below).
 
 > The orchestrator must not compose worker prompts inline.
 
-Prompts belong in `fsm/prompt-templates/*.md`, with reusable fragments imported from `@ctxr/fsm/prompt-fragments` (specialist header, output-contract block, forbidden-paths notice, brief block). Composing prompts inline puts the worker contract in the runner where it cannot be reviewed, reused, or diffed independently.
+Prompts belong in the file referenced by the FSM state's `worker.prompt_template`, optionally composed with project-local fragments (specialist header, output-contract block, forbidden-paths notice, brief block). Where exactly those files live is the consumer's choice; the lint rule only fires on inline composition inside the runner. Composing prompts inline puts the worker contract in the runner where it cannot be reviewed, reused, or diffed independently.
 
 The linter flags multi-line template literals (backtick strings spanning two or more source lines) that contain BOTH:
 

--- a/docs/orchestrator-discipline.md
+++ b/docs/orchestrator-discipline.md
@@ -29,7 +29,7 @@ LLM work happens inside the worker the FSM engine dispatches. If the runner itse
 The linter flags calls to the known LLM-dispatch verbs:
 
 - Anthropic SDK shapes: `messages.create`, `completions.create`, `anthropic.messages`, `client.messages`.
-- Harness-tool-shaped invocations from JS: `Task(`, `Agent(`, `WebFetch(`, `WebSearch(`.
+- Harness-tool-shaped invocations from JS: `Task(`, `Agent(`, `Skill(`, `Bash(`, `WebFetch(`, `WebSearch(`. Legitimate orchestrator dispatches that match these shapes (e.g. an `Agent(...)` worker spawn that IS the intended pattern) suppress with `// fsm-lint:ignore`.
 
 This rule has the most false-positive risk (see below).
 

--- a/docs/orchestrator-discipline.md
+++ b/docs/orchestrator-discipline.md
@@ -18,7 +18,7 @@ When the runner stays a shell, the FSM is the single source of truth for control
 
 The engine owns YAML parsing. A runner that `readFileSync`s the FSM YAML is either (a) duplicating logic the engine already does, or (b) making decisions the FSM should make. Both cases break the "FSM is the single source of truth" invariant.
 
-The linter flags any of `readFileSync`, `readFile`, `createReadStream`, `open`, `openSync` whose call argument on the same line contains the substring `.fsm.yaml`.
+The linter flags any of `readFileSync`, `readFile`, `createReadStream`, `open`, `openSync` whose call argument on the same line is a **quoted string literal** containing `.fsm.yaml` (single, double, or template-string quotes). Variable-based paths like `readFileSync(p)` where `p` resolves to a `.fsm.yaml` path at runtime are NOT detected; the heuristic is intentionally syntactic so it can run without parsing the source.
 
 ### 2. `no-orchestrator-llm-call`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "bin": {
         "fsm-commit": "scripts/fsm-commit.mjs",
         "fsm-inspect": "scripts/fsm-inspect.mjs",
+        "fsm-lint-runner": "scripts/fsm-lint-runner.mjs",
         "fsm-next": "scripts/fsm-next.mjs",
         "fsm-validate-static": "scripts/fsm-validate-static.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "fsm-next": "scripts/fsm-next.mjs",
     "fsm-commit": "scripts/fsm-commit.mjs",
     "fsm-inspect": "scripts/fsm-inspect.mjs",
-    "fsm-validate-static": "scripts/fsm-validate-static.mjs"
+    "fsm-validate-static": "scripts/fsm-validate-static.mjs",
+    "fsm-lint-runner": "scripts/fsm-lint-runner.mjs"
   },
   "files": [
     "scripts/",

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -33,10 +33,14 @@
 //     making decisions the FSM should make).
 //
 //   no-orchestrator-llm-call
-//     Pattern: a call expression whose callee name matches one of
-//     the known LLM-tool dispatch verbs. The match is name-only (no
-//     payload inspection); a legitimate invocation suppresses with
-//     `// fsm-lint:ignore`.
+//     Pattern: a token-shape scan that fires when the line contains
+//     a known LLM-tool dispatch name followed by an open paren. This
+//     is NOT a call-expression detector: a function declaration
+//     (`function Task() { ... }`), object method definition
+//     (`{ Task() { ... } }`), or destructure (`{ Task } = ...`)
+//     followed by `Task(` on the same line will also match.
+//     Authors can suppress with `// fsm-lint:ignore` for legitimate
+//     occurrences.
 //       Anthropic SDK / clients: messages.create, completions.create,
 //         anthropic.messages, client.messages.
 //       Harness tool-shaped invocations: Task(, Agent(, Skill(,
@@ -289,10 +293,17 @@ export function lintFile(filePath, source) {
       inBlockComment = true;
     }
     // `inBlockComment` reflects the state AFTER this line; the
-    // current line is comment if it WAS in a block, opened one, or
-    // closes one.
+    // current line is fully comment if it WAS in a block (started on
+    // a prior line and continues / closes here) or opens a new
+    // multi-line block. A SINGLE-LINE block comment that closes on
+    // the same line (`/* x */ readFileSync("x.fsm.yaml")`) is NOT
+    // wholly comment; real code can follow `*/` on the same line and
+    // must still be analysed by the per-line rules.
+    const isSingleLineBlockComment =
+      trimmedForBc.startsWith("/*") && trimmedForBc.includes("*/");
     const lineIsBlockComment =
-      inBlockComment || isBlockClosingLine || trimmedForBc.startsWith("/*");
+      (inBlockComment || isBlockClosingLine || trimmedForBc.startsWith("/*")) &&
+      !isSingleLineBlockComment;
     // The fsm-lint:ignore marker is intentionally per-line for the
     // single-line rules (no-direct-fsm-yaml-read and
     // no-orchestrator-llm-call); previous-line suppression is

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -193,6 +193,19 @@ export function lintFile(filePath, source) {
     `\\b(?:${readApiAlternation})\\s*\\([^)\\n]*?(['"\`])[^'"\`\\n]*\\.fsm\\.yaml[^'"\`\\n]*\\1`,
   );
 
+  // Pre-compute the set of line numbers that fall inside a multi-line
+  // template literal so the per-line rules can skip them (those bodies
+  // are owned by no-inline-prompt-composition, and the YAML-read /
+  // LLM-call regexes should not fire on prompt-fixture prose).
+  const templateLineSet = new Set();
+  for (const tmpl of collectTemplateLiterals(source)) {
+    if (tmpl.endLine > tmpl.startLine) {
+      for (let n = tmpl.startLine; n <= tmpl.endLine; n++) {
+        templateLineSet.add(n);
+      }
+    }
+  }
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const lineNumber = i + 1;
@@ -212,17 +225,27 @@ export function lintFile(filePath, source) {
 
     // Skip lines that are clearly source comments -- both the read-API
     // and the LLM-call rules are about real code, not prose in the
-    // header banner. We detect a comment by the first non-space chars
-    // being `//`, `/*`, ` *` (block-comment middles), or `#!`
-    // (shebang only; a bare `#` would falsely skip valid ES class
-    // private members like `#client = ...`).
+    // header banner. We narrow to actual comment shapes: `//`, `/*`,
+    // ` * `, and `#!` (shebang). Bare leading `*` was previously
+    // treated as a comment too, but that also matched valid JS
+    // generator method definitions (e.g. `* foo() {}`), hiding real
+    // violations on the body line.
     const trimmed = line.trimStart();
     const isComment =
       trimmed.startsWith("//") ||
       trimmed.startsWith("/*") ||
-      trimmed.startsWith("*") ||
+      trimmed.startsWith("* ") ||
+      trimmed === "*" ||
       trimmed.startsWith("#!");
     if (isComment) continue;
+
+    // Skip lines that fall inside a multi-line template literal: the
+    // per-line YAML-read and LLM-call rules look at literal text, not
+    // executable code, and a multi-line prompt fixture can legitimately
+    // contain shapes like `readFileSync("x.fsm.yaml")` or `Task(` as
+    // documentation. The no-inline-prompt-composition rule already
+    // owns the template-literal case.
+    if (templateLineSet.has(lineNumber)) continue;
 
     // Rule: no-direct-fsm-yaml-read. Match a known read API name
     // followed by `(`, with `.fsm.yaml` appearing somewhere on the

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -152,11 +152,26 @@ const SCHEMA_MARKERS = [
 // `console.log("fsm-lint:ignore")`. The scan walks the line tracking
 // string-literal state so a `//` inside a string (e.g. a URL like
 // "http://x") is NOT treated as a comment start.
+// Characters that, as the previous non-whitespace token, indicate the
+// next `/` opens a regex literal rather than a division operator.
+// Conservative set: punctuation that cannot end an expression, plus
+// the empty prefix (regex at start of line). Distinguishing regex
+// vs division in JavaScript is in general context-sensitive (e.g.
+// `a /b/g` vs `a / b / g`), but for the purpose of a lint heuristic
+// this set covers the common cases without ever mis-treating a real
+// `//` line comment as inside a regex.
+const REGEX_PREFIX_OPS = new Set([
+  "", "(", "[", "{", "}", ",", ";", ":", "?", "!", "&", "|", "=",
+  "+", "-", "*", "/", "^", "~", "%", "<", ">",
+]);
+
 function lineCommentHasIgnoreMarker(line) {
   if (typeof line !== "string" || !line.includes(IGNORE_MARKER)) return false;
   let i = 0;
   const len = line.length;
   let inString = null; // null | "'" | '"' | "`"
+  let inRegex = false;
+  let lastNonWs = "";
   while (i < len) {
     const ch = line[i];
     if (inString) {
@@ -170,8 +185,33 @@ function lineCommentHasIgnoreMarker(line) {
       i++;
       continue;
     }
+    if (inRegex) {
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      if (ch === "[") {
+        // Walk a regex character class so that `/` inside `[...]` does
+        // not terminate the literal.
+        i++;
+        while (i < len && line[i] !== "]") {
+          if (line[i] === "\\") i++;
+          i++;
+        }
+        i++;
+        continue;
+      }
+      if (ch === "/") {
+        inRegex = false;
+        i++;
+        continue;
+      }
+      i++;
+      continue;
+    }
     if (ch === "'" || ch === '"' || ch === "`") {
       inString = ch;
+      lastNonWs = ch;
       i++;
       continue;
     }
@@ -179,6 +219,13 @@ function lineCommentHasIgnoreMarker(line) {
       // Real line comment starts here.
       return line.indexOf(IGNORE_MARKER, i) >= 0;
     }
+    if (ch === "/" && REGEX_PREFIX_OPS.has(lastNonWs)) {
+      // Treat as regex literal start; consume until matching `/`.
+      inRegex = true;
+      i++;
+      continue;
+    }
+    if (ch !== " " && ch !== "\t") lastNonWs = ch;
     i++;
   }
   return false;
@@ -216,9 +263,25 @@ export function lintFile(filePath, source) {
     }
   }
 
+  let inBlockComment = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const lineNumber = i + 1;
+    // Track multi-line block-comment state. If `inBlockComment` is
+    // true at the start of this line we are inside a `/* ... */`
+    // block; we still process the line but the "leading `*`" comment
+    // shape below will skip it. When the line closes the block with
+    // `*/`, leave the state on after the line so subsequent code on
+    // the same line (rare but legal) is not analysed; the next line
+    // resumes normally.
+    if (inBlockComment) {
+      // If the line closes the block we toggle off; the line itself is
+      // treated as comment for the per-line rules below.
+      if (line.includes("*/")) inBlockComment = false;
+    } else if (line.includes("/*") && !line.includes("*/")) {
+      // Opens a multi-line block on this line.
+      inBlockComment = true;
+    }
     // The fsm-lint:ignore marker is intentionally per-line for the
     // single-line rules (no-direct-fsm-yaml-read and
     // no-orchestrator-llm-call); previous-line suppression is
@@ -235,17 +298,16 @@ export function lintFile(filePath, source) {
 
     // Skip lines that are clearly source comments -- both the read-API
     // and the LLM-call rules are about real code, not prose in the
-    // header banner. We narrow to actual comment shapes: `//`, `/*`,
-    // ` * `, and `#!` (shebang). Bare leading `*` was previously
-    // treated as a comment too, but that also matched valid JS
-    // generator method definitions (e.g. `* foo() {}`), hiding real
-    // violations on the body line.
+    // header banner. Narrow to actual comment shapes: `//`, `/*`, and
+    // `#!` (shebang). Lines inside a multi-line `/* ... */` block are
+    // skipped via `inBlockComment` above, which avoids the false
+    // positive where `* foo()` (a generator method definition OUTSIDE
+    // a block comment) used to be treated as comment text.
     const trimmed = line.trimStart();
     const isComment =
+      inBlockComment ||
       trimmed.startsWith("//") ||
       trimmed.startsWith("/*") ||
-      trimmed.startsWith("* ") ||
-      trimmed === "*" ||
       trimmed.startsWith("#!");
     if (isComment) continue;
 

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -67,6 +67,7 @@
 
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const USAGE = `Usage: fsm-lint-runner [--help] <runner-file> [<runner-file> ...]
 
@@ -84,8 +85,10 @@ offending line (or the line immediately before, for multi-line
 constructs).
 `;
 
-// Public entry points are exported so the test suite can drive the
-// linter without spawning a subprocess for every assertion.
+// Public entry points are exported so callers (other tools, or future
+// in-process tests) can drive the lint pipeline directly; the current
+// test suite still uses spawnSync against the CLI to also exercise the
+// argv / exit-code path that real consumers go through.
 
 export const RULES = {
   NO_DIRECT_FSM_YAML_READ: "no-direct-fsm-yaml-read",
@@ -116,6 +119,8 @@ const LLM_CALL_PATTERNS = [
   /\bclient\s*\.\s*messages\b/,
   /\bTask\s*\(/,
   /\bAgent\s*\(/,
+  /\bSkill\s*\(/,
+  /\bBash\s*\(/,
   /\bWebFetch\s*\(/,
   /\bWebSearch\s*\(/,
 ];
@@ -335,7 +340,11 @@ function isDirectInvocation() {
   if (!process.argv[1]) return false;
   try {
     const entry = resolve(process.argv[1]);
-    const self = new URL(import.meta.url).pathname;
+    // fileURLToPath decodes URL escapes (e.g. %20 for spaces) and
+    // produces an OS-native path on Windows, where `new URL(...).pathname`
+    // gives a leading-slash POSIX-style string that does not match
+    // `resolve(process.argv[1])`. Decode first; compare second.
+    const self = fileURLToPath(import.meta.url);
     return entry === self;
   } catch {
     return false;

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -141,6 +141,18 @@ const SCHEMA_MARKERS = [
   /response_schema/,
 ];
 
+// Suppression is documented as `// fsm-lint:ignore`. Returning true only
+// when the marker lives in a `//` line comment prevents bypassing
+// diagnostics by embedding the literal string inside source like
+// `console.log("fsm-lint:ignore")`. The match looks for `//` followed
+// by any prefix and then the marker, scanned left to right.
+function lineCommentHasIgnoreMarker(line) {
+  if (typeof line !== "string" || !line.includes(IGNORE_MARKER)) return false;
+  const commentIdx = line.indexOf("//");
+  if (commentIdx < 0) return false;
+  return line.indexOf(IGNORE_MARKER, commentIdx) >= 0;
+}
+
 export function lintFile(filePath, source) {
   const diagnostics = [];
   const lines = source.split(/\r?\n/);
@@ -165,18 +177,22 @@ export function lintFile(filePath, source) {
     // marker can legitimately precede the literal it suppresses.
     // Applying previous-line suppression to per-line rules silently
     // hid the diagnostic immediately after any other ignored line.
-    if (line.includes(IGNORE_MARKER)) {
+    // Additionally: require the marker to live in a `//` line comment
+    // so the substring inside a string literal (e.g.
+    // `console.log("fsm-lint:ignore")`) cannot bypass diagnostics.
+    if (lineCommentHasIgnoreMarker(line)) {
       continue;
     }
 
     // Skip lines that are clearly source comments -- both the read-API
     // and the LLM-call rules are about real code, not prose in the
     // header banner. We detect a comment by the first non-space chars
-    // being `//`, `*`, or `#` (shebangs / shell). Block-comment middle
-    // lines start with ` *` which is also covered.
+    // being `//`, `/*`, `*`, or `#` (shebangs / shell). Block-comment
+    // openers / middles all start with `/*` or ` *`.
     const trimmed = line.trimStart();
     const isComment =
       trimmed.startsWith("//") ||
+      trimmed.startsWith("/*") ||
       trimmed.startsWith("*") ||
       trimmed.startsWith("#");
     if (isComment) continue;
@@ -229,8 +245,8 @@ export function lintFile(filePath, source) {
     const startLineText = lines[startIdx] ?? "";
     const prevLineText = prevIdx >= 0 ? lines[prevIdx] : "";
     if (
-      startLineText.includes(IGNORE_MARKER) ||
-      prevLineText.includes(IGNORE_MARKER)
+      lineCommentHasIgnoreMarker(startLineText) ||
+      lineCommentHasIgnoreMarker(prevLineText)
     ) {
       continue;
     }
@@ -280,7 +296,13 @@ function collectTemplateLiterals(source) {
     if (ch === "'") {
       i++;
       while (i < len && source[i] !== "'") {
-        if (source[i] === "\\") i++;
+        if (source[i] === "\\") {
+          // Account for the escaped character: when it is a newline
+          // (line-continuation), the line counter must still tick.
+          if (source[i + 1] === "\n") line++;
+          i += 2;
+          continue;
+        }
         if (source[i] === "\n") line++;
         i++;
       }
@@ -291,7 +313,11 @@ function collectTemplateLiterals(source) {
     if (ch === '"') {
       i++;
       while (i < len && source[i] !== '"') {
-        if (source[i] === "\\") i++;
+        if (source[i] === "\\") {
+          if (source[i + 1] === "\n") line++;
+          i += 2;
+          continue;
+        }
         if (source[i] === "\n") line++;
         i++;
       }
@@ -305,6 +331,12 @@ function collectTemplateLiterals(source) {
       i++;
       while (i < len && source[i] !== "`") {
         if (source[i] === "\\") {
+          // Account for backslash-newline (line-continuation) inside a
+          // template body: stepping past the pair without ticking
+          // `line` shifted endLine in the diagnostic, blaming the
+          // wrong source line. Tick when we step over a literal
+          // newline as part of the escape pair.
+          if (source[i + 1] === "\n") line++;
           i += 2;
           continue;
         }

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -144,13 +144,39 @@ const SCHEMA_MARKERS = [
 // Suppression is documented as `// fsm-lint:ignore`. Returning true only
 // when the marker lives in a `//` line comment prevents bypassing
 // diagnostics by embedding the literal string inside source like
-// `console.log("fsm-lint:ignore")`. The match looks for `//` followed
-// by any prefix and then the marker, scanned left to right.
+// `console.log("fsm-lint:ignore")`. The scan walks the line tracking
+// string-literal state so a `//` inside a string (e.g. a URL like
+// "http://x") is NOT treated as a comment start.
 function lineCommentHasIgnoreMarker(line) {
   if (typeof line !== "string" || !line.includes(IGNORE_MARKER)) return false;
-  const commentIdx = line.indexOf("//");
-  if (commentIdx < 0) return false;
-  return line.indexOf(IGNORE_MARKER, commentIdx) >= 0;
+  let i = 0;
+  const len = line.length;
+  let inString = null; // null | "'" | '"' | "`"
+  while (i < len) {
+    const ch = line[i];
+    if (inString) {
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      if (ch === inString) {
+        inString = null;
+      }
+      i++;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === "`") {
+      inString = ch;
+      i++;
+      continue;
+    }
+    if (ch === "/" && line[i + 1] === "/") {
+      // Real line comment starts here.
+      return line.indexOf(IGNORE_MARKER, i) >= 0;
+    }
+    i++;
+  }
+  return false;
 }
 
 export function lintFile(filePath, source) {
@@ -187,14 +213,15 @@ export function lintFile(filePath, source) {
     // Skip lines that are clearly source comments -- both the read-API
     // and the LLM-call rules are about real code, not prose in the
     // header banner. We detect a comment by the first non-space chars
-    // being `//`, `/*`, `*`, or `#` (shebangs / shell). Block-comment
-    // openers / middles all start with `/*` or ` *`.
+    // being `//`, `/*`, ` *` (block-comment middles), or `#!`
+    // (shebang only; a bare `#` would falsely skip valid ES class
+    // private members like `#client = ...`).
     const trimmed = line.trimStart();
     const isComment =
       trimmed.startsWith("//") ||
       trimmed.startsWith("/*") ||
       trimmed.startsWith("*") ||
-      trimmed.startsWith("#");
+      trimmed.startsWith("#!");
     if (isComment) continue;
 
     // Rule: no-direct-fsm-yaml-read. Match a known read API name
@@ -416,35 +443,39 @@ function isDirectInvocation() {
 }
 
 if (isDirectInvocation()) {
+  // Set process.exitCode and let Node exit naturally after the
+  // stdout/stderr streams flush, rather than calling process.exit()
+  // immediately after the last write. process.exit() can truncate a
+  // multi-KB diagnostics dump on piped stdio (same failure mode that
+  // motivated scripts/lib/emit.mjs in this repo).
   const args = process.argv.slice(2);
   if (args.includes("--help") || args.includes("-h")) {
     process.stdout.write(USAGE);
-    process.exit(0);
-  }
-  if (args.length === 0) {
+    process.exitCode = 0;
+  } else if (args.length === 0) {
     process.stderr.write(
       "fsm-lint-runner: at least one runner file path is required\n",
     );
     process.stderr.write(USAGE);
-    process.exit(2);
-  }
+    process.exitCode = 2;
+  } else {
+    const { diagnostics, missing, unreadable } = lintPaths(args);
 
-  const { diagnostics, missing, unreadable } = lintPaths(args);
+    for (const m of missing) {
+      process.stderr.write(`fsm-lint-runner: file not found: ${m}\n`);
+    }
+    for (const u of unreadable) {
+      process.stderr.write(
+        `fsm-lint-runner: unreadable: ${u.path} (${u.error})\n`,
+      );
+    }
 
-  for (const m of missing) {
-    process.stderr.write(`fsm-lint-runner: file not found: ${m}\n`);
-  }
-  for (const u of unreadable) {
-    process.stderr.write(
-      `fsm-lint-runner: unreadable: ${u.path} (${u.error})\n`,
-    );
-  }
+    for (const d of diagnostics) {
+      process.stdout.write(`${formatDiagnostic(d)}\n`);
+    }
 
-  for (const d of diagnostics) {
-    process.stdout.write(`${formatDiagnostic(d)}\n`);
+    const failed =
+      diagnostics.length > 0 || missing.length > 0 || unreadable.length > 0;
+    process.exitCode = failed ? 1 : 0;
   }
-
-  const failed =
-    diagnostics.length > 0 || missing.length > 0 || unreadable.length > 0;
-  process.exit(failed ? 1 : 0);
 }

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -65,7 +65,7 @@
 //     prompt that omits all markers will evade it. Authors who want
 //     to suppress a known-false positive use `// fsm-lint:ignore`.
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -322,17 +322,29 @@ export function formatDiagnostic(d) {
 export function lintPaths(paths) {
   const allDiagnostics = [];
   const missing = [];
+  const unreadable = [];
   for (const rawPath of paths) {
     const abs = resolve(process.cwd(), rawPath);
     if (!existsSync(abs)) {
       missing.push(rawPath);
       continue;
     }
-    const source = readFileSync(abs, "utf8");
+    let source;
+    try {
+      source = readFileSync(abs, "utf8");
+    } catch (err) {
+      // `existsSync` only checks `stat`; a directory, an unreadable
+      // file (EISDIR / EPERM / etc.) or a broken symlink will still
+      // throw here. Surface it as a structured "unreadable" entry
+      // rather than crashing the CLI with a stack trace; the lint
+      // pass is advisory and should continue scanning siblings.
+      unreadable.push({ path: rawPath, error: err.code ?? err.message });
+      continue;
+    }
     const diags = lintFile(rawPath, source);
     allDiagnostics.push(...diags);
   }
-  return { diagnostics: allDiagnostics, missing };
+  return { diagnostics: allDiagnostics, missing, unreadable };
 }
 
 function isDirectInvocation() {
@@ -345,7 +357,18 @@ function isDirectInvocation() {
     // gives a leading-slash POSIX-style string that does not match
     // `resolve(process.argv[1])`. Decode first; compare second.
     const self = fileURLToPath(import.meta.url);
-    return entry === self;
+    if (entry === self) return true;
+    // npm installs a bin entry by symlinking node_modules/.bin/<name> to
+    // the actual script. When the CLI is launched via the symlink,
+    // process.argv[1] is the symlink path while import.meta.url is the
+    // resolved script path, so a literal string compare misses. Resolve
+    // both sides through realpath to handle this case (silently fall
+    // back to the literal compare if realpath fails for either side).
+    let entryReal = entry;
+    let selfReal = self;
+    try { entryReal = realpathSync(entry); } catch { /* keep literal */ }
+    try { selfReal = realpathSync(self); } catch { /* keep literal */ }
+    return entryReal === selfReal;
   } catch {
     return false;
   }
@@ -365,16 +388,22 @@ if (isDirectInvocation()) {
     process.exit(2);
   }
 
-  const { diagnostics, missing } = lintPaths(args);
+  const { diagnostics, missing, unreadable } = lintPaths(args);
 
   for (const m of missing) {
     process.stderr.write(`fsm-lint-runner: file not found: ${m}\n`);
+  }
+  for (const u of unreadable) {
+    process.stderr.write(
+      `fsm-lint-runner: unreadable: ${u.path} (${u.error})\n`,
+    );
   }
 
   for (const d of diagnostics) {
     process.stdout.write(`${formatDiagnostic(d)}\n`);
   }
 
-  const failed = diagnostics.length > 0 || missing.length > 0;
+  const failed =
+    diagnostics.length > 0 || missing.length > 0 || unreadable.length > 0;
   process.exit(failed ? 1 : 0);
 }

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -56,8 +56,12 @@
 //           "## Role", "## Brief", "Specialist:", "Output Contract".
 //       (b) a JSON-schema-like marker -- one of "$schema",
 //           '"type": "object"', '"required":', 'response_schema'.
-//     Why: prompts should live in fsm/prompt-templates/*.md and be
-//     composed via @ctxr/fsm/prompt-fragments. Inline composition
+//     Why: prompts should live in the file referenced by the FSM
+//     state's `worker.prompt_template` field (typically a separate
+//     markdown file the runner stages on disk), not embedded in the
+//     runner source. Where exactly that file lives is the consumer's
+//     choice; the rule fires on inline composition regardless of
+//     project layout. Inline composition
 //     puts the contract in the runner where it cannot be reviewed
 //     or reused.
 //
@@ -257,7 +261,7 @@ export function lintFile(filePath, source) {
   // `.fsm.yaml` literal that lives only inside a `/* ... */` segment
   // is not matched.
   const readApiRegex = new RegExp(
-    `\\b(?:${readApiAlternation})\\s*\\([^)\\n]*?(['"\`])[^'"\`\\n]*\\.fsm\\.yaml[^'"\`\\n]*\\1`,
+    `\\b(?:${readApiAlternation})\\s*\\([^\\n]*?(['"\`])[^'"\`\\n]*\\.fsm\\.yaml[^'"\`\\n]*\\1`,
   );
   // Strip inline `/* ... */` segments from a single line for the
   // per-line regexes. Stops at the first newline (block comments that
@@ -439,7 +443,7 @@ export function lintFile(filePath, source) {
       line: startLine,
       rule: RULES.NO_INLINE_PROMPT_COMPOSITION,
       message:
-        "inline multi-line prompt with role + schema markers; move to fsm/prompt-templates/*.md and compose via @ctxr/fsm/prompt-fragments",
+        "inline multi-line prompt with role + schema markers; move the body to the file referenced by the FSM state's worker.prompt_template (so the prompt is reviewed and versioned next to the FSM YAML, not embedded in the runner)",
     });
   }
 

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -489,27 +489,38 @@ if (isDirectInvocation()) {
   // consumer that closes early (e.g. `fsm-lint-runner ... | head`)
   // Node would otherwise crash with `Error: write EPIPE`. The
   // diagnostics are advisory; a downstream reader closing the pipe
-  // mid-stream is a graceful exit, not a failure.
+  // mid-stream is a graceful exit, but it must NOT mask a non-zero
+  // verdict, so we forward process.exitCode (which the
+  // computeExitCode-then-emit pattern below has already set) rather
+  // than always exiting 0.
   process.stdout.on("error", (err) => {
-    if (err.code === "EPIPE") process.exit(0);
+    if (err.code === "EPIPE") process.exit(process.exitCode ?? 0);
     throw err;
   });
   process.stderr.on("error", (err) => {
-    if (err.code === "EPIPE") process.exit(0);
+    if (err.code === "EPIPE") process.exit(process.exitCode ?? 0);
     throw err;
   });
   const args = process.argv.slice(2);
   if (args.includes("--help") || args.includes("-h")) {
-    process.stdout.write(USAGE);
     process.exitCode = 0;
+    process.stdout.write(USAGE);
   } else if (args.length === 0) {
+    process.exitCode = 2;
     process.stderr.write(
       "fsm-lint-runner: at least one runner file path is required\n",
     );
     process.stderr.write(USAGE);
-    process.exitCode = 2;
   } else {
     const { diagnostics, missing, unreadable } = lintPaths(args);
+
+    // Compute and stamp process.exitCode BEFORE any write. If a
+    // downstream pipe closes mid-write (EPIPE) the EPIPE handler reads
+    // the already-set exitCode, so a verdict computed as "failed"
+    // does not silently become success.
+    const failed =
+      diagnostics.length > 0 || missing.length > 0 || unreadable.length > 0;
+    process.exitCode = failed ? 1 : 0;
 
     for (const m of missing) {
       process.stderr.write(`fsm-lint-runner: file not found: ${m}\n`);
@@ -523,9 +534,5 @@ if (isDirectInvocation()) {
     for (const d of diagnostics) {
       process.stdout.write(`${formatDiagnostic(d)}\n`);
     }
-
-    const failed =
-      diagnostics.length > 0 || missing.length > 0 || unreadable.length > 0;
-    process.exitCode = failed ? 1 : 0;
   }
 }

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -267,21 +267,32 @@ export function lintFile(filePath, source) {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const lineNumber = i + 1;
-    // Track multi-line block-comment state. If `inBlockComment` is
-    // true at the start of this line we are inside a `/* ... */`
-    // block; we still process the line but the "leading `*`" comment
-    // shape below will skip it. When the line closes the block with
-    // `*/`, leave the state on after the line so subsequent code on
-    // the same line (rare but legal) is not analysed; the next line
-    // resumes normally.
+    // Track multi-line block-comment state. To avoid false positives
+    // from `/*` or `*/` substrings that appear inside string literals
+    // (e.g. `const s = "/*";` or `console.log("*/")`), only flip the
+    // state on lines that ACTUALLY START with the delimiter (after
+    // leading whitespace). This is a conservative heuristic that may
+    // miss exotic shapes but never wrongly skips real code.
+    const trimmedForBc = line.trimStart();
+    const isBlockClosingLine = inBlockComment && trimmedForBc.startsWith("*/");
     if (inBlockComment) {
-      // If the line closes the block we toggle off; the line itself is
-      // treated as comment for the per-line rules below.
-      if (line.includes("*/")) inBlockComment = false;
-    } else if (line.includes("/*") && !line.includes("*/")) {
+      // Close on a `*/`-led line. The closing line itself is treated
+      // as comment for the per-line rules via the isComment check
+      // below; we keep `inBlockComment` true through this iteration
+      // and flip it off at the end so subsequent iterations resume.
+      if (isBlockClosingLine) inBlockComment = false;
+    } else if (
+      trimmedForBc.startsWith("/*") &&
+      !trimmedForBc.includes("*/")
+    ) {
       // Opens a multi-line block on this line.
       inBlockComment = true;
     }
+    // `inBlockComment` reflects the state AFTER this line; the
+    // current line is comment if it WAS in a block, opened one, or
+    // closes one.
+    const lineIsBlockComment =
+      inBlockComment || isBlockClosingLine || trimmedForBc.startsWith("/*");
     // The fsm-lint:ignore marker is intentionally per-line for the
     // single-line rules (no-direct-fsm-yaml-read and
     // no-orchestrator-llm-call); previous-line suppression is
@@ -305,9 +316,8 @@ export function lintFile(filePath, source) {
     // a block comment) used to be treated as comment text.
     const trimmed = line.trimStart();
     const isComment =
-      inBlockComment ||
+      lineIsBlockComment ||
       trimmed.startsWith("//") ||
-      trimmed.startsWith("/*") ||
       trimmed.startsWith("#!");
     if (isComment) continue;
 

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -193,14 +193,19 @@ export function lintFile(filePath, source) {
     `\\b(?:${readApiAlternation})\\s*\\([^)\\n]*?(['"\`])[^'"\`\\n]*\\.fsm\\.yaml[^'"\`\\n]*\\1`,
   );
 
-  // Pre-compute the set of line numbers that fall inside a multi-line
-  // template literal so the per-line rules can skip them (those bodies
-  // are owned by no-inline-prompt-composition, and the YAML-read /
-  // LLM-call regexes should not fire on prompt-fixture prose).
+  // Pre-compute the set of line numbers that fall STRICTLY INSIDE a
+  // multi-line template literal so the per-line rules can skip them
+  // (those bodies are owned by no-inline-prompt-composition, and the
+  // YAML-read / LLM-call regexes should not fire on prompt-fixture
+  // prose). The start and end lines are intentionally NOT included:
+  // executable code can legitimately share a line with the opening
+  // backtick (`foo(` ... `)`) or follow the closing backtick on the
+  // same line (`` `...`; readFileSync("x.fsm.yaml") ``), and the
+  // per-line rules must still catch violations there.
   const templateLineSet = new Set();
   for (const tmpl of collectTemplateLiterals(source)) {
-    if (tmpl.endLine > tmpl.startLine) {
-      for (let n = tmpl.startLine; n <= tmpl.endLine; n++) {
+    if (tmpl.endLine > tmpl.startLine + 1) {
+      for (let n = tmpl.startLine + 1; n < tmpl.endLine; n++) {
         templateLineSet.add(n);
       }
     }
@@ -424,11 +429,14 @@ export function lintPaths(paths) {
     try {
       source = readFileSync(abs, "utf8");
     } catch (err) {
-      // `existsSync` only checks `stat`; a directory, an unreadable
-      // file (EISDIR / EPERM / etc.) or a broken symlink will still
-      // throw here. Surface it as a structured "unreadable" entry
-      // rather than crashing the CLI with a stack trace; the lint
-      // pass is advisory and should continue scanning siblings.
+      // `existsSync` uses an access check, so a broken symlink is
+      // usually already reported as "file not found" above and
+      // never reaches this catch. What can still throw here is a
+      // path that exists but is unreadable (a directory -> EISDIR,
+      // restrictive permissions -> EPERM/EACCES, or a transient
+      // filesystem error). Surface it as a structured "unreadable"
+      // entry rather than crashing the CLI with a stack trace; the
+      // lint pass is advisory and should continue scanning siblings.
       unreadable.push({ path: rawPath, error: err.code ?? err.message });
       continue;
     }
@@ -471,6 +479,20 @@ if (isDirectInvocation()) {
   // immediately after the last write. process.exit() can truncate a
   // multi-KB diagnostics dump on piped stdio (same failure mode that
   // motivated scripts/lib/emit.mjs in this repo).
+  //
+  // Also swallow EPIPE on both streams: when the linter is piped to a
+  // consumer that closes early (e.g. `fsm-lint-runner ... | head`)
+  // Node would otherwise crash with `Error: write EPIPE`. The
+  // diagnostics are advisory; a downstream reader closing the pipe
+  // mid-stream is a graceful exit, not a failure.
+  process.stdout.on("error", (err) => {
+    if (err.code === "EPIPE") process.exit(0);
+    throw err;
+  });
+  process.stderr.on("error", (err) => {
+    if (err.code === "EPIPE") process.exit(0);
+    throw err;
+  });
   const args = process.argv.slice(2);
   if (args.includes("--help") || args.includes("-h")) {
     process.stdout.write(USAGE);

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -33,18 +33,18 @@
 //     making decisions the FSM should make).
 //
 //   no-orchestrator-llm-call
-//     Pattern: a token-shape scan that fires when the line contains
-//     a known LLM-tool dispatch name followed by an open paren. This
-//     is NOT a call-expression detector: a function declaration
+//     Pattern: a token-shape scan that fires when the line contains a
+//     known LLM-dispatch token. Two token shapes are matched:
+//       - bare property paths like `anthropic.messages` /
+//         `client.messages` (no trailing `(` required), so accessing
+//         the LLM client surface also counts.
+//       - call shapes like `messages.create(`, `Task(`, `Agent(`,
+//         `Skill(`, `Bash(`, `WebFetch(`, `WebSearch(`.
+//     This is NOT a call-expression detector: a function declaration
 //     (`function Task() { ... }`), object method definition
 //     (`{ Task() { ... } }`), or destructure (`{ Task } = ...`)
-//     followed by `Task(` on the same line will also match.
-//     Authors can suppress with `// fsm-lint:ignore` for legitimate
-//     occurrences.
-//       Anthropic SDK / clients: messages.create, completions.create,
-//         anthropic.messages, client.messages.
-//       Harness tool-shaped invocations: Task(, Agent(, Skill(,
-//         Bash(, WebFetch(, WebSearch(.
+//     followed by `Task(` on the same line will also match. Authors
+//     suppress legitimate occurrences with `// fsm-lint:ignore`.
 //     Why: the orchestrator shells out to fsm-next / fsm-commit; the
 //     LLM work happens inside the worker the FSM engine asks the
 //     harness to dispatch.
@@ -241,13 +241,21 @@ export function lintFile(filePath, source) {
 
   const readApiAlternation = READ_APIS.join("|");
   // Require the .fsm.yaml occurrence to be inside a quoted string
-  // literal so block comments or commented-out args (e.g.
-  // `readFileSync(/* ".fsm.yaml" */ x)`) do not fire. The argument
-  // expression up to the `.fsm.yaml` occurrence is matched lazily,
-  // then the suffix must end inside the SAME quote that opened it.
+  // literal: the argument expression up to the `.fsm.yaml` occurrence
+  // is matched lazily, then the suffix must end inside the SAME quote
+  // that opened it. Inline block comments inside the call
+  // (`readFileSync(/* ".fsm.yaml" */ x)`) ARE stripped before the
+  // regex runs (see scrub-inline-block-comments below), so a quoted
+  // `.fsm.yaml` literal that lives only inside a `/* ... */` segment
+  // is not matched.
   const readApiRegex = new RegExp(
     `\\b(?:${readApiAlternation})\\s*\\([^)\\n]*?(['"\`])[^'"\`\\n]*\\.fsm\\.yaml[^'"\`\\n]*\\1`,
   );
+  // Strip inline `/* ... */` segments from a single line for the
+  // per-line regexes. Stops at the first newline (block comments that
+  // span lines are handled by the inBlockComment state machine
+  // below).
+  const stripInlineBlockComments = (s) => s.replace(/\/\*[^\n]*?\*\//g, "");
 
   // Pre-compute the set of line numbers that fall STRICTLY INSIDE a
   // multi-line template literal so the per-line rules can skip them
@@ -340,10 +348,17 @@ export function lintFile(filePath, source) {
     // owns the template-literal case.
     if (templateLineSet.has(lineNumber)) continue;
 
+    // Strip any inline /* ... */ from the current line before the
+    // per-line regexes look at it, so a `.fsm.yaml` string literal
+    // sitting only inside a commented-out arg (`readFileSync(/* "x.fsm.yaml" */ y)`)
+    // is not matched. The inBlockComment state above handles the
+    // multi-line case; this handles a single-line inline block.
+    const codeOnly = stripInlineBlockComments(line);
+
     // Rule: no-direct-fsm-yaml-read. Match a known read API name
     // followed by `(`, with `.fsm.yaml` appearing somewhere on the
     // same line inside a string literal.
-    if (readApiRegex.test(line)) {
+    if (readApiRegex.test(codeOnly)) {
       diagnostics.push({
         file: filePath,
         line: lineNumber,
@@ -355,7 +370,7 @@ export function lintFile(filePath, source) {
 
     // Rule: no-orchestrator-llm-call.
     for (const pattern of LLM_CALL_PATTERNS) {
-      if (pattern.test(line)) {
+      if (pattern.test(codeOnly)) {
         diagnostics.push({
           file: filePath,
           line: lineNumber,

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -71,7 +71,7 @@ import { readFileSync, existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const USAGE = `Usage: fsm-lint-runner [--help] <runner-file> [<runner-file> ...]
+const USAGE = `Usage: fsm-lint-runner [--help|-h] <runner-file> [<runner-file> ...]
 
 Advisory lint for orchestrator-shell skill runners. Reports any of:
   - direct reads of *.fsm.yaml from the runner
@@ -164,8 +164,16 @@ const SCHEMA_MARKERS = [
 // `a /b/g` vs `a / b / g`), but for the purpose of a lint heuristic
 // this set covers the common cases without ever mis-treating a real
 // `//` line comment as inside a regex.
+// `}` is intentionally NOT included: closing braces can legally
+// precede a division operator (e.g. `function f(){ return 1 } / 2 /
+// g`), and including them here would mis-treat the next `/` as
+// opening a regex literal, hiding a real `// fsm-lint:ignore` later
+// on the same line. The trade-off is that a real regex literal that
+// immediately follows a `}` (rare in idiomatic code) is not tracked;
+// that produces at worst a duplicate `//` match downstream, which is
+// less harmful than silent suppression failure.
 const REGEX_PREFIX_OPS = new Set([
-  "", "(", "[", "{", "}", ",", ";", ":", "?", "!", "&", "|", "=",
+  "", "(", "[", "{", ",", ";", ":", "?", "!", "&", "|", "=",
   "+", "-", "*", "/", "^", "~", "%", "<", ">",
 ]);
 
@@ -288,10 +296,12 @@ export function lintFile(filePath, source) {
     const trimmedForBc = line.trimStart();
     const isBlockClosingLine = inBlockComment && trimmedForBc.startsWith("*/");
     if (inBlockComment) {
-      // Close on a `*/`-led line. The closing line itself is treated
-      // as comment for the per-line rules via the isComment check
-      // below; we keep `inBlockComment` true through this iteration
-      // and flip it off at the end so subsequent iterations resume.
+      // Close on a `*/`-led line. We flip `inBlockComment` off
+      // immediately; the closing line is still treated as comment for
+      // the per-line rules via `lineIsBlockComment` below (which
+      // captures `isBlockClosingLine` independently), and trailing
+      // executable code after `*/` on the same line is analysed by
+      // the prefix-stripping path below.
       if (isBlockClosingLine) inBlockComment = false;
     } else if (
       trimmedForBc.startsWith("/*") &&

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -309,9 +309,19 @@ export function lintFile(filePath, source) {
     // must still be analysed by the per-line rules.
     const isSingleLineBlockComment =
       trimmedForBc.startsWith("/*") && trimmedForBc.includes("*/");
+    // The closing line of a multi-line block is treated as comment
+    // ONLY when nothing follows the terminator on the same line. If
+    // there is real code after `*/` (e.g. `*/ readFileSync(...)`),
+    // we still analyse the line; the stripBlockTail step below strips
+    // the leading `text */` prefix before the regexes see it.
+    const closerWithCode =
+      isBlockClosingLine && /\*\/\s*\S/.test(trimmedForBc.slice(trimmedForBc.indexOf("*/")));
     const lineIsBlockComment =
-      (inBlockComment || isBlockClosingLine || trimmedForBc.startsWith("/*")) &&
-      !isSingleLineBlockComment;
+      (
+        inBlockComment ||
+        (isBlockClosingLine && !closerWithCode) ||
+        trimmedForBc.startsWith("/*")
+      ) && !isSingleLineBlockComment;
     // The fsm-lint:ignore marker is intentionally per-line for the
     // single-line rules (no-direct-fsm-yaml-read and
     // no-orchestrator-llm-call); previous-line suppression is
@@ -351,9 +361,15 @@ export function lintFile(filePath, source) {
     // Strip any inline /* ... */ from the current line before the
     // per-line regexes look at it, so a `.fsm.yaml` string literal
     // sitting only inside a commented-out arg (`readFileSync(/* "x.fsm.yaml" */ y)`)
-    // is not matched. The inBlockComment state above handles the
-    // multi-line case; this handles a single-line inline block.
-    const codeOnly = stripInlineBlockComments(line);
+    // is not matched. If this line is the closer of a multi-line
+    // block (and contains real code after `*/`), additionally strip
+    // the leading `text */` prefix so the regexes only see the
+    // executable tail.
+    let scrubbed = line;
+    if (closerWithCode) {
+      scrubbed = scrubbed.slice(scrubbed.indexOf("*/") + 2);
+    }
+    const codeOnly = stripInlineBlockComments(scrubbed);
 
     // Rule: no-direct-fsm-yaml-read. Match a known read API name
     // followed by `(`, with `.fsm.yaml` appearing somewhere on the

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -34,15 +34,13 @@
 //
 //   no-orchestrator-llm-call
 //     Pattern: a call expression whose callee name matches one of
-//     the known LLM-tool dispatch verbs:
+//     the known LLM-tool dispatch verbs. The match is name-only (no
+//     payload inspection); a legitimate invocation suppresses with
+//     `// fsm-lint:ignore`.
 //       Anthropic SDK / clients: messages.create, completions.create,
 //         anthropic.messages, client.messages.
-//       Tool-name shaped invocations: Task(, Agent(, Skill(, WebFetch(,
-//         WebSearch(, Bash( when followed by an LLM-shaped payload.
-//     This is the loosest heuristic; comments in the runner that
-//     explain WHY a Task( call is legitimately at orchestrator level
-//     (e.g. spawning a worker via the harness's Agent tool, which IS
-//     the intended pattern) can suppress with `// fsm-lint:ignore`.
+//       Harness tool-shaped invocations: Task(, Agent(, Skill(,
+//         Bash(, WebFetch(, WebSearch(.
 //     Why: the orchestrator shells out to fsm-next / fsm-commit; the
 //     LLM work happens inside the worker the FSM engine asks the
 //     harness to dispatch.

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -137,7 +137,12 @@ const ROLE_MARKERS = [
 const SCHEMA_MARKERS = [
   /\$schema/,
   /"type"\s*:\s*"object"/,
-  /"required"\s*:\s*\[/,
+  // Match the documented `"required":` marker on its own (object or
+  // array RHS, or even with the RHS missing in a partial fixture).
+  // Previously the regex required `[` immediately after the colon,
+  // contradicting the header comment and producing surprising
+  // false negatives.
+  /"required"\s*:/,
   /response_schema/,
 ];
 

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+// fsm-lint-runner -- advisory lint for orchestrator-shell skill runners.
+//
+// Background. The orchestrator-shell discipline (see
+// docs/orchestrator-discipline.md) says a skill's runner is a SHELL
+// around the @ctxr/fsm CLIs: it should not read the FSM YAML itself,
+// it should not call LLM tools at the orchestrator level, and it
+// should not compose worker prompts inline. The FSM engine reads YAML
+// and validates outputs; workers receive prompts via the staged
+// prompt-template files; the orchestrator only shells out and routes
+// JSON.
+//
+// This linter is ADVISORY. It scans each given runner file with
+// simple line-based heuristics and reports diagnostics in the form:
+//
+//   <file>:<line>: <rule>: <suggestion>
+//
+// Exit 0 if every file is clean; exit 1 if any diagnostic was
+// emitted. The linter never modifies files. False positives can be
+// suppressed by appending `// fsm-lint:ignore` on the offending line
+// (or the line immediately before, for multi-line constructs).
+//
+// Heuristics:
+//
+//   no-direct-fsm-yaml-read
+//     Pattern: any node:fs read API whose argument string contains
+//     `.fsm.yaml`. Examples:
+//       readFileSync("path/to/foo.fsm.yaml")
+//       readFile("./bar.fsm.yaml", "utf8")
+//       createReadStream("baz.fsm.yaml")
+//     Why: the engine owns YAML parsing. A runner that reads the
+//     YAML is duplicating logic the engine already does (and likely
+//     making decisions the FSM should make).
+//
+//   no-orchestrator-llm-call
+//     Pattern: a call expression whose callee name matches one of
+//     the known LLM-tool dispatch verbs:
+//       Anthropic SDK / clients: messages.create, completions.create,
+//         anthropic.messages, client.messages.
+//       Tool-name shaped invocations: Task(, Agent(, Skill(, WebFetch(,
+//         WebSearch(, Bash( when followed by an LLM-shaped payload.
+//     This is the loosest heuristic; comments in the runner that
+//     explain WHY a Task( call is legitimately at orchestrator level
+//     (e.g. spawning a worker via the harness's Agent tool, which IS
+//     the intended pattern) can suppress with `// fsm-lint:ignore`.
+//     Why: the orchestrator shells out to fsm-next / fsm-commit; the
+//     LLM work happens inside the worker the FSM engine asks the
+//     harness to dispatch.
+//
+//   no-inline-prompt-composition
+//     Pattern: a multi-line template literal (backtick string spanning
+//     2+ lines in the source) that contains BOTH of:
+//       (a) a role/header marker -- one of "You are", "Role:",
+//           "## Role", "## Brief", "Specialist:", "Output Contract".
+//       (b) a JSON-schema-like marker -- one of "$schema",
+//           '"type": "object"', '"required":', 'response_schema'.
+//     Why: prompts should live in fsm/prompt-templates/*.md and be
+//     composed via @ctxr/fsm/prompt-fragments. Inline composition
+//     puts the contract in the runner where it cannot be reviewed
+//     or reused.
+//
+// Limitations (honest list, repeated in docs/orchestrator-discipline.md):
+//   - The LLM-call heuristic is name-based; a renamed import will
+//     evade it. The inline-prompt heuristic uses string markers; a
+//     prompt that omits all markers will evade it. Authors who want
+//     to suppress a known-false positive use `// fsm-lint:ignore`.
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const USAGE = `Usage: fsm-lint-runner [--help] <runner-file> [<runner-file> ...]
+
+Advisory lint for orchestrator-shell skill runners. Reports any of:
+  - direct reads of *.fsm.yaml from the runner
+  - LLM-tool calls at the orchestrator level
+  - inline multi-line prompt composition (role + schema markers)
+
+Diagnostics print to stdout as:
+  <file>:<line>: <rule>: <suggestion>
+
+Exit 0 when every file is clean; exit 1 when any diagnostic was emitted.
+Suppress a known false positive by appending '// fsm-lint:ignore' to the
+offending line (or the line immediately before, for multi-line
+constructs).
+`;
+
+// Public entry points are exported so the test suite can drive the
+// linter without spawning a subprocess for every assertion.
+
+export const RULES = {
+  NO_DIRECT_FSM_YAML_READ: "no-direct-fsm-yaml-read",
+  NO_ORCHESTRATOR_LLM_CALL: "no-orchestrator-llm-call",
+  NO_INLINE_PROMPT_COMPOSITION: "no-inline-prompt-composition",
+};
+
+const IGNORE_MARKER = "fsm-lint:ignore";
+
+// Read-API names whose first string argument may legitimately be a
+// path. We match the function name; the regex below ensures the
+// argument string contains ".fsm.yaml".
+const READ_APIS = [
+  "readFileSync",
+  "readFile",
+  "createReadStream",
+  "open",
+  "openSync",
+];
+
+// LLM-tool dispatch verbs / call shapes. The first group covers
+// Anthropic SDK shapes; the second covers Claude Code harness tools
+// commonly invoked from JS (rare but possible).
+const LLM_CALL_PATTERNS = [
+  /\bmessages\s*\.\s*create\s*\(/,
+  /\bcompletions\s*\.\s*create\s*\(/,
+  /\banthropic\s*\.\s*messages\b/,
+  /\bclient\s*\.\s*messages\b/,
+  /\bTask\s*\(/,
+  /\bAgent\s*\(/,
+  /\bWebFetch\s*\(/,
+  /\bWebSearch\s*\(/,
+];
+
+// Role / contract markers for the inline-prompt heuristic.
+const ROLE_MARKERS = [
+  /You are\b/i,
+  /\bRole:\s/,
+  /^##\s+Role\b/m,
+  /^##\s+Brief\b/m,
+  /\bSpecialist:\s/,
+  /Output Contract/i,
+];
+
+// Schema markers for the inline-prompt heuristic.
+const SCHEMA_MARKERS = [
+  /\$schema/,
+  /"type"\s*:\s*"object"/,
+  /"required"\s*:\s*\[/,
+  /response_schema/,
+];
+
+export function lintFile(filePath, source) {
+  const diagnostics = [];
+  const lines = source.split(/\r?\n/);
+
+  const readApiAlternation = READ_APIS.join("|");
+  const readApiRegex = new RegExp(
+    `\\b(?:${readApiAlternation})\\s*\\([^)\\n]*\\.fsm\\.yaml`,
+  );
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNumber = i + 1;
+    const previous = i > 0 ? lines[i - 1] : "";
+    if (line.includes(IGNORE_MARKER) || previous.includes(IGNORE_MARKER)) {
+      continue;
+    }
+
+    // Skip lines that are clearly source comments -- both the read-API
+    // and the LLM-call rules are about real code, not prose in the
+    // header banner. We detect a comment by the first non-space chars
+    // being `//`, `*`, or `#` (shebangs / shell). Block-comment middle
+    // lines start with ` *` which is also covered.
+    const trimmed = line.trimStart();
+    const isComment =
+      trimmed.startsWith("//") ||
+      trimmed.startsWith("*") ||
+      trimmed.startsWith("#");
+    if (isComment) continue;
+
+    // Rule: no-direct-fsm-yaml-read. Match a known read API name
+    // followed by `(`, with `.fsm.yaml` appearing somewhere on the
+    // same line inside a string literal.
+    if (readApiRegex.test(line)) {
+      diagnostics.push({
+        file: filePath,
+        line: lineNumber,
+        rule: RULES.NO_DIRECT_FSM_YAML_READ,
+        message:
+          "runner reads *.fsm.yaml directly; let the FSM engine parse the YAML via fsm-next / fsm-commit",
+      });
+    }
+
+    // Rule: no-orchestrator-llm-call.
+    for (const pattern of LLM_CALL_PATTERNS) {
+      if (pattern.test(line)) {
+        diagnostics.push({
+          file: filePath,
+          line: lineNumber,
+          rule: RULES.NO_ORCHESTRATOR_LLM_CALL,
+          message:
+            "runner appears to call an LLM tool directly; dispatch workers via the FSM engine's worker contract instead",
+        });
+        break;
+      }
+    }
+  }
+
+  // Rule: no-inline-prompt-composition. Scan for template literals
+  // (backtick strings) spanning two or more source lines and check
+  // whether the captured body contains both a role marker and a
+  // schema marker. We walk the source character-by-character so
+  // multi-line literals are reconstructed reliably.
+  const templates = collectTemplateLiterals(source);
+  for (const tmpl of templates) {
+    const span = tmpl.endLine - tmpl.startLine;
+    if (span < 1) continue; // single-line literal: not "inline composition"
+    const hasRole = ROLE_MARKERS.some((re) => re.test(tmpl.body));
+    const hasSchema = SCHEMA_MARKERS.some((re) => re.test(tmpl.body));
+    if (!(hasRole && hasSchema)) continue;
+    // Check ignore marker on the literal's first line or the line
+    // immediately before it.
+    const startLine = tmpl.startLine;
+    const startIdx = startLine - 1;
+    const prevIdx = startIdx - 1;
+    const startLineText = lines[startIdx] ?? "";
+    const prevLineText = prevIdx >= 0 ? lines[prevIdx] : "";
+    if (
+      startLineText.includes(IGNORE_MARKER) ||
+      prevLineText.includes(IGNORE_MARKER)
+    ) {
+      continue;
+    }
+    diagnostics.push({
+      file: filePath,
+      line: startLine,
+      rule: RULES.NO_INLINE_PROMPT_COMPOSITION,
+      message:
+        "inline multi-line prompt with role + schema markers; move to fsm/prompt-templates/*.md and compose via @ctxr/fsm/prompt-fragments",
+    });
+  }
+
+  return diagnostics;
+}
+
+// Walk the source and capture every backtick template literal as
+// { startLine, endLine, body }. Skips template literals that appear
+// inside comments. This is intentionally simple: it does not parse
+// nested `${ ... }` expressions, which is fine for the role+schema
+// heuristic (the markers we look for are not inside expression
+// blocks in practice).
+function collectTemplateLiterals(source) {
+  const out = [];
+  let i = 0;
+  let line = 1;
+  const len = source.length;
+
+  while (i < len) {
+    const ch = source[i];
+
+    // Skip line comments.
+    if (ch === "/" && source[i + 1] === "/") {
+      while (i < len && source[i] !== "\n") i++;
+      continue;
+    }
+    // Skip block comments.
+    if (ch === "/" && source[i + 1] === "*") {
+      i += 2;
+      while (i < len && !(source[i] === "*" && source[i + 1] === "/")) {
+        if (source[i] === "\n") line++;
+        i++;
+      }
+      i += 2; // skip closing */
+      continue;
+    }
+    // Skip single-quoted strings.
+    if (ch === "'") {
+      i++;
+      while (i < len && source[i] !== "'") {
+        if (source[i] === "\\") i++;
+        if (source[i] === "\n") line++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    // Skip double-quoted strings.
+    if (ch === '"') {
+      i++;
+      while (i < len && source[i] !== '"') {
+        if (source[i] === "\\") i++;
+        if (source[i] === "\n") line++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    // Capture a template literal.
+    if (ch === "`") {
+      const startLine = line;
+      const bodyStart = i + 1;
+      i++;
+      while (i < len && source[i] !== "`") {
+        if (source[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (source[i] === "\n") line++;
+        i++;
+      }
+      const endLine = line;
+      const body = source.slice(bodyStart, i);
+      i++; // skip closing backtick
+      out.push({ startLine, endLine, body });
+      continue;
+    }
+    if (ch === "\n") line++;
+    i++;
+  }
+
+  return out;
+}
+
+export function formatDiagnostic(d) {
+  return `${d.file}:${d.line}: ${d.rule}: ${d.message}`;
+}
+
+export function lintPaths(paths) {
+  const allDiagnostics = [];
+  const missing = [];
+  for (const rawPath of paths) {
+    const abs = resolve(process.cwd(), rawPath);
+    if (!existsSync(abs)) {
+      missing.push(rawPath);
+      continue;
+    }
+    const source = readFileSync(abs, "utf8");
+    const diags = lintFile(rawPath, source);
+    allDiagnostics.push(...diags);
+  }
+  return { diagnostics: allDiagnostics, missing };
+}
+
+function isDirectInvocation() {
+  // True when this module is the program's entry point.
+  if (!process.argv[1]) return false;
+  try {
+    const entry = resolve(process.argv[1]);
+    const self = new URL(import.meta.url).pathname;
+    return entry === self;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectInvocation()) {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+  if (args.length === 0) {
+    process.stderr.write(
+      "fsm-lint-runner: at least one runner file path is required\n",
+    );
+    process.stderr.write(USAGE);
+    process.exit(2);
+  }
+
+  const { diagnostics, missing } = lintPaths(args);
+
+  for (const m of missing) {
+    process.stderr.write(`fsm-lint-runner: file not found: ${m}\n`);
+  }
+
+  for (const d of diagnostics) {
+    process.stdout.write(`${formatDiagnostic(d)}\n`);
+  }
+
+  const failed = diagnostics.length > 0 || missing.length > 0;
+  process.exit(failed ? 1 : 0);
+}

--- a/scripts/fsm-lint-runner.mjs
+++ b/scripts/fsm-lint-runner.mjs
@@ -148,15 +148,26 @@ export function lintFile(filePath, source) {
   const lines = source.split(/\r?\n/);
 
   const readApiAlternation = READ_APIS.join("|");
+  // Require the .fsm.yaml occurrence to be inside a quoted string
+  // literal so block comments or commented-out args (e.g.
+  // `readFileSync(/* ".fsm.yaml" */ x)`) do not fire. The argument
+  // expression up to the `.fsm.yaml` occurrence is matched lazily,
+  // then the suffix must end inside the SAME quote that opened it.
   const readApiRegex = new RegExp(
-    `\\b(?:${readApiAlternation})\\s*\\([^)\\n]*\\.fsm\\.yaml`,
+    `\\b(?:${readApiAlternation})\\s*\\([^)\\n]*?(['"\`])[^'"\`\\n]*\\.fsm\\.yaml[^'"\`\\n]*\\1`,
   );
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const lineNumber = i + 1;
-    const previous = i > 0 ? lines[i - 1] : "";
-    if (line.includes(IGNORE_MARKER) || previous.includes(IGNORE_MARKER)) {
+    // The fsm-lint:ignore marker is intentionally per-line for the
+    // single-line rules (no-direct-fsm-yaml-read and
+    // no-orchestrator-llm-call); previous-line suppression is
+    // reserved for the multi-line template-literal rule, where the
+    // marker can legitimately precede the literal it suppresses.
+    // Applying previous-line suppression to per-line rules silently
+    // hid the diagnostic immediately after any other ignored line.
+    if (line.includes(IGNORE_MARKER)) {
       continue;
     }
 

--- a/tests/unit/fsm-lint-runner.test.js
+++ b/tests/unit/fsm-lint-runner.test.js
@@ -99,7 +99,7 @@ test("clean runner produces no diagnostics and exits 0", () => {
   }
 });
 
-test("readFileSync(\".fsm.yaml\") fires no-direct-fsm-yaml-read and exits 1", () => {
+test("readFileSync of a *.fsm.yaml path fires no-direct-fsm-yaml-read and exits 1", () => {
   const dir = tmpDir();
   try {
     write(dir, "bad-yaml-read.mjs", DIRECT_YAML_READ_RUNNER);

--- a/tests/unit/fsm-lint-runner.test.js
+++ b/tests/unit/fsm-lint-runner.test.js
@@ -139,7 +139,7 @@ test("Anthropic SDK call fires no-orchestrator-llm-call and exits 1", () => {
   }
 });
 
-test("harness Agent( dispatch fires no-orchestrator-llm-call and exits 1", () => {
+test("harness Agent() dispatch fires no-orchestrator-llm-call and exits 1", () => {
   const dir = tmpDir();
   try {
     const RUNNER = [

--- a/tests/unit/fsm-lint-runner.test.js
+++ b/tests/unit/fsm-lint-runner.test.js
@@ -1,0 +1,169 @@
+// fsm-lint-runner.test.js -- exercises the orchestrator-shell-only lint
+// helper. Each test writes a fixture runner into a tmp directory, runs
+// the linter against it via spawnSync, and asserts on (a) exit code,
+// (b) stdout diagnostic shape, and (c) which rule fired.
+//
+// Covers: clean runner (exit 0), readFileSync(".fsm.yaml") trigger
+// (exit 1), inline multi-line prompt literal trigger (exit 1), and the
+// --help short-circuit (exit 0 + usage on stdout).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+  "fsm-lint-runner.mjs",
+);
+
+function runCli(args, opts = {}) {
+  return spawnSync("node", [CLI, ...args], {
+    encoding: "utf8",
+    cwd: opts.cwd,
+  });
+}
+
+function tmpDir() {
+  return mkdtempSync(join(tmpdir(), "fsm-lint-"));
+}
+
+function write(dir, name, contents) {
+  const path = join(dir, name);
+  writeFileSync(path, contents);
+  return path;
+}
+
+const CLEAN_RUNNER = `#!/usr/bin/env node
+// Clean orchestrator-shell runner: only shells out to the FSM CLIs.
+
+import { spawnSync } from "node:child_process";
+
+const next = spawnSync("fsm-next", ["--run-id", process.argv[2]], {
+  encoding: "utf8",
+});
+const brief = JSON.parse(next.stdout);
+console.log(JSON.stringify({ brief }));
+`;
+
+const DIRECT_YAML_READ_RUNNER = `#!/usr/bin/env node
+// Bad: reads the FSM YAML directly.
+
+import { readFileSync } from "node:fs";
+
+const raw = readFileSync("./fsm/explorer.fsm.yaml", "utf8");
+console.log(raw.length);
+`;
+
+// A multi-line template literal with BOTH a role marker ("You are")
+// and a schema marker ("$schema") -- the two conditions that trip
+// no-inline-prompt-composition.
+const INLINE_PROMPT_RUNNER = [
+  "#!/usr/bin/env node",
+  "// Bad: composes a worker prompt inline with role + schema markers.",
+  "",
+  "const prompt = `",
+  "You are a codebase-explorer worker.",
+  "",
+  "Output Contract:",
+  "  $schema: http://json-schema.org/draft-07/schema#",
+  '  "type": "object"',
+  '  "required": ["findings"]',
+  "`;",
+  "console.log(prompt.length);",
+  "",
+].join("\n");
+
+test("--help prints usage to stdout and exits 0", () => {
+  const r = runCli(["--help"]);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.match(r.stdout, /Usage: fsm-lint-runner/);
+  assert.equal(r.stderr, "");
+});
+
+test("clean runner produces no diagnostics and exits 0", () => {
+  const dir = tmpDir();
+  try {
+    write(dir, "clean-runner.mjs", CLEAN_RUNNER);
+    const r = runCli(["clean-runner.mjs"], { cwd: dir });
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.equal(r.stdout, "");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readFileSync(\".fsm.yaml\") fires no-direct-fsm-yaml-read and exits 1", () => {
+  const dir = tmpDir();
+  try {
+    write(dir, "bad-yaml-read.mjs", DIRECT_YAML_READ_RUNNER);
+    const r = runCli(["bad-yaml-read.mjs"], { cwd: dir });
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    // Diagnostic format: <file>:<line>: <rule>: <message>
+    assert.match(
+      r.stdout,
+      /bad-yaml-read\.mjs:\d+: no-direct-fsm-yaml-read: /,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("inline multi-line prompt with role+schema markers fires no-inline-prompt-composition and exits 1", () => {
+  const dir = tmpDir();
+  try {
+    write(dir, "bad-inline-prompt.mjs", INLINE_PROMPT_RUNNER);
+    const r = runCli(["bad-inline-prompt.mjs"], { cwd: dir });
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /bad-inline-prompt\.mjs:\d+: no-inline-prompt-composition: /,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("missing file is reported on stderr and exits 1", () => {
+  const dir = tmpDir();
+  try {
+    const r = runCli(["does-not-exist.mjs"], { cwd: dir });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /file not found: does-not-exist\.mjs/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("no arguments and no --help exits 2 with usage on stderr", () => {
+  const r = runCli([]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /at least one runner file path is required/);
+  assert.match(r.stderr, /Usage: fsm-lint-runner/);
+});
+
+test("fsm-lint:ignore on the offending line suppresses the diagnostic", () => {
+  const dir = tmpDir();
+  try {
+    const SUPPRESSED = [
+      "#!/usr/bin/env node",
+      "import { readFileSync } from \"node:fs\";",
+      "// Legit reason: test fixture. // fsm-lint:ignore",
+      "const raw = readFileSync(\"./fsm/explorer.fsm.yaml\", \"utf8\"); // fsm-lint:ignore",
+      "console.log(raw.length);",
+      "",
+    ].join("\n");
+    write(dir, "suppressed.mjs", SUPPRESSED);
+    const r = runCli(["suppressed.mjs"], { cwd: dir });
+    assert.equal(r.status, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.equal(r.stdout, "");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/fsm-lint-runner.test.js
+++ b/tests/unit/fsm-lint-runner.test.js
@@ -115,6 +115,52 @@ test("readFileSync(\".fsm.yaml\") fires no-direct-fsm-yaml-read and exits 1", ()
   }
 });
 
+test("Anthropic SDK call fires no-orchestrator-llm-call and exits 1", () => {
+  const dir = tmpDir();
+  try {
+    const RUNNER = [
+      "#!/usr/bin/env node",
+      "// Bad: makes a direct LLM call instead of dispatching a worker.",
+      "import Anthropic from \"@anthropic-ai/sdk\";",
+      "const client = new Anthropic();",
+      "const r = await client.messages.create({ model: \"x\", messages: [] });",
+      "console.log(r.content);",
+      "",
+    ].join("\n");
+    write(dir, "bad-llm-call.mjs", RUNNER);
+    const r = runCli(["bad-llm-call.mjs"], { cwd: dir });
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /bad-llm-call\.mjs:\d+: no-orchestrator-llm-call: /,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("harness Agent( dispatch fires no-orchestrator-llm-call and exits 1", () => {
+  const dir = tmpDir();
+  try {
+    const RUNNER = [
+      "#!/usr/bin/env node",
+      "// Bad: invokes harness Agent dispatch at orchestrator level.",
+      "const out = Agent({ description: \"x\", prompt: \"y\" });",
+      "console.log(out);",
+      "",
+    ].join("\n");
+    write(dir, "bad-agent-call.mjs", RUNNER);
+    const r = runCli(["bad-agent-call.mjs"], { cwd: dir });
+    assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /bad-agent-call\.mjs:\d+: no-orchestrator-llm-call: /,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("inline multi-line prompt with role+schema markers fires no-inline-prompt-composition and exits 1", () => {
   const dir = tmpDir();
   try {


### PR DESCRIPTION
Adds `scripts/fsm-lint-runner.mjs` (advisory CLI), `docs/orchestrator-discipline.md`, and tests covering clean fixtures, direct `.fsm.yaml` reads, inline prompt composition, `--help`, and the `// fsm-lint:ignore` suppression marker. Per plan A8. +7 tests, all green. `package.json` bin `fsm-lint-runner`.