### PR TITLE
feat(aggregator): cross-state manifest aggregator (A3)

### DIFF
--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -18,6 +18,9 @@ The package writes only to `<storage-root>/`. Consumers configure `storage_root`
               0002-exit-<state>.yaml
               ...
             workers/                ← consumer-managed worker artifacts (optional)
+            manifest-aggregates/    ← cross-state aggregate arrays (optional)
+              findings.json
+              <merge-field>.json
 ```
 
 ### Why each path component
@@ -86,6 +89,67 @@ See [`orchestration-design.md`](orchestration-design.md) "File schemas" for the 
 - `status` enum: `in_progress | paused | completed | faulted | abandoned | stale | superseded`.
 - `current_state` is the last-entered state (the one the orchestrator is currently working on); `next_state` is null between commits.
 - `transitions_count` increments on every `fsm-commit`.
+
+### Optional `aggregates` map
+
+Skills whose FSMs produce arrays across multiple states (e.g. a loop state that emits `findings[]` followed by a verifier state that emits more `findings[]`) can carry a single unified array in the manifest via a top-level `aggregates` map. The map is keyed by the merge field name (one key per cross-state aggregate). Each entry points at the on-disk unified file under `manifest-aggregates/` and records which states contributed.
+
+Schema:
+
+```json
+{
+  "aggregates": {
+    "<merge-field>": {
+      "from_states": ["<state-id>", "<state-id>"],
+      "field": "<merge-field>",
+      "path": "manifest-aggregates/<merge-field>.json",
+      "merged_length": 8,
+      "missing_states": []
+    }
+  }
+}
+```
+
+Example (a plan-reviewer-style skill that folds findings from two states into one list):
+
+```json
+{
+  "run_id": "20260426-001512-a3f7c9b",
+  "...": "...",
+  "aggregates": {
+    "findings": {
+      "from_states": ["explore_loop", "verify_coverage"],
+      "field": "findings",
+      "path": "manifest-aggregates/findings.json",
+      "merged_length": 8,
+      "missing_states": []
+    }
+  }
+}
+```
+
+The file at `<run_dir>/<entry.path>` has the shape:
+
+```json
+{
+  "field": "findings",
+  "from_states": ["explore_loop", "verify_coverage"],
+  "state_count": 2,
+  "missing_states": [],
+  "merged_length": 8,
+  "items": [ /* ... */ ]
+}
+```
+
+#### How it gets produced
+
+The `@ctxr/fsm` package exports `aggregateAcrossStates(runDir, { stateIds, mergeField })` from `scripts/lib/fsm-aggregator.mjs`. It reads each state's most recent exit-trace record from `<run_dir>/fsm-trace/`, pulls `outputs[mergeField]` from each, concatenates the arrays in the caller-supplied order, and atomic-writes `<run_dir>/manifest-aggregates/<merge-field>.json`. It returns `{ aggregated_path, state_count, merged_length, missing_states }`. Missing states (no exit trace yet) are reported, never thrown.
+
+The companion `manifestAggregateEntry(...)` helper returns the canonical entry shape above, so every skill runner stamps the same fields with the same names. Wiring the entry into `manifest.aggregates` is the **skill runner's** responsibility: the FSM YAML has no aggregate-declaration syntax in 0.2.0, so the runner calls `updateManifest` itself after the cross-state state completes. See the file header of `scripts/lib/fsm-aggregator.mjs` for the deferred-wiring rationale.
+
+#### Loop-state caveat
+
+A loop state's exit trace stores an `aggregated_<state-id>` path (produced by `aggregateLoopOutputs`), NOT a flat `findings[]` array. If a skill needs to fold a loop state into a cross-state aggregate, the runner must first re-stamp the loop state's exit-trace outputs with the flattened array under `outputs[mergeField]`, or emit a follow-on inline state that does so. The cross-state aggregator deliberately does NOT auto-resolve aggregated paths; the one-line contract stays: `outputs[mergeField]` must be an array.
 
 ## Trace records
 

--- a/scripts/lib/fsm-aggregator.mjs
+++ b/scripts/lib/fsm-aggregator.mjs
@@ -1,17 +1,41 @@
-// fsm-aggregator.mjs — loop-state output aggregator.
+// fsm-aggregator.mjs: loop-state + cross-state output aggregators.
 //
-// Loop states write per-iteration JSON outputs to
-// <run_dir>/workers/<state.loop.iteration_outputs_dir>/iter-<N>.json.
-// When the loop terminates, this helper reads every iter-*.json file in
-// sequence order, validates each against the loop worker's response_schema,
-// concatenates the per-iteration `findings[]` (or any configured mergeField)
-// arrays, and atomic-writes a single aggregated output file under
-// <run_dir>/workers/. A sibling meta file captures per-iteration metadata
-// (strategy, ruled_out, rationale, done) so the manifest can summarise the
-// loop without re-reading every iter file.
+// Two aggregators live here:
 //
-// All filesystem operations are atomic; re-running the aggregator on the
-// same run_dir is idempotent. The aggregator never mutates iter files.
+// 1. aggregateLoopOutputs (A2): within a single loop state, reads every
+//    iter-<N>.json under <run_dir>/workers/<state.loop.iteration_outputs_dir>/,
+//    validates each against the loop worker's response_schema, concatenates
+//    the per-iteration `findings[]` (or any configured mergeField) arrays,
+//    and atomic-writes a single aggregated output file plus a sibling
+//    iteration-meta file (strategy, ruled_out, rationale, done).
+//
+// 2. aggregateAcrossStates (A3): across multiple FSM states within one
+//    run, reads each state's exit-trace `outputs[mergeField]` array,
+//    concatenates them, and atomic-writes
+//    <run_dir>/manifest-aggregates/<merge-field>.json. Returns the path,
+//    the number of states actually contributing, the total merged length,
+//    and a list of state ids that had no exit trace (missing_states[]).
+//    This is the substrate a skill runner uses when its FSM produces
+//    findings across several states (loop + verify, fan-out + collect,
+//    etc.) and the final manifest should carry one unified findings list.
+//
+// All filesystem operations are atomic; re-running either aggregator on
+// the same run_dir is idempotent. Neither aggregator mutates source
+// files.
+//
+// Convention for loop states + cross-state aggregation: aggregateAcross-
+// States reads `outputs[mergeField]` directly from each state's exit
+// trace. A loop state's raw exit trace does NOT contain the flattened
+// findings array (it contains an `aggregated_<state-id>` path produced
+// by aggregateLoopOutputs). If a skill runner needs to fold a loop state
+// into a cross-state aggregation it must, before calling
+// aggregateAcrossStates, either (a) re-stamp the exit trace's outputs
+// with the flattened items as `outputs[mergeField]`, or (b) emit a
+// follow-on inline state whose outputs carry the flattened array. The
+// exact wiring is deferred to the skill-level runner; this library
+// intentionally does NOT auto-resolve aggregated_<state-id> paths to
+// keep the cross-state contract a one-liner: "outputs[mergeField] must
+// be an array".
 
 import {
   existsSync,
@@ -20,6 +44,7 @@ import {
   readdirSync,
 } from "node:fs";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 
 import { sanitiseLoopOutputsDirSegment } from "./fsm-engine.mjs";
 import { atomicWriteJson } from "./fsm-storage.mjs";
@@ -159,5 +184,158 @@ export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } 
     iteration_count: iters.length,
     merged_length: merged.length,
     validation_errors: validationErrors,
+  };
+}
+
+// aggregateAcrossStates concatenates `outputs[mergeField]` arrays from
+// the exit-trace records of every state in `stateIds`, in the order the
+// caller supplied (NOT the order traces were written). Writes the
+// unified array to <run_dir>/manifest-aggregates/<merge-field>.json.
+//
+// Inputs:
+//   runDir   absolute (or cwd-relative) path to the run directory.
+//   stateIds array of FSM state ids to merge across, in order. Must be
+//            a non-empty array of strings; duplicates are allowed (each
+//            occurrence is merged once).
+//   mergeField top-level array field on the exit-trace `outputs` object
+//              to concatenate. Defaults to "findings".
+//
+// Returns:
+//   {
+//     aggregated_path: "manifest-aggregates/<merge-field>.json",
+//     state_count:    <number of stateIds that contributed any value>,
+//     merged_length:  <total length of the concatenated array>,
+//     missing_states: [<state-id>, ...],   // had no exit trace in this run
+//   }
+//
+// A state whose exit trace exists but whose `outputs[mergeField]` is
+// missing or not an array is treated as contributing zero items (the
+// state IS counted in state_count if its trace exists). Only the
+// complete absence of an exit-phase trace lands the state in
+// missing_states[].
+//
+// The output file is written atomically (write-tmp + fsync + rename),
+// so a re-run on the same inputs produces the same bytes and there are
+// no .tmp leftovers.
+export function aggregateAcrossStates(runDir, { stateIds, mergeField = "findings" } = {}) {
+  if (!runDir || typeof runDir !== "string") {
+    throw new TypeError("aggregateAcrossStates: runDir must be a non-empty string path");
+  }
+  if (!Array.isArray(stateIds) || stateIds.length === 0) {
+    throw new TypeError("aggregateAcrossStates: stateIds must be a non-empty array of state ids");
+  }
+  for (const id of stateIds) {
+    if (typeof id !== "string" || id.length === 0) {
+      throw new TypeError(`aggregateAcrossStates: stateIds entries must be non-empty strings, got ${JSON.stringify(id)}`);
+    }
+  }
+  if (typeof mergeField !== "string" || mergeField.length === 0) {
+    throw new TypeError("aggregateAcrossStates: mergeField must be a non-empty string");
+  }
+
+  const traceDir = join(runDir, "fsm-trace");
+
+  // Build a one-pass map: state-id -> outputs of its (last) exit trace.
+  // We walk the trace dir once; for the same state, a later exit
+  // record overwrites the earlier one. This handles A4-style resume
+  // semantics naturally (a re-entered state's most recent exit wins).
+  const exitOutputsByState = new Map();
+  if (existsSync(traceDir)) {
+    const entries = readdirSync(traceDir)
+      .filter((n) => /^\d+-exit-.*\.yaml$/.test(n))
+      .sort(); // sequence prefix makes lexical sort = chronological.
+    for (const name of entries) {
+      const path = join(traceDir, name);
+      let parsed;
+      try {
+        parsed = parseYaml(readFileSync(path, "utf8"));
+      } catch {
+        // Malformed trace file; skip rather than crash the aggregation.
+        continue;
+      }
+      if (!parsed || parsed.phase !== "exit") continue;
+      const st = parsed.state;
+      if (typeof st !== "string") continue;
+      exitOutputsByState.set(st, parsed.outputs ?? {});
+    }
+  }
+
+  const merged = [];
+  const missingStates = [];
+  let stateCount = 0;
+  for (const id of stateIds) {
+    if (!exitOutputsByState.has(id)) {
+      missingStates.push(id);
+      continue;
+    }
+    stateCount += 1;
+    const outputs = exitOutputsByState.get(id);
+    const arr = outputs == null ? undefined : outputs[mergeField];
+    if (Array.isArray(arr)) {
+      for (const item of arr) merged.push(item);
+    }
+    // Non-array or missing: contributes zero items, but state is counted.
+  }
+
+  const aggregatesDir = join(runDir, "manifest-aggregates");
+  mkdirSync(aggregatesDir, { recursive: true });
+  const aggregatedRel = join("manifest-aggregates", `${mergeField}.json`);
+  atomicWriteJson(join(runDir, aggregatedRel), {
+    field: mergeField,
+    from_states: [...stateIds],
+    state_count: stateCount,
+    missing_states: missingStates,
+    merged_length: merged.length,
+    items: merged,
+  });
+
+  return {
+    aggregated_path: aggregatedRel,
+    state_count: stateCount,
+    merged_length: merged.length,
+    missing_states: missingStates,
+  };
+}
+
+// manifestAggregateEntry returns the canonical shape a skill runner
+// should stamp into manifest.aggregates[<merge-field>] after calling
+// aggregateAcrossStates. Keeping the shape in one place ensures every
+// consumer writes the same fields with the same names.
+//
+// Skill runners typically call:
+//
+//   const agg = aggregateAcrossStates(runDir, { stateIds: [...], mergeField: "findings" });
+//   const entry = manifestAggregateEntry({
+//     fromStates: [...],
+//     field: "findings",
+//     aggregatedPath: agg.aggregated_path,
+//     mergedLength: agg.merged_length,
+//     missingStates: agg.missing_states,
+//   });
+//   updateManifest(runId, { aggregates: { ...(manifest.aggregates ?? {}), findings: entry } }, opts);
+//
+// The library does not wire this into fsm-commit automatically: the
+// FSM YAML has no way to declare cross-state aggregates today, and
+// adding one would be a schema change outside A3's scope. The wiring
+// stays in skill-level runners; this helper keeps the shape consistent.
+export function manifestAggregateEntry({ fromStates, field, aggregatedPath, mergedLength, missingStates = [] }) {
+  if (!Array.isArray(fromStates) || fromStates.length === 0) {
+    throw new TypeError("manifestAggregateEntry: fromStates must be a non-empty array");
+  }
+  if (typeof field !== "string" || field.length === 0) {
+    throw new TypeError("manifestAggregateEntry: field must be a non-empty string");
+  }
+  if (typeof aggregatedPath !== "string" || aggregatedPath.length === 0) {
+    throw new TypeError("manifestAggregateEntry: aggregatedPath must be a non-empty string");
+  }
+  if (typeof mergedLength !== "number" || mergedLength < 0 || !Number.isInteger(mergedLength)) {
+    throw new TypeError("manifestAggregateEntry: mergedLength must be a non-negative integer");
+  }
+  return {
+    from_states: [...fromStates],
+    field,
+    path: aggregatedPath,
+    merged_length: mergedLength,
+    missing_states: Array.isArray(missingStates) ? [...missingStates] : [],
   };
 }

--- a/tests/unit/fsm-cross-state-aggregator.test.js
+++ b/tests/unit/fsm-cross-state-aggregator.test.js
@@ -1,0 +1,433 @@
+// fsm-cross-state-aggregator.test.js: unit coverage for the cross-
+// state aggregator (A3). Reads exit-trace outputs across multiple
+// states in a single run and writes a unified
+// <run_dir>/manifest-aggregates/<merge-field>.json file.
+//
+// Tests exercise: input validation, missing-states accounting, the
+// canonical "two states with findings 3 + 5 produce length-8" path,
+// default mergeField = "findings", atomic write (no tmp leftovers),
+// idempotent re-run, missing states do NOT throw, malformed trace
+// files are tolerated, and the manifestAggregateEntry helper shape.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { stringify as stringifyYaml } from "yaml";
+
+import {
+  aggregateAcrossStates,
+  manifestAggregateEntry,
+} from "../../scripts/lib/fsm-aggregator.mjs";
+
+function makeRunDir() {
+  return mkdtempSync(join(tmpdir(), "fsm-xagg-rd-"));
+}
+
+// writeExit appends a synthetic exit-trace YAML to <runDir>/fsm-trace/
+// using the same NNNN-exit-<state>.yaml convention the real engine
+// emits. Each call bumps the sequence number so files sort
+// chronologically.
+function writeExit(runDir, seq, stateId, outputs) {
+  const traceDir = join(runDir, "fsm-trace");
+  mkdirSync(traceDir, { recursive: true });
+  const seqStr = String(seq).padStart(4, "0");
+  const fileName = `${seqStr}-exit-${stateId}.yaml`;
+  const payload = {
+    phase: "exit",
+    state: stateId,
+    sequence: seq,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    outputs,
+    post_validations: [],
+    transition_evaluation: [],
+    transition: null,
+  };
+  writeFileSync(join(traceDir, fileName), stringifyYaml(payload));
+}
+
+test("aggregateAcrossStates: rejects empty stateIds", () => {
+  const runDir = makeRunDir();
+  try {
+    assert.throws(
+      () => aggregateAcrossStates(runDir, { stateIds: [] }),
+      /non-empty array/,
+    );
+    assert.throws(
+      () => aggregateAcrossStates(runDir, {}),
+      /non-empty array/,
+    );
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: rejects non-string stateIds entries", () => {
+  const runDir = makeRunDir();
+  try {
+    assert.throws(
+      () => aggregateAcrossStates(runDir, { stateIds: ["ok", 7] }),
+      /non-empty strings/,
+    );
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: rejects empty mergeField", () => {
+  const runDir = makeRunDir();
+  try {
+    assert.throws(
+      () => aggregateAcrossStates(runDir, { stateIds: ["a"], mergeField: "" }),
+      /mergeField must be a non-empty string/,
+    );
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: rejects missing runDir", () => {
+  assert.throws(
+    () => aggregateAcrossStates(undefined, { stateIds: ["a"] }),
+    /runDir/,
+  );
+});
+
+test("aggregateAcrossStates: two states with findings 3 + 5 produce length-8 unified file", () => {
+  const runDir = makeRunDir();
+  try {
+    writeExit(runDir, 1, "explore_loop", {
+      findings: [
+        { id: "f1" },
+        { id: "f2" },
+        { id: "f3" },
+      ],
+    });
+    writeExit(runDir, 2, "verify_coverage", {
+      findings: [
+        { id: "f4" },
+        { id: "f5" },
+        { id: "f6" },
+        { id: "f7" },
+        { id: "f8" },
+      ],
+    });
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["explore_loop", "verify_coverage"],
+      mergeField: "findings",
+    });
+    assert.equal(result.state_count, 2);
+    assert.equal(result.merged_length, 8);
+    assert.deepEqual(result.missing_states, []);
+    assert.equal(result.aggregated_path, "manifest-aggregates/findings.json");
+
+    const written = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.equal(written.field, "findings");
+    assert.deepEqual(written.from_states, ["explore_loop", "verify_coverage"]);
+    assert.equal(written.merged_length, 8);
+    assert.equal(written.items.length, 8);
+    assert.deepEqual(
+      written.items.map((i) => i.id),
+      ["f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8"],
+    );
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: defaults mergeField to 'findings'", () => {
+  const runDir = makeRunDir();
+  try {
+    writeExit(runDir, 1, "a", { findings: [{ x: 1 }, { x: 2 }] });
+    const result = aggregateAcrossStates(runDir, { stateIds: ["a"] });
+    assert.equal(result.merged_length, 2);
+    assert.equal(result.aggregated_path, "manifest-aggregates/findings.json");
+    const written = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.equal(written.field, "findings");
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: non-default mergeField writes the matching file", () => {
+  const runDir = makeRunDir();
+  try {
+    writeExit(runDir, 1, "scan", {
+      issues: [{ q: "one" }, { q: "two" }],
+    });
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["scan"],
+      mergeField: "issues",
+    });
+    assert.equal(result.aggregated_path, "manifest-aggregates/issues.json");
+    assert.equal(result.merged_length, 2);
+    const written = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.equal(written.field, "issues");
+    assert.deepEqual(written.items.map((i) => i.q), ["one", "two"]);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: missing states are reported, not thrown", () => {
+  const runDir = makeRunDir();
+  try {
+    writeExit(runDir, 1, "present", { findings: [{ a: 1 }, { a: 2 }] });
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["present", "missing_a", "missing_b"],
+      mergeField: "findings",
+    });
+    assert.equal(result.state_count, 1);
+    assert.equal(result.merged_length, 2);
+    assert.deepEqual(result.missing_states, ["missing_a", "missing_b"]);
+    const written = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.deepEqual(written.missing_states, ["missing_a", "missing_b"]);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: every state missing yields empty array and full missing_states list", () => {
+  const runDir = makeRunDir();
+  try {
+    // No trace dir at all.
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["a", "b"],
+      mergeField: "findings",
+    });
+    assert.equal(result.state_count, 0);
+    assert.equal(result.merged_length, 0);
+    assert.deepEqual(result.missing_states, ["a", "b"]);
+    const written = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.deepEqual(written.items, []);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: state with exit trace but no mergeField is counted with zero contribution", () => {
+  const runDir = makeRunDir();
+  try {
+    writeExit(runDir, 1, "produces", { findings: [{ a: 1 }] });
+    writeExit(runDir, 2, "empty_outputs", { other_field: "nothing here" });
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["produces", "empty_outputs"],
+      mergeField: "findings",
+    });
+    // Both states present; only one contributes.
+    assert.equal(result.state_count, 2);
+    assert.equal(result.merged_length, 1);
+    assert.deepEqual(result.missing_states, []);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: state ordering follows caller's stateIds, not trace order", () => {
+  const runDir = makeRunDir();
+  try {
+    // Trace written B first, then A.
+    writeExit(runDir, 1, "b", { findings: [{ src: "b1" }, { src: "b2" }] });
+    writeExit(runDir, 2, "a", { findings: [{ src: "a1" }] });
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["a", "b"],
+      mergeField: "findings",
+    });
+    const written = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.deepEqual(written.items.map((i) => i.src), ["a1", "b1", "b2"]);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: most recent exit wins when a state has multiple exit traces", () => {
+  const runDir = makeRunDir();
+  try {
+    // Resume scenario: state A entered twice, two exit traces.
+    writeExit(runDir, 1, "a", { findings: [{ id: "old1" }, { id: "old2" }] });
+    writeExit(runDir, 5, "a", { findings: [{ id: "new1" }] });
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["a"],
+      mergeField: "findings",
+    });
+    assert.equal(result.merged_length, 1);
+    const written = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.deepEqual(written.items.map((i) => i.id), ["new1"]);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: idempotent re-run produces identical bytes", () => {
+  const runDir = makeRunDir();
+  try {
+    writeExit(runDir, 1, "a", { findings: [{ k: 1 }, { k: 2 }] });
+    writeExit(runDir, 2, "b", { findings: [{ k: 3 }] });
+    const first = aggregateAcrossStates(runDir, {
+      stateIds: ["a", "b"],
+      mergeField: "findings",
+    });
+    const firstBody = readFileSync(join(runDir, first.aggregated_path), "utf8");
+    const second = aggregateAcrossStates(runDir, {
+      stateIds: ["a", "b"],
+      mergeField: "findings",
+    });
+    const secondBody = readFileSync(join(runDir, second.aggregated_path), "utf8");
+    assert.equal(first.merged_length, second.merged_length);
+    assert.equal(first.state_count, second.state_count);
+    assert.equal(firstBody, secondBody);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: atomic write leaves no .tmp files in manifest-aggregates/", () => {
+  const runDir = makeRunDir();
+  try {
+    writeExit(runDir, 1, "a", { findings: [{ id: "x" }] });
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["a"],
+      mergeField: "findings",
+    });
+    assert.ok(existsSync(join(runDir, result.aggregated_path)));
+    const aggDir = join(runDir, "manifest-aggregates");
+    const leftovers = readdirSync(aggDir).filter(
+      (n) => n.includes(".tmp") || n.endsWith("~"),
+    );
+    assert.equal(leftovers.length, 0, `tmp leftovers: ${JSON.stringify(leftovers)}`);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: tolerates malformed trace YAML files", () => {
+  const runDir = makeRunDir();
+  try {
+    writeExit(runDir, 1, "good", { findings: [{ k: 1 }] });
+    // Synthesize a malformed YAML file with the same naming convention.
+    const traceDir = join(runDir, "fsm-trace");
+    writeFileSync(
+      join(traceDir, "0002-exit-bad.yaml"),
+      "this: : : not parseable: [[[\n",
+    );
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["good", "bad"],
+      mergeField: "findings",
+    });
+    assert.equal(result.merged_length, 1);
+    // "bad" had no PARSEABLE exit trace, so it's missing.
+    assert.deepEqual(result.missing_states, ["bad"]);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("aggregateAcrossStates: ignores entry-phase trace files even with matching state", () => {
+  const runDir = makeRunDir();
+  try {
+    const traceDir = join(runDir, "fsm-trace");
+    mkdirSync(traceDir, { recursive: true });
+    // Entry trace, NOT exit. The aggregator must NOT pick this up.
+    writeFileSync(
+      join(traceDir, "0001-entry-a.yaml"),
+      stringifyYaml({
+        phase: "entry",
+        state: "a",
+        sequence: 1,
+        outputs: { findings: [{ ignored: true }] },
+      }),
+    );
+    writeExit(runDir, 2, "b", { findings: [{ kept: true }] });
+    const result = aggregateAcrossStates(runDir, {
+      stateIds: ["a", "b"],
+      mergeField: "findings",
+    });
+    assert.deepEqual(result.missing_states, ["a"]);
+    assert.equal(result.merged_length, 1);
+    const written = JSON.parse(readFileSync(join(runDir, result.aggregated_path), "utf8"));
+    assert.equal(written.items[0].kept, true);
+  } finally {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+});
+
+test("manifestAggregateEntry: produces the canonical shape", () => {
+  const entry = manifestAggregateEntry({
+    fromStates: ["explore_loop", "verify_coverage"],
+    field: "findings",
+    aggregatedPath: "manifest-aggregates/findings.json",
+    mergedLength: 8,
+    missingStates: [],
+  });
+  assert.deepEqual(entry, {
+    from_states: ["explore_loop", "verify_coverage"],
+    field: "findings",
+    path: "manifest-aggregates/findings.json",
+    merged_length: 8,
+    missing_states: [],
+  });
+});
+
+test("manifestAggregateEntry: rejects invalid inputs", () => {
+  assert.throws(
+    () => manifestAggregateEntry({
+      fromStates: [],
+      field: "findings",
+      aggregatedPath: "x",
+      mergedLength: 0,
+    }),
+    /non-empty array/,
+  );
+  assert.throws(
+    () => manifestAggregateEntry({
+      fromStates: ["a"],
+      field: "",
+      aggregatedPath: "x",
+      mergedLength: 0,
+    }),
+    /field must be a non-empty string/,
+  );
+  assert.throws(
+    () => manifestAggregateEntry({
+      fromStates: ["a"],
+      field: "findings",
+      aggregatedPath: "",
+      mergedLength: 0,
+    }),
+    /aggregatedPath/,
+  );
+  assert.throws(
+    () => manifestAggregateEntry({
+      fromStates: ["a"],
+      field: "findings",
+      aggregatedPath: "p",
+      mergedLength: -1,
+    }),
+    /non-negative integer/,
+  );
+});
+
+test("manifestAggregateEntry: copies arrays defensively", () => {
+  const fromStates = ["a", "b"];
+  const missing = ["c"];
+  const entry = manifestAggregateEntry({
+    fromStates,
+    field: "findings",
+    aggregatedPath: "p",
+    mergedLength: 0,
+    missingStates: missing,
+  });
+  fromStates.push("MUTATED");
+  missing.push("MUTATED");
+  assert.deepEqual(entry.from_states, ["a", "b"]);
+  assert.deepEqual(entry.missing_states, ["c"]);
+});


### PR DESCRIPTION
Reopened after #19 was auto-closed when its base branch (`feat/loop-state-primitive`) was deleted on #14 merge. Branch was rebased onto new main; the A1+A2 commits that were squashed into the #14 merge are now skipped. All Copilot threads on the original #19 were resolved before close; `copilot-pull-request-reviewer` returned a green verdict at HEAD `d5c031f`. Same scope and code.