### PR TITLE
feat(engine): post-validations runtime evaluator (A5)

### DIFF
--- a/docs/state-yaml-reference.md
+++ b/docs/state-yaml-reference.md
@@ -197,6 +197,7 @@ The post-validation DSL is the same as the transition DSL, summarised here for c
 | Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, `||`, `!` |
 | Grouping | `(`, `)` |
 | Functions | `len(x)`, `empty(x)`, `in(x, list)` |
+| Literals (extras) | `always` evaluates `true` (matches the transition DSL); useful for documenting an intentionally always-pass check during development |
 
 ### Examples
 

--- a/docs/state-yaml-reference.md
+++ b/docs/state-yaml-reference.md
@@ -142,7 +142,7 @@ A missing identifier resolves to `undefined`. Comparisons with `undefined` follo
 | Category | Tokens |
 |----------|--------|
 | Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
-| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, double-pipe, `!` |
+| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, `||`, `!` |
 | Grouping | `(`, `)` |
 
 Operator precedence (highest to lowest): grouping, function-call, `NOT`, comparison, `AND`, `OR`.
@@ -194,7 +194,7 @@ The post-validation DSL is the same as the transition DSL, summarised here for c
 | Literals | numbers, `'...'` / `"..."` strings, `true`, `false`, `null` |
 | Identifiers | dotted paths into `outputs` (e.g. `findings`, `summary.total`) |
 | Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
-| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, double-pipe, `!` |
+| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, `||`, `!` |
 | Grouping | `(`, `)` |
 | Functions | `len(x)`, `empty(x)`, `in(x, list)` |
 

--- a/docs/state-yaml-reference.md
+++ b/docs/state-yaml-reference.md
@@ -32,8 +32,8 @@ fsm:
       properties: {...}
   outputs:                        # required (use [] for terminal states)
     - <name>
-  post_validations:               # optional; declarative in v0.1
-    - "<free-form check>"
+  post_validations:               # optional; evaluated at runtime via the predicate DSL
+    - "<predicate expression>"
   transitions:                    # required (use [] for terminal states)
     - to: <state-id>
       when: <when-clause>
@@ -169,6 +169,47 @@ expression: "diff_stats.lines_changed > 100 OR diff_stats.files_changed > 5"
 ## Inline states (no worker)
 
 States without a `worker:` block are computed by the orchestrator deterministically — typically aggregations, simple branching, or filesystem side effects. Their `outputs[]` are still declared so downstream states' inputs can reference them. The orchestrator passes outputs to `fsm-commit --outputs`; the package validates nothing schema-side (no `response_schema` to check) but still writes the exit trace and evaluates transitions.
+
+## Post-validations (runtime predicates)
+
+The optional `post_validations:` array runs after JSON-Schema validation of the worker output (or after `fsm-commit --outputs` for inline states) and before transition resolution. Each entry is a predicate expression in the same DSL that powers deterministic `when:` clauses (see "Predicate DSL" above). The predicates are evaluated against the just-committed outputs map, so the field names refer directly to keys of `outputs`.
+
+Multiple predicates are AND-composed: the state is considered valid only when every predicate evaluates true. If any predicate evaluates false, or fails to parse / evaluate, `fsm-commit`:
+
+1. Writes a `fault` trace with `reason: "post_validation_failed"` and details of every predicate result.
+2. Sets `manifest.status = "faulted"` and stamps `ended_at`.
+3. Releases the run's lock.
+4. Emits a structured error on stdout (`{ error: "post_validation_failed", state, post_validations: [...] }`) and exits with code `1`.
+
+The state does NOT advance; no transition is resolved when post-validations fail.
+
+A malformed expression captures the parser/runtime error in the corresponding `results[].error` field and counts as a failed validation.
+
+### Available operators
+
+The post-validation DSL is the same as the transition DSL, summarised here for convenience:
+
+| Category | Tokens |
+|----------|--------|
+| Literals | numbers, `'...'` / `"..."` strings, `true`, `false`, `null` |
+| Identifiers | dotted paths into `outputs` (e.g. `findings`, `summary.total`) |
+| Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
+| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, double-pipe, `!` |
+| Grouping | `(`, `)` |
+| Functions | `len(x)`, `empty(x)`, `in(x, list)` |
+
+### Examples
+
+```yaml
+post_validations:
+  - "len(findings) > 0"
+  - "verdict == 'PASS' OR verdict == 'CONDITIONAL'"
+  - "NOT empty(summary)"
+```
+
+### Limitations
+
+Predicates can express comparisons, membership, length, and boolean combinations over scalar/array fields of `outputs`. They cannot express structural JSON-Schema-grade checks beyond what the worker's `response_schema` already validates. Use the worker `response_schema` for structural shape; use `post_validations` for runtime business-rule checks (non-empty result set, expected verdict values, cross-field invariants).
 
 ## Validation
 

--- a/docs/state-yaml-reference.md
+++ b/docs/state-yaml-reference.md
@@ -142,7 +142,7 @@ A missing identifier resolves to `undefined`. Comparisons with `undefined` follo
 | Category | Tokens |
 |----------|--------|
 | Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
-| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, `||`, `!` |
+| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, `&#124;&#124;`, `!` |
 | Grouping | `(`, `)` |
 
 Operator precedence (highest to lowest): grouping, function-call, `NOT`, comparison, `AND`, `OR`.
@@ -194,7 +194,7 @@ The post-validation DSL is the same as the transition DSL, summarised here for c
 | Literals | numbers, `'...'` / `"..."` strings, `true`, `false`, `null` |
 | Identifiers | dotted paths into `outputs` (e.g. `findings`, `summary.total`) |
 | Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
-| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, `||`, `!` |
+| Logical | `AND`, `OR`, `NOT` (case-insensitive); aliases `&&`, `&#124;&#124;`, `!` |
 | Grouping | `(`, `)` |
 | Functions | `len(x)`, `empty(x)`, `in(x, list)` |
 | Literals (extras) | `always` evaluates `true` (matches the transition DSL); useful for documenting an intentionally always-pass check during development |

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -221,7 +221,38 @@ if (state.loop) {
   };
 }
 
-const postValidations = runPostValidations(state);
+// Post-validations run against the freshly-committed outputs. For a
+// terminating loop state, outputsForFlow is the aggregated record (the
+// canonical post-loop output), so predicates that need to inspect the
+// aggregate (`total_iterations`, etc.) see them; for a non-loop state
+// outputsForFlow === parsed.outputs.
+const postValidations = runPostValidations(state, outputsForFlow);
+if (!postValidations.valid) {
+  writeFaultTrace(
+    parsed.runId,
+    {
+      state,
+      reason: "post_validation_failed",
+      details: { post_validations: postValidations.results },
+    },
+    { storageRoot: settings.storageRoot },
+  );
+  updateManifest(
+    parsed.runId,
+    { status: "faulted", ended_at: new Date().toISOString() },
+    { storageRoot: settings.storageRoot },
+  );
+  releaseLock(parsed.runId, {
+    sessionId: settings.sessionId,
+    storageRoot: settings.storageRoot,
+  });
+  emit({
+    error: "post_validation_failed",
+    state: state.id,
+    post_validations: postValidations.results,
+  });
+  process.exit(1);
+}
 
 const env = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
 const envWithCommit = { ...env, ...outputsForFlow };

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -357,6 +357,22 @@ export function runPostValidations(state, outputs = {}) {
   const results = [];
   let valid = true;
   for (const check of checks) {
+    // Schema validation only enforces that post_validations is an
+    // array; individual elements may slip through as non-strings if the
+    // YAML author makes a typo. Surface that as a typed evaluation
+    // failure rather than crashing evaluatePredicate, so the trace +
+    // CLI payload always carry the documented { check, expression,
+    // result, error } shape with string fields.
+    if (typeof check !== "string") {
+      results.push({
+        check: String(check),
+        expression: String(check),
+        result: false,
+        error: `post_validations entry must be a string, got ${typeof check}`,
+      });
+      valid = false;
+      continue;
+    }
     const entry = { check, expression: check };
     try {
       const passed = Boolean(evaluatePredicate(check, env));

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -337,16 +337,39 @@ export function resolveTransition(state, env, { judgementPick } = {}) {
   return { transition: firstMatch, evaluations };
 }
 
-// runPostValidations is a stub for v0.1 — the post_validations array is
-// declarative documentation today. v0.2 can wire predicate evaluation
-// here. Returns { valid, results[] } for trace recording.
-export function runPostValidations(state) {
-  const results = (state.post_validations ?? []).map((check) => ({
-    check,
-    result: "skipped",
-    note: "post_validations are declarative in v0.1; runtime evaluation deferred",
-  }));
-  return { valid: true, results };
+// runPostValidations evaluates each post_validations[] entry as a
+// predicate-DSL expression (see fsm-predicates.mjs) against the just-
+// committed outputs map. Multiple predicates are AND-composed: the overall
+// result is valid only if every entry evaluates true.
+//
+// Returns { valid, results[] } where each result is
+//   { check, result: true|false, expression, error? }.
+//
+// A malformed expression yields result=false with `error` carrying the
+// evaluator's message; overall valid is false in that case.
+//
+// `outputs` is the map of fields the worker just emitted (or the inline
+// state's computed outputs). Predicates reference those fields by name
+// (e.g. `len(findings) > 0`, `verdict == 'PASS'`).
+export function runPostValidations(state, outputs = {}) {
+  const env = outputs && typeof outputs === "object" ? outputs : {};
+  const checks = state.post_validations ?? [];
+  const results = [];
+  let valid = true;
+  for (const check of checks) {
+    const entry = { check, expression: check };
+    try {
+      const passed = Boolean(evaluatePredicate(check, env));
+      entry.result = passed;
+      if (!passed) valid = false;
+    } catch (err) {
+      entry.result = false;
+      entry.error = err.message;
+      valid = false;
+    }
+    results.push(entry);
+  }
+  return { valid, results };
 }
 
 // validateOutputs runs the worker.response_schema (if any) over the

--- a/tests/unit/post-validations-runtime.test.js
+++ b/tests/unit/post-validations-runtime.test.js
@@ -1,0 +1,277 @@
+// post-validations-runtime.test.js: runtime evaluation of
+// post_validations[] predicates (Workstream A5).
+//
+// Covers:
+//   - unit: runPostValidations() with single pass, single fail, AND-composed
+//     multi-predicate, malformed expression.
+//   - integration: fsm-commit CLI fails a state whose post_validations
+//     evaluates to false, writes a fault trace, sets manifest faulted,
+//     emits structured stdout, exits 1.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runPostValidations } from "../../scripts/lib/fsm-engine.mjs";
+import { readTrace } from "../../scripts/lib/fsm-storage.mjs";
+
+const SCRIPT_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+);
+
+// ─── Unit: runPostValidations() ────────────────────────────────────────
+
+test("runPostValidations: no checks → valid with empty results", () => {
+  const state = { post_validations: [] };
+  const result = runPostValidations(state, { findings: [] });
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.results, []);
+});
+
+test("runPostValidations: single predicate that evaluates true", () => {
+  const state = { post_validations: ["len(findings) > 0"] };
+  const result = runPostValidations(state, { findings: [{ id: 1 }] });
+  assert.equal(result.valid, true);
+  assert.equal(result.results.length, 1);
+  assert.equal(result.results[0].check, "len(findings) > 0");
+  assert.equal(result.results[0].expression, "len(findings) > 0");
+  assert.equal(result.results[0].result, true);
+  assert.equal(result.results[0].error, undefined);
+});
+
+test("runPostValidations: single predicate that evaluates false", () => {
+  const state = { post_validations: ["len(findings) > 0"] };
+  const result = runPostValidations(state, { findings: [] });
+  assert.equal(result.valid, false);
+  assert.equal(result.results.length, 1);
+  assert.equal(result.results[0].result, false);
+  assert.equal(result.results[0].error, undefined);
+});
+
+test("runPostValidations: multiple predicates AND-composed (true + true is valid)", () => {
+  const state = {
+    post_validations: [
+      "len(findings) > 0",
+      "verdict == 'PASS'",
+    ],
+  };
+  const result = runPostValidations(state, {
+    findings: [{ id: 1 }, { id: 2 }],
+    verdict: "PASS",
+  });
+  assert.equal(result.valid, true);
+  assert.equal(result.results.length, 2);
+  assert.equal(result.results[0].result, true);
+  assert.equal(result.results[1].result, true);
+});
+
+test("runPostValidations: multiple predicates AND-composed (true + false is invalid)", () => {
+  const state = {
+    post_validations: [
+      "len(findings) > 0",
+      "verdict == 'PASS'",
+    ],
+  };
+  const result = runPostValidations(state, {
+    findings: [{ id: 1 }],
+    verdict: "FAIL",
+  });
+  assert.equal(result.valid, false);
+  assert.equal(result.results.length, 2);
+  assert.equal(result.results[0].result, true);
+  assert.equal(result.results[1].result, false);
+});
+
+test("runPostValidations: malformed expression returns valid=false with error captured", () => {
+  const state = { post_validations: ["len(findings >"] };
+  const result = runPostValidations(state, { findings: [1, 2, 3] });
+  assert.equal(result.valid, false);
+  assert.equal(result.results.length, 1);
+  assert.equal(result.results[0].result, false);
+  assert.ok(
+    typeof result.results[0].error === "string" && result.results[0].error.length > 0,
+    "expected malformed expression to capture an error message",
+  );
+});
+
+test("runPostValidations: missing post_validations array defaults to valid=true", () => {
+  const state = {};
+  const result = runPostValidations(state, { findings: [] });
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.results, []);
+});
+
+// ─── Integration: fsm-commit CLI fails on violated predicate ───────────
+
+const POSTVAL_FSM = `
+fsm:
+  id: postval
+  version: 1
+  entry: scan
+  states:
+    - id: scan
+      purpose: "Entry; produces findings array."
+      preconditions: []
+      worker:
+        role: stub
+        prompt_template: workers/stub.md
+        inputs: ["args"]
+        response_schema:
+          type: object
+          required: [findings]
+          properties:
+            findings:
+              type: array
+              items: { type: object }
+      outputs: ["findings"]
+      post_validations:
+        - "len(findings) > 0"
+      transitions:
+        - to: terminal
+          when: always
+    - id: terminal
+      purpose: "Terminal."
+      preconditions: []
+      outputs: []
+      transitions: []
+`;
+
+function setupPostvalFixture() {
+  const tmp = mkdtempSync(join(tmpdir(), "fsm-postval-"));
+  writeFileSync(join(tmp, "fsm.yaml"), POSTVAL_FSM);
+  mkdirSync(join(tmp, "workers"));
+  writeFileSync(join(tmp, "workers", "stub.md"), "# stub worker\n");
+  mkdirSync(join(tmp, "store"));
+  return tmp;
+}
+
+function runScript(name, args, opts = {}) {
+  return spawnSync("node", [join(SCRIPT_DIR, name), ...args], {
+    encoding: "utf8",
+    cwd: opts.cwd ?? process.cwd(),
+  });
+}
+
+function parseJsonStdout(result) {
+  if (result.status !== 0) {
+    throw new Error(
+      `script exited ${result.status}; stderr: ${result.stderr}; stdout: ${result.stdout}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+function commonArgs(tmp) {
+  return ["--fsm-path", join(tmp, "fsm.yaml"), "--storage-root", join(tmp, "store")];
+}
+
+test("fsm-commit: post_validation_failed when predicate violated (findings empty)", () => {
+  const tmp = setupPostvalFixture();
+  try {
+    const session = "postval-fail-session";
+    const newRun = parseJsonStdout(
+      runScript("fsm-next.mjs", [
+        "--new-run",
+        "--repo", "testrepo",
+        "--base-sha", "aaa",
+        "--head-sha", "bbb",
+        "--session-id", session,
+        "--args", "{}",
+        ...commonArgs(tmp),
+      ]),
+    );
+    const commit = runScript("fsm-commit.mjs", [
+      "--run-id", newRun.run_id,
+      "--outputs", JSON.stringify({ findings: [] }),
+      "--session-id", session,
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(commit.status, 0);
+    const payload = JSON.parse(commit.stdout);
+    assert.equal(payload.error, "post_validation_failed");
+    assert.equal(payload.state, "scan");
+    assert.ok(Array.isArray(payload.post_validations));
+    assert.equal(payload.post_validations.length, 1);
+    assert.equal(payload.post_validations[0].check, "len(findings) > 0");
+    assert.equal(payload.post_validations[0].result, false);
+
+    // Manifest should be faulted, lock should be released, fault trace recorded.
+    const inspect = parseJsonStdout(
+      runScript("fsm-inspect.mjs", [
+        "--run-id", newRun.run_id,
+        "--storage-root", join(tmp, "store"),
+      ]),
+    );
+    assert.equal(inspect.manifest.status, "faulted");
+    assert.equal(inspect.lock, null);
+    const trace = readTrace(newRun.run_id, { storageRoot: join(tmp, "store") });
+    const faultTrace = trace.find((r) => r.data.phase === "fault");
+    assert.ok(faultTrace, "expected a fault trace record");
+    assert.equal(faultTrace.data.state, "scan");
+    assert.equal(faultTrace.data.reason, "post_validation_failed");
+    assert.ok(faultTrace.data.details, "expected fault details");
+    assert.equal(
+      faultTrace.data.details.post_validations[0].check,
+      "len(findings) > 0",
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("fsm-commit: passes post_validations when predicate satisfied (findings non-empty)", () => {
+  const tmp = setupPostvalFixture();
+  try {
+    const session = "postval-pass-session";
+    const newRun = parseJsonStdout(
+      runScript("fsm-next.mjs", [
+        "--new-run",
+        "--repo", "testrepo",
+        "--base-sha", "aaa",
+        "--head-sha", "bbb",
+        "--session-id", session,
+        "--args", "{}",
+        ...commonArgs(tmp),
+      ]),
+    );
+    const commit = parseJsonStdout(
+      runScript("fsm-commit.mjs", [
+        "--run-id", newRun.run_id,
+        "--outputs", JSON.stringify({ findings: [{ id: 1 }] }),
+        "--session-id", session,
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(commit.ok, true);
+    assert.equal(commit.advanced_from, "scan");
+    assert.equal(commit.state, "terminal");
+
+    // Trace must include the exit record with the predicate result.
+    const trace = readTrace(newRun.run_id, { storageRoot: join(tmp, "store") });
+    const exitTrace = trace.find(
+      (r) => r.data.phase === "exit" && r.data.state === "scan",
+    );
+    assert.ok(exitTrace, "expected exit trace for the scan state");
+    assert.ok(Array.isArray(exitTrace.data.post_validations));
+    assert.equal(exitTrace.data.post_validations.length, 1);
+    assert.equal(exitTrace.data.post_validations[0].result, true);
+    assert.equal(
+      exitTrace.data.post_validations[0].check,
+      "len(findings) > 0",
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Replaces the declarative-only `runPostValidations` stub with a runtime evaluator over the predicate DSL. `fsm-commit` fails the commit cleanly on a violated predicate: fault trace (`reason: post_validation_failed`), manifest `faulted`, lock released, structured stdout, exit 1. Docs updated. Per plan A5. +9 tests, all green.