### PR TITLE
feat(cli): fsm-resume CLI for resume/replay (A4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "fsm-inspect": "scripts/fsm-inspect.mjs",
         "fsm-lint-runner": "scripts/fsm-lint-runner.mjs",
         "fsm-next": "scripts/fsm-next.mjs",
+        "fsm-resume": "scripts/fsm-resume.mjs",
         "fsm-validate-static": "scripts/fsm-validate-static.mjs"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "fsm-commit": "scripts/fsm-commit.mjs",
     "fsm-inspect": "scripts/fsm-inspect.mjs",
     "fsm-validate-static": "scripts/fsm-validate-static.mjs",
-    "fsm-lint-runner": "scripts/fsm-lint-runner.mjs"
+    "fsm-lint-runner": "scripts/fsm-lint-runner.mjs",
+    "fsm-resume": "scripts/fsm-resume.mjs"
   },
   "files": [
     "scripts/",

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -243,6 +243,11 @@ updateManifest(
     resume_history: [...priorHistory, annotation],
     transitions_count: retainedExitCount,
     ended_at: null,
+    // Clear any pause metadata so the manifest does not advertise a
+    // stale paused_at/pause_reason on what is now an in_progress run.
+    // These fields only have meaning while status === "paused".
+    paused_at: null,
+    pause_reason: null,
   },
   { storageRoot: settings.storageRoot },
 );
@@ -268,12 +273,19 @@ const brief = buildBrief({
 // the manifest. The manifest is the source of truth; this is convenience.
 function writeResumeSidecar() {
   const sidecarPath = join(runDir, "fsm-trace", `RESUMED-from-${parsed.fromState}-at-${timestamp.replace(/[:.]/g, "-")}.yaml`);
+  // The CLI session_id (and, defensively, every other scalar emitted
+  // here) is user-supplied and may contain ":", newlines, or quotes;
+  // emitting it as an unquoted plain scalar could either produce
+  // malformed YAML or, worse, inject extra fields into the sidecar.
+  // Wrap each scalar in a single-quoted YAML string and double up any
+  // embedded single quote per the YAML 1.2 single-quoted-style spec.
+  const quote = (v) => `'${String(v).replace(/'/g, "''")}'`;
   const payload = [
     `# Resume annotation (mirror of manifest.resume_history[-1])`,
-    `from_state: ${parsed.fromState}`,
-    `timestamp: ${timestamp}`,
-    `pruned_traces_count: ${pruneResult.removed}`,
-    `session_id: ${settings.sessionId}`,
+    `from_state: ${quote(parsed.fromState)}`,
+    `timestamp: ${quote(timestamp)}`,
+    `pruned_traces_count: ${Number.isInteger(pruneResult.removed) ? pruneResult.removed : 0}`,
+    `session_id: ${quote(settings.sessionId)}`,
     "",
   ].join("\n");
   const fd = openSync(sidecarPath, "w", 0o644);

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -181,18 +181,42 @@ const entryRecord = entriesForState.reduce((best, r) => {
 }, entriesForState[0]);
 const entrySequence = entryRecord.data.sequence;
 
-// Release any prior lock regardless of holder, since resume is an explicit
-// operator action. The lock file path lives under the run dir; release
-// via session match first, then force-delete if a stale or alien lock
-// remains. This guarantees we acquire a fresh lock cleanly.
+// Lock takeover policy. fsm-commit only checks the lock at startup,
+// so if we force-stole the lock from an active in_progress writer it
+// would keep writing traces and the manifest after we've pruned and
+// reset the run, leaving state corrupted. Therefore:
+//
+//  1. If the existing lock is stale (TTL expired), forcibly remove it
+//     and acquire a fresh one.
+//  2. Otherwise, only take over when the manifest's status is paused
+//     or faulted (those statuses have no active writer by definition,
+//     and the lock file is leftover metadata).
+//  3. For an active in_progress run with a live lock, refuse: the
+//     operator must wait for the writer to release or escalate via
+//     pause / fault before retrying resume.
 const runDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
 const lockPath = join(runDir, "lock.json");
 if (existsSync(lockPath)) {
-  // Best-effort owner release: if the existing lock belongs to the
-  // calling session, take the friendly path. Otherwise, force-unlink.
   const existing = readLock(parsed.runId, { storageRoot: settings.storageRoot });
   if (existing) {
-    rmSync(lockPath, { force: true });
+    const now = Date.now();
+    const expiresAt = Date.parse(existing.expires_at ?? "");
+    const isStale = Number.isFinite(expiresAt) && expiresAt < now;
+    const isPassiveStatus =
+      manifest.status === "paused" || manifest.status === "faulted";
+    if (isStale || isPassiveStatus) {
+      rmSync(lockPath, { force: true });
+    } else {
+      emit({
+        error: "run_locked",
+        run_id: parsed.runId,
+        run_status: manifest.status,
+        lock: existing,
+        hint:
+          "resume refuses to take a non-stale lock from an in_progress run; pause the run or wait for the writer to release before retrying.",
+      });
+      process.exit(1);
+    }
   }
 }
 

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -101,6 +101,23 @@ if (!manifest) {
   process.exit(1);
 }
 
+// Resume is for runs that can legitimately be rewound: an `in_progress`
+// run the operator wants to pivot, a `paused` run waiting to be picked
+// back up, or a `faulted` run the operator wants to retry past the
+// fault. Refuse the other lifecycle states (`completed`, `abandoned`,
+// `superseded`, `stale`, anything else): rewinding them would silently
+// re-open a terminal record and lose the durable verdict.
+const RESUMABLE_STATUSES = new Set(["in_progress", "paused", "faulted"]);
+if (!RESUMABLE_STATUSES.has(manifest.status)) {
+  emit({
+    error: "run_not_resumable",
+    run_id: parsed.runId,
+    status: manifest.status,
+    resumable_statuses: [...RESUMABLE_STATUSES],
+  });
+  process.exit(1);
+}
+
 if (manifest.fsm_yaml_hash !== fsm.hash) {
   emit({
     error: "fsm_yaml_changed",
@@ -152,7 +169,16 @@ if (entriesForState.length === 0) {
   });
   process.exit(1);
 }
-const entryRecord = entriesForState[entriesForState.length - 1];
+// readTrace returns records sorted by filename TEXT, so once trace
+// sequences reach five digits (`10000-...`) `0009999-...` would sort
+// after `00010000-...` and the array's last element is no longer the
+// most recent entry. Pick the highest numeric sequence explicitly so
+// resume always prunes back to the latest entry trace for the state.
+const entryRecord = entriesForState.reduce((best, r) => {
+  const seq = Number.isFinite(r.data?.sequence) ? r.data.sequence : -Infinity;
+  const bestSeq = Number.isFinite(best.data?.sequence) ? best.data.sequence : -Infinity;
+  return seq > bestSeq ? r : best;
+}, entriesForState[0]);
 const entrySequence = entryRecord.data.sequence;
 
 // Release any prior lock regardless of holder, since resume is an explicit

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -198,6 +198,16 @@ const annotation = {
 const priorHistory = Array.isArray(manifest.resume_history)
   ? manifest.resume_history
   : [];
+
+// Recompute transitions_count from the retained trace. Each completed
+// state transition leaves an exit trace, so the post-prune exit-trace
+// count is the authoritative new transitions_count. Without this, the
+// manifest carries the pre-resume count which includes transitions
+// whose exit traces have just been removed.
+const retainedExitCount = readTrace(parsed.runId, {
+  storageRoot: settings.storageRoot,
+}).filter((r) => r.data?.phase === "exit").length;
+
 updateManifest(
   parsed.runId,
   {
@@ -205,6 +215,7 @@ updateManifest(
     current_state: parsed.fromState,
     next_state: null,
     resume_history: [...priorHistory, annotation],
+    transitions_count: retainedExitCount,
     ended_at: null,
   },
   { storageRoot: settings.storageRoot },

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -197,20 +197,50 @@ const entrySequence = entryRecord.data.sequence;
 const runDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
 const lockPath = join(runDir, "lock.json");
 if (existsSync(lockPath)) {
+  // Re-read manifest AND lock at takeover time so two concurrent
+  // resumers cannot both see a stale "paused / faulted" snapshot and
+  // each unlink the other's freshly-acquired lock. The combination
+  // protects against:
+  //  - manifest status flipped to in_progress between the initial
+  //    read at the top of this script and now;
+  //  - another resumer just acquired a fresh lock for itself (we'd
+  //    see a different session_id / expires_at and must refuse).
+  const freshManifest = readManifest(parsed.runId, { storageRoot: settings.storageRoot });
   const existing = readLock(parsed.runId, { storageRoot: settings.storageRoot });
   if (existing) {
     const now = Date.now();
     const expiresAt = Date.parse(existing.expires_at ?? "");
     const isStale = Number.isFinite(expiresAt) && expiresAt < now;
-    const isPassiveStatus =
-      manifest.status === "paused" || manifest.status === "faulted";
+    const fmStatus = freshManifest?.status ?? manifest.status;
+    const isPassiveStatus = fmStatus === "paused" || fmStatus === "faulted";
     if (isStale || isPassiveStatus) {
-      rmSync(lockPath, { force: true });
+      // Compare-and-swap: unlink ONLY if the lock on disk RIGHT NOW
+      // is the same lock we just inspected. If another resumer has
+      // already replaced it with their own fresh lock, the
+      // re-read here will differ and we refuse to clobber.
+      const afterRead = readLock(parsed.runId, { storageRoot: settings.storageRoot });
+      const sameLock =
+        afterRead &&
+        afterRead.session_id === existing.session_id &&
+        afterRead.expires_at === existing.expires_at;
+      if (sameLock) {
+        rmSync(lockPath, { force: true });
+      } else {
+        emit({
+          error: "run_locked",
+          run_id: parsed.runId,
+          run_status: fmStatus,
+          lock: afterRead ?? existing,
+          hint:
+            "another resume / writer raced ahead and replaced the lock; re-read state and retry if appropriate.",
+        });
+        process.exit(1);
+      }
     } else {
       emit({
         error: "run_locked",
         run_id: parsed.runId,
-        run_status: manifest.status,
+        run_status: fmStatus,
         lock: existing,
         hint:
           "resume refuses to take a non-stale lock from an in_progress run; pause the run or wait for the writer to release before retrying.",

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// fsm-resume: rewind a run back to a prior-entered state and re-emit
+// that state's brief. Used to recover from a fault or to replay from a
+// known-good checkpoint without manual trace surgery.
+//
+// Usage:
+//   --run-id <id>           required; the run to resume.
+//   --from-state <state-id> required; must have been entered earlier in
+//                           this run (i.e. has an entry trace).
+//   [--session-id S]        defaults to a PID-based identifier, matching
+//                           fsm-next / fsm-commit.
+//   [--fsm-path P]          overrides .fsmrc.json.
+//   [--storage-root D]      overrides .fsmrc.json.
+//
+// Behavior:
+//   1. Validate the run exists (read manifest).
+//   2. Validate <state-id> appears as a prior entry trace in this run;
+//      refuse with a structured error if not.
+//   3. Prune trace files past the resume target's entry trace.
+//   4. Release any prior lock; acquire a fresh lock for --session-id.
+//   5. Reset manifest current_state to <state-id> (status: in_progress).
+//   6. Append a structured annotation to manifest.resume_history[].
+//   7. Emit the brief for the resumed state on stdout.
+//
+// Output: JSON brief on stdout. Exit 0 on success; non-zero on lock
+// conflict, run-not-found, fsm_yaml_changed, unknown_state, or
+// state_not_entered_in_run.
+
+import { writeFileSync, openSync, closeSync, fsyncSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { emitJson } from "./lib/emit.mjs";
+import {
+  acquireLock,
+  pruneTraceAfter,
+  readLock,
+  readManifest,
+  readTrace,
+  runDirPath,
+} from "./lib/fsm-storage.mjs";
+import {
+  buildBrief,
+  loadFsm,
+  runEnv,
+  stateById,
+  updateManifest,
+} from "./lib/fsm-engine.mjs";
+import { resolveSettings } from "./lib/fsm-config.mjs";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--run-id") args.runId = argv[++i];
+    else if (arg === "--from-state") args.fromState = argv[++i];
+    else if (arg === "--session-id") args.sessionId = argv[++i];
+    else if (arg === "--fsm" || arg === "--fsm-name") args.fsmName = argv[++i];
+    else if (arg === "--fsm-path") args.fsmPath = argv[++i];
+    else if (arg === "--storage-root") args.storageRoot = argv[++i];
+    else throw new Error(`fsm-resume: unknown argument "${arg}"`);
+  }
+  if (!args.runId) throw new Error("--run-id is required");
+  if (!args.fromState) throw new Error("--from-state is required");
+  return args;
+}
+
+// Delegates to ./lib/emit.mjs which loops fs.writeSync until the full
+// payload is written (single writeSync may partial-write) and swallows
+// EPIPE when the reader closes early. Issue #12.
+const emit = emitJson;
+
+function fail(error, code = 1) {
+  process.stderr.write(`fsm-resume: ${error}\n`);
+  process.exit(code);
+}
+
+let parsed;
+try {
+  parsed = parseArgs(process.argv.slice(2));
+} catch (err) {
+  fail(err.message, 2);
+}
+
+let settings;
+try {
+  settings = resolveSettings(parsed);
+} catch (err) {
+  fail(err.message, 2);
+}
+
+let fsm;
+try {
+  fsm = loadFsm({ fsmPath: settings.fsmPath });
+} catch (err) {
+  fail(err.message, 1);
+}
+
+const manifest = readManifest(parsed.runId, { storageRoot: settings.storageRoot });
+if (!manifest) {
+  emit({ error: "run_not_found", run_id: parsed.runId });
+  process.exit(1);
+}
+
+if (manifest.fsm_yaml_hash !== fsm.hash) {
+  emit({
+    error: "fsm_yaml_changed",
+    run_id: parsed.runId,
+    run_hash: manifest.fsm_yaml_hash,
+    current_hash: fsm.hash,
+    current_state: manifest.current_state,
+  });
+  process.exit(1);
+}
+
+// Validate the target state exists in the FSM definition. A typo here
+// is a different failure mode from "state existed in the FSM but the run
+// never entered it" (the second is state_not_entered_in_run; this one
+// is unknown_state).
+let targetState;
+try {
+  targetState = stateById(fsm.doc, parsed.fromState);
+} catch (err) {
+  emit({
+    error: "unknown_state",
+    run_id: parsed.runId,
+    from_state: parsed.fromState,
+    detail: err.message,
+  });
+  process.exit(1);
+}
+
+// Locate the most recent entry trace for the target state. If no entry
+// trace exists for that state, the run never entered it: refuse.
+const trace = readTrace(parsed.runId, { storageRoot: settings.storageRoot });
+const entriesForState = trace.filter(
+  (r) => r.data?.phase === "entry" && r.data?.state === parsed.fromState,
+);
+if (entriesForState.length === 0) {
+  const enteredStates = Array.from(
+    new Set(
+      trace
+        .filter((r) => r.data?.phase === "entry")
+        .map((r) => r.data?.state)
+        .filter((s) => typeof s === "string"),
+    ),
+  );
+  emit({
+    error: "state_not_entered_in_run",
+    run_id: parsed.runId,
+    from_state: parsed.fromState,
+    entered_states: enteredStates,
+  });
+  process.exit(1);
+}
+const entryRecord = entriesForState[entriesForState.length - 1];
+const entrySequence = entryRecord.data.sequence;
+
+// Release any prior lock regardless of holder, since resume is an explicit
+// operator action. The lock file path lives under the run dir; release
+// via session match first, then force-delete if a stale or alien lock
+// remains. This guarantees we acquire a fresh lock cleanly.
+const runDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
+const lockPath = join(runDir, "lock.json");
+if (existsSync(lockPath)) {
+  // Best-effort owner release: if the existing lock belongs to the
+  // calling session, take the friendly path. Otherwise, force-unlink.
+  const existing = readLock(parsed.runId, { storageRoot: settings.storageRoot });
+  if (existing) {
+    rmSync(lockPath, { force: true });
+  }
+}
+
+const lockResult = acquireLock(parsed.runId, {
+  sessionId: settings.sessionId,
+  storageRoot: settings.storageRoot,
+});
+if (!lockResult.acquired) {
+  emit({ error: "run_locked", lock: lockResult.lock });
+  process.exit(1);
+}
+
+// Prune everything past the target state's entry trace. The entry trace
+// itself is kept: the run is now positioned at "just entered fromState",
+// ready for a fresh commit.
+const pruneResult = pruneTraceAfter(
+  parsed.runId,
+  entrySequence,
+  { storageRoot: settings.storageRoot },
+);
+
+const timestamp = new Date().toISOString();
+const annotation = {
+  from_state: parsed.fromState,
+  timestamp,
+  pruned_traces_count: pruneResult.removed,
+  session_id: settings.sessionId,
+};
+const priorHistory = Array.isArray(manifest.resume_history)
+  ? manifest.resume_history
+  : [];
+updateManifest(
+  parsed.runId,
+  {
+    status: "in_progress",
+    current_state: parsed.fromState,
+    next_state: null,
+    resume_history: [...priorHistory, annotation],
+    ended_at: null,
+  },
+  { storageRoot: settings.storageRoot },
+);
+
+// Re-read the env from the (now pruned) trace so the brief reflects only
+// outputs that actually preceded the resumed state.
+const env = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
+if (!env.args && manifest.args && typeof manifest.args === "object") {
+  // Recover args from the manifest if the entry trace for the original
+  // run head was pruned (the manifest is the durable source of args).
+  env.args = manifest.args;
+}
+const brief = buildBrief({
+  doc: fsm.doc,
+  state: targetState,
+  env,
+  runId: parsed.runId,
+});
+
+// Helper kept inline (not exported) so we don't grow the public lib API
+// for a single CLI concern: stamp a sidecar file so operators inspecting
+// the run dir see the resume annotation at a glance even before reading
+// the manifest. The manifest is the source of truth; this is convenience.
+function writeResumeSidecar() {
+  const sidecarPath = join(runDir, "fsm-trace", `RESUMED-from-${parsed.fromState}-at-${timestamp.replace(/[:.]/g, "-")}.yaml`);
+  const payload = [
+    `# Resume annotation (mirror of manifest.resume_history[-1])`,
+    `from_state: ${parsed.fromState}`,
+    `timestamp: ${timestamp}`,
+    `pruned_traces_count: ${pruneResult.removed}`,
+    `session_id: ${settings.sessionId}`,
+    "",
+  ].join("\n");
+  const fd = openSync(sidecarPath, "w", 0o644);
+  try {
+    writeFileSync(fd, payload);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+writeResumeSidecar();
+
+emit({
+  ok: true,
+  resumed: true,
+  resumed_from_state: parsed.fromState,
+  pruned_traces_count: pruneResult.removed,
+  pruned_traces: pruneResult.files,
+  resume_annotation: annotation,
+  ...brief,
+});
+process.exit(0);

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -396,6 +396,7 @@ export function initialiseManifest({
     args: args ?? {},
     verdict: null,
     transitions_count: 0,
+    resume_history: [],
   };
   writeManifest(runId, data, { storageRoot });
   return data;

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -64,21 +64,38 @@ export function stateById(doc, id) {
 // runEnv reads all exit trace records for a run and produces the cumulative
 // environment of outputs collected so far. Pulls args from the entry trace
 // of the entry state if present.
+//
+// readTrace returns records sorted by filename TEXT, which goes wrong once
+// the sequence counter reaches 5 digits ("0009999-..." sorts AFTER
+// "00010000-..."), so two exit records producing the same output key can
+// land in the env in the wrong order on cyclic / resumed runs. Re-sort by
+// the numeric `data.sequence` (falling back to the record's `sequence`
+// field) so the LAST write wins by chronological order, matching the run's
+// actual progression. Args use the FIRST entry trace chronologically, so
+// they get the same sort and pick `.find()`.
 export function runEnv(runId, opts = {}) {
   const trace = readTrace(runId, opts);
+  const seqOf = (r) => {
+    const fromData = r?.data?.sequence;
+    if (Number.isFinite(fromData)) return fromData;
+    const fromRecord = r?.sequence;
+    if (Number.isFinite(fromRecord)) return fromRecord;
+    return -Infinity;
+  };
+  const ordered = [...trace].sort((a, b) => seqOf(a) - seqOf(b));
   const env = {};
-  for (const record of trace) {
+  for (const record of ordered) {
     if (record.data?.phase !== "exit") continue;
     const outputs = record.data?.outputs;
     if (outputs && typeof outputs === "object") {
       Object.assign(env, outputs);
     }
   }
-  for (const record of trace) {
-    if (record.data?.phase === "entry" && record.data?.inputs?.args) {
-      env.args = record.data.inputs.args;
-      break;
-    }
+  const firstEntry = ordered.find(
+    (r) => r.data?.phase === "entry" && r.data?.inputs?.args,
+  );
+  if (firstEntry) {
+    env.args = firstEntry.data.inputs.args;
   }
   return env;
 }

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -300,6 +300,33 @@ export function readTrace(runId, opts = {}) {
     });
 }
 
+// pruneTraceAfter removes every trace file whose NNNN- sequence is strictly
+// greater than the given `sequence`. The file at sequence itself is kept;
+// everything past it is unlinked. Returns the count of files removed and
+// the names of the files that were pruned (sorted ascending).
+//
+// Used by fsm-resume: after locating the target state's entry trace at
+// sequence N, the caller prunes everything past N so the run resumes
+// from a clean slate at that state.
+export function pruneTraceAfter(runId, sequence, opts = {}) {
+  if (!Number.isInteger(sequence) || sequence < 0) {
+    throw new Error(
+      `pruneTraceAfter: sequence must be a non-negative integer, got ${sequence}`,
+    );
+  }
+  const traceDir = join(runDirPath(runId, opts), "fsm-trace");
+  if (!existsSync(traceDir)) return { removed: 0, files: [] };
+  const candidates = readdirSync(traceDir)
+    .filter((n) => /^\d+-/.test(n))
+    .map((n) => ({ name: n, seq: Number.parseInt(n.split("-", 1)[0], 10) }))
+    .filter((entry) => entry.seq > sequence)
+    .sort((a, b) => a.seq - b.seq);
+  for (const entry of candidates) {
+    rmSync(join(traceDir, entry.name), { force: true });
+  }
+  return { removed: candidates.length, files: candidates.map((c) => c.name) };
+}
+
 // ─── cross-run queries ──────────────────────────────────────────────────
 
 // listRecentRuns walks the date-sharded directory tree for the last

--- a/scripts/lib/index.mjs
+++ b/scripts/lib/index.mjs
@@ -17,6 +17,7 @@ export {
   ensureRunDir,
   listRecentRuns,
   parseRunId,
+  pruneTraceAfter,
   readLock,
   readManifest,
   readTrace,

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -30,7 +30,33 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { pruneTraceAfter, readManifest, readTrace } from "../../scripts/lib/fsm-storage.mjs";
+import {
+  pruneTraceAfter,
+  readManifest,
+  readTrace,
+  writeManifest,
+} from "../../scripts/lib/fsm-storage.mjs";
+
+// Resume refuses to take a non-stale lock from an in_progress run (so
+// it cannot race a live writer that has not yet checked the lock).
+// The tests do not actually run a concurrent writer; they just leave
+// behind the in_progress manifest + lock from the drive-to-state
+// preamble. Flip the status to "paused" so the lock takeover is
+// allowed under the same code path a real operator would use after
+// pausing the run.
+function markPausedForResumeTest(runId, storageRoot) {
+  const m = readManifest(runId, { storageRoot });
+  writeManifest(
+    runId,
+    {
+      ...m,
+      status: "paused",
+      paused_at: new Date().toISOString(),
+      pause_reason: "test-fixture",
+    },
+    { storageRoot },
+  );
+}
 
 const SCRIPT_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -160,6 +186,7 @@ test("pruneTraceAfter: removes only files with sequence > given value", () => {
   try {
     const session = "prune-1";
     const runId = driveToInline(tmp, session);
+    markPausedForResumeTest(runId, join(tmp, "store"));
     const before = readTrace(runId, { storageRoot: join(tmp, "store") });
     // Sanity: we expect ≥ 5 trace files (entry-a, exit-a, entry-b, exit-b, entry-c).
     assert.ok(before.length >= 5, `expected ≥5 trace files, got ${before.length}`);
@@ -223,6 +250,7 @@ test("fsm-resume: resumes from a worker state (b); prunes later traces; annotate
   try {
     const session = "resume-worker";
     const runId = driveToInline(tmp, session);
+    markPausedForResumeTest(runId, join(tmp, "store"));
     const beforeTrace = readTrace(runId, { storageRoot: join(tmp, "store") });
     // Locate b's entry sequence so we can assert the prune cut-off.
     const entryB = beforeTrace.find(
@@ -303,6 +331,7 @@ test("fsm-resume: resumes from an inline state (c) with no worker; brief reflect
   try {
     const session = "resume-inline";
     const runId = driveToInline(tmp, session);
+    markPausedForResumeTest(runId, join(tmp, "store"));
     const resume = parseJsonStdout(
       runScript("fsm-resume.mjs", [
         "--run-id", runId,
@@ -335,6 +364,7 @@ test("fsm-resume: refuses on a state name that is not in the FSM at all (unknown
   try {
     const session = "resume-unknown";
     const runId = driveToInline(tmp, session);
+    markPausedForResumeTest(runId, join(tmp, "store"));
     const result = runScript("fsm-resume.mjs", [
       "--run-id", runId,
       "--from-state", "does-not-exist",
@@ -432,6 +462,7 @@ test("fsm-resume: after resume from b, a fresh commit advances normally (b→c)"
   try {
     const session = "resume-then-commit";
     const runId = driveToInline(tmp, session);
+    markPausedForResumeTest(runId, join(tmp, "store"));
     const resumeSession = "resume-session-5";
     parseJsonStdout(
       runScript("fsm-resume.mjs", [
@@ -465,6 +496,7 @@ test("fsm-resume: takes over a prior lock held by a different session", () => {
   try {
     const originalSession = "original";
     const runId = driveToInline(tmp, originalSession);
+    markPausedForResumeTest(runId, join(tmp, "store"));
     // The original session still holds the lock. Resume with a fresh session.
     const newSession = "resume-takeover";
     const resume = parseJsonStdout(

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -524,6 +524,42 @@ test("fsm-resume: takes over a prior lock held by a different session", () => {
   }
 });
 
+test("fsm-resume: refuses takeover of a non-stale lock on an in_progress run", () => {
+  const tmp = setupFixture();
+  try {
+    const originalSession = "live-writer";
+    const runId = driveToInline(tmp, originalSession);
+    // Intentionally DO NOT call markPausedForResumeTest here: the run
+    // is still status=in_progress with the original session's lock,
+    // which is exactly the live-writer scenario the new takeover
+    // policy must refuse. A regression here would corrupt the run.
+
+    const result = runScript("fsm-resume.mjs", [
+      "--run-id", runId,
+      "--from-state", "b",
+      "--session-id", "resume-attempt",
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(result.status, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.error, "run_locked");
+    assert.equal(payload.run_status, "in_progress");
+    assert.ok(payload.lock, "expected the lock payload to be surfaced");
+    assert.match(
+      payload.hint || "",
+      /pause the run or wait for the writer to release/i,
+    );
+
+    // Manifest must NOT have been mutated: status, current_state and
+    // resume_history remain whatever drive-to-state left behind.
+    const m = readManifest(runId, { storageRoot: join(tmp, "store") });
+    assert.equal(m.status, "in_progress");
+    assert.equal((m.resume_history ?? []).length, 0);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 // ─── arg validation ────────────────────────────────────────────────────
 
 test("fsm-resume: rejects missing --run-id", () => {

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -1,0 +1,535 @@
+// fsm-resume.test.js: coverage for the resume/replay CLI.
+//
+// The fixture FSM has four states:
+//   a (worker)  -> b (worker)  -> c (inline) -> d (terminal)
+//
+// 'a' produces x; 'b' produces y; 'c' is inline (no worker, no outputs).
+// This lets us cover:
+//   - resume from a worker state mid-run (b)
+//   - resume from an inline state with no worker output (c)
+//   - resume refusal on a state name not in the FSM definition
+//   - resume refusal on a state that exists in the FSM but was never
+//     entered in this run
+//
+// Each test sets up an isolated workdir with the FSM YAML, a worker
+// prompt stub, and a fresh storage root, then drives the CLIs via
+// spawnSync to mirror the orchestrator's contract.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { pruneTraceAfter, readManifest, readTrace } from "../../scripts/lib/fsm-storage.mjs";
+
+const SCRIPT_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+);
+
+const RESUME_FSM = `
+fsm:
+  id: resume-fixture
+  version: 1
+  entry: a
+  states:
+    - id: a
+      purpose: "Entry; produces x."
+      preconditions: []
+      worker:
+        role: stub
+        prompt_template: workers/stub.md
+        inputs: ["args"]
+        response_schema:
+          type: object
+          required: [x]
+          properties:
+            x: { type: integer, minimum: 0 }
+      outputs: ["x"]
+      transitions:
+        - to: b
+          when: always
+    - id: b
+      purpose: "Mid; produces y."
+      preconditions: []
+      worker:
+        role: stub
+        prompt_template: workers/stub.md
+        inputs: ["x"]
+        response_schema:
+          type: object
+          required: [y]
+          properties:
+            y: { type: string, minLength: 1 }
+      outputs: ["y"]
+      transitions:
+        - to: c
+          when: always
+    - id: c
+      purpose: "Inline checkpoint; no worker."
+      preconditions: []
+      outputs: []
+      transitions:
+        - to: d
+          when: always
+    - id: d
+      purpose: "Terminal."
+      preconditions: []
+      outputs: []
+      transitions: []
+`;
+
+function setupFixture() {
+  const tmp = mkdtempSync(join(tmpdir(), "fsm-resume-"));
+  writeFileSync(join(tmp, "fsm.yaml"), RESUME_FSM);
+  mkdirSync(join(tmp, "workers"));
+  writeFileSync(join(tmp, "workers", "stub.md"), "# stub worker\n");
+  mkdirSync(join(tmp, "store"));
+  return tmp;
+}
+
+function runScript(name, args, opts = {}) {
+  return spawnSync("node", [join(SCRIPT_DIR, name), ...args], {
+    encoding: "utf8",
+    cwd: opts.cwd ?? process.cwd(),
+  });
+}
+
+function parseJsonStdout(result) {
+  if (result.status !== 0) {
+    throw new Error(
+      `script exited ${result.status}; stderr: ${result.stderr}; stdout: ${result.stdout}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+function commonArgs(tmp) {
+  return ["--fsm-path", join(tmp, "fsm.yaml"), "--storage-root", join(tmp, "store")];
+}
+
+// Drives the run from a→b→c so the run state contains entry traces for
+// all three of (a, b, c). Returns the run-id used.
+function driveToInline(tmp, session) {
+  const newRun = parseJsonStdout(
+    runScript("fsm-next.mjs", [
+      "--new-run",
+      "--repo", "testrepo",
+      "--base-sha", "aaa",
+      "--head-sha", "bbb",
+      "--session-id", session,
+      "--args", "{}",
+      ...commonArgs(tmp),
+    ]),
+  );
+  parseJsonStdout(
+    runScript("fsm-commit.mjs", [
+      "--run-id", newRun.run_id,
+      "--outputs", JSON.stringify({ x: 5 }),
+      "--session-id", session,
+      ...commonArgs(tmp),
+    ]),
+  );
+  parseJsonStdout(
+    runScript("fsm-commit.mjs", [
+      "--run-id", newRun.run_id,
+      "--outputs", JSON.stringify({ y: "done" }),
+      "--session-id", session,
+      ...commonArgs(tmp),
+    ]),
+  );
+  return newRun.run_id;
+}
+
+// ─── pruneTraceAfter unit ───────────────────────────────────────────────
+
+test("pruneTraceAfter: removes only files with sequence > given value", () => {
+  const tmp = setupFixture();
+  try {
+    const session = "prune-1";
+    const runId = driveToInline(tmp, session);
+    const before = readTrace(runId, { storageRoot: join(tmp, "store") });
+    // Sanity: we expect ≥ 5 trace files (entry-a, exit-a, entry-b, exit-b, entry-c).
+    assert.ok(before.length >= 5, `expected ≥5 trace files, got ${before.length}`);
+    const result = pruneTraceAfter(runId, 2, { storageRoot: join(tmp, "store") });
+    const after = readTrace(runId, { storageRoot: join(tmp, "store") });
+    assert.equal(after.length, 2);
+    assert.equal(result.removed, before.length - 2);
+    for (const r of after) {
+      assert.ok(r.data.sequence <= 2);
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("pruneTraceAfter: rejects non-integer or negative sequence", () => {
+  const tmp = setupFixture();
+  try {
+    assert.throws(
+      () => pruneTraceAfter("20260101-000000-1234567", -1, { storageRoot: join(tmp, "store") }),
+      /non-negative integer/,
+    );
+    assert.throws(
+      () => pruneTraceAfter("20260101-000000-1234567", 1.5, { storageRoot: join(tmp, "store") }),
+      /non-negative integer/,
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── resume_history defaults ───────────────────────────────────────────
+
+test("initialiseManifest writes resume_history: [] by default", () => {
+  const tmp = setupFixture();
+  try {
+    const session = "init-1";
+    const newRun = parseJsonStdout(
+      runScript("fsm-next.mjs", [
+        "--new-run",
+        "--repo", "testrepo",
+        "--base-sha", "aaa",
+        "--head-sha", "bbb",
+        "--session-id", session,
+        "--args", "{}",
+        ...commonArgs(tmp),
+      ]),
+    );
+    const manifest = readManifest(newRun.run_id, { storageRoot: join(tmp, "store") });
+    assert.ok(Array.isArray(manifest.resume_history));
+    assert.equal(manifest.resume_history.length, 0);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── resume from a worker state ────────────────────────────────────────
+
+test("fsm-resume: resumes from a worker state (b); prunes later traces; annotates manifest", () => {
+  const tmp = setupFixture();
+  try {
+    const session = "resume-worker";
+    const runId = driveToInline(tmp, session);
+    const beforeTrace = readTrace(runId, { storageRoot: join(tmp, "store") });
+    // Locate b's entry sequence so we can assert the prune cut-off.
+    const entryB = beforeTrace.find(
+      (r) => r.data?.phase === "entry" && r.data?.state === "b",
+    );
+    assert.ok(entryB, "expected entry trace for state b");
+    const entrySeq = entryB.data.sequence;
+
+    const resume = parseJsonStdout(
+      runScript("fsm-resume.mjs", [
+        "--run-id", runId,
+        "--from-state", "b",
+        "--session-id", "resume-session-1",
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(resume.ok, true);
+    assert.equal(resume.resumed, true);
+    assert.equal(resume.resumed_from_state, "b");
+    assert.equal(resume.state, "b");
+    assert.equal(resume.has_worker, true);
+    assert.equal(resume.worker.role, "stub");
+    // The brief should expose b's input (x), recovered from the surviving exit trace of a.
+    assert.deepEqual(resume.inputs, { x: 5 });
+    assert.ok(resume.pruned_traces_count > 0, "expected some traces pruned past b's entry");
+
+    const afterTrace = readTrace(runId, { storageRoot: join(tmp, "store") });
+    for (const r of afterTrace) {
+      assert.ok(
+        r.data.sequence <= entrySeq,
+        `expected no traces past sequence ${entrySeq}, found ${r.fileName}`,
+      );
+    }
+
+    const manifest = readManifest(runId, { storageRoot: join(tmp, "store") });
+    assert.equal(manifest.status, "in_progress");
+    assert.equal(manifest.current_state, "b");
+    assert.equal(manifest.ended_at, null);
+    assert.equal(manifest.resume_history.length, 1);
+    const annotation = manifest.resume_history[0];
+    assert.equal(annotation.from_state, "b");
+    assert.equal(annotation.session_id, "resume-session-1");
+    assert.equal(annotation.pruned_traces_count, resume.pruned_traces_count);
+    assert.match(annotation.timestamp, /^\d{4}-\d{2}-\d{2}T/);
+
+    // A fresh lock should be held by the resuming session.
+    const lockFiles = readdirSync(join(
+      join(tmp, "store"),
+      manifest.run_id.slice(0, 4),
+      manifest.run_id.slice(4, 6),
+      manifest.run_id.slice(6, 8),
+      manifest.run_id.slice(16, 18),
+      manifest.run_id.slice(18),
+    )).filter((n) => n === "lock.json");
+    assert.equal(lockFiles.length, 1);
+
+    // A sidecar RESUMED-* annotation file should exist in fsm-trace/.
+    const traceDir = join(
+      join(tmp, "store"),
+      manifest.run_id.slice(0, 4),
+      manifest.run_id.slice(4, 6),
+      manifest.run_id.slice(6, 8),
+      manifest.run_id.slice(16, 18),
+      manifest.run_id.slice(18),
+      "fsm-trace",
+    );
+    const resumedSidecar = readdirSync(traceDir).find((n) => n.startsWith("RESUMED-from-b-at-"));
+    assert.ok(resumedSidecar, "expected a RESUMED-from-b-at-* sidecar in fsm-trace/");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── resume from an inline state ───────────────────────────────────────
+
+test("fsm-resume: resumes from an inline state (c) with no worker; brief reflects no worker", () => {
+  const tmp = setupFixture();
+  try {
+    const session = "resume-inline";
+    const runId = driveToInline(tmp, session);
+    const resume = parseJsonStdout(
+      runScript("fsm-resume.mjs", [
+        "--run-id", runId,
+        "--from-state", "c",
+        "--session-id", "resume-session-2",
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(resume.ok, true);
+    assert.equal(resume.resumed_from_state, "c");
+    assert.equal(resume.state, "c");
+    assert.equal(resume.has_worker, false);
+    assert.equal(resume.worker, undefined);
+    assert.deepEqual(resume.outputs_expected, []);
+    assert.deepEqual(resume.inputs, {});
+
+    const manifest = readManifest(runId, { storageRoot: join(tmp, "store") });
+    assert.equal(manifest.current_state, "c");
+    assert.equal(manifest.resume_history.length, 1);
+    assert.equal(manifest.resume_history[0].from_state, "c");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── refusal: unknown state ────────────────────────────────────────────
+
+test("fsm-resume: refuses on a state name that is not in the FSM at all (unknown_state)", () => {
+  const tmp = setupFixture();
+  try {
+    const session = "resume-unknown";
+    const runId = driveToInline(tmp, session);
+    const result = runScript("fsm-resume.mjs", [
+      "--run-id", runId,
+      "--from-state", "does-not-exist",
+      "--session-id", "resume-session-3",
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(result.status, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.error, "unknown_state");
+    assert.equal(payload.from_state, "does-not-exist");
+
+    // Manifest must be untouched: no resume_history entry, no current_state change.
+    const manifest = readManifest(runId, { storageRoot: join(tmp, "store") });
+    assert.equal(manifest.resume_history.length, 0);
+    assert.equal(manifest.current_state, "c");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── refusal: state exists in FSM but never entered in this run ────────
+
+test("fsm-resume: refuses on a state that exists in the FSM but was never entered (state_not_entered_in_run)", () => {
+  const tmp = setupFixture();
+  try {
+    const session = "resume-not-entered";
+    // Only drive to b's entry, NOT past it, so 'c' has never been entered.
+    const newRun = parseJsonStdout(
+      runScript("fsm-next.mjs", [
+        "--new-run",
+        "--repo", "testrepo",
+        "--base-sha", "aaa",
+        "--head-sha", "bbb",
+        "--session-id", session,
+        "--args", "{}",
+        ...commonArgs(tmp),
+      ]),
+    );
+    parseJsonStdout(
+      runScript("fsm-commit.mjs", [
+        "--run-id", newRun.run_id,
+        "--outputs", JSON.stringify({ x: 5 }),
+        "--session-id", session,
+        ...commonArgs(tmp),
+      ]),
+    );
+    // The run is now at b (entered). c has NOT been entered.
+    const result = runScript("fsm-resume.mjs", [
+      "--run-id", newRun.run_id,
+      "--from-state", "c",
+      "--session-id", "resume-session-4",
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(result.status, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.error, "state_not_entered_in_run");
+    assert.equal(payload.from_state, "c");
+    assert.ok(Array.isArray(payload.entered_states));
+    assert.ok(payload.entered_states.includes("a"));
+    assert.ok(payload.entered_states.includes("b"));
+    assert.ok(!payload.entered_states.includes("c"));
+
+    // Manifest unchanged.
+    const manifest = readManifest(newRun.run_id, { storageRoot: join(tmp, "store") });
+    assert.equal(manifest.resume_history.length, 0);
+    assert.equal(manifest.current_state, "b");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── refusal: run not found ────────────────────────────────────────────
+
+test("fsm-resume: refuses on an unknown run-id (run_not_found)", () => {
+  const tmp = setupFixture();
+  try {
+    const result = runScript("fsm-resume.mjs", [
+      "--run-id", "20260101-000000-fffffff",
+      "--from-state", "a",
+      "--session-id", "x",
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(result.status, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.error, "run_not_found");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── resume + commit cycle works after resume ──────────────────────────
+
+test("fsm-resume: after resume from b, a fresh commit advances normally (b→c)", () => {
+  const tmp = setupFixture();
+  try {
+    const session = "resume-then-commit";
+    const runId = driveToInline(tmp, session);
+    const resumeSession = "resume-session-5";
+    parseJsonStdout(
+      runScript("fsm-resume.mjs", [
+        "--run-id", runId,
+        "--from-state", "b",
+        "--session-id", resumeSession,
+        ...commonArgs(tmp),
+      ]),
+    );
+    // Fresh commit under the new session.
+    const commit = parseJsonStdout(
+      runScript("fsm-commit.mjs", [
+        "--run-id", runId,
+        "--outputs", JSON.stringify({ y: "replayed" }),
+        "--session-id", resumeSession,
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(commit.ok, true);
+    assert.equal(commit.advanced_from, "b");
+    assert.equal(commit.state, "c");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── lock takeover ─────────────────────────────────────────────────────
+
+test("fsm-resume: takes over a prior lock held by a different session", () => {
+  const tmp = setupFixture();
+  try {
+    const originalSession = "original";
+    const runId = driveToInline(tmp, originalSession);
+    // The original session still holds the lock. Resume with a fresh session.
+    const newSession = "resume-takeover";
+    const resume = parseJsonStdout(
+      runScript("fsm-resume.mjs", [
+        "--run-id", runId,
+        "--from-state", "b",
+        "--session-id", newSession,
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(resume.ok, true);
+
+    // Original session can no longer commit: lock now belongs to new session.
+    const blocked = runScript("fsm-commit.mjs", [
+      "--run-id", runId,
+      "--outputs", JSON.stringify({ y: "should-be-blocked" }),
+      "--session-id", originalSession,
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(blocked.status, 0);
+    const payload = JSON.parse(blocked.stdout);
+    assert.equal(payload.error, "lock_not_held");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── arg validation ────────────────────────────────────────────────────
+
+test("fsm-resume: rejects missing --run-id", () => {
+  const tmp = setupFixture();
+  try {
+    const result = runScript("fsm-resume.mjs", [
+      "--from-state", "a",
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--run-id is required/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("fsm-resume: rejects missing --from-state", () => {
+  const tmp = setupFixture();
+  try {
+    const result = runScript("fsm-resume.mjs", [
+      "--run-id", "20260101-000000-1234567",
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--from-state is required/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("fsm-resume: rejects unknown argument", () => {
+  const result = runScript("fsm-resume.mjs", ["--bogus"]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unknown argument/);
+});
+
+// ─── final sanity: the runner file is present in scripts/.
+test("fsm-resume.mjs file is present in scripts/", () => {
+  // Sanity: file exists at the canonical path.
+  assert.ok(existsSync(join(SCRIPT_DIR, "fsm-resume.mjs")));
+});


### PR DESCRIPTION
Adds `scripts/fsm-resume.mjs` for resuming a faulted or paused run from a prior-entered state. Prunes trace files past the target's entry trace, takes over the lock, appends a structured `resume_history[]` entry to the manifest. New helper `pruneTraceAfter` in storage. Per plan A4. +14 tests, all green. `package.json` bin `fsm-resume`.