### PR TITLE
feat(storage,cli): atomic-tx storage journal for crash-safe fsm-commit (A7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to `@ctxr/fsm` are documented here. The format is
+loosely [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+project follows [SemVer](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- **A7: atomic-tx storage journal.** Every `fsm-commit` now runs inside a
+  journal-style transaction (`withJournal`). All participating files
+  (manifest patch, trace records, aggregator outputs) stage to
+  `<run_dir>/.journal/<txn-id>/<mirror-of-rel-path>` and the rename loop
+  finalises them in one atomic step. A crash between "fn returned" and
+  the rename loop leaves a `ready_to_finalise` journal on disk;
+  `fsm-next --resume` and `fsm-commit` both refuse to advance until the
+  user explicitly recovers with `fsm-resume --journal {discard|replay}`.
+  `fsm-inspect` surfaces the journal state in its standard output.
+- New storage helpers exported from `@ctxr/fsm/storage`:
+  `withJournal(runDir, fn)`, `journalState(runDir)`,
+  `discardJournal(runDir, txnId)`, `replayJournal(runDir, txnId)`.
+- `fsm-resume` gained a `--journal {discard|replay}` mode that does NOT
+  require `--from-state`. Use `discard` to roll back an incomplete
+  commit (e.g. `pending` status) or `replay` to idempotently finalise a
+  `ready_to_finalise` commit.
+- `appendTraceFile`, `readManifest`, `writeManifest`, `updateManifest`,
+  `aggregateLoopOutputs`, and `aggregateAcrossStates` now honour an
+  optional `transaction` option that routes writes through the journal
+  staging area.
+- Test injection hook: `FSM_TEST_PAUSE_BEFORE_FINALISE=<ms>` env var
+  inserts a synchronous busy-wait between the "ready_to_finalise"
+  journal write and the rename loop. Integration tests
+  (`tests/integration/atomic-tx.test.js`) SIGKILL the child during the
+  pause to assert journal recovery semantics.
+
+### Changed
+
+- `fsm-commit` was restructured around `withJournal`: every multi-write
+  sequence (loop-iteration commit, post-validation fault, no-transition
+  fault, terminal completion, advance with entry trace + manifest
+  patch) runs inside one transaction. Brief computation for the emitted
+  payload now runs AFTER the journal finalises so disk-read counters
+  (`countLoopIterations`, `runEnv`) observe the just-written records.
+- `fsm-next --resume` refuses with
+  `{"error":"incomplete_commit_detected"}` when a journal is present,
+  carrying the `recovery` commands the operator should run.
+- `fsm-inspect` output now includes a `journal` field
+  (`{ present, txn_id, status, staged, recovery }`).
+- Package `scripts` split into `test` (unit + integration), `test:unit`,
+  and `test:integration`.
+
+## [0.1.0] - 2026-05-29
+
+Initial publish. FSM substrate with file-only state storage,
+JSON-Schema-validated worker contracts, predicate DSL for transitions,
+hub-and-spoke orchestrator-shell architecture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,11 @@ project follows [SemVer](https://semver.org/).
   optional `transaction` option that routes writes through the journal
   staging area.
 - Test injection hook: `FSM_TEST_PAUSE_BEFORE_FINALISE=<ms>` env var
-  inserts a synchronous busy-wait between the "ready_to_finalise"
-  journal write and the rename loop. Integration tests
-  (`tests/integration/atomic-tx.test.js`) SIGKILL the child during the
-  pause to assert journal recovery semantics.
+  inserts a synchronous sleep (implemented via `Atomics.wait` on a
+  private `SharedArrayBuffer`, so no CPU is burned) between the
+  "ready_to_finalise" journal write and the rename loop. Integration
+  tests (`tests/integration/atomic-tx.test.js`) SIGKILL the child
+  during the pause window to assert journal recovery semantics.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/unit/*.test.js",
+    "test": "node --test tests/unit/*.test.js tests/integration/*.test.js",
+    "test:unit": "node --test tests/unit/*.test.js",
+    "test:integration": "node --test tests/integration/*.test.js",
     "lint": "markdownlint-cli2 '**/*.md' '#node_modules'",
     "lint:fix": "markdownlint-cli2 --fix '**/*.md' '#node_modules'"
   },

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -13,16 +13,22 @@
 // Output: JSON brief for the next state on success, or
 // { status: "terminal", verdict, run_dir_path } at terminal.
 // Exit 0 on success, non-zero on schema/validation failure.
+//
+// A7 atomic-tx: every multi-file write sequence below runs inside
+// withJournal(). On crash, the journal stays on disk and either
+// fsm-resume --journal discard rolls back or --journal replay finalises.
 
 import { readFileSync } from "node:fs";
 
 import { emitJson } from "./lib/emit.mjs";
 import {
   appendTraceFile,
+  journalState,
   readLock,
   readManifest,
   releaseLock,
   runDirPath,
+  withJournal,
 } from "./lib/fsm-storage.mjs";
 import {
   buildBrief,
@@ -128,234 +134,322 @@ if (!stateId) {
 }
 
 const state = stateById(fsm.doc, stateId);
+const runDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
 
-const validationResult = validateOutputs(state, parsed.outputs);
-if (!validationResult.valid) {
-  writeFaultTrace(
-    parsed.runId,
-    {
-      state,
-      reason: "output_schema_violation",
-      details: validationResult.errors,
-    },
-    { storageRoot: settings.storageRoot },
-  );
-  updateManifest(
-    parsed.runId,
-    { status: "faulted", ended_at: new Date().toISOString() },
-    { storageRoot: settings.storageRoot },
-  );
-  releaseLock(parsed.runId, {
-    sessionId: settings.sessionId,
-    storageRoot: settings.storageRoot,
-  });
+// A7: a previous commit may have crashed between "ready_to_finalise" and
+// the rename loop, leaving a journal on disk. Refuse to commit anything
+// new until the user recovers (fsm-resume --journal discard|replay).
+const existingJournal = journalState(runDir);
+if (existingJournal.hasJournal) {
   emit({
-    error: "output_schema_violation",
-    state: state.id,
-    errors: validationResult.errors,
+    error: "incomplete_commit_detected",
+    run_id: parsed.runId,
+    journal: {
+      txn_id: existingJournal.txnId,
+      status: existingJournal.status,
+      staged: existingJournal.staged.map((s) => s.relPath),
+    },
+    recovery: {
+      discard: `fsm-resume --run-id ${parsed.runId} --journal discard`,
+      replay: `fsm-resume --run-id ${parsed.runId} --journal replay`,
+    },
   });
   process.exit(1);
 }
 
-// Loop-state branch: write the iter trace and either re-emit the next
-// loop brief (continue) or aggregate + fall through to the regular
-// exit-trace + transition path (terminate).
-let outputsForFlow = parsed.outputs;
-if (state.loop) {
-  const iterationN =
-    countLoopIterations(parsed.runId, state.id, { storageRoot: settings.storageRoot }) + 1;
-  appendTraceFile(
-    parsed.runId,
-    {
-      phase: "iter",
-      state: state.id,
-      data: { iteration_n: iterationN, outputs: parsed.outputs },
-    },
-    { storageRoot: settings.storageRoot },
-  );
-  const decision = runLoopDecision(state, parsed.outputs, iterationN);
-  if (!decision.terminate) {
-    // Bump the manifest's last_update_at on every loop iteration so
-    // run-health and stale-run signals still tick over while the loop
-    // is making progress. current_state is reaffirmed defensively (it
-    // is unchanged for a continuing loop, but this keeps the patch
-    // self-explanatory and survives manifest schema drift).
-    updateManifest(
-      parsed.runId,
-      { current_state: state.id },
-      { storageRoot: settings.storageRoot },
-    );
-    const envSoFar = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
-    const continueBrief = buildBrief({
-      doc: fsm.doc,
-      state,
-      env: envSoFar,
-      runId: parsed.runId,
-      opts: { storageRoot: settings.storageRoot },
+// commitPlan holds the post-finalise actions decided inside the journal.
+// Each branch sets one shape:
+//   { kind: "loop_continued" } — re-emit current state's next-iter brief.
+//   { kind: "fault", releaseLock: true, payload, exitCode: 1 } — schema
+//        violation, post-validation failure, or no-transition fault.
+//   { kind: "terminal", releaseLock: true, payload } — run completed.
+//   { kind: "advance", nextStateId, envWithCommit } — advance to next.
+let commitPlan;
+
+try {
+  withJournal(runDir, (txn) => {
+    const txOpts = { storageRoot: settings.storageRoot, transaction: txn };
+
+    const validationResult = validateOutputs(state, parsed.outputs);
+    if (!validationResult.valid) {
+      writeFaultTrace(
+        parsed.runId,
+        {
+          state,
+          reason: "output_schema_violation",
+          details: validationResult.errors,
+        },
+        txOpts,
+      );
+      updateManifest(
+        parsed.runId,
+        { status: "faulted", ended_at: new Date().toISOString() },
+        txOpts,
+      );
+      commitPlan = {
+        kind: "fault",
+        releaseLock: true,
+        payload: {
+          error: "output_schema_violation",
+          state: state.id,
+          errors: validationResult.errors,
+        },
+        exitCode: 1,
+      };
+      return;
+    }
+
+    // Loop-state branch: write the iter trace and either re-emit the
+    // next loop brief (continue) or aggregate + fall through to the
+    // regular exit-trace + transition path (terminate).
+    let outputsForFlow = parsed.outputs;
+    if (state.loop) {
+      const iterationN =
+        countLoopIterations(parsed.runId, state.id, txOpts) + 1;
+      appendTraceFile(
+        parsed.runId,
+        {
+          phase: "iter",
+          state: state.id,
+          data: { iteration_n: iterationN, outputs: parsed.outputs },
+        },
+        txOpts,
+      );
+      const decision = runLoopDecision(state, parsed.outputs, iterationN);
+      if (!decision.terminate) {
+        // Bump the manifest's last_update_at on every loop iteration so
+        // run-health and stale-run signals still tick over while the
+        // loop is making progress. current_state is reaffirmed
+        // defensively (unchanged for a continuing loop, but keeps the
+        // patch self-explanatory and survives manifest schema drift).
+        updateManifest(
+          parsed.runId,
+          { current_state: state.id },
+          txOpts,
+        );
+        commitPlan = { kind: "loop_continued" };
+        return;
+      }
+      // Terminating: aggregate iter outputs into one canonical record
+      // and use that as the loop state's outputs for the rest of the
+      // commit flow. The aggregator writes through the journal so the
+      // aggregated.json + iteration-meta.json land in the same atomic
+      // step as the exit trace.
+      const agg = aggregateLoopOutputs(runDir, state, {
+        mergeField: "findings",
+        transaction: txn,
+      });
+      outputsForFlow = {
+        [`aggregated_${state.id}`]: agg.aggregated_path,
+        iteration_meta_path: agg.iteration_meta_path,
+        // total_iterations is the COMMITTED iteration count (taken from
+        // iterationN, the trace-driven counter), NOT agg.iteration_count
+        // which only counts iter-N.json files the aggregator could
+        // parse and schema-validate. Otherwise tolerated invalid iters
+        // would make the manifest's iteration count disagree with
+        // max_iterations bookkeeping and the trace.
+        total_iterations: iterationN,
+        aggregated_iteration_count: agg.iteration_count,
+        aggregator_validation_errors: agg.validation_errors,
+        merged_length: agg.merged_length,
+        terminated_by: decision.reason,
+      };
+    }
+
+    // Post-validations run against the freshly-committed outputs. For
+    // a terminating loop state, outputsForFlow is the aggregated record
+    // (the canonical post-loop output), so predicates that need to
+    // inspect the aggregate (`total_iterations`, etc.) see them; for a
+    // non-loop state outputsForFlow === parsed.outputs.
+    const postValidations = runPostValidations(state, outputsForFlow);
+    if (!postValidations.valid) {
+      writeFaultTrace(
+        parsed.runId,
+        {
+          state,
+          reason: "post_validation_failed",
+          details: { post_validations: postValidations.results },
+        },
+        txOpts,
+      );
+      updateManifest(
+        parsed.runId,
+        { status: "faulted", ended_at: new Date().toISOString() },
+        txOpts,
+      );
+      commitPlan = {
+        kind: "fault",
+        releaseLock: true,
+        payload: {
+          error: "post_validation_failed",
+          state: state.id,
+          post_validations: postValidations.results,
+        },
+        exitCode: 1,
+      };
+      return;
+    }
+
+    const env = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
+    const envWithCommit = { ...env, ...outputsForFlow };
+    const { transition, evaluations } = resolveTransition(state, envWithCommit, {
+      judgementPick: parsed.judgementPick,
     });
-    emit({
-      ok: true,
-      loop_continued: true,
-      ...continueBrief,
-    });
-    process.exit(0);
-  }
-  // Terminating: aggregate iter outputs into one canonical record and use
-  // that as the loop state's outputs for the rest of the commit flow.
-  // `total_iterations` is the COMMITTED iteration count (taken from
-  // iterationN, the trace-driven counter), NOT agg.iteration_count
-  // which only counts iter-N.json files the aggregator could parse
-  // and schema-validate. Otherwise tolerated invalid iters would make
-  // the manifest's iteration count disagree with max_iterations
-  // bookkeeping and the trace.
-  const runDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
-  const agg = aggregateLoopOutputs(runDir, state, { mergeField: "findings" });
-  outputsForFlow = {
-    [`aggregated_${state.id}`]: agg.aggregated_path,
-    iteration_meta_path: agg.iteration_meta_path,
-    total_iterations: iterationN,
-    aggregated_iteration_count: agg.iteration_count,
-    aggregator_validation_errors: agg.validation_errors,
-    merged_length: agg.merged_length,
-    terminated_by: decision.reason,
-  };
-}
 
-// Post-validations run against the freshly-committed outputs. For a
-// terminating loop state, outputsForFlow is the aggregated record (the
-// canonical post-loop output), so predicates that need to inspect the
-// aggregate (`total_iterations`, etc.) see them; for a non-loop state
-// outputsForFlow === parsed.outputs.
-const postValidations = runPostValidations(state, outputsForFlow);
-if (!postValidations.valid) {
-  writeFaultTrace(
-    parsed.runId,
-    {
-      state,
-      reason: "post_validation_failed",
-      details: { post_validations: postValidations.results },
-    },
-    { storageRoot: settings.storageRoot },
-  );
-  updateManifest(
-    parsed.runId,
-    { status: "faulted", ended_at: new Date().toISOString() },
-    { storageRoot: settings.storageRoot },
-  );
-  releaseLock(parsed.runId, {
-    sessionId: settings.sessionId,
-    storageRoot: settings.storageRoot,
-  });
-  emit({
-    error: "post_validation_failed",
-    state: state.id,
-    post_validations: postValidations.results,
-  });
-  process.exit(1);
-}
-
-const env = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
-const envWithCommit = { ...env, ...outputsForFlow };
-const { transition, evaluations } = resolveTransition(state, envWithCommit, {
-  judgementPick: parsed.judgementPick,
-});
-
-writeExitTrace(
-  parsed.runId,
-  {
-    state,
-    outputs: outputsForFlow,
-    postValidations: postValidations.results,
-    transitionEvals: evaluations,
-    chosenTransition: transition?.to ?? null,
-  },
-  { storageRoot: settings.storageRoot },
-);
-
-if (!transition) {
-  if ((state.transitions ?? []).length > 0) {
-    writeFaultTrace(
+    writeExitTrace(
       parsed.runId,
       {
         state,
-        reason: "no_transition_matched",
-        details: { evaluations },
+        outputs: outputsForFlow,
+        postValidations: postValidations.results,
+        transitionEvals: evaluations,
+        chosenTransition: transition?.to ?? null,
       },
-      { storageRoot: settings.storageRoot },
+      txOpts,
+    );
+
+    if (!transition) {
+      if ((state.transitions ?? []).length > 0) {
+        writeFaultTrace(
+          parsed.runId,
+          {
+            state,
+            reason: "no_transition_matched",
+            details: { evaluations },
+          },
+          txOpts,
+        );
+        updateManifest(
+          parsed.runId,
+          { status: "faulted", ended_at: new Date().toISOString() },
+          txOpts,
+        );
+        commitPlan = {
+          kind: "fault",
+          releaseLock: true,
+          payload: {
+            error: "no_transition_matched",
+            state: state.id,
+            evaluations,
+          },
+          exitCode: 1,
+        };
+        return;
+      }
+      updateManifest(
+        parsed.runId,
+        {
+          status: "completed",
+          current_state: state.id,
+          next_state: null,
+          ended_at: new Date().toISOString(),
+          verdict: envWithCommit.verdict ?? null,
+          transitions_count: (manifest.transitions_count ?? 0) + 1,
+        },
+        txOpts,
+      );
+      commitPlan = {
+        kind: "terminal",
+        releaseLock: true,
+        payload: {
+          ok: true,
+          status: "terminal",
+          state: state.id,
+          verdict: envWithCommit.verdict ?? null,
+          run_dir_path: runDir,
+        },
+      };
+      return;
+    }
+
+    const nextState = stateById(fsm.doc, transition.to);
+    // Loop states declare their worker under state.loop.worker; falling
+    // back here keeps the entry trace's recorded inputs consistent with
+    // what buildBrief will pass to the worker dispatch.
+    const nextInputsDecl =
+      nextState.worker?.inputs ?? nextState.loop?.worker?.inputs ?? [];
+    const nextInputs = nextInputsDecl.reduce((acc, name) => {
+      acc[name] = envWithCommit[name];
+      return acc;
+    }, {});
+    writeEntryTrace(
+      parsed.runId,
+      { state: nextState, inputs: nextInputs },
+      txOpts,
     );
     updateManifest(
       parsed.runId,
-      { status: "faulted", ended_at: new Date().toISOString() },
-      { storageRoot: settings.storageRoot },
+      {
+        current_state: nextState.id,
+        next_state: null,
+        transitions_count: (manifest.transitions_count ?? 0) + 1,
+      },
+      txOpts,
     );
-    releaseLock(parsed.runId, {
-      sessionId: settings.sessionId,
-      storageRoot: settings.storageRoot,
-    });
+    commitPlan = {
+      kind: "advance",
+      nextStateId: nextState.id,
+      envWithCommit,
+      advancedFrom: state.id,
+    };
+  });
+} catch (err) {
+  // If withJournal itself refused (e.g. a journal raced into existence
+  // between our pre-check and the start of the txn) surface it as a
+  // structured error rather than a stack trace.
+  if (err && err.code === "JOURNAL_PRESENT") {
     emit({
-      error: "no_transition_matched",
-      state: state.id,
-      evaluations,
+      error: "incomplete_commit_detected",
+      run_id: parsed.runId,
+      journal: err.journal,
     });
     process.exit(1);
   }
-  updateManifest(
-    parsed.runId,
-    {
-      status: "completed",
-      current_state: state.id,
-      next_state: null,
-      ended_at: new Date().toISOString(),
-      verdict: envWithCommit.verdict ?? null,
-      transitions_count: (manifest.transitions_count ?? 0) + 1,
-    },
-    { storageRoot: settings.storageRoot },
-  );
+  fail(err.message, 1);
+}
+
+// All journal writes have finalised. The post-finalise phase reads from
+// disk to compute emit-only payloads (briefs, etc.) and optionally
+// releases the lock. None of the work below is required for crash
+// recovery: the manifest already records the new state.
+
+if (commitPlan.releaseLock) {
   releaseLock(parsed.runId, {
     sessionId: settings.sessionId,
     storageRoot: settings.storageRoot,
   });
+}
+
+if (commitPlan.kind === "fault" || commitPlan.kind === "terminal") {
+  emit(commitPlan.payload);
+  process.exit(commitPlan.exitCode ?? 0);
+}
+
+if (commitPlan.kind === "loop_continued") {
+  const envSoFar = runEnv(parsed.runId, { storageRoot: settings.storageRoot });
+  const continueBrief = buildBrief({
+    doc: fsm.doc,
+    state,
+    env: envSoFar,
+    runId: parsed.runId,
+    opts: { storageRoot: settings.storageRoot },
+  });
   emit({
     ok: true,
-    status: "terminal",
-    state: state.id,
-    verdict: envWithCommit.verdict ?? null,
-    run_dir_path: runDirPath(parsed.runId, { storageRoot: settings.storageRoot }),
+    loop_continued: true,
+    ...continueBrief,
   });
   process.exit(0);
 }
 
-const nextState = stateById(fsm.doc, transition.to);
-// Loop states declare their worker under state.loop.worker; falling back
-// here keeps the entry trace's recorded inputs consistent with what
-// buildBrief will pass to the worker dispatch (otherwise the trace shows
-// no inputs for a loop-entry state, which is misleading on inspection).
-const nextInputsDecl =
-  nextState.worker?.inputs ?? nextState.loop?.worker?.inputs ?? [];
-const nextInputs = nextInputsDecl.reduce((acc, name) => {
-  acc[name] = envWithCommit[name];
-  return acc;
-}, {});
-writeEntryTrace(
-  parsed.runId,
-  { state: nextState, inputs: nextInputs },
-  { storageRoot: settings.storageRoot },
-);
-updateManifest(
-  parsed.runId,
-  {
-    current_state: nextState.id,
-    next_state: null,
-    transitions_count: (manifest.transitions_count ?? 0) + 1,
-  },
-  { storageRoot: settings.storageRoot },
-);
+// kind === "advance"
+const nextState = stateById(fsm.doc, commitPlan.nextStateId);
 const brief = buildBrief({
   doc: fsm.doc,
   state: nextState,
-  env: envWithCommit,
+  env: commitPlan.envWithCommit,
   runId: parsed.runId,
   opts: { storageRoot: settings.storageRoot },
 });
-emit({ ok: true, advanced_from: state.id, ...brief });
+emit({ ok: true, advanced_from: commitPlan.advancedFrom, ...brief });
 process.exit(0);

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -140,7 +140,22 @@ const runDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
 // A7: a previous commit may have crashed between "ready_to_finalise" and
 // the rename loop, leaving a journal on disk. Refuse to commit anything
 // new until the user recovers (fsm-resume --journal discard|replay).
-const existingJournal = journalState(runDir);
+//
+// journalState can throw if `.journal` exists but is unreadable (filesystem
+// error, permission issue, or `.journal` is a regular file rather than a
+// directory). Surface that as a structured payload instead of an
+// unhandled stack trace so automation can react.
+let existingJournal;
+try {
+  existingJournal = journalState(runDir);
+} catch (err) {
+  emit({
+    error: "journal_inspect_failed",
+    run_id: parsed.runId,
+    detail: err.message,
+  });
+  process.exit(1);
+}
 if (existingJournal.hasJournal) {
   emit({
     error: "incomplete_commit_detected",

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -20,7 +20,7 @@
 
 import { readFileSync } from "node:fs";
 
-import { emitJson } from "./lib/emit.mjs";
+import { emitJson, shellQuote } from "./lib/emit.mjs";
 import {
   appendTraceFile,
   journalState,
@@ -162,8 +162,8 @@ if (existingJournal.hasJournal) {
     run_id: parsed.runId,
     journal: publicJournalProjection(existingJournal),
     recovery: {
-      discard: `fsm-resume --run-id ${parsed.runId} --journal discard --storage-root ${settings.storageRoot}`,
-      replay: `fsm-resume --run-id ${parsed.runId} --journal replay --storage-root ${settings.storageRoot}`,
+      discard: `fsm-resume --run-id ${shellQuote(parsed.runId)} --journal discard --storage-root ${shellQuote(settings.storageRoot)}`,
+      replay: `fsm-resume --run-id ${shellQuote(parsed.runId)} --journal replay --storage-root ${shellQuote(settings.storageRoot)}`,
     },
   });
   process.exit(1);
@@ -417,8 +417,8 @@ try {
       run_id: parsed.runId,
       journal: publicJournalProjection(err.journal),
       recovery: {
-        discard: `fsm-resume --run-id ${parsed.runId} --journal discard --storage-root ${settings.storageRoot}`,
-        replay: `fsm-resume --run-id ${parsed.runId} --journal replay --storage-root ${settings.storageRoot}`,
+        discard: `fsm-resume --run-id ${shellQuote(parsed.runId)} --journal discard --storage-root ${shellQuote(settings.storageRoot)}`,
+        replay: `fsm-resume --run-id ${shellQuote(parsed.runId)} --journal replay --storage-root ${shellQuote(settings.storageRoot)}`,
       },
     });
     process.exit(1);

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -147,8 +147,8 @@ if (existingJournal.hasJournal) {
     run_id: parsed.runId,
     journal: publicJournalProjection(existingJournal),
     recovery: {
-      discard: `fsm-resume --run-id ${parsed.runId} --journal discard`,
-      replay: `fsm-resume --run-id ${parsed.runId} --journal replay`,
+      discard: `fsm-resume --run-id ${parsed.runId} --journal discard --storage-root ${settings.storageRoot}`,
+      replay: `fsm-resume --run-id ${parsed.runId} --journal replay --storage-root ${settings.storageRoot}`,
     },
   });
   process.exit(1);

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -402,8 +402,8 @@ try {
       run_id: parsed.runId,
       journal: publicJournalProjection(err.journal),
       recovery: {
-        discard: `fsm-resume --run-id ${parsed.runId} --journal discard`,
-        replay: `fsm-resume --run-id ${parsed.runId} --journal replay`,
+        discard: `fsm-resume --run-id ${parsed.runId} --journal discard --storage-root ${settings.storageRoot}`,
+        replay: `fsm-resume --run-id ${parsed.runId} --journal replay --storage-root ${settings.storageRoot}`,
       },
     });
     process.exit(1);

--- a/scripts/fsm-commit.mjs
+++ b/scripts/fsm-commit.mjs
@@ -24,6 +24,7 @@ import { emitJson } from "./lib/emit.mjs";
 import {
   appendTraceFile,
   journalState,
+  publicJournalProjection,
   readLock,
   readManifest,
   releaseLock,
@@ -144,11 +145,7 @@ if (existingJournal.hasJournal) {
   emit({
     error: "incomplete_commit_detected",
     run_id: parsed.runId,
-    journal: {
-      txn_id: existingJournal.txnId,
-      status: existingJournal.status,
-      staged: existingJournal.staged.map((s) => s.relPath),
-    },
+    journal: publicJournalProjection(existingJournal),
     recovery: {
       discard: `fsm-resume --run-id ${parsed.runId} --journal discard`,
       replay: `fsm-resume --run-id ${parsed.runId} --journal replay`,
@@ -398,10 +395,16 @@ try {
   // between our pre-check and the start of the txn) surface it as a
   // structured error rather than a stack trace.
   if (err && err.code === "JOURNAL_PRESENT") {
+    // Same stable shape as the pre-check above — the CLI error payload
+    // must not vary based on which code path detected the journal.
     emit({
       error: "incomplete_commit_detected",
       run_id: parsed.runId,
-      journal: err.journal,
+      journal: publicJournalProjection(err.journal),
+      recovery: {
+        discard: `fsm-resume --run-id ${parsed.runId} --journal discard`,
+        replay: `fsm-resume --run-id ${parsed.runId} --journal replay`,
+      },
     });
     process.exit(1);
   }

--- a/scripts/fsm-inspect.mjs
+++ b/scripts/fsm-inspect.mjs
@@ -6,7 +6,7 @@
 //
 // Output: JSON with manifest + lock state + ordered list of trace records.
 
-import { emitJson } from "./lib/emit.mjs";
+import { emitJson, shellQuote } from "./lib/emit.mjs";
 import {
   journalState,
   publicJournalProjection,
@@ -86,8 +86,8 @@ const journal = journalInspectError
       present: true,
       ...publicJournalProjection(jstate),
       recovery: {
-        discard: `fsm-resume --run-id ${parsed.runId} --journal discard --storage-root ${storageRoot}`,
-        replay: `fsm-resume --run-id ${parsed.runId} --journal replay --storage-root ${storageRoot}`,
+        discard: `fsm-resume --run-id ${shellQuote(parsed.runId)} --journal discard --storage-root ${shellQuote(storageRoot)}`,
+        replay: `fsm-resume --run-id ${shellQuote(parsed.runId)} --journal replay --storage-root ${shellQuote(storageRoot)}`,
       },
     }
   : { present: false };

--- a/scripts/fsm-inspect.mjs
+++ b/scripts/fsm-inspect.mjs
@@ -67,8 +67,21 @@ if (!manifest) {
 const lock = readLock(parsed.runId, { storageRoot });
 const trace = readTrace(parsed.runId, { storageRoot });
 const runDir = runDirPath(parsed.runId, { storageRoot });
-const jstate = journalState(runDir);
-const journal = jstate.hasJournal
+// journalState can throw if `.journal` is unreadable or is a regular
+// file rather than a directory. Inspect should still emit a usable
+// payload — surface the inspection failure under a structured
+// `journal.error` field, leave the rest of the output intact.
+let jstate;
+let journalInspectError;
+try {
+  jstate = journalState(runDir);
+} catch (err) {
+  jstate = { hasJournal: false };
+  journalInspectError = err.message;
+}
+const journal = journalInspectError
+  ? { present: false, error: journalInspectError }
+  : jstate.hasJournal
   ? {
       present: true,
       ...publicJournalProjection(jstate),

--- a/scripts/fsm-inspect.mjs
+++ b/scripts/fsm-inspect.mjs
@@ -10,6 +10,7 @@ import { resolve } from "node:path";
 
 import { emitJson } from "./lib/emit.mjs";
 import {
+  journalState,
   readLock,
   readManifest,
   readTrace,
@@ -92,13 +93,30 @@ if (!manifest) {
 
 const lock = readLock(parsed.runId, { storageRoot });
 const trace = readTrace(parsed.runId, { storageRoot });
+const runDir = runDirPath(parsed.runId, { storageRoot });
+const jstate = journalState(runDir);
+const journal = jstate.hasJournal
+  ? {
+      present: true,
+      txn_id: jstate.txnId,
+      status: jstate.status,
+      staged: jstate.staged.map((s) =>
+        typeof s === "string" ? s : s.relPath,
+      ),
+      recovery: {
+        discard: `fsm-resume --run-id ${parsed.runId} --journal discard`,
+        replay: `fsm-resume --run-id ${parsed.runId} --journal replay`,
+      },
+    }
+  : { present: false };
 
 emit({
   ok: true,
   run_id: parsed.runId,
-  run_dir_path: runDirPath(parsed.runId, { storageRoot }),
+  run_dir_path: runDir,
   manifest,
   lock,
+  journal,
   trace_count: trace.length,
   trace: trace.map((r) => ({
     file: r.fileName,

--- a/scripts/fsm-inspect.mjs
+++ b/scripts/fsm-inspect.mjs
@@ -6,8 +6,6 @@
 //
 // Output: JSON with manifest + lock state + ordered list of trace records.
 
-import { resolve } from "node:path";
-
 import { emitJson } from "./lib/emit.mjs";
 import {
   journalState,
@@ -17,7 +15,7 @@ import {
   readTrace,
   runDirPath,
 } from "./lib/fsm-storage.mjs";
-import { loadConfig } from "./lib/fsm-config.mjs";
+import { resolveStorageRoot as resolveStorageRootFromConfig } from "./lib/fsm-config.mjs";
 
 function parseArgs(argv) {
   const args = {};
@@ -49,41 +47,15 @@ try {
   process.exit(2);
 }
 
-// fsm-inspect only needs storage_root (no FSM YAML loaded). Resolve it
-// directly via loadConfig + CLI override, without the full resolveSettings
-// machinery that requires fsmPath.
+// fsm-inspect only needs storage_root (no FSM YAML loaded). Use the
+// shared resolveStorageRoot helper (also used by fsm-resume's journal
+// recovery short-circuit) so the resolution rules stay in one place.
 let storageRoot;
 try {
-  storageRoot = resolveStorageRoot(parsed);
+  storageRoot = resolveStorageRootFromConfig(parsed);
 } catch (err) {
   process.stderr.write(`fsm-inspect: ${err.message}\n`);
   process.exit(2);
-}
-
-function resolveStorageRoot(cliArgs) {
-  const cwd = process.cwd();
-  if (cliArgs.storageRoot) return resolve(cwd, cliArgs.storageRoot);
-  const cfg = loadConfig(cwd);
-  let entry;
-  if (cliArgs.fsmName) {
-    entry = cfg.fsms.find((f) => f.name === cliArgs.fsmName);
-    if (!entry) {
-      const available = cfg.fsms.map((f) => f.name).join(", ") || "(none)";
-      throw new Error(
-        `--fsm "${cliArgs.fsmName}" not found in ${cfg._config_path ?? ".fsmrc.json"}. Available: ${available}`,
-      );
-    }
-  } else if (cfg.fsms.length === 1) {
-    entry = cfg.fsms[0];
-  } else if (cfg.fsms.length === 0) {
-    throw new Error("must pass --storage-root or have a .fsmrc.json with fsms[]");
-  } else {
-    const available = cfg.fsms.map((f) => f.name).join(", ");
-    throw new Error(
-      `multiple FSMs configured (${available}); pass --fsm <name> or --storage-root`,
-    );
-  }
-  return resolve(cwd, entry.storage_root);
 }
 
 const manifest = readManifest(parsed.runId, { storageRoot });
@@ -101,8 +73,8 @@ const journal = jstate.hasJournal
       present: true,
       ...publicJournalProjection(jstate),
       recovery: {
-        discard: `fsm-resume --run-id ${parsed.runId} --journal discard`,
-        replay: `fsm-resume --run-id ${parsed.runId} --journal replay`,
+        discard: `fsm-resume --run-id ${parsed.runId} --journal discard --storage-root ${storageRoot}`,
+        replay: `fsm-resume --run-id ${parsed.runId} --journal replay --storage-root ${storageRoot}`,
       },
     }
   : { present: false };

--- a/scripts/fsm-inspect.mjs
+++ b/scripts/fsm-inspect.mjs
@@ -11,6 +11,7 @@ import { resolve } from "node:path";
 import { emitJson } from "./lib/emit.mjs";
 import {
   journalState,
+  publicJournalProjection,
   readLock,
   readManifest,
   readTrace,
@@ -98,11 +99,7 @@ const jstate = journalState(runDir);
 const journal = jstate.hasJournal
   ? {
       present: true,
-      txn_id: jstate.txnId,
-      status: jstate.status,
-      staged: jstate.staged.map((s) =>
-        typeof s === "string" ? s : s.relPath,
-      ),
+      ...publicJournalProjection(jstate),
       recovery: {
         discard: `fsm-resume --run-id ${parsed.runId} --journal discard`,
         replay: `fsm-resume --run-id ${parsed.runId} --journal replay`,

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -28,6 +28,7 @@ import {
   buildRunId,
   ensureRunDir,
   journalState,
+  publicJournalProjection,
   readManifest,
   runDirPath,
 } from "./lib/fsm-storage.mjs";
@@ -194,11 +195,7 @@ if (resumeJournal.hasJournal) {
   emit({
     error: "incomplete_commit_detected",
     run_id: runId,
-    journal: {
-      txn_id: resumeJournal.txnId,
-      status: resumeJournal.status,
-      staged: resumeJournal.staged.map((s) => s.relPath),
-    },
+    journal: publicJournalProjection(resumeJournal),
     recovery: {
       discard: `fsm-resume --run-id ${runId} --journal discard`,
       replay: `fsm-resume --run-id ${runId} --journal replay`,

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -189,8 +189,22 @@ if (manifest.status !== "in_progress" && manifest.status !== "paused") {
 // The journal contains the intent of the last (crashed) commit; the
 // user must explicitly recover via `fsm-resume --journal discard|replay`
 // before any new state work can be done.
+//
+// journalState can throw on a filesystem error or if `.journal` is a
+// regular file rather than a directory. Surface as a structured
+// payload (instead of a stack trace) so automation can react.
 const resumeRunDir = runDirPath(runId, { storageRoot: settings.storageRoot });
-const resumeJournal = journalState(resumeRunDir);
+let resumeJournal;
+try {
+  resumeJournal = journalState(resumeRunDir);
+} catch (err) {
+  emit({
+    error: "journal_inspect_failed",
+    run_id: runId,
+    detail: err.message,
+  });
+  process.exit(1);
+}
 if (resumeJournal.hasJournal) {
   emit({
     error: "incomplete_commit_detected",

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -21,7 +21,7 @@
 
 import { readFileSync } from "node:fs";
 
-import { emitJson } from "./lib/emit.mjs";
+import { emitJson, shellQuote } from "./lib/emit.mjs";
 
 import {
   acquireLock,
@@ -211,8 +211,8 @@ if (resumeJournal.hasJournal) {
     run_id: runId,
     journal: publicJournalProjection(resumeJournal),
     recovery: {
-      discard: `fsm-resume --run-id ${runId} --journal discard --storage-root ${settings.storageRoot}`,
-      replay: `fsm-resume --run-id ${runId} --journal replay --storage-root ${settings.storageRoot}`,
+      discard: `fsm-resume --run-id ${shellQuote(runId)} --journal discard --storage-root ${shellQuote(settings.storageRoot)}`,
+      replay: `fsm-resume --run-id ${shellQuote(runId)} --journal replay --storage-root ${shellQuote(settings.storageRoot)}`,
     },
   });
   process.exit(1);

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -27,7 +27,9 @@ import {
   acquireLock,
   buildRunId,
   ensureRunDir,
+  journalState,
   readManifest,
+  runDirPath,
 } from "./lib/fsm-storage.mjs";
 import {
   buildBrief,
@@ -179,6 +181,28 @@ if (manifest.status !== "in_progress" && manifest.status !== "paused") {
     error: "run_not_resumable",
     run_id: runId,
     status: manifest.status,
+  });
+  process.exit(1);
+}
+// A7: refuse to advance if a previous commit left a journal on disk.
+// The journal contains the intent of the last (crashed) commit; the
+// user must explicitly recover via `fsm-resume --journal discard|replay`
+// before any new state work can be done.
+const resumeRunDir = runDirPath(runId, { storageRoot: settings.storageRoot });
+const resumeJournal = journalState(resumeRunDir);
+if (resumeJournal.hasJournal) {
+  emit({
+    error: "incomplete_commit_detected",
+    run_id: runId,
+    journal: {
+      txn_id: resumeJournal.txnId,
+      status: resumeJournal.status,
+      staged: resumeJournal.staged.map((s) => s.relPath),
+    },
+    recovery: {
+      discard: `fsm-resume --run-id ${runId} --journal discard`,
+      replay: `fsm-resume --run-id ${runId} --journal replay`,
+    },
   });
   process.exit(1);
 }

--- a/scripts/fsm-next.mjs
+++ b/scripts/fsm-next.mjs
@@ -197,8 +197,8 @@ if (resumeJournal.hasJournal) {
     run_id: runId,
     journal: publicJournalProjection(resumeJournal),
     recovery: {
-      discard: `fsm-resume --run-id ${runId} --journal discard`,
-      replay: `fsm-resume --run-id ${runId} --journal replay`,
+      discard: `fsm-resume --run-id ${runId} --journal discard --storage-root ${settings.storageRoot}`,
+      replay: `fsm-resume --run-id ${runId} --journal replay --storage-root ${settings.storageRoot}`,
     },
   });
   process.exit(1);

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -32,10 +32,13 @@ import { join } from "node:path";
 import { emitJson } from "./lib/emit.mjs";
 import {
   acquireLock,
+  discardJournal,
+  journalState,
   pruneTraceAfter,
   readLock,
   readManifest,
   readTrace,
+  replayJournal,
   runDirPath,
 } from "./lib/fsm-storage.mjs";
 import {
@@ -53,6 +56,7 @@ function parseArgs(argv) {
     const arg = argv[i];
     if (arg === "--run-id") args.runId = argv[++i];
     else if (arg === "--from-state") args.fromState = argv[++i];
+    else if (arg === "--journal") args.journalAction = argv[++i];
     else if (arg === "--session-id") args.sessionId = argv[++i];
     else if (arg === "--fsm" || arg === "--fsm-name") args.fsmName = argv[++i];
     else if (arg === "--fsm-path") args.fsmPath = argv[++i];
@@ -60,7 +64,18 @@ function parseArgs(argv) {
     else throw new Error(`fsm-resume: unknown argument "${arg}"`);
   }
   if (!args.runId) throw new Error("--run-id is required");
-  if (!args.fromState) throw new Error("--from-state is required");
+  if (args.journalAction) {
+    if (!["discard", "replay"].includes(args.journalAction)) {
+      throw new Error(
+        `--journal must be "discard" or "replay", got "${args.journalAction}"`,
+      );
+    }
+    if (args.fromState) {
+      throw new Error("--journal and --from-state are mutually exclusive");
+    }
+  } else if (!args.fromState) {
+    throw new Error("either --from-state or --journal <discard|replay> is required");
+  }
   return args;
 }
 
@@ -99,6 +114,60 @@ const manifest = readManifest(parsed.runId, { storageRoot: settings.storageRoot 
 if (!manifest) {
   emit({ error: "run_not_found", run_id: parsed.runId });
   process.exit(1);
+}
+
+// --journal {discard|replay}: dedicated A7 recovery short-circuit.
+// Inspects <run_dir>/.journal/ and either rolls back the pending
+// transaction (discard) or finalises it idempotently (replay). Does NOT
+// touch the lock, the trace, or the manifest beyond what the recovery
+// op naturally produces (replay's rename loop finalises any staged
+// manifest.json the crash captured). Pre-existing journals from a
+// previous crashed fsm-commit are the only target.
+if (parsed.journalAction) {
+  const recoveryRunDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
+  const jstate = journalState(recoveryRunDir);
+  if (!jstate.hasJournal) {
+    emit({
+      ok: true,
+      run_id: parsed.runId,
+      journal_action: parsed.journalAction,
+      result: "no_journal_present",
+    });
+    process.exit(0);
+  }
+  if (parsed.journalAction === "discard") {
+    const out = discardJournal(recoveryRunDir, jstate.txnId);
+    emit({
+      ok: true,
+      run_id: parsed.runId,
+      journal_action: "discard",
+      txn_id: jstate.txnId,
+      status_before: jstate.status,
+      ...out,
+    });
+    process.exit(0);
+  }
+  // replay
+  if (jstate.status !== "ready_to_finalise") {
+    emit({
+      error: "replay_not_safe",
+      run_id: parsed.runId,
+      txn_id: jstate.txnId,
+      status: jstate.status,
+      hint:
+        "journal status must be ready_to_finalise to replay; a pending journal means the producing fn never returned. Use --journal discard.",
+    });
+    process.exit(1);
+  }
+  const out = replayJournal(recoveryRunDir, jstate.txnId);
+  emit({
+    ok: true,
+    run_id: parsed.runId,
+    journal_action: "replay",
+    txn_id: jstate.txnId,
+    ...out,
+  });
+  process.exit(0);
 }
 
 // Resume is for runs that can legitimately be rewound: an `in_progress`

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -142,7 +142,18 @@ if (parsed.journalAction) {
     process.exit(0);
   }
   if (parsed.journalAction === "discard") {
-    const out = discardJournal(recoveryRunDir, jstate.txnId);
+    let out;
+    try {
+      out = discardJournal(recoveryRunDir, jstate.txnId);
+    } catch (err) {
+      emit({
+        error: "discard_failed",
+        run_id: parsed.runId,
+        txn_id: jstate.txnId,
+        detail: err.message,
+      });
+      process.exit(1);
+    }
     emit({
       ok: true,
       run_id: parsed.runId,
@@ -165,7 +176,22 @@ if (parsed.journalAction) {
     });
     process.exit(1);
   }
-  const out = replayJournal(recoveryRunDir, jstate.txnId);
+  let out;
+  try {
+    out = replayJournal(recoveryRunDir, jstate.txnId);
+  } catch (err) {
+    // replayJournal's tightened checks (symlink containment,
+    // missing-source-AND-missing-dest, etc.) all throw. Surface as
+    // a structured CLI error so operators and automation can react
+    // instead of getting a stack trace.
+    emit({
+      error: "replay_failed",
+      run_id: parsed.runId,
+      txn_id: jstate.txnId,
+      detail: err.message,
+    });
+    process.exit(1);
+  }
   emit({
     ok: true,
     run_id: parsed.runId,

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -224,7 +224,10 @@ function doJournalRecovery(storageRoot) {
       txn_id: jstate.txnId,
       status: jstate.status,
       hint:
-        "journal status must be ready_to_finalise to replay; a pending journal means the producing fn never returned. Use --journal discard.",
+        "journal status must be ready_to_finalise to replay. " +
+        "`pending` means the producing fn never returned; " +
+        "`lock_only` means a crash left only the single-writer lock " +
+        "(no staged work to replay). In both cases use --journal discard.",
     });
     process.exit(1);
   }

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -150,7 +150,21 @@ try {
 // --from-state resume impossible, but a journal can still be
 // discarded or replayed bytewise.
 function doJournalRecovery(storageRoot) {
-  const recoveryRunDir = runDirPath(parsed.runId, { storageRoot });
+  // runDirPath calls parseRunId, which throws on a malformed run-id.
+  // Surface that as a structured malformed_run_id payload rather
+  // than crashing the recovery CLI with a stack trace.
+  let recoveryRunDir;
+  try {
+    recoveryRunDir = runDirPath(parsed.runId, { storageRoot });
+  } catch (err) {
+    emit({
+      error: "malformed_run_id",
+      run_id: parsed.runId,
+      journal_action: parsed.journalAction,
+      detail: err.message,
+    });
+    process.exit(1);
+  }
   // Distinguish "run dir does not exist" from "run dir exists but
   // carries no journal". The previous unconditional `no_journal_present`
   // misled operators into thinking recovery succeeded when they had

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -115,19 +115,6 @@ try {
   fail(err.message, 2);
 }
 
-let fsm;
-try {
-  fsm = loadFsm({ fsmPath: settings.fsmPath });
-} catch (err) {
-  fail(err.message, 1);
-}
-
-const manifest = readManifest(parsed.runId, { storageRoot: settings.storageRoot });
-if (!manifest) {
-  emit({ error: "run_not_found", run_id: parsed.runId });
-  process.exit(1);
-}
-
 // --journal {discard|replay}: dedicated A7 recovery short-circuit.
 // Inspects <run_dir>/.journal/ and either rolls back the pending
 // transaction (discard) or finalises it idempotently (replay). Does NOT
@@ -135,6 +122,13 @@ if (!manifest) {
 // op naturally produces (replay's rename loop finalises any staged
 // manifest.json the crash captured). Pre-existing journals from a
 // previous crashed fsm-commit are the only target.
+//
+// Runs BEFORE loadFsm + readManifest because recovery only needs
+// storageRoot + runId. An operator should be able to recover an
+// incomplete commit even when the FSM YAML has been moved/renamed or
+// the run's manifest somehow got truncated — both would make a regular
+// --from-state resume impossible, but a journal can still be
+// discarded or replayed bytewise.
 if (parsed.journalAction) {
   const recoveryRunDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
   const jstate = journalState(recoveryRunDir);
@@ -180,6 +174,19 @@ if (parsed.journalAction) {
     ...out,
   });
   process.exit(0);
+}
+
+let fsm;
+try {
+  fsm = loadFsm({ fsmPath: settings.fsmPath });
+} catch (err) {
+  fail(err.message, 1);
+}
+
+const manifest = readManifest(parsed.runId, { storageRoot: settings.storageRoot });
+if (!manifest) {
+  emit({ error: "run_not_found", run_id: parsed.runId });
+  process.exit(1);
 }
 
 // Resume is for runs that can legitimately be rewound: an `in_progress`

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -150,6 +150,21 @@ try {
 // discarded or replayed bytewise.
 function doJournalRecovery(storageRoot) {
   const recoveryRunDir = runDirPath(parsed.runId, { storageRoot });
+  // Distinguish "run dir does not exist" from "run dir exists but
+  // carries no journal". The previous unconditional `no_journal_present`
+  // misled operators into thinking recovery succeeded when they had
+  // simply mistyped the run-id or storage-root. Emit run_not_found
+  // (exit 1) for the missing-run-dir case so automation can tell
+  // them apart without needing to load the manifest (which we
+  // intentionally avoid in the recovery short-circuit).
+  if (!existsSync(recoveryRunDir)) {
+    emit({
+      error: "run_not_found",
+      run_id: parsed.runId,
+      journal_action: parsed.journalAction,
+    });
+    process.exit(1);
+  }
   const jstate = journalState(recoveryRunDir);
   if (!jstate.hasJournal) {
     emit({

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -173,13 +173,17 @@ function doJournalRecovery(storageRoot) {
       });
       process.exit(1);
     }
+    // Emit only snake_case keys. Spreading `...out` would mix the
+    // helper's camelCase `txnId` into the payload alongside the
+    // explicit `txn_id` and confuse downstream consumers.
     emit({
       ok: true,
       run_id: parsed.runId,
       journal_action: "discard",
       txn_id: jstate.txnId,
       status_before: jstate.status,
-      ...out,
+      discarded: out.discarded,
+      reason: out.reason ?? null,
     });
     process.exit(0);
   }
@@ -211,12 +215,16 @@ function doJournalRecovery(storageRoot) {
     });
     process.exit(1);
   }
+  // Emit only snake_case keys. Spreading `...out` would mix the
+  // helper's camelCase `txnId` into the payload alongside the
+  // explicit `txn_id`.
   emit({
     ok: true,
     run_id: parsed.runId,
     journal_action: "replay",
     txn_id: jstate.txnId,
-    ...out,
+    replayed: out.replayed,
+    finalised: out.finalised ?? [],
   });
   process.exit(0);
 }

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -165,7 +165,21 @@ function doJournalRecovery(storageRoot) {
     });
     process.exit(1);
   }
-  const jstate = journalState(recoveryRunDir);
+  // journalState can throw if `.journal` is unreadable / a regular
+  // file. Recovery should still surface a usable error payload
+  // rather than crash with a stack trace.
+  let jstate;
+  try {
+    jstate = journalState(recoveryRunDir);
+  } catch (err) {
+    emit({
+      error: "journal_inspect_failed",
+      run_id: parsed.runId,
+      journal_action: parsed.journalAction,
+      detail: err.message,
+    });
+    process.exit(1);
+  }
   if (!jstate.hasJournal) {
     emit({
       ok: true,

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -33,6 +33,7 @@ import { emitJson } from "./lib/emit.mjs";
 import {
   acquireLock,
   discardJournal,
+  discardOrphanedLock,
   journalState,
   pruneTraceAfter,
   readLock,
@@ -192,7 +193,16 @@ function doJournalRecovery(storageRoot) {
   if (parsed.journalAction === "discard") {
     let out;
     try {
-      out = discardJournal(recoveryRunDir, jstate.txnId);
+      // Orphaned-lock branch: if journalState surfaced lock_only AND
+      // could not parse the lock payload's txn_id, calling
+      // discardJournal(null) would throw "txnId must be a non-empty
+      // string". Route to discardOrphanedLock instead, which clears
+      // the lock without requiring a txnId match.
+      if (jstate.lock_only && !jstate.txnId) {
+        out = discardOrphanedLock(recoveryRunDir);
+      } else {
+        out = discardJournal(recoveryRunDir, jstate.txnId);
+      }
     } catch (err) {
       emit({
         error: "discard_failed",

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -52,15 +52,27 @@ import { resolveSettings } from "./lib/fsm-config.mjs";
 
 function parseArgs(argv) {
   const args = {};
+  // Helper: every flag below expects exactly one argument value. Reject
+  // a flag whose value is missing (end of argv) or another flag, so
+  // mistakes like `fsm-resume --journal` (no action) surface as a
+  // pointed parse error rather than the generic
+  // "either --from-state or --journal ..." fallback.
+  const takeValue = (flag, i) => {
+    const v = argv[i + 1];
+    if (v === undefined || (typeof v === "string" && v.startsWith("--"))) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return v;
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === "--run-id") args.runId = argv[++i];
-    else if (arg === "--from-state") args.fromState = argv[++i];
-    else if (arg === "--journal") args.journalAction = argv[++i];
-    else if (arg === "--session-id") args.sessionId = argv[++i];
-    else if (arg === "--fsm" || arg === "--fsm-name") args.fsmName = argv[++i];
-    else if (arg === "--fsm-path") args.fsmPath = argv[++i];
-    else if (arg === "--storage-root") args.storageRoot = argv[++i];
+    if (arg === "--run-id") args.runId = takeValue(arg, i++);
+    else if (arg === "--from-state") args.fromState = takeValue(arg, i++);
+    else if (arg === "--journal") args.journalAction = takeValue(arg, i++);
+    else if (arg === "--session-id") args.sessionId = takeValue(arg, i++);
+    else if (arg === "--fsm" || arg === "--fsm-name") args.fsmName = takeValue(arg, i++);
+    else if (arg === "--fsm-path") args.fsmPath = takeValue(arg, i++);
+    else if (arg === "--storage-root") args.storageRoot = takeValue(arg, i++);
     else throw new Error(`fsm-resume: unknown argument "${arg}"`);
   }
   if (!args.runId) throw new Error("--run-id is required");

--- a/scripts/fsm-resume.mjs
+++ b/scripts/fsm-resume.mjs
@@ -48,7 +48,7 @@ import {
   stateById,
   updateManifest,
 } from "./lib/fsm-engine.mjs";
-import { resolveSettings } from "./lib/fsm-config.mjs";
+import { resolveSettings, resolveStorageRoot } from "./lib/fsm-config.mjs";
 
 function parseArgs(argv) {
   const args = {};
@@ -108,6 +108,26 @@ try {
   fail(err.message, 2);
 }
 
+// --journal {discard|replay}: dedicated A7 recovery short-circuit.
+//
+// Runs BEFORE resolveSettings + loadFsm because recovery only needs
+// `storageRoot + runId`. resolveSettings requires fsmPath (CLI override
+// OR a .fsmrc.json entry), which would block recovery in setups
+// without config. Use the lightweight resolveStorageRoot helper to
+// honour --storage-root if passed, or fall back to .fsmrc.json's
+// storage_root. An operator should be able to discard or replay an
+// incomplete commit even when the FSM YAML has been moved / renamed /
+// deleted.
+if (parsed.journalAction) {
+  let recoveryStorageRoot;
+  try {
+    recoveryStorageRoot = resolveStorageRoot(parsed);
+  } catch (err) {
+    fail(err.message, 2);
+  }
+  doJournalRecovery(recoveryStorageRoot);
+}
+
 let settings;
 try {
   settings = resolveSettings(parsed);
@@ -115,7 +135,6 @@ try {
   fail(err.message, 2);
 }
 
-// --journal {discard|replay}: dedicated A7 recovery short-circuit.
 // Inspects <run_dir>/.journal/ and either rolls back the pending
 // transaction (discard) or finalises it idempotently (replay). Does NOT
 // touch the lock, the trace, or the manifest beyond what the recovery
@@ -129,8 +148,8 @@ try {
 // the run's manifest somehow got truncated — both would make a regular
 // --from-state resume impossible, but a journal can still be
 // discarded or replayed bytewise.
-if (parsed.journalAction) {
-  const recoveryRunDir = runDirPath(parsed.runId, { storageRoot: settings.storageRoot });
+function doJournalRecovery(storageRoot) {
+  const recoveryRunDir = runDirPath(parsed.runId, { storageRoot });
   const jstate = journalState(recoveryRunDir);
   if (!jstate.hasJournal) {
     emit({

--- a/scripts/lib/emit.mjs
+++ b/scripts/lib/emit.mjs
@@ -20,6 +20,18 @@
 import { writeSync } from "node:fs";
 import { Buffer } from "node:buffer";
 
+// shellQuote wraps a value in POSIX single-quotes so it can be
+// concatenated into a copy-pasteable shell command even when it
+// contains spaces, $, backticks, or other special characters. Embedded
+// single quotes are handled with the standard `'\''` close-reopen
+// trick. Used by the CLI recovery hints in fsm-commit / fsm-next /
+// fsm-inspect / fsm-resume.
+export function shellQuote(value) {
+  if (value === undefined || value === null) return "''";
+  const s = String(value);
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
 export function emitJson(payload) {
   const text = `${JSON.stringify(payload, null, 2)}\n`;
   const buf = Buffer.from(text, "utf8");

--- a/scripts/lib/fsm-aggregator.mjs
+++ b/scripts/lib/fsm-aggregator.mjs
@@ -77,7 +77,7 @@ function posixRel(...segments) {
 //   }
 // On schema-violation in any iter file, the path appears in validation_errors
 // but aggregation still proceeds with the remaining valid files.
-export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } = {}) {
+export function aggregateLoopOutputs(runDir, state, { mergeField = "findings", transaction } = {}) {
   if (!state?.loop) {
     throw new Error("aggregateLoopOutputs: state is not a loop state");
   }
@@ -174,9 +174,25 @@ export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } 
   // join() so they use OS-native separators locally.
   const aggregatedRel = posixRel("workers", `${stateId}-aggregated.json`);
   const metaRel = posixRel("workers", `${stateId}-iteration-meta.json`);
-  mkdirSync(join(runDir, "workers"), { recursive: true });
-  atomicWriteJson(join(runDir, "workers", `${stateId}-aggregated.json`), { state: stateId, merge_field: mergeField, items: merged });
-  atomicWriteJson(join(runDir, "workers", `${stateId}-iteration-meta.json`), { state: stateId, iterations: iterationMeta });
+  const aggregatedBody = { state: stateId, merge_field: mergeField, items: merged };
+  const metaBody = { state: stateId, iterations: iterationMeta };
+  if (transaction) {
+    // Inside a withJournal transaction, route writes to the staged
+    // journal paths so the loop's terminate-and-aggregate sequence
+    // becomes part of the same atomic commit. The rename loop in
+    // withJournal moves them into place when the transaction
+    // finalises.
+    const aggregatedStaged = transaction.stage(aggregatedRel);
+    const metaStaged = transaction.stage(metaRel);
+    atomicWriteJson(aggregatedStaged, aggregatedBody);
+    atomicWriteJson(metaStaged, metaBody);
+    transaction.addStaged(aggregatedRel, aggregatedStaged);
+    transaction.addStaged(metaRel, metaStaged);
+  } else {
+    mkdirSync(join(runDir, "workers"), { recursive: true });
+    atomicWriteJson(join(runDir, "workers", `${stateId}-aggregated.json`), aggregatedBody);
+    atomicWriteJson(join(runDir, "workers", `${stateId}-iteration-meta.json`), metaBody);
+  }
 
   return {
     aggregated_path: aggregatedRel,
@@ -217,7 +233,7 @@ export function aggregateLoopOutputs(runDir, state, { mergeField = "findings" } 
 // The output file is written atomically (write-tmp + fsync + rename),
 // so a re-run on the same inputs produces the same bytes and there are
 // no .tmp leftovers.
-export function aggregateAcrossStates(runDir, { stateIds, mergeField = "findings" } = {}) {
+export function aggregateAcrossStates(runDir, { stateIds, mergeField = "findings", transaction } = {}) {
   if (!runDir || typeof runDir !== "string") {
     throw new TypeError("aggregateAcrossStates: runDir must be a non-empty string path");
   }
@@ -277,17 +293,24 @@ export function aggregateAcrossStates(runDir, { stateIds, mergeField = "findings
     // Non-array or missing: contributes zero items, but state is counted.
   }
 
-  const aggregatesDir = join(runDir, "manifest-aggregates");
-  mkdirSync(aggregatesDir, { recursive: true });
-  const aggregatedRel = join("manifest-aggregates", `${mergeField}.json`);
-  atomicWriteJson(join(runDir, aggregatedRel), {
+  const aggregatedRel = posixRel("manifest-aggregates", `${mergeField}.json`);
+  const body = {
     field: mergeField,
     from_states: [...stateIds],
     state_count: stateCount,
     missing_states: missingStates,
     merged_length: merged.length,
     items: merged,
-  });
+  };
+  if (transaction) {
+    const stagedPath = transaction.stage(aggregatedRel);
+    atomicWriteJson(stagedPath, body);
+    transaction.addStaged(aggregatedRel, stagedPath);
+  } else {
+    const aggregatesDir = join(runDir, "manifest-aggregates");
+    mkdirSync(aggregatesDir, { recursive: true });
+    atomicWriteJson(join(runDir, aggregatedRel), body);
+  }
 
   return {
     aggregated_path: aggregatedRel,

--- a/scripts/lib/fsm-config.mjs
+++ b/scripts/lib/fsm-config.mjs
@@ -181,3 +181,44 @@ export function resolveSettings(cliArgs = {}, cwd = process.cwd()) {
 function defaultSessionId() {
   return `session-${process.pid}-${Date.now()}`;
 }
+
+// resolveStorageRoot returns just the storageRoot (absolute path).
+// Used by CLIs that DO NOT need the FSM YAML — fsm-inspect for read-only
+// inspection, fsm-resume --journal {discard|replay} for journal-only
+// recovery. Skipping the fsmPath requirement lets these flows succeed
+// even when the FSM YAML has been moved, renamed, or deleted.
+//
+// Resolution order matches resolveSettings:
+//   1. CLI `--storage-root` if provided (no config lookup needed).
+//   2. Single .fsmrc.json entry: use its storage_root.
+//   3. Multi-FSM .fsmrc.json with `--fsm <name>`: pick the named entry.
+//   4. Multi-FSM .fsmrc.json without `--fsm`: error (must disambiguate).
+//   5. No config: error (must pass `--storage-root`).
+export function resolveStorageRoot(cliArgs = {}, cwd = process.cwd()) {
+  if (cliArgs.storageRoot) {
+    return resolve(cwd, cliArgs.storageRoot);
+  }
+  const cfg = loadConfig(cwd);
+  let entry;
+  if (cliArgs.fsmName) {
+    entry = cfg.fsms.find((f) => f.name === cliArgs.fsmName);
+    if (!entry) {
+      const available = cfg.fsms.map((f) => f.name).join(", ") || "(none)";
+      throw new Error(
+        `fsm: --fsm "${cliArgs.fsmName}" not found in ${cfg._config_path ?? ".fsmrc.json"}. Available: ${available}`,
+      );
+    }
+  } else if (cfg.fsms.length === 1) {
+    entry = cfg.fsms[0];
+  } else if (cfg.fsms.length === 0) {
+    throw new Error(
+      "fsm: no FSM configured. Pass --storage-root, or add a .fsmrc.json with fsms[].",
+    );
+  } else {
+    const available = cfg.fsms.map((f) => f.name).join(", ");
+    throw new Error(
+      `fsm: multiple FSMs configured (${available}). Pass --fsm <name> to pick one, or --storage-root to bypass the config.`,
+    );
+  }
+  return resolve(cwd, entry.storage_root);
+}

--- a/scripts/lib/fsm-engine.mjs
+++ b/scripts/lib/fsm-engine.mjs
@@ -458,8 +458,10 @@ export function initialiseManifest({
   return data;
 }
 
-export function updateManifest(runId, patch, { storageRoot, now = new Date() } = {}) {
-  const existing = readManifest(runId, { storageRoot });
+export function updateManifest(runId, patch, opts = {}) {
+  const { storageRoot, now = new Date(), transaction } = opts;
+  const storageOpts = { storageRoot, transaction };
+  const existing = readManifest(runId, storageOpts);
   if (!existing) {
     throw new Error(`updateManifest: no manifest at run-id "${runId}"`);
   }
@@ -468,7 +470,7 @@ export function updateManifest(runId, patch, { storageRoot, now = new Date() } =
     ...patch,
     last_update_at: now.toISOString(),
   };
-  writeManifest(runId, updated, { storageRoot });
+  writeManifest(runId, updated, storageOpts);
   return updated;
 }
 

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -611,6 +611,11 @@ export function discardJournal(runDir, txnId) {
     return { discarded: false, reason: "not_found" };
   }
   rmSync(txnDir, { recursive: true, force: true });
+  // Recovery also clears the single-writer lock that withJournal
+  // would have left in place if the crash happened mid-transaction;
+  // without this the next fsm-commit would refuse with JOURNAL_PRESENT
+  // forever.
+  rmSync(join(root, "tx.lock"), { force: true });
   // Clean up empty journal root (root is the containment-checked
   // journalRoot computed at the top of this function).
   if (existsSync(root) && readdirSync(root).length === 0) {
@@ -702,6 +707,10 @@ export function replayJournal(runDir, txnId) {
     finalised.push({ relPath: entry.relPath, already: false });
   }
   rmSync(txnDir, { recursive: true, force: true });
+  // Recovery also clears the single-writer lock so the next
+  // withJournal isn't refused with JOURNAL_PRESENT after a successful
+  // replay (the lock would be a leftover from the crashed writer).
+  rmSync(join(root, "tx.lock"), { force: true });
   // root was computed and containment-checked at the top of this
   // function; reuse it for the empty-journal cleanup.
   if (existsSync(root) && readdirSync(root).length === 0) {
@@ -755,6 +764,64 @@ export function withJournal(runDir, fn) {
     runDir,
     "withJournal (txnDir ancestor)",
   );
+  // Ensure the journal root exists BEFORE acquiring the atomic lock
+  // (next), since the lock file lives inside it.
+  mkdirSync(root, { recursive: true });
+  assertWithin(root, runDir, "withJournal (journal root)");
+
+  // ATOMIC SINGLE-WRITER GUARD: O_EXCL on `<root>/tx.lock`. The
+  // earlier journalState refuse-block catches the case where a
+  // PREVIOUS withJournal crashed and left a txn dir on disk; the
+  // O_EXCL lock here catches the case where ANOTHER process is
+  // currently mid-withJournal on the same run. Without this, two
+  // processes could both observe hasJournal=false, both create
+  // distinct txn dirs, and both run rename loops that would trample
+  // each other's manifest.json and trace files. The lock holds for
+  // the whole transaction lifecycle and is removed only as part of
+  // success cleanup (or by discard/replay during recovery).
+  const txnLockPath = join(root, "tx.lock");
+  const lockPayload = JSON.stringify({
+    txn_id: txnId,
+    pid: process.pid,
+    started_at: new Date().toISOString(),
+  });
+  try {
+    const fd = openSync(txnLockPath, "wx", 0o644);
+    try {
+      writeFileSync(fd, lockPayload);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  } catch (err) {
+    if (err.code === "EEXIST") {
+      // Another transaction holds the lock. Surface the journal
+      // state we can read so the caller knows what's blocking.
+      let activeLock = null;
+      try {
+        activeLock = JSON.parse(readFileSync(txnLockPath, "utf8"));
+      } catch {
+        // Lock file unreadable; report what we can.
+      }
+      let observedState = { hasJournal: false };
+      try {
+        observedState = journalState(runDir);
+      } catch {
+        // Don't let an inspection failure mask the real lock-held cause.
+      }
+      const lockErr = new Error(
+        `withJournal: another transaction holds the lock (active=${activeLock ? activeLock.txn_id : "unknown"}); recover via fsm-resume --journal {discard|replay}`,
+      );
+      lockErr.code = "JOURNAL_PRESENT";
+      lockErr.journal = {
+        ...observedState,
+        active_lock: activeLock,
+      };
+      throw lockErr;
+    }
+    throw err;
+  }
+
   mkdirSync(txnDir, { recursive: true });
   // Post-mkdir check so a race that drops a symlink AT the journal
   // root between the pre-flight and now is still caught.
@@ -948,6 +1015,11 @@ export function withJournal(runDir, fn) {
     renameSync(entry.stagedPath, finalPath);
   }
   rmSync(txnDir, { recursive: true, force: true });
+  // Release the single-writer lock BEFORE attempting the root
+  // cleanup so the empty-dir check sees the journal root as truly
+  // empty (the lock file is the only thing left after the txn dir
+  // is gone).
+  rmSync(txnLockPath, { force: true });
   if (existsSync(root) && readdirSync(root).length === 0) {
     try {
       rmdirSync(root);

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -181,7 +181,13 @@ export function writeManifest(runId, data, opts = {}) {
     const relPath = "manifest.json";
     const stagedPath = txn.stage(relPath);
     atomicWriteJson(stagedPath, data);
-    if (!txn.staged.some((s) => s.relPath === relPath)) {
+    // Skip the duplicate registration when manifest.json is rewritten
+    // multiple times in one transaction (e.g. an inline state that
+    // patches the manifest after the engine has already staged its
+    // own update). atomicWriteJson over the same stagedPath gives
+    // last-write-wins, which is the correct semantics for a single
+    // commit.
+    if (!txn.hasStaged(relPath)) {
       txn.addStaged(relPath, stagedPath);
     }
     return;
@@ -627,6 +633,20 @@ export function replayJournal(runDir, txnId) {
     const stagedPath = join(txnDir, entry.relPath);
     const finalPath = join(runDir, entry.relPath);
     if (!existsSync(stagedPath)) {
+      // Idempotency only holds when the destination already carries
+      // the bytes. If neither the staged source NOR the final
+      // destination exists, the journal has been partially cleaned
+      // up (manual intervention, disk corruption, restored from a
+      // partial backup) and silently completing would let us delete
+      // the journal directory, losing the last recoverable
+      // artifact. Refuse loudly so the operator can inspect what
+      // happened.
+      if (!existsSync(finalPath)) {
+        throw new Error(
+          `replayJournal: staged source for "${entry.relPath}" is missing AND the destination does not exist; ` +
+            "the journal was partially cleaned up. Inspect the run directory manually before retrying.",
+        );
+      }
       finalised.push({ relPath: entry.relPath, already: true });
       continue;
     }
@@ -717,7 +737,18 @@ export function withJournal(runDir, fn) {
     txnId,
     runDir,
     txnDir,
-    staged: stagedFiles,
+    // `staged` is a snapshot, not a live reference. Returning the
+    // internal array would let a caller bypass stage()/addStaged()
+    // validation by pushing arbitrary entries straight in, which the
+    // finalisation rename loop would then move into runDir without
+    // any checks. The getter returns a fresh frozen copy each access
+    // — read-only by contract, immune to in-place mutation.
+    get staged() {
+      return Object.freeze(stagedFiles.map((s) => ({ ...s })));
+    },
+    hasStaged(relPath) {
+      return stagedFiles.some((s) => s.relPath === relPath);
+    },
     stage(relPath) {
       // stage() is the public surface for staging a write inside a
       // transaction. String-side relPath validation rejects "..",
@@ -757,6 +788,20 @@ export function withJournal(runDir, fn) {
       if (stagedPath !== canonical) {
         throw new Error(
           `transaction.addStaged: stagedPath "${stagedPath}" must equal canonical "${canonical}" (use the value returned by stage(relPath))`,
+        );
+      }
+      // Duplicate-relPath guard. If the same relPath is registered
+      // twice, the finalisation rename loop would call renameSync on
+      // the (now non-existent) staged source the second time and
+      // throw mid-finalise, leaving the run with some files moved
+      // and others not. Callers that legitimately re-stage a path
+      // (e.g. writeManifest writing manifest.json multiple times in
+      // one tx) must use hasStaged() to skip the duplicate
+      // registration; atomicWrite over the same stagedPath is the
+      // expected idiom.
+      if (stagedFiles.some((s) => s.relPath === relPath)) {
+        throw new Error(
+          `transaction.addStaged: relPath "${relPath}" is already staged; use hasStaged() to skip the duplicate registration`,
         );
       }
       stagedFiles.push({ relPath, stagedPath: canonical });

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -395,6 +395,33 @@ export function journalRoot(runDir) {
 // from a journal manifest during replayJournal — a crafted or corrupted
 // journal.json must not be able to rename staged files outside the run
 // directory.
+// assertSafeTxnId rejects any txnId that contains path separators,
+// traversal segments, colons, or backslashes, so a caller-supplied
+// value can never escape <journalRoot>. discardJournal and
+// replayJournal each rmSync / renameSync against a path computed as
+// `join(journalRoot(runDir), txnId)`; without this guard, a crafted
+// txnId like "../../" would let those functions touch arbitrary paths
+// on disk. Internally-generated txn ids look like
+// "2026-05-29T18-30-45-123Z-abc123" — a single safe filesystem
+// segment.
+function assertSafeTxnId(txnId, context) {
+  if (typeof txnId !== "string" || txnId.length === 0) {
+    throw new Error(`${context}: txnId must be a non-empty string`);
+  }
+  if (
+    txnId === "." ||
+    txnId === ".." ||
+    txnId.includes("/") ||
+    txnId.includes("\\") ||
+    txnId.includes(":")
+  ) {
+    throw new Error(
+      `${context}: txnId "${txnId}" must be a single safe filesystem segment ` +
+        "(no '/', '\\\\', ':', '.' or '..')",
+    );
+  }
+}
+
 function assertSafeJournalRelPath(relPath, context) {
   if (typeof relPath !== "string" || relPath.length === 0) {
     throw new Error(`${context}: relPath must be a non-empty string`);
@@ -494,6 +521,7 @@ export function journalState(runDir) {
 // transaction is "ready_to_finalise", callers should usually replay instead
 // — discarding loses the work — but the explicit choice is the user's.
 export function discardJournal(runDir, txnId) {
+  assertSafeTxnId(txnId, "discardJournal");
   const txnDir = join(journalRoot(runDir), txnId);
   if (!existsSync(txnDir)) {
     return { discarded: false, reason: "not_found" };
@@ -515,6 +543,7 @@ export function discardJournal(runDir, txnId) {
 // staged file to its final location. Safe to re-run: a missing staged
 // source is treated as already-finalised.
 export function replayJournal(runDir, txnId) {
+  assertSafeTxnId(txnId, "replayJournal");
   const txnDir = join(journalRoot(runDir), txnId);
   const manifest = readJournalManifestSync(txnDir);
   if (!manifest) {

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -24,6 +24,7 @@ import {
   readdirSync,
   readFileSync,
   renameSync,
+  rmdirSync,
   rmSync,
   writeFileSync,
   openSync,
@@ -31,10 +32,11 @@ import {
   fsyncSync,
   statSync,
 } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { stringify as stringifyYaml, parse as parseYaml } from "yaml";
 
 const LOCK_TTL_MS_DEFAULT = 60 * 60 * 1000; // 1 hour
+const JOURNAL_DIR_NAME = ".journal";
 
 // ─── run-id ─────────────────────────────────────────────────────────────
 
@@ -159,12 +161,30 @@ export function atomicWriteYaml(path, data) {
 // ─── manifest.json ──────────────────────────────────────────────────────
 
 export function readManifest(runId, opts = {}) {
+  // When called inside a transaction, prefer the staged manifest if one
+  // has already been written this turn so successive updateManifest
+  // calls compose (read-merge-write) instead of clobbering each other.
+  const txn = opts.transaction;
+  if (txn && typeof txn.readStagedManifest === "function") {
+    const staged = txn.readStagedManifest();
+    if (staged) return staged;
+  }
   const path = join(runDirPath(runId, opts), "manifest.json");
   if (!existsSync(path)) return null;
   return JSON.parse(readFileSync(path, "utf8"));
 }
 
 export function writeManifest(runId, data, opts = {}) {
+  const txn = opts.transaction;
+  if (txn) {
+    const relPath = "manifest.json";
+    const stagedPath = txn.stage(relPath);
+    atomicWriteJson(stagedPath, data);
+    if (!txn.staged.some((s) => s.relPath === relPath)) {
+      txn.addStaged(relPath, stagedPath);
+    }
+    return;
+  }
   const dir = ensureRunDir(runId, opts);
   atomicWriteJson(join(dir, "manifest.json"), data);
 }
@@ -271,19 +291,34 @@ export function appendTraceFile(runId, { phase, state, data }, opts = {}) {
   if (!state || typeof state !== "string") {
     throw new Error("appendTraceFile: state must be a non-empty string");
   }
-  const dir = ensureRunDir(runId, opts);
-  const seq = nextTraceSequence(runId, opts);
-  const seqStr = String(seq).padStart(4, "0");
-  const fileName = `${seqStr}-${phase}-${state}.yaml`;
-  const filePath = join(dir, "fsm-trace", fileName);
-  const payload = {
+  const txn = opts.transaction;
+  const payload = (seq) => ({
     phase,
     state,
     sequence: seq,
     timestamp: new Date().toISOString(),
     ...data,
-  };
-  atomicWriteYaml(filePath, payload);
+  });
+  if (txn) {
+    // Sequence accounting must include both on-disk traces and traces
+    // already staged in this transaction so a single commit that
+    // writes (entry-N, exit-N) gets sequential numbers even though
+    // neither file has been moved into place yet.
+    const seq = nextTraceSequence(runId, opts) + txn.stagedTraceCount();
+    const seqStr = String(seq).padStart(4, "0");
+    const fileName = `${seqStr}-${phase}-${state}.yaml`;
+    const relPath = `fsm-trace/${fileName}`;
+    const stagedPath = txn.stage(relPath);
+    atomicWriteYaml(stagedPath, payload(seq));
+    txn.addStaged(relPath, stagedPath);
+    return { sequence: seq, fileName, path: join(txn.runDir, relPath) };
+  }
+  const dir = ensureRunDir(runId, opts);
+  const seq = nextTraceSequence(runId, opts);
+  const seqStr = String(seq).padStart(4, "0");
+  const fileName = `${seqStr}-${phase}-${state}.yaml`;
+  const filePath = join(dir, "fsm-trace", fileName);
+  atomicWriteYaml(filePath, payload(seq));
   return { sequence: seq, fileName, path: filePath };
 }
 
@@ -325,6 +360,258 @@ export function pruneTraceAfter(runId, sequence, opts = {}) {
     rmSync(join(traceDir, entry.name), { force: true });
   }
   return { removed: candidates.length, files: candidates.map((c) => c.name) };
+}
+
+// ─── atomic-tx journal (A7) ─────────────────────────────────────────────
+//
+// withJournal(runDir, fn) is the journal-style transaction wrapper that
+// makes a multi-file fsm-commit a single atomic step. Inside `fn`, callers
+// stage writes to <runDir>/.journal/<txnId>/<mirror-of-relPath> instead of
+// the final location. After `fn` returns successfully:
+//   1. mark the journal manifest as "ready_to_finalise"
+//   2. rename each staged file from its journal path to its final path
+//   3. delete the journal directory
+//
+// If any step throws or the process is killed, the journal stays on disk
+// and recovery is explicit:
+//   - journalState(runDir) returns { hasJournal, status, txnId, staged }.
+//   - discardJournal(runDir, txnId) removes the journal (rollback).
+//   - replayJournal(runDir, txnId) idempotently finalises a journal whose
+//     status is "ready_to_finalise" — safe to call repeatedly.
+//
+// fsm-next refuses to advance while a journal is present; fsm-resume
+// exposes `--journal discard|replay` as the recovery path.
+
+export function journalRoot(runDir) {
+  return join(runDir, JOURNAL_DIR_NAME);
+}
+
+function readJournalManifestSync(txnDir) {
+  const path = join(txnDir, "journal.json");
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeJournalManifestSync(txnDir, data) {
+  atomicWriteJson(join(txnDir, "journal.json"), data);
+}
+
+// journalState inspects <runDir>/.journal/ and returns the most recent
+// transaction if any. Returns { hasJournal:false } when the directory is
+// absent or empty.
+export function journalState(runDir) {
+  const root = journalRoot(runDir);
+  if (!existsSync(root)) return { hasJournal: false };
+  const entries = readdirSync(root).filter((n) => {
+    const p = join(root, n);
+    try {
+      return statSync(p).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+  if (entries.length === 0) return { hasJournal: false };
+  // Most recent by name (txnId is timestamp-prefixed) is the active one.
+  const txnIds = entries.sort();
+  const all = txnIds.map((id) => {
+    const txnDir = join(root, id);
+    const manifest = readJournalManifestSync(txnDir);
+    return { txnId: id, txnDir, manifest };
+  });
+  const active = all[all.length - 1];
+  return {
+    hasJournal: true,
+    txnId: active.txnId,
+    txnDir: active.txnDir,
+    status: active.manifest ? active.manifest.status : "unknown",
+    staged: active.manifest ? active.manifest.staged_files || [] : [],
+    runDir: active.manifest ? active.manifest.run_dir : runDir,
+    all,
+  };
+}
+
+// discardJournal removes a specific journal transaction directory. If the
+// transaction is "ready_to_finalise", callers should usually replay instead
+// — discarding loses the work — but the explicit choice is the user's.
+export function discardJournal(runDir, txnId) {
+  const txnDir = join(journalRoot(runDir), txnId);
+  if (!existsSync(txnDir)) {
+    return { discarded: false, reason: "not_found" };
+  }
+  rmSync(txnDir, { recursive: true, force: true });
+  // Clean up empty journal root.
+  const root = journalRoot(runDir);
+  if (existsSync(root) && readdirSync(root).length === 0) {
+    try {
+      rmdirSync(root);
+    } catch {
+      // Race on cleanup is harmless.
+    }
+  }
+  return { discarded: true, txnId };
+}
+
+// replayJournal finalises a "ready_to_finalise" journal by renaming each
+// staged file to its final location. Safe to re-run: a missing staged
+// source is treated as already-finalised.
+export function replayJournal(runDir, txnId) {
+  const txnDir = join(journalRoot(runDir), txnId);
+  const manifest = readJournalManifestSync(txnDir);
+  if (!manifest) {
+    return { replayed: false, reason: "no_manifest" };
+  }
+  if (manifest.status !== "ready_to_finalise") {
+    return { replayed: false, reason: `status_${manifest.status}` };
+  }
+  const finalised = [];
+  for (const entry of manifest.staged_files || []) {
+    const stagedPath = join(txnDir, entry.relPath);
+    const finalPath = join(runDir, entry.relPath);
+    if (!existsSync(stagedPath)) {
+      finalised.push({ relPath: entry.relPath, already: true });
+      continue;
+    }
+    mkdirSync(dirname(finalPath), { recursive: true });
+    renameSync(stagedPath, finalPath);
+    finalised.push({ relPath: entry.relPath, already: false });
+  }
+  rmSync(txnDir, { recursive: true, force: true });
+  const root = journalRoot(runDir);
+  if (existsSync(root) && readdirSync(root).length === 0) {
+    try {
+      rmdirSync(root);
+    } catch {
+      // Empty-dir cleanup race is harmless.
+    }
+  }
+  return { replayed: true, txnId, finalised };
+}
+
+// withJournal(runDir, fn): runs `fn(txn)` inside a journal transaction.
+// `fn` MUST route its file writes through the storage helpers with
+// `opts.transaction = txn` so writes land in the journal. After fn returns,
+// the journal is marked ready_to_finalise and the rename loop runs.
+// On any throw, the journal is left in place for explicit recovery.
+//
+// FSM_TEST_PAUSE_BEFORE_FINALISE=<ms> (env): synchronously sleep before
+// the rename loop. Lets integration tests SIGKILL the process at that
+// instant to simulate a crash between "fn returned" and "finalisation".
+export function withJournal(runDir, fn) {
+  if (!runDir || typeof runDir !== "string") {
+    throw new Error("withJournal: runDir is required");
+  }
+  if (typeof fn !== "function") {
+    throw new Error("withJournal: fn must be a function");
+  }
+  // Refuse to start a new transaction while an unrecovered journal exists.
+  const existing = journalState(runDir);
+  if (existing.hasJournal) {
+    const err = new Error(
+      `withJournal: refusing to start — existing journal txn=${existing.txnId} status=${existing.status}; recover via fsm-resume --journal {discard|replay}`,
+    );
+    err.code = "JOURNAL_PRESENT";
+    err.journal = existing;
+    throw err;
+  }
+
+  const txnId = `${new Date().toISOString().replace(/[:.]/g, "-")}-${randomBytes(3).toString("hex")}`;
+  const root = journalRoot(runDir);
+  const txnDir = join(root, txnId);
+  mkdirSync(txnDir, { recursive: true });
+
+  const stagedFiles = [];
+
+  const txn = {
+    txnId,
+    runDir,
+    txnDir,
+    staged: stagedFiles,
+    stage(relPath) {
+      const stagedPath = join(txnDir, relPath);
+      mkdirSync(dirname(stagedPath), { recursive: true });
+      return stagedPath;
+    },
+    addStaged(relPath, stagedPath) {
+      stagedFiles.push({ relPath, stagedPath });
+    },
+    stagedTraceCount() {
+      return stagedFiles.filter((s) => s.relPath.startsWith("fsm-trace/"))
+        .length;
+    },
+    readStagedManifest() {
+      const entry = stagedFiles.find((s) => s.relPath === "manifest.json");
+      if (!entry) return null;
+      try {
+        return JSON.parse(readFileSync(entry.stagedPath, "utf8"));
+      } catch {
+        return null;
+      }
+    },
+  };
+
+  // Write the pending manifest first so a crash during fn still leaves a
+  // discoverable journal.
+  writeJournalManifestSync(txnDir, {
+    txn_id: txnId,
+    status: "pending",
+    run_dir: runDir,
+    started_at: new Date().toISOString(),
+    staged_files: [],
+  });
+
+  let result;
+  try {
+    result = fn(txn);
+  } catch (err) {
+    // Leave journal on disk for inspection / discard.
+    throw err;
+  }
+
+  // Mark ready_to_finalise BEFORE the rename loop so a crash mid-rename
+  // can be safely replayed (idempotent).
+  writeJournalManifestSync(txnDir, {
+    txn_id: txnId,
+    status: "ready_to_finalise",
+    run_dir: runDir,
+    started_at: new Date().toISOString(),
+    ready_at: new Date().toISOString(),
+    staged_files: stagedFiles.map((s) => ({ relPath: s.relPath })),
+  });
+
+  const pauseMs = Number.parseInt(
+    process.env.FSM_TEST_PAUSE_BEFORE_FINALISE || "0",
+    10,
+  );
+  if (Number.isFinite(pauseMs) && pauseMs > 0) {
+    // Synchronous busy wait so SIGKILL during this window simulates a
+    // crash between "ready_to_finalise" and the rename loop. We do not
+    // use Atomics.wait/setTimeout because the integration test needs the
+    // pause to be observable as a wall-clock window.
+    const deadline = Date.now() + pauseMs;
+    while (Date.now() < deadline) {
+      // intentional busy wait
+    }
+  }
+
+  for (const entry of stagedFiles) {
+    const finalPath = join(runDir, entry.relPath);
+    mkdirSync(dirname(finalPath), { recursive: true });
+    renameSync(entry.stagedPath, finalPath);
+  }
+  rmSync(txnDir, { recursive: true, force: true });
+  if (existsSync(root) && readdirSync(root).length === 0) {
+    try {
+      rmdirSync(root);
+    } catch {
+      // Empty-dir cleanup race is harmless.
+    }
+  }
+
+  return { result, txnId, staged: stagedFiles.map((s) => s.relPath) };
 }
 
 // ─── cross-run queries ──────────────────────────────────────────────────

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -559,6 +559,11 @@ function writeJournalManifestSync(txnDir, data) {
 export function journalState(runDir) {
   const root = journalRoot(runDir);
   if (!existsSync(root)) return { hasJournal: false };
+  // Containment guard at the `.journal` root itself: if `.journal`
+  // was replaced with a symlink pointing outside runDir, every
+  // downstream readdirSync / readFileSync below would happily read
+  // from the escape target. Resolve and refuse before any reads.
+  assertWithin(root, runDir, "journalState");
   // Use Dirent.isDirectory() so a symlink under `.journal/` is NOT
   // treated as a txn dir. statSync follows symlinks, which would let
   // a planted symlink (e.g. `.journal/foo -> /etc`) get inspected as
@@ -592,13 +597,22 @@ export function journalState(runDir) {
 // — discarding loses the work — but the explicit choice is the user's.
 export function discardJournal(runDir, txnId) {
   assertSafeTxnId(txnId, "discardJournal");
-  const txnDir = join(journalRoot(runDir), txnId);
+  const root = journalRoot(runDir);
+  // Containment guard: if `.journal` itself is a symlink resolving
+  // outside runDir, rmSync(txnDir, { recursive: true }) would happily
+  // delete directories elsewhere on the filesystem. Verify the
+  // journal root stays inside runDir BEFORE constructing the txn
+  // path or touching disk.
+  if (existsSync(root)) {
+    assertWithin(root, runDir, "discardJournal");
+  }
+  const txnDir = join(root, txnId);
   if (!existsSync(txnDir)) {
     return { discarded: false, reason: "not_found" };
   }
   rmSync(txnDir, { recursive: true, force: true });
-  // Clean up empty journal root.
-  const root = journalRoot(runDir);
+  // Clean up empty journal root (root is the containment-checked
+  // journalRoot computed at the top of this function).
   if (existsSync(root) && readdirSync(root).length === 0) {
     try {
       rmdirSync(root);
@@ -614,7 +628,21 @@ export function discardJournal(runDir, txnId) {
 // source is treated as already-finalised.
 export function replayJournal(runDir, txnId) {
   assertSafeTxnId(txnId, "replayJournal");
-  const txnDir = join(journalRoot(runDir), txnId);
+  const root = journalRoot(runDir);
+  // Containment guard at the journal root. If `.journal` is a
+  // symlink resolving outside runDir, every readFileSync /
+  // renameSync below would happily operate on paths outside the run
+  // dir. Verify before any read.
+  if (existsSync(root)) {
+    assertWithin(root, runDir, "replayJournal");
+  }
+  const txnDir = join(root, txnId);
+  // Second containment guard at the txn directory: even with the
+  // root verified, an individual txn dir could itself be a symlink
+  // pointing elsewhere. Verify before reading its journal manifest.
+  if (existsSync(txnDir)) {
+    assertWithin(txnDir, root, "replayJournal (txnDir)");
+  }
   const manifest = readJournalManifestSync(txnDir);
   if (!manifest) {
     return { replayed: false, reason: "no_manifest" };
@@ -674,7 +702,8 @@ export function replayJournal(runDir, txnId) {
     finalised.push({ relPath: entry.relPath, already: false });
   }
   rmSync(txnDir, { recursive: true, force: true });
-  const root = journalRoot(runDir);
+  // root was computed and containment-checked at the top of this
+  // function; reuse it for the empty-journal cleanup.
   if (existsSync(root) && readdirSync(root).length === 0) {
     try {
       rmdirSync(root);

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -23,6 +23,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmdirSync,
   rmSync,
@@ -32,7 +33,7 @@ import {
   fsyncSync,
   statSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep as pathSep } from "node:path";
 import { stringify as stringifyYaml, parse as parseYaml } from "yaml";
 
 const LOCK_TTL_MS_DEFAULT = 60 * 60 * 1000; // 1 hour
@@ -311,7 +312,17 @@ export function appendTraceFile(runId, { phase, state, data }, opts = {}) {
     const stagedPath = txn.stage(relPath);
     atomicWriteYaml(stagedPath, payload(seq));
     txn.addStaged(relPath, stagedPath);
-    return { sequence: seq, fileName, path: join(txn.runDir, relPath) };
+    // `path` always points at the bytes on disk right now: inside a
+    // transaction the file lives at the staged path until withJournal
+    // finalises. `final_path` is what it will become; `staged` flags
+    // the transition state so a caller can branch if needed.
+    return {
+      sequence: seq,
+      fileName,
+      path: stagedPath,
+      final_path: join(txn.runDir, relPath),
+      staged: true,
+    };
   }
   const dir = ensureRunDir(runId, opts);
   const seq = nextTraceSequence(runId, opts);
@@ -395,6 +406,35 @@ export function journalRoot(runDir) {
 // from a journal manifest during replayJournal — a crafted or corrupted
 // journal.json must not be able to rename staged files outside the run
 // directory.
+// assertWithin verifies that `targetDir`, after symlink resolution,
+// lies inside `parentDir`. Catches the symlink-escape class:
+// `assertSafeJournalRelPath` validates relPath segments string-side,
+// but a crafted journal directory containing a symlinked subdir (e.g.
+// `<txnDir>/fsm-trace -> /etc`) could still make `join(txnDir, relPath)`
+// resolve outside the journal root and let renameSync touch arbitrary
+// paths. We resolve real paths just before the rename and refuse if
+// the target escapes its parent.
+//
+// targetDir is created with mkdirSync(..., { recursive: true }) by the
+// caller before this check, so realpathSync will succeed on it.
+// parentDir is always either runDir or txnDir; both are known to exist
+// at this point.
+function assertWithin(targetDir, parentDir, context) {
+  const realTarget = realpathSync(targetDir);
+  const realParent = realpathSync(parentDir);
+  // Equal real paths are fine (target IS parent). Otherwise, the real
+  // target must start with `realParent + path.sep` so a sibling like
+  // "/runs/abc" does not satisfy a containment check for "/runs/ab".
+  if (
+    realTarget !== realParent &&
+    !realTarget.startsWith(realParent + pathSep)
+  ) {
+    throw new Error(
+      `${context}: refusing to operate on path "${targetDir}" — resolves to "${realTarget}" which is outside "${realParent}"`,
+    );
+  }
+}
+
 // assertSafeTxnId rejects any txnId that contains path separators,
 // traversal segments, colons, or backslashes, so a caller-supplied
 // value can never escape <journalRoot>. discardJournal and
@@ -566,7 +606,15 @@ export function replayJournal(runDir, txnId) {
       finalised.push({ relPath: entry.relPath, already: true });
       continue;
     }
+    // Symlink-escape guard: relPath segments are valid strings, but a
+    // symlinked subdir along the resolved path (e.g.
+    // `<txnDir>/fsm-trace -> /etc`) could still make join() resolve
+    // outside the journal root or run root. Verify the real path of
+    // both the staged source dir AND the final destination dir stays
+    // inside their respective parents before any rename.
+    assertWithin(dirname(stagedPath), txnDir, "replayJournal (stagedPath)");
     mkdirSync(dirname(finalPath), { recursive: true });
+    assertWithin(dirname(finalPath), runDir, "replayJournal (finalPath)");
     renameSync(stagedPath, finalPath);
     finalised.push({ relPath: entry.relPath, already: false });
   }
@@ -702,19 +750,29 @@ export function withJournal(runDir, fn) {
     10,
   );
   if (Number.isFinite(pauseMs) && pauseMs > 0) {
-    // Synchronous busy wait so SIGKILL during this window simulates a
-    // crash between "ready_to_finalise" and the rename loop. We do not
-    // use Atomics.wait/setTimeout because the integration test needs the
-    // pause to be observable as a wall-clock window.
-    const deadline = Date.now() + pauseMs;
-    while (Date.now() < deadline) {
-      // intentional busy wait
-    }
+    // Synchronous block so a SIGKILL during this window simulates a
+    // crash between "ready_to_finalise" and the rename loop. Uses
+    // Atomics.wait on a private SharedArrayBuffer for a real sleep
+    // (no CPU burn) instead of `while (Date.now() < deadline)`, which
+    // pegged a core for the duration whenever the env var was set —
+    // including accidentally in prod or CI. The wait condition is
+    // permanently false (we never store to view[0]) so the call
+    // returns "timed-out" after pauseMs every time.
+    const sab = new SharedArrayBuffer(4);
+    const view = new Int32Array(sab);
+    Atomics.wait(view, 0, 0, pauseMs);
   }
 
   for (const entry of stagedFiles) {
     const finalPath = join(runDir, entry.relPath);
     mkdirSync(dirname(finalPath), { recursive: true });
+    // Symlink-escape guard: if a subdir under runDir was replaced by a
+    // symlink between fn() returning and the rename loop (or by a
+    // malicious actor with write access), renameSync could write
+    // outside the run directory. Verify the resolved real path of
+    // dirname(finalPath) stays within realpathSync(runDir) before
+    // moving the staged file into place.
+    assertWithin(dirname(finalPath), runDir, "withJournal (finalPath)");
     renameSync(entry.stagedPath, finalPath);
   }
   rmSync(txnDir, { recursive: true, force: true });

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -911,11 +911,44 @@ export function withJournal(runDir, fn) {
       } catch {
         // Lock file unreadable; report what we can.
       }
-      let observedState = { hasJournal: false };
+      let observedState;
       try {
         observedState = journalState(runDir);
       } catch {
-        // Don't let an inspection failure mask the real lock-held cause.
+        // Don't let an inspection failure mask the real lock-held
+        // cause. Synthesise a lock_only stub so downstream error
+        // payloads still report hasJournal:true (the tx.lock file IS
+        // the blocking artifact).
+        observedState = {
+          hasJournal: true,
+          lock_only: true,
+          txnId: activeLock?.txn_id ?? null,
+          txnDir: null,
+          status: "lock_only",
+          staged: [],
+          active_lock: activeLock,
+          runDir,
+          all: [],
+        };
+      }
+      // If journalState succeeded but reported hasJournal:false (e.g.
+      // a race where the lock was written but the synthetic
+      // lock_only branch was missed), the lock file we just caught
+      // EEXIST on IS a journal artifact. Force-upgrade the shape so
+      // downstream callers don't emit the contradictory
+      // "present:false" payload.
+      if (!observedState.hasJournal) {
+        observedState = {
+          hasJournal: true,
+          lock_only: true,
+          txnId: activeLock?.txn_id ?? null,
+          txnDir: null,
+          status: "lock_only",
+          staged: [],
+          active_lock: activeLock,
+          runDir,
+          all: [],
+        };
       }
       const lockErr = new Error(
         `withJournal: another transaction holds the lock (active=${activeLock ? activeLock.txn_id : "unknown"}); recover via fsm-resume --journal {discard|replay}`,

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -690,7 +690,21 @@ export function withJournal(runDir, fn) {
   const txnId = `${new Date().toISOString().replace(/[:.]/g, "-")}-${randomBytes(3).toString("hex")}`;
   const root = journalRoot(runDir);
   const txnDir = join(root, txnId);
+  // Symlink-escape pre-flight on the journal root itself: if
+  // `<runDir>/.journal` was replaced with a symlink to /tmp/elsewhere
+  // before we got here, mkdirSync(txnDir, {recursive:true}) would
+  // happily create the txn directory outside runDir. The walk in
+  // assertNearestExistingAncestorWithin stops at `.journal` if it
+  // exists (and rejects), or falls through to `runDir` (trusted).
+  assertNearestExistingAncestorWithin(
+    txnDir,
+    runDir,
+    "withJournal (txnDir ancestor)",
+  );
   mkdirSync(txnDir, { recursive: true });
+  // Post-mkdir check so a race that drops a symlink AT the journal
+  // root between the pre-flight and now is still caught.
+  assertWithin(txnDir, runDir, "withJournal (txnDir)");
 
   const stagedFiles = [];
 
@@ -706,10 +720,22 @@ export function withJournal(runDir, fn) {
       // symlink-escape class: if a subdir under `txnDir` (or `.journal`
       // itself) was swapped for a symlink, the directory we are about
       // to mkdirSync into and write into could resolve outside the
-      // journal root. Refuse to return a path whose resolved real
-      // dirname is not inside txnDir.
+      // journal root.
+      //
+      // Same pre-flight pattern as the finalisation rename loop:
+      //   1. assertNearestExistingAncestorWithin BEFORE mkdirSync so we
+      //      never create directories outside txnDir even on a deep
+      //      relPath whose existing ancestor is a symlink that escapes.
+      //   2. assertWithin AFTER mkdirSync to catch a race where a
+      //      symlink is dropped in between the pre-flight and the
+      //      caller using the returned path.
       assertSafeJournalRelPath(relPath, "transaction.stage");
       const stagedPath = join(txnDir, relPath);
+      assertNearestExistingAncestorWithin(
+        dirname(stagedPath),
+        txnDir,
+        "transaction.stage (ancestor)",
+      );
       mkdirSync(dirname(stagedPath), { recursive: true });
       assertWithin(dirname(stagedPath), txnDir, "transaction.stage");
       return stagedPath;

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -572,7 +572,36 @@ export function journalState(runDir) {
   const entries = readdirSync(root, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name);
-  if (entries.length === 0) return { hasJournal: false };
+  // Orphaned-lock case: withJournal acquires tx.lock BEFORE creating
+  // its txn directory. If it crashes in that small window, the lock
+  // is left behind with no txn dir. Without surfacing it, withJournal
+  // would refuse with EEXIST forever AND `fsm-resume --journal
+  // discard` would report `not_found`, permanently blocking the run.
+  // Treat the orphaned lock as an "active journal" with
+  // status:"lock_only" so the recovery CLI can see it and discard
+  // can clear it.
+  const lockPath = join(root, "tx.lock");
+  if (entries.length === 0) {
+    if (!existsSync(lockPath)) return { hasJournal: false };
+    let activeLock = null;
+    try {
+      activeLock = JSON.parse(readFileSync(lockPath, "utf8"));
+    } catch {
+      // Lock file unreadable; still surface as lock-only so the
+      // recovery path can clear it.
+    }
+    return {
+      hasJournal: true,
+      lock_only: true,
+      txnId: activeLock?.txn_id ?? null,
+      txnDir: null,
+      status: "lock_only",
+      staged: [],
+      active_lock: activeLock,
+      runDir,
+      all: [],
+    };
+  }
   // Most recent by name (txnId is timestamp-prefixed) is the active one.
   const txnIds = entries.sort();
   const all = txnIds.map((id) => {
@@ -581,6 +610,14 @@ export function journalState(runDir) {
     return { txnId: id, txnDir, manifest };
   });
   const active = all[all.length - 1];
+  let activeLock = null;
+  if (existsSync(lockPath)) {
+    try {
+      activeLock = JSON.parse(readFileSync(lockPath, "utf8"));
+    } catch {
+      // ignore
+    }
+  }
   return {
     hasJournal: true,
     txnId: active.txnId,
@@ -588,6 +625,7 @@ export function journalState(runDir) {
     status: active.manifest ? active.manifest.status : "unknown",
     staged: active.manifest ? active.manifest.staged_files || [] : [],
     runDir: active.manifest ? active.manifest.run_dir : runDir,
+    active_lock: activeLock,
     all,
   };
 }
@@ -607,15 +645,47 @@ export function discardJournal(runDir, txnId) {
     assertWithin(root, runDir, "discardJournal");
   }
   const txnDir = join(root, txnId);
-  if (!existsSync(txnDir)) {
-    return { discarded: false, reason: "not_found" };
+  const lockPath = join(root, "tx.lock");
+  const txnDirExists = existsSync(txnDir);
+  // Orphaned-lock case: withJournal acquires tx.lock BEFORE creating
+  // the txn dir. A crash in that small window leaves tx.lock with no
+  // matching txn dir. Allow discard to clear the orphaned lock when
+  // its recorded txn_id matches the one the caller passed (so a
+  // typo can't accidentally clear someone else's lock).
+  if (!txnDirExists) {
+    if (!existsSync(lockPath)) {
+      return { discarded: false, reason: "not_found" };
+    }
+    let activeLock = null;
+    try {
+      activeLock = JSON.parse(readFileSync(lockPath, "utf8"));
+    } catch {
+      // Unreadable lock file: still safe to clear since the only
+      // recovery option for an unreadable lock IS to remove it.
+    }
+    if (activeLock && activeLock.txn_id && activeLock.txn_id !== txnId) {
+      return {
+        discarded: false,
+        reason: "lock_txn_id_mismatch",
+        active_lock_txn_id: activeLock.txn_id,
+      };
+    }
+    rmSync(lockPath, { force: true });
+    if (existsSync(root) && readdirSync(root).length === 0) {
+      try {
+        rmdirSync(root);
+      } catch {
+        // Race on cleanup is harmless.
+      }
+    }
+    return { discarded: true, txnId, lock_only: true };
   }
   rmSync(txnDir, { recursive: true, force: true });
   // Recovery also clears the single-writer lock that withJournal
   // would have left in place if the crash happened mid-transaction;
   // without this the next fsm-commit would refuse with JOURNAL_PRESENT
   // forever.
-  rmSync(join(root, "tx.lock"), { force: true });
+  rmSync(lockPath, { force: true });
   // Clean up empty journal root (root is the containment-checked
   // journalRoot computed at the top of this function).
   if (existsSync(root) && readdirSync(root).length === 0) {

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -630,6 +630,44 @@ export function journalState(runDir) {
   };
 }
 
+// discardOrphanedLock clears a `.journal/tx.lock` file when no txn dir
+// exists alongside it. The recovery path for a crash so severe that
+// the lock's own JSON payload never got finished writing — journalState
+// surfaces this as `{lock_only:true, txnId:null}`, and discardJournal
+// would reject the null txnId. Callers must verify there are no txn
+// dirs (e.g. by calling journalState first) so this cannot clobber a
+// legitimate in-progress transaction.
+export function discardOrphanedLock(runDir) {
+  const root = journalRoot(runDir);
+  if (!existsSync(root)) {
+    return { discarded: false, reason: "not_found" };
+  }
+  assertWithin(root, runDir, "discardOrphanedLock");
+  const txnDirs = readdirSync(root, { withFileTypes: true })
+    .filter((d) => d.isDirectory());
+  if (txnDirs.length > 0) {
+    // Refuse: there's a real txn here. Use discardJournal(runDir, txnId).
+    return {
+      discarded: false,
+      reason: "txn_dirs_present",
+      txn_dirs: txnDirs.map((d) => d.name),
+    };
+  }
+  const lockPath = join(root, "tx.lock");
+  if (!existsSync(lockPath)) {
+    return { discarded: false, reason: "not_found" };
+  }
+  rmSync(lockPath, { force: true });
+  if (existsSync(root) && readdirSync(root).length === 0) {
+    try {
+      rmdirSync(root);
+    } catch {
+      // Empty-dir cleanup race is harmless.
+    }
+  }
+  return { discarded: true, lock_only: true };
+}
+
 // discardJournal removes a specific journal transaction directory. If the
 // transaction is "ready_to_finalise", callers should usually replay instead
 // — discarding loses the work — but the explicit choice is the user's.

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -435,6 +435,25 @@ function assertWithin(targetDir, parentDir, context) {
   }
 }
 
+// assertNearestExistingAncestorWithin walks `targetDir` upward to the
+// deepest existing ancestor (the last segment that exists on disk) and
+// asserts THAT path stays inside `parentDir`. Use this as a pre-flight
+// check before `mkdirSync({ recursive: true })`: assertWithin alone runs
+// AFTER mkdir, which would have already created directories outside
+// parentDir if an existing ancestor was a symlink. Calling this first
+// makes the operation fail with NO side effects when an ancestor escapes.
+function assertNearestExistingAncestorWithin(targetDir, parentDir, context) {
+  let candidate = targetDir;
+  while (!existsSync(candidate)) {
+    const up = dirname(candidate);
+    if (up === candidate) break;
+    candidate = up;
+  }
+  if (existsSync(candidate)) {
+    assertWithin(candidate, parentDir, context);
+  }
+}
+
 // assertSafeTxnId rejects any txnId that contains path separators,
 // traversal segments, colons, or backslashes, so a caller-supplied
 // value can never escape <journalRoot>. discardJournal and
@@ -612,7 +631,18 @@ export function replayJournal(runDir, txnId) {
     // outside the journal root or run root. Verify the real path of
     // both the staged source dir AND the final destination dir stays
     // inside their respective parents before any rename.
+    //
+    // The destination dir is checked BEFORE mkdirSync (pre-flight on
+    // the nearest existing ancestor) so we don't create directories
+    // outside runDir if an existing parent segment is a symlink. The
+    // staged source dir already exists at this point, so the direct
+    // assertWithin is sufficient.
     assertWithin(dirname(stagedPath), txnDir, "replayJournal (stagedPath)");
+    assertNearestExistingAncestorWithin(
+      dirname(finalPath),
+      runDir,
+      "replayJournal (finalPath ancestor)",
+    );
     mkdirSync(dirname(finalPath), { recursive: true });
     assertWithin(dirname(finalPath), runDir, "replayJournal (finalPath)");
     renameSync(stagedPath, finalPath);
@@ -781,18 +811,27 @@ export function withJournal(runDir, fn) {
 
   for (const entry of stagedFiles) {
     const finalPath = join(runDir, entry.relPath);
-    mkdirSync(dirname(finalPath), { recursive: true });
     // Symlink-escape guards on BOTH sides of the rename:
     //   1. SOURCE: txnDir or one of its subdirs could be swapped to a
     //      symlink between staging and finalisation. Verify the
     //      resolved real path of dirname(entry.stagedPath) stays
     //      inside realpathSync(txnDir).
     //   2. DEST: a subdir under runDir could be swapped to a symlink
-    //      by an external actor with write access. Verify the
-    //      resolved real path of dirname(finalPath) stays inside
-    //      realpathSync(runDir).
+    //      by an external actor with write access. Pre-flight on the
+    //      nearest existing ancestor BEFORE mkdir, so we never create
+    //      directories outside runDir even on a deep relPath where an
+    //      existing parent segment is a symlink that escapes. Then
+    //      assertWithin AGAIN after mkdir so a race that drops a
+    //      symlink in between the pre-flight and the rename is still
+    //      caught.
     // Either failure throws; the journal stays on disk for inspection.
     assertWithin(dirname(entry.stagedPath), txnDir, "withJournal (stagedPath)");
+    assertNearestExistingAncestorWithin(
+      dirname(finalPath),
+      runDir,
+      "withJournal (finalPath ancestor)",
+    );
+    mkdirSync(dirname(finalPath), { recursive: true });
     assertWithin(dirname(finalPath), runDir, "withJournal (finalPath)");
     renameSync(entry.stagedPath, finalPath);
   }

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -20,6 +20,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -425,6 +426,23 @@ export function journalRoot(runDir) {
 // caller before this check, so realpathSync will succeed on it.
 // parentDir is always either runDir or txnDir; both are known to exist
 // at this point.
+// lexistsSync returns true if `path` exists as a filesystem entry,
+// INCLUDING dangling symlinks. `existsSync` (and statSync without
+// throwIfNoEntry) silently follows symlinks, so a broken `.journal
+// -> /missing` symlink would slip through as "doesn't exist", and
+// the containment / no-journal-present paths would silently misclassify
+// the run. lstatSync without following surfaces the symlink itself,
+// so any error means "really doesn't exist".
+function lexistsSync(path) {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (err) {
+    if (err && err.code === "ENOENT") return false;
+    throw err;
+  }
+}
+
 function assertWithin(targetDir, parentDir, context) {
   const realTarget = realpathSync(targetDir);
   const realParent = realpathSync(parentDir);
@@ -449,13 +467,19 @@ function assertWithin(targetDir, parentDir, context) {
 // parentDir if an existing ancestor was a symlink. Calling this first
 // makes the operation fail with NO side effects when an ancestor escapes.
 function assertNearestExistingAncestorWithin(targetDir, parentDir, context) {
+  // Use lexistsSync (no-follow): a broken symlink IS an entry that
+  // would otherwise make existsSync return false, and the walk would
+  // skip past it. With lexistsSync, a broken `.journal -> /missing`
+  // symlink stops the walk and triggers assertWithin, which will
+  // throw a clear containment error rather than letting the caller's
+  // subsequent mkdirSync / realpathSync emit a confused ENOENT.
   let candidate = targetDir;
-  while (!existsSync(candidate)) {
+  while (!lexistsSync(candidate)) {
     const up = dirname(candidate);
     if (up === candidate) break;
     candidate = up;
   }
-  if (existsSync(candidate)) {
+  if (lexistsSync(candidate)) {
     assertWithin(candidate, parentDir, context);
   }
 }
@@ -558,7 +582,11 @@ function writeJournalManifestSync(txnDir, data) {
 // absent or empty.
 export function journalState(runDir) {
   const root = journalRoot(runDir);
-  if (!existsSync(root)) return { hasJournal: false };
+  // lexistsSync (no-follow) so a broken `.journal` symlink is
+  // surfaced as "present" — assertWithin will then throw a
+  // structured containment failure rather than silently returning
+  // hasJournal:false and letting fsm-commit advance.
+  if (!lexistsSync(root)) return { hasJournal: false };
   // Containment guard at the `.journal` root itself: if `.journal`
   // was replaced with a symlink pointing outside runDir, every
   // downstream readdirSync / readFileSync below would happily read
@@ -639,7 +667,10 @@ export function journalState(runDir) {
 // legitimate in-progress transaction.
 export function discardOrphanedLock(runDir) {
   const root = journalRoot(runDir);
-  if (!existsSync(root)) {
+  // lexistsSync so a broken `.journal` symlink trips assertWithin
+  // (rather than reporting not_found and leaving the bad state in
+  // place).
+  if (!lexistsSync(root)) {
     return { discarded: false, reason: "not_found" };
   }
   assertWithin(root, runDir, "discardOrphanedLock");
@@ -678,8 +709,10 @@ export function discardJournal(runDir, txnId) {
   // outside runDir, rmSync(txnDir, { recursive: true }) would happily
   // delete directories elsewhere on the filesystem. Verify the
   // journal root stays inside runDir BEFORE constructing the txn
-  // path or touching disk.
-  if (existsSync(root)) {
+  // path or touching disk. lexistsSync (no-follow) so a broken
+  // `.journal` symlink trips the containment check rather than
+  // skipping it.
+  if (lexistsSync(root)) {
     assertWithin(root, runDir, "discardJournal");
   }
   const txnDir = join(root, txnId);
@@ -745,8 +778,9 @@ export function replayJournal(runDir, txnId) {
   // Containment guard at the journal root. If `.journal` is a
   // symlink resolving outside runDir, every readFileSync /
   // renameSync below would happily operate on paths outside the run
-  // dir. Verify before any read.
-  if (existsSync(root)) {
+  // dir. Verify before any read. lexistsSync (no-follow) so a broken
+  // `.journal` symlink trips the containment check.
+  if (lexistsSync(root)) {
     assertWithin(root, runDir, "replayJournal");
   }
   const txnDir = join(root, txnId);

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -671,18 +671,34 @@ export function withJournal(runDir, fn) {
     staged: stagedFiles,
     stage(relPath) {
       // stage() is the public surface for staging a write inside a
-      // transaction. Reject any relPath that could escape the txn dir
-      // here, so callers (including third-party storage helpers) cannot
-      // accidentally write outside <txnDir> by passing an absolute path
-      // or a ".."-bearing string.
+      // transaction. String-side relPath validation rejects "..",
+      // absolute paths, etc. Realpath containment then catches the
+      // symlink-escape class: if a subdir under `txnDir` (or `.journal`
+      // itself) was swapped for a symlink, the directory we are about
+      // to mkdirSync into and write into could resolve outside the
+      // journal root. Refuse to return a path whose resolved real
+      // dirname is not inside txnDir.
       assertSafeJournalRelPath(relPath, "transaction.stage");
       const stagedPath = join(txnDir, relPath);
       mkdirSync(dirname(stagedPath), { recursive: true });
+      assertWithin(dirname(stagedPath), txnDir, "transaction.stage");
       return stagedPath;
     },
     addStaged(relPath, stagedPath) {
+      // The canonical contract: stagedPath MUST equal
+      // join(txnDir, relPath). Accepting an arbitrary stagedPath would
+      // let a caller (or a compromised helper) register an arbitrary
+      // filesystem path that the finalisation rename loop then moves
+      // into runDir. Enforce equality so the only path the rename loop
+      // ever sees is the canonical staged path under txnDir.
       assertSafeJournalRelPath(relPath, "transaction.addStaged");
-      stagedFiles.push({ relPath, stagedPath });
+      const canonical = join(txnDir, relPath);
+      if (stagedPath !== canonical) {
+        throw new Error(
+          `transaction.addStaged: stagedPath "${stagedPath}" must equal canonical "${canonical}" (use the value returned by stage(relPath))`,
+        );
+      }
+      stagedFiles.push({ relPath, stagedPath: canonical });
     },
     stagedTraceCount() {
       return stagedFiles.filter((s) => s.relPath.startsWith("fsm-trace/"))
@@ -766,12 +782,17 @@ export function withJournal(runDir, fn) {
   for (const entry of stagedFiles) {
     const finalPath = join(runDir, entry.relPath);
     mkdirSync(dirname(finalPath), { recursive: true });
-    // Symlink-escape guard: if a subdir under runDir was replaced by a
-    // symlink between fn() returning and the rename loop (or by a
-    // malicious actor with write access), renameSync could write
-    // outside the run directory. Verify the resolved real path of
-    // dirname(finalPath) stays within realpathSync(runDir) before
-    // moving the staged file into place.
+    // Symlink-escape guards on BOTH sides of the rename:
+    //   1. SOURCE: txnDir or one of its subdirs could be swapped to a
+    //      symlink between staging and finalisation. Verify the
+    //      resolved real path of dirname(entry.stagedPath) stays
+    //      inside realpathSync(txnDir).
+    //   2. DEST: a subdir under runDir could be swapped to a symlink
+    //      by an external actor with write access. Verify the
+    //      resolved real path of dirname(finalPath) stays inside
+    //      realpathSync(runDir).
+    // Either failure throws; the journal stays on disk for inspection.
+    assertWithin(dirname(entry.stagedPath), txnDir, "withJournal (stagedPath)");
     assertWithin(dirname(finalPath), runDir, "withJournal (finalPath)");
     renameSync(entry.stagedPath, finalPath);
   }

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -386,6 +386,62 @@ export function journalRoot(runDir) {
   return join(runDir, JOURNAL_DIR_NAME);
 }
 
+// assertSafeJournalRelPath rejects any relPath that could escape the
+// journal directory when joined against it. Same constraints we apply to
+// loop iteration_outputs_dir in fsm-engine: no absolute paths, no
+// backslashes, no ".." or "." segments, no ":" (Windows drive letters or
+// colon-bearing segments). This is the validation gate for the public
+// `transaction.stage()` API surface AND for relPath values read back
+// from a journal manifest during replayJournal — a crafted or corrupted
+// journal.json must not be able to rename staged files outside the run
+// directory.
+function assertSafeJournalRelPath(relPath, context) {
+  if (typeof relPath !== "string" || relPath.length === 0) {
+    throw new Error(`${context}: relPath must be a non-empty string`);
+  }
+  if (relPath.includes("\\")) {
+    throw new Error(
+      `${context}: relPath "${relPath}" must not contain backslashes (use forward slashes)`,
+    );
+  }
+  if (relPath.startsWith("/")) {
+    throw new Error(
+      `${context}: relPath "${relPath}" must be relative; absolute paths are not allowed`,
+    );
+  }
+  if (relPath.includes(":")) {
+    throw new Error(
+      `${context}: relPath "${relPath}" must not contain ":" (Windows drive letters or colon segments could escape the journal)`,
+    );
+  }
+  const parts = relPath.split("/");
+  for (const part of parts) {
+    if (part === "" || part === "." || part === "..") {
+      throw new Error(
+        `${context}: relPath "${relPath}" contains an invalid segment ("${part}")`,
+      );
+    }
+  }
+}
+
+// publicJournalProjection returns the stable error-payload shape that
+// fsm-commit / fsm-next / fsm-inspect emit when reporting a journal.
+// Filters out internal fields (txnDir, runDir, all[]) so the CLI surface
+// is the same shape regardless of whether the journal was observed via
+// journalState() up front or surfaced through a withJournal
+// JOURNAL_PRESENT error.
+export function publicJournalProjection(jstate) {
+  if (!jstate || !jstate.hasJournal) return { present: false };
+  const stagedNormalised = (jstate.staged || []).map((s) =>
+    typeof s === "string" ? s : s.relPath,
+  );
+  return {
+    txn_id: jstate.txnId,
+    status: jstate.status,
+    staged: stagedNormalised,
+  };
+}
+
 function readJournalManifestSync(txnDir) {
   const path = join(txnDir, "journal.json");
   if (!existsSync(path)) return null;
@@ -469,6 +525,12 @@ export function replayJournal(runDir, txnId) {
   }
   const finalised = [];
   for (const entry of manifest.staged_files || []) {
+    // Defensive: the journal manifest is a file on disk and can be
+    // corrupted, hand-edited, or maliciously crafted between the crash
+    // and recovery. Reject any relPath that could escape the run dir
+    // via absolute path, ".." traversal, backslashes, or drive letters
+    // before letting it into the rename loop.
+    assertSafeJournalRelPath(entry.relPath, "replayJournal");
     const stagedPath = join(txnDir, entry.relPath);
     const finalPath = join(runDir, entry.relPath);
     if (!existsSync(stagedPath)) {
@@ -531,11 +593,18 @@ export function withJournal(runDir, fn) {
     txnDir,
     staged: stagedFiles,
     stage(relPath) {
+      // stage() is the public surface for staging a write inside a
+      // transaction. Reject any relPath that could escape the txn dir
+      // here, so callers (including third-party storage helpers) cannot
+      // accidentally write outside <txnDir> by passing an absolute path
+      // or a ".."-bearing string.
+      assertSafeJournalRelPath(relPath, "transaction.stage");
       const stagedPath = join(txnDir, relPath);
       mkdirSync(dirname(stagedPath), { recursive: true });
       return stagedPath;
     },
     addStaged(relPath, stagedPath) {
+      assertSafeJournalRelPath(relPath, "transaction.addStaged");
       stagedFiles.push({ relPath, stagedPath });
     },
     stagedTraceCount() {
@@ -568,6 +637,23 @@ export function withJournal(runDir, fn) {
     result = fn(txn);
   } catch (err) {
     // Leave journal on disk for inspection / discard.
+    throw err;
+  }
+
+  // Reject async / thenable functions. withJournal finalises
+  // synchronously the instant fn returns; if fn is async, the awaited
+  // writes are still in-flight when the rename loop runs and the
+  // atomicity contract breaks. Caught here (after fn has already
+  // returned the Promise) the journal is still on disk, so the user
+  // can discard it; failing fast is much better than producing a
+  // partial commit.
+  if (result && typeof result.then === "function") {
+    const err = new Error(
+      "withJournal: fn must be a synchronous function — got a thenable / Promise. " +
+        "Stage all writes synchronously inside fn; the journal would otherwise finalise " +
+        "before async writes complete and break atomicity.",
+    );
+    err.code = "JOURNAL_FN_ASYNC";
     throw err;
   }
 

--- a/scripts/lib/fsm-storage.mjs
+++ b/scripts/lib/fsm-storage.mjs
@@ -521,7 +521,12 @@ export function publicJournalProjection(jstate) {
   const stagedNormalised = (jstate.staged || []).map((s) =>
     typeof s === "string" ? s : s.relPath,
   );
+  // Always carry the `present` discriminator so callers see one shape:
+  // `{ present: boolean, ... }`. Without it, present-vs-absent forks
+  // had different key sets, which is exactly the inconsistency this
+  // helper was meant to eliminate.
   return {
+    present: true,
     txn_id: jstate.txnId,
     status: jstate.status,
     staged: stagedNormalised,
@@ -548,14 +553,14 @@ function writeJournalManifestSync(txnDir, data) {
 export function journalState(runDir) {
   const root = journalRoot(runDir);
   if (!existsSync(root)) return { hasJournal: false };
-  const entries = readdirSync(root).filter((n) => {
-    const p = join(root, n);
-    try {
-      return statSync(p).isDirectory();
-    } catch {
-      return false;
-    }
-  });
+  // Use Dirent.isDirectory() so a symlink under `.journal/` is NOT
+  // treated as a txn dir. statSync follows symlinks, which would let
+  // a planted symlink (e.g. `.journal/foo -> /etc`) get inspected as
+  // if it were a valid transaction directory, with readJournalManifestSync
+  // then reading a journal.json from outside the run dir.
+  const entries = readdirSync(root, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
   if (entries.length === 0) return { hasJournal: false };
   // Most recent by name (txnId is timestamp-prefixed) is the active one.
   const txnIds = entries.sort();
@@ -772,12 +777,15 @@ export function withJournal(runDir, fn) {
   };
 
   // Write the pending manifest first so a crash during fn still leaves a
-  // discoverable journal.
+  // discoverable journal. started_at captures the wall-clock time the
+  // transaction opened; the ready_to_finalise rewrite preserves this
+  // value rather than overwriting it.
+  const startedAt = new Date().toISOString();
   writeJournalManifestSync(txnDir, {
     txn_id: txnId,
     status: "pending",
     run_dir: runDir,
-    started_at: new Date().toISOString(),
+    started_at: startedAt,
     staged_files: [],
   });
 
@@ -807,12 +815,16 @@ export function withJournal(runDir, fn) {
   }
 
   // Mark ready_to_finalise BEFORE the rename loop so a crash mid-rename
-  // can be safely replayed (idempotent).
+  // can be safely replayed (idempotent). Preserve the original
+  // started_at from the pending manifest (do NOT rewrite it: an
+  // operator reading the journal after the fact should be able to see
+  // the true transaction open time, with ready_at as the moment the
+  // finalisation began).
   writeJournalManifestSync(txnDir, {
     txn_id: txnId,
     status: "ready_to_finalise",
     run_dir: runDir,
-    started_at: new Date().toISOString(),
+    started_at: startedAt,
     ready_at: new Date().toISOString(),
     staged_files: stagedFiles.map((s) => ({ relPath: s.relPath })),
   });

--- a/tests/integration/atomic-tx.test.js
+++ b/tests/integration/atomic-tx.test.js
@@ -182,17 +182,22 @@ function killDuringPause(tmp, runId, pauseMs) {
     child.on("exit", (code, signal) => {
       resolve({ code, signal, stdout, stderr });
     });
-    // Give the child enough time to mark the journal ready_to_finalise
-    // and enter the pause busy-wait. The busy wait is synchronous so a
-    // SIGKILL during the window is guaranteed to land before the rename
-    // loop runs.
+    // Schedule SIGKILL near the END of the pause window — far enough
+    // back from the boundary that the rename loop hasn't started yet,
+    // but well past child startup / journal manifest write so the kill
+    // lands during the busy-wait. Picking the midpoint of the window
+    // was timing-sensitive on slow CI hosts (the child sometimes
+    // hadn't reached the pause yet, leaving a `pending` journal). The
+    // last-quarter target gives the child every preceding millisecond
+    // to get into the pause busy-wait.
+    const killAfterMs = Math.max(pauseMs - 250, Math.floor(pauseMs * 0.75));
     setTimeout(() => {
       try {
         child.kill("SIGKILL");
       } catch {
         // already exited
       }
-    }, Math.min(pauseMs - 500, pauseMs * 0.5));
+    }, killAfterMs);
   });
 }
 

--- a/tests/integration/atomic-tx.test.js
+++ b/tests/integration/atomic-tx.test.js
@@ -1,0 +1,361 @@
+// atomic-tx.test.js — integration coverage for the A7 atomic-tx journal.
+//
+// Drives fsm-next + fsm-commit + fsm-resume + fsm-inspect end-to-end and
+// proves:
+//
+//   1. A successful fsm-commit leaves no journal on disk.
+//   2. SIGKILL during FSM_TEST_PAUSE_BEFORE_FINALISE leaves a
+//      ready_to_finalise journal AND no final files.
+//   3. fsm-next --resume refuses to advance with "incomplete_commit_detected"
+//      while a journal is present.
+//   4. fsm-resume --journal replay finalises the staged commit and a
+//      subsequent fsm-next --resume succeeds.
+//   5. (Separate run) fsm-resume --journal discard rolls back instead.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+);
+
+const FSM_YAML = `
+fsm:
+  id: atomic-tx
+  version: 1
+  entry: a
+  states:
+    - id: a
+      purpose: "Entry; produces x."
+      preconditions: []
+      worker:
+        role: stub
+        prompt_template: workers/stub.md
+        inputs: ["args"]
+        response_schema:
+          type: object
+          required: [x]
+          properties:
+            x: { type: integer, minimum: 0 }
+      outputs: ["x"]
+      transitions:
+        - to: b
+          when: always
+    - id: b
+      purpose: "Terminal."
+      preconditions: []
+      outputs: []
+      transitions: []
+`;
+
+function setupFixture() {
+  const tmp = mkdtempSync(join(tmpdir(), "fsm-atomictx-"));
+  writeFileSync(join(tmp, "fsm.yaml"), FSM_YAML);
+  mkdirSync(join(tmp, "workers"));
+  writeFileSync(join(tmp, "workers", "stub.md"), "# stub worker\n");
+  mkdirSync(join(tmp, "store"));
+  return tmp;
+}
+
+function commonArgs(tmp) {
+  return ["--fsm-path", join(tmp, "fsm.yaml"), "--storage-root", join(tmp, "store")];
+}
+
+function runScript(name, args, opts = {}) {
+  return spawnSync("node", [join(SCRIPT_DIR, name), ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...(opts.env ?? {}) },
+  });
+}
+
+function parseJsonStdout(result) {
+  if (result.status !== 0) {
+    throw new Error(
+      `script exited ${result.status}; stderr: ${result.stderr}; stdout: ${result.stdout}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+function startNewRun(tmp) {
+  const next = runScript("fsm-next.mjs", [
+    "--new-run",
+    "--repo",
+    "ctxr-dev/fsm",
+    "--base-sha",
+    "deadbee",
+    "--head-sha",
+    "cafefee",
+    "--session-id",
+    "test-session",
+    ...commonArgs(tmp),
+  ]);
+  return parseJsonStdout(next);
+}
+
+function findJournalDir(storeRoot) {
+  // Walk YYYY/MM/DD/shard/rest to find any .journal directory.
+  if (!existsSync(storeRoot)) return null;
+  const walk = (dir) => {
+    if (!existsSync(dir)) return null;
+    for (const name of readdirSync(dir)) {
+      const child = join(dir, name);
+      if (name === ".journal") return child;
+      try {
+        const found = walk(child);
+        if (found) return found;
+      } catch {
+        // not a dir; skip
+      }
+    }
+    return null;
+  };
+  return walk(storeRoot);
+}
+
+// ─── happy path: no journal residue ─────────────────────────────────────
+
+test("atomic-tx: successful commit leaves no journal on disk", () => {
+  const tmp = setupFixture();
+  try {
+    const brief = startNewRun(tmp);
+    const commitResult = runScript("fsm-commit.mjs", [
+      "--run-id",
+      brief.run_id,
+      "--outputs",
+      JSON.stringify({ x: 7 }),
+      "--session-id",
+      "test-session",
+      ...commonArgs(tmp),
+    ]);
+    parseJsonStdout(commitResult); // throws if non-zero
+    assert.equal(findJournalDir(join(tmp, "store")), null);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── SIGKILL during pause leaves a recoverable journal ──────────────────
+
+function killDuringPause(tmp, runId, pauseMs) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "node",
+      [
+        join(SCRIPT_DIR, "fsm-commit.mjs"),
+        "--run-id",
+        runId,
+        "--outputs",
+        JSON.stringify({ x: 11 }),
+        "--session-id",
+        "test-session",
+        ...commonArgs(tmp),
+      ],
+      {
+        env: {
+          ...process.env,
+          FSM_TEST_PAUSE_BEFORE_FINALISE: String(pauseMs),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stderr = "";
+    let stdout = "";
+    child.stdout.on("data", (b) => (stdout += b.toString("utf8")));
+    child.stderr.on("data", (b) => (stderr += b.toString("utf8")));
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      resolve({ code, signal, stdout, stderr });
+    });
+    // Give the child enough time to mark the journal ready_to_finalise
+    // and enter the pause busy-wait. The busy wait is synchronous so a
+    // SIGKILL during the window is guaranteed to land before the rename
+    // loop runs.
+    setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already exited
+      }
+    }, Math.min(pauseMs - 500, pauseMs * 0.5));
+  });
+}
+
+test("atomic-tx: SIGKILL during finalise pause leaves journal; fsm-next refuses; replay finalises", async () => {
+  const tmp = setupFixture();
+  try {
+    const brief = startNewRun(tmp);
+    const killed = await killDuringPause(tmp, brief.run_id, 3000);
+    // The child was killed; it should NOT have exited cleanly.
+    assert.notEqual(killed.signal, null, "expected SIGKILL to be delivered");
+
+    const journalDir = findJournalDir(join(tmp, "store"));
+    assert.ok(journalDir, "expected a .journal directory after the kill");
+
+    // fsm-inspect surfaces the journal.
+    const inspect = parseJsonStdout(
+      runScript("fsm-inspect.mjs", [
+        "--run-id",
+        brief.run_id,
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(inspect.journal.present, true);
+    assert.equal(inspect.journal.status, "ready_to_finalise");
+    assert.ok(inspect.journal.staged.length > 0);
+
+    // fsm-next --resume refuses to advance.
+    const nextRefused = runScript("fsm-next.mjs", [
+      "--resume",
+      brief.run_id,
+      "--session-id",
+      "test-session-2",
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(nextRefused.status, 0);
+    const nextRefusedBody = JSON.parse(nextRefused.stdout);
+    assert.equal(nextRefusedBody.error, "incomplete_commit_detected");
+
+    // fsm-resume --journal replay finalises.
+    const replayed = parseJsonStdout(
+      runScript("fsm-resume.mjs", [
+        "--run-id",
+        brief.run_id,
+        "--journal",
+        "replay",
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(replayed.journal_action, "replay");
+    assert.equal(replayed.replayed, true);
+    assert.ok(Array.isArray(replayed.finalised));
+    assert.equal(findJournalDir(join(tmp, "store")), null);
+
+    // After replay, the commit IS visible: fsm-inspect shows state=b
+    // (or equivalent) and trace has the exit + entry records.
+    const inspectAfter = parseJsonStdout(
+      runScript("fsm-inspect.mjs", [
+        "--run-id",
+        brief.run_id,
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(inspectAfter.journal.present, false);
+    // Manifest carries the committed advance.
+    assert.equal(inspectAfter.manifest.current_state, "b");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("atomic-tx: SIGKILL during finalise pause + discard rolls back to pre-commit state", async () => {
+  const tmp = setupFixture();
+  try {
+    const brief = startNewRun(tmp);
+    const killed = await killDuringPause(tmp, brief.run_id, 3000);
+    assert.notEqual(killed.signal, null);
+
+    const inspectBefore = parseJsonStdout(
+      runScript("fsm-inspect.mjs", [
+        "--run-id",
+        brief.run_id,
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(inspectBefore.journal.present, true);
+    // Manifest still shows pre-commit state (current_state is the entry
+    // state "a" because the journal was killed before finalisation).
+    assert.equal(inspectBefore.manifest.current_state, "a");
+
+    const discarded = parseJsonStdout(
+      runScript("fsm-resume.mjs", [
+        "--run-id",
+        brief.run_id,
+        "--journal",
+        "discard",
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(discarded.journal_action, "discard");
+    assert.equal(discarded.discarded, true);
+    assert.equal(findJournalDir(join(tmp, "store")), null);
+
+    // After discard, the manifest is unchanged and the journal-detect
+    // gate in fsm-next and fsm-commit no longer triggers — the run is
+    // back to its pre-commit state, ready for normal lock-recovery and
+    // re-attempt by the operator. (Lock takeover after a crashed writer
+    // is a separate concern covered by the fsm-resume tests; A7's
+    // scope is strictly the journal mechanic.)
+    const inspectAfter = parseJsonStdout(
+      runScript("fsm-inspect.mjs", [
+        "--run-id",
+        brief.run_id,
+        ...commonArgs(tmp),
+      ]),
+    );
+    assert.equal(inspectAfter.journal.present, false);
+    assert.equal(inspectAfter.manifest.current_state, "a");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── fsm-commit detects journal at startup too ──────────────────────────
+
+test("atomic-tx: fsm-commit refuses to start when a journal already exists", () => {
+  const tmp = setupFixture();
+  try {
+    const brief = startNewRun(tmp);
+    // Plant a journal directly under the run dir by reading manifest to
+    // get the run-dir path via fsm-inspect.
+    const inspect = parseJsonStdout(
+      runScript("fsm-inspect.mjs", [
+        "--run-id",
+        brief.run_id,
+        ...commonArgs(tmp),
+      ]),
+    );
+    const runDir = inspect.run_dir_path;
+    const txnDir = join(runDir, ".journal", "planted-txn-001");
+    mkdirSync(txnDir, { recursive: true });
+    writeFileSync(
+      join(txnDir, "journal.json"),
+      JSON.stringify({
+        txn_id: "planted-txn-001",
+        status: "pending",
+        staged_files: [],
+      }),
+    );
+
+    const result = runScript("fsm-commit.mjs", [
+      "--run-id",
+      brief.run_id,
+      "--outputs",
+      JSON.stringify({ x: 1 }),
+      "--session-id",
+      "test-session",
+      ...commonArgs(tmp),
+    ]);
+    assert.notEqual(result.status, 0);
+    const body = JSON.parse(result.stdout);
+    assert.equal(body.error, "incomplete_commit_detected");
+    assert.equal(body.journal.status, "pending");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/atomic-tx.test.js
+++ b/tests/integration/atomic-tx.test.js
@@ -234,8 +234,12 @@ test("atomic-tx: SIGKILL during finalise pause leaves journal; fsm-next refuses;
     const journalManifestPath = (() => {
       const found = findJournalDir(join(tmp, "store"));
       // findJournalDir returns the .journal root; descend into the
-      // single txn dir to read its journal.json.
-      const txnDirs = readdirSync(found);
+      // single txn dir to read its journal.json. Filter by Dirent
+      // because `.journal/` also contains the `tx.lock` file from
+      // A7's atomic-single-writer guard.
+      const txnDirs = readdirSync(found, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
       assert.equal(txnDirs.length, 1, "expected exactly one txn dir");
       return join(found, txnDirs[0], "journal.json");
     })();

--- a/tests/integration/atomic-tx.test.js
+++ b/tests/integration/atomic-tx.test.js
@@ -20,6 +20,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -223,6 +224,29 @@ test("atomic-tx: SIGKILL during finalise pause leaves journal; fsm-next refuses;
     assert.equal(inspect.journal.present, true);
     assert.equal(inspect.journal.status, "ready_to_finalise");
     assert.ok(inspect.journal.staged.length > 0);
+
+    // The on-disk journal manifest must carry BOTH started_at (set on
+    // the pending write before fn ran) AND ready_at (set on the
+    // ready_to_finalise rewrite, just after fn returned). They are
+    // distinct timestamps, never identical: started_at MUST predate
+    // ready_at, proving the rewrite does NOT clobber the original
+    // start time.
+    const journalManifestPath = (() => {
+      const found = findJournalDir(join(tmp, "store"));
+      // findJournalDir returns the .journal root; descend into the
+      // single txn dir to read its journal.json.
+      const txnDirs = readdirSync(found);
+      assert.equal(txnDirs.length, 1, "expected exactly one txn dir");
+      return join(found, txnDirs[0], "journal.json");
+    })();
+    const onDiskJournal = JSON.parse(readFileSync(journalManifestPath, "utf8"));
+    assert.equal(onDiskJournal.status, "ready_to_finalise");
+    assert.ok(onDiskJournal.started_at, "expected started_at");
+    assert.ok(onDiskJournal.ready_at, "expected ready_at");
+    assert.ok(
+      Date.parse(onDiskJournal.started_at) <= Date.parse(onDiskJournal.ready_at),
+      `started_at (${onDiskJournal.started_at}) must be <= ready_at (${onDiskJournal.ready_at})`,
+    );
 
     // fsm-next --resume refuses to advance.
     const nextRefused = runScript("fsm-next.mjs", [

--- a/tests/unit/fsm-emit-shellquote.test.js
+++ b/tests/unit/fsm-emit-shellquote.test.js
@@ -1,0 +1,55 @@
+// fsm-emit-shellquote.test.js — coverage for the shellQuote helper
+// used by every CLI recovery hint. The contract: the returned string,
+// when concatenated into a `sh -c` command line, expands back to the
+// original input regardless of spaces, $, backticks, embedded quotes,
+// newlines, or other shell-special characters.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+
+import { shellQuote } from "../../scripts/lib/emit.mjs";
+
+function shellExpand(quoted) {
+  // Use a real shell to expand the quoted form back; that's the
+  // strictest check we can make and matches the operator's
+  // copy-paste path.
+  return execFileSync("sh", ["-c", `printf %s ${quoted}`], { encoding: "utf8" });
+}
+
+test("shellQuote: plain alphanumeric round-trips", () => {
+  assert.equal(shellExpand(shellQuote("hello")), "hello");
+});
+
+test("shellQuote: spaces preserved", () => {
+  assert.equal(shellExpand(shellQuote("a path with spaces")), "a path with spaces");
+});
+
+test("shellQuote: shell-special characters do not expand", () => {
+  for (const input of [
+    "$HOME/no-expansion",
+    "`whoami`",
+    "rm -rf /; echo pwn",
+    "with*glob?chars",
+    "with(parens)",
+    "with|pipe",
+    'with"double"quotes',
+    "with\\backslash",
+  ]) {
+    assert.equal(shellExpand(shellQuote(input)), input, `failed round-trip for: ${input}`);
+  }
+});
+
+test("shellQuote: embedded single quote handled via close-reopen trick", () => {
+  const input = "it's a path";
+  assert.equal(shellExpand(shellQuote(input)), input);
+});
+
+test("shellQuote: empty string round-trips to empty", () => {
+  assert.equal(shellExpand(shellQuote("")), "");
+});
+
+test("shellQuote: null/undefined produce empty-quoted form", () => {
+  assert.equal(shellQuote(null), "''");
+  assert.equal(shellQuote(undefined), "''");
+});

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -175,6 +175,69 @@ test("withJournal: O_EXCL tx.lock refuses a concurrent withJournal call", () => 
   }
 });
 
+test("journalState: surfaces orphaned tx.lock with status='lock_only'", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    // Simulate a crash that left only the tx.lock — withJournal
+    // creates the lock BEFORE the txn dir, so the small window
+    // between the two writes can produce this state.
+    mkdirSync(journalRoot(runDir), { recursive: true });
+    writeFileSync(
+      join(journalRoot(runDir), "tx.lock"),
+      JSON.stringify({ txn_id: "orphan-001", pid: 42 }),
+    );
+    const j = journalState(runDir);
+    assert.equal(j.hasJournal, true);
+    assert.equal(j.status, "lock_only");
+    assert.equal(j.lock_only, true);
+    assert.equal(j.txnId, "orphan-001");
+    assert.deepEqual(j.staged, []);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("discardJournal: clears an orphaned tx.lock when txnId matches", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    mkdirSync(journalRoot(runDir), { recursive: true });
+    writeFileSync(
+      join(journalRoot(runDir), "tx.lock"),
+      JSON.stringify({ txn_id: "orphan-001", pid: 42 }),
+    );
+    const result = discardJournal(runDir, "orphan-001");
+    assert.equal(result.discarded, true);
+    assert.equal(result.lock_only, true);
+    assert.equal(existsSync(journalRoot(runDir)), false);
+    // A fresh withJournal can now run.
+    withJournal(runDir, () => {});
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("discardJournal: refuses to clear an orphaned tx.lock with a different txnId", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    mkdirSync(journalRoot(runDir), { recursive: true });
+    writeFileSync(
+      join(journalRoot(runDir), "tx.lock"),
+      JSON.stringify({ txn_id: "real-txn-001", pid: 42 }),
+    );
+    const result = discardJournal(runDir, "wrong-txn-id");
+    assert.equal(result.discarded, false);
+    assert.equal(result.reason, "lock_txn_id_mismatch");
+    assert.equal(result.active_lock_txn_id, "real-txn-001");
+    // Lock still on disk.
+    assert.equal(existsSync(join(journalRoot(runDir), "tx.lock")), true);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
 test("discardJournal: removes the tx.lock so the next withJournal succeeds", () => {
   const store = tmpStore();
   try {

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -293,6 +293,105 @@ test("replayJournal: finalises a ready_to_finalise journal idempotently", () => 
   }
 });
 
+// ─── path-traversal guards (security) ───────────────────────────────────
+
+test("transaction.stage: rejects absolute paths", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(
+      () =>
+        withJournal(runDir, (txn) => {
+          txn.stage("/etc/passwd");
+        }),
+      /must be relative/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("transaction.stage: rejects '..' segments", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(
+      () =>
+        withJournal(runDir, (txn) => {
+          txn.stage("../escape.json");
+        }),
+      /invalid segment/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("transaction.stage: rejects backslashes (Windows traversal)", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(
+      () =>
+        withJournal(runDir, (txn) => {
+          txn.stage("foo\\..\\bar");
+        }),
+      /must not contain backslashes/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("replayJournal: rejects relPaths with traversal from a crafted manifest", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    const txnId = "crafted-txn-001";
+    const txnDir = join(runDir, ".journal", txnId);
+    mkdirSync(txnDir, { recursive: true });
+    writeFileSync(
+      join(txnDir, "journal.json"),
+      JSON.stringify({
+        txn_id: txnId,
+        status: "ready_to_finalise",
+        staged_files: [{ relPath: "../../escape.json" }],
+      }),
+    );
+    assert.throws(() => replayJournal(runDir, txnId), /invalid segment/);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+// ─── thenable rejection (atomicity) ─────────────────────────────────────
+
+test("withJournal: rejects async fn (thenable return)", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(
+      () => withJournal(runDir, async () => {}),
+      /must be a synchronous function/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("withJournal: rejects fn returning a manual Promise", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(
+      () => withJournal(runDir, () => Promise.resolve("oops")),
+      /must be a synchronous function/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
 test("replayJournal: refuses to finalise a pending journal", () => {
   const store = tmpStore();
   try {

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -22,6 +22,7 @@ import {
   appendTraceFile,
   buildRunId,
   discardJournal,
+  discardOrphanedLock,
   ensureRunDir,
   journalRoot,
   journalState,
@@ -232,6 +233,59 @@ test("discardJournal: refuses to clear an orphaned tx.lock with a different txnI
     assert.equal(result.reason, "lock_txn_id_mismatch");
     assert.equal(result.active_lock_txn_id, "real-txn-001");
     // Lock still on disk.
+    assert.equal(existsSync(join(journalRoot(runDir), "tx.lock")), true);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("journalState: orphaned tx.lock with unparseable JSON returns lock_only with txnId=null", () => {
+  // The lock payload is written then fsynced after open. If the
+  // process dies mid-write, the lock file can be present but
+  // truncated or malformed. journalState must still surface it.
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    mkdirSync(journalRoot(runDir), { recursive: true });
+    writeFileSync(join(journalRoot(runDir), "tx.lock"), "{ truncated_json"); // malformed
+    const j = journalState(runDir);
+    assert.equal(j.hasJournal, true);
+    assert.equal(j.status, "lock_only");
+    assert.equal(j.txnId, null);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("discardOrphanedLock: clears tx.lock when no txn dirs exist", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    mkdirSync(journalRoot(runDir), { recursive: true });
+    writeFileSync(join(journalRoot(runDir), "tx.lock"), "{malformed");
+    const result = discardOrphanedLock(runDir);
+    assert.equal(result.discarded, true);
+    assert.equal(result.lock_only, true);
+    assert.equal(existsSync(journalRoot(runDir)), false);
+    // Fresh withJournal works after the orphaned-lock clear.
+    withJournal(runDir, () => {});
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("discardOrphanedLock: refuses when txn dirs are present", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    // Plant both a txn dir AND a tx.lock — this is a real (not
+    // orphaned) state and discardOrphanedLock must refuse.
+    mkdirSync(join(journalRoot(runDir), "real-txn-001"), { recursive: true });
+    writeFileSync(join(journalRoot(runDir), "tx.lock"), "{}");
+    const result = discardOrphanedLock(runDir);
+    assert.equal(result.discarded, false);
+    assert.equal(result.reason, "txn_dirs_present");
+    assert.deepEqual(result.txn_dirs, ["real-txn-001"]);
     assert.equal(existsSync(join(journalRoot(runDir), "tx.lock")), true);
   } finally {
     rmSync(store, { recursive: true, force: true });

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -26,6 +26,7 @@ import {
   ensureRunDir,
   journalRoot,
   journalState,
+  publicJournalProjection,
   readManifest,
   replayJournal,
   runDirPath,
@@ -497,6 +498,83 @@ test("withJournal: refuses to rename into a symlinked subdir that escapes runDir
   } finally {
     rmSync(store, { recursive: true, force: true });
     rmSync(escapeRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── publicJournalProjection stable shape ───────────────────────────────
+
+test("publicJournalProjection: returns present:true with a stable key set when a journal is present", () => {
+  const shape = publicJournalProjection({
+    hasJournal: true,
+    txnId: "txn-001",
+    status: "ready_to_finalise",
+    staged: [{ relPath: "manifest.json" }, "fsm-trace/0001-exit-a.yaml"],
+  });
+  assert.deepEqual(Object.keys(shape).sort(), ["present", "staged", "status", "txn_id"]);
+  assert.equal(shape.present, true);
+  assert.deepEqual(shape.staged, ["manifest.json", "fsm-trace/0001-exit-a.yaml"]);
+});
+
+test("publicJournalProjection: returns present:false when no journal", () => {
+  const shape = publicJournalProjection({ hasJournal: false });
+  assert.deepEqual(shape, { present: false });
+});
+
+// ─── journalState ignores symlinks under .journal ───────────────────────
+
+test("journalState: a symlink under .journal is NOT treated as a txn dir", () => {
+  const store = tmpStore();
+  const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-symlink-"));
+  try {
+    const { runDir } = makeRun(store);
+    // Plant a malicious journal-content file outside the run dir.
+    mkdirSync(join(escapeRoot, "fake"), { recursive: true });
+    writeFileSync(
+      join(escapeRoot, "fake", "journal.json"),
+      JSON.stringify({ txn_id: "evil", status: "ready_to_finalise", staged_files: [] }),
+    );
+    // Plant a symlink under .journal that points at the escape dir.
+    mkdirSync(journalRoot(runDir), { recursive: true });
+    symlinkSync(join(escapeRoot, "fake"), join(journalRoot(runDir), "symlink-txn"));
+    // journalState must NOT see the symlink as a txn dir.
+    const result = journalState(runDir);
+    assert.equal(result.hasJournal, false);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+    rmSync(escapeRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── started_at preservation across pending → ready_to_finalise ─────────
+
+test("withJournal: pending manifest carries a started_at that is preserved on disk after fn throws", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    let observedStartedAt;
+    try {
+      withJournal(runDir, (txn) => {
+        // Read what was written for the pending manifest.
+        observedStartedAt = JSON.parse(
+          readFileSync(join(txn.txnDir, "journal.json"), "utf8"),
+        ).started_at;
+        throw new Error("crash-during-fn");
+      });
+    } catch {
+      // expected
+    }
+    const j = journalState(runDir);
+    assert.equal(j.hasJournal, true);
+    assert.equal(j.status, "pending");
+    // The disk-resident journal manifest still has the original
+    // started_at written before fn ran.
+    const onDisk = JSON.parse(
+      readFileSync(join(j.txnDir, "journal.json"), "utf8"),
+    );
+    assert.equal(onDisk.started_at, observedStartedAt);
+    assert.equal(onDisk.ready_at, undefined);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
   }
 });
 

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -149,6 +149,63 @@ test("withJournal: throw inside fn leaves a pending journal on disk", () => {
   }
 });
 
+test("withJournal: O_EXCL tx.lock refuses a concurrent withJournal call", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    // Plant a tx.lock to simulate another process holding the
+    // single-writer lock. A new withJournal call must refuse.
+    const root = journalRoot(runDir);
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, "tx.lock"),
+      JSON.stringify({ txn_id: "concurrent-other", pid: 99999 }),
+    );
+    let caught;
+    try {
+      withJournal(runDir, () => {});
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught, "expected withJournal to throw");
+    assert.equal(caught.code, "JOURNAL_PRESENT");
+    assert.equal(caught.journal.active_lock.txn_id, "concurrent-other");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("discardJournal: removes the tx.lock so the next withJournal succeeds", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    // Provoke a crashed journal with the tx.lock still in place.
+    try {
+      withJournal(runDir, (txn) => {
+        writeManifest(
+          runId,
+          { run_id: runId, status: "in_progress", current_state: "b" },
+          { ...opts, transaction: txn },
+        );
+        throw new Error("crash");
+      });
+    } catch {
+      // expected
+    }
+    const j = journalState(runDir);
+    assert.equal(j.hasJournal, true);
+    // tx.lock is present.
+    assert.equal(existsSync(join(journalRoot(runDir), "tx.lock")), true);
+    // Discard removes BOTH the txn dir AND the tx.lock.
+    discardJournal(runDir, j.txnId);
+    assert.equal(existsSync(journalRoot(runDir)), false);
+    // A fresh withJournal can now run.
+    withJournal(runDir, () => {});
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
 test("withJournal: refuses to start while an unrecovered journal exists", () => {
   const store = tmpStore();
   try {

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -1,0 +1,313 @@
+// fsm-journal.test.js — unit coverage for the A7 atomic-tx journal:
+// withJournal happy path + crash simulation, journalState inspection,
+// discardJournal rollback, replayJournal idempotent finalisation,
+// refuse-on-existing-journal guard.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  appendTraceFile,
+  buildRunId,
+  discardJournal,
+  ensureRunDir,
+  journalRoot,
+  journalState,
+  readManifest,
+  replayJournal,
+  runDirPath,
+  withJournal,
+  writeManifest,
+} from "../../scripts/lib/fsm-storage.mjs";
+
+function tmpStore() {
+  return mkdtempSync(join(tmpdir(), "fsm-journal-"));
+}
+
+function makeRun(store) {
+  const runId = buildRunId({ repo: "ctxr-dev/fsm", baseSha: "b", headSha: "h" }).runId;
+  const runDir = ensureRunDir(runId, { storageRoot: store });
+  writeManifest(
+    runId,
+    { run_id: runId, status: "in_progress", current_state: "a" },
+    { storageRoot: store },
+  );
+  return { runId, runDir, opts: { storageRoot: store } };
+}
+
+// ─── withJournal happy path ─────────────────────────────────────────────
+
+test("withJournal: stages writes then atomically finalises and removes the journal", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    const initialTrace = readdirSync(join(runDir, "fsm-trace"));
+    assert.equal(initialTrace.length, 0);
+
+    const { txnId, staged } = withJournal(runDir, (txn) => {
+      writeManifest(
+        runId,
+        { run_id: runId, status: "in_progress", current_state: "b" },
+        { ...opts, transaction: txn },
+      );
+      appendTraceFile(
+        runId,
+        { phase: "exit", state: "a", data: { outputs: { x: 1 } } },
+        { ...opts, transaction: txn },
+      );
+      appendTraceFile(
+        runId,
+        { phase: "entry", state: "b", data: { inputs: { x: 1 } } },
+        { ...opts, transaction: txn },
+      );
+    });
+
+    assert.equal(typeof txnId, "string");
+    assert.deepEqual(
+      staged.sort(),
+      ["fsm-trace/0001-exit-a.yaml", "fsm-trace/0002-entry-b.yaml", "manifest.json"].sort(),
+    );
+    // Journal directory is gone after a successful commit.
+    assert.equal(existsSync(journalRoot(runDir)), false);
+    // Final files exist and carry the new state.
+    const manifest = readManifest(runId, opts);
+    assert.equal(manifest.current_state, "b");
+    const traceFiles = readdirSync(join(runDir, "fsm-trace")).sort();
+    assert.deepEqual(traceFiles, ["0001-exit-a.yaml", "0002-entry-b.yaml"]);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("withJournal: sequence accounting includes both staged and on-disk traces", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    // One pre-existing on-disk trace at seq=1.
+    appendTraceFile(
+      runId,
+      { phase: "entry", state: "a", data: {} },
+      opts,
+    );
+    withJournal(runDir, (txn) => {
+      const txOpts = { ...opts, transaction: txn };
+      const r1 = appendTraceFile(runId, { phase: "exit", state: "a", data: {} }, txOpts);
+      const r2 = appendTraceFile(runId, { phase: "entry", state: "b", data: {} }, txOpts);
+      assert.equal(r1.sequence, 2);
+      assert.equal(r2.sequence, 3);
+    });
+    const files = readdirSync(join(runDir, "fsm-trace")).sort();
+    assert.deepEqual(files, [
+      "0001-entry-a.yaml",
+      "0002-exit-a.yaml",
+      "0003-entry-b.yaml",
+    ]);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+// ─── crash simulation ───────────────────────────────────────────────────
+
+test("withJournal: throw inside fn leaves a pending journal on disk", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    assert.throws(
+      () =>
+        withJournal(runDir, (txn) => {
+          writeManifest(
+            runId,
+            { run_id: runId, status: "in_progress", current_state: "b" },
+            { ...opts, transaction: txn },
+          );
+          throw new Error("simulated worker fault");
+        }),
+      /simulated worker fault/,
+    );
+    const j = journalState(runDir);
+    assert.equal(j.hasJournal, true);
+    assert.equal(j.status, "pending");
+    // Final manifest still shows the OLD state.
+    const manifest = readManifest(runId, opts);
+    assert.equal(manifest.current_state, "a");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("withJournal: refuses to start while an unrecovered journal exists", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    // Plant a journal manually.
+    mkdirSync(join(runDir, ".journal", "txn-001"), { recursive: true });
+    writeFileSync(
+      join(runDir, ".journal", "txn-001", "journal.json"),
+      JSON.stringify({ txn_id: "txn-001", status: "pending", staged_files: [] }),
+    );
+    assert.throws(
+      () => withJournal(runDir, () => {}),
+      /existing journal/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+// ─── journalState ───────────────────────────────────────────────────────
+
+test("journalState: returns hasJournal=false when no journal dir", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.deepEqual(journalState(runDir), { hasJournal: false });
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("journalState: returns hasJournal=false when journal dir exists but empty", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    mkdirSync(journalRoot(runDir), { recursive: true });
+    assert.deepEqual(journalState(runDir), { hasJournal: false });
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+// ─── discardJournal ─────────────────────────────────────────────────────
+
+test("discardJournal: removes the txn and cleans the empty journal root", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    try {
+      withJournal(runDir, (txn) => {
+        writeManifest(
+          runId,
+          { run_id: runId, status: "in_progress", current_state: "b" },
+          { ...opts, transaction: txn },
+        );
+        throw new Error("crash");
+      });
+    } catch {
+      // expected
+    }
+    const before = journalState(runDir);
+    assert.equal(before.hasJournal, true);
+    const result = discardJournal(runDir, before.txnId);
+    assert.equal(result.discarded, true);
+    assert.equal(result.txnId, before.txnId);
+    assert.equal(existsSync(journalRoot(runDir)), false);
+    // Original manifest preserved.
+    const manifest = readManifest(runId, opts);
+    assert.equal(manifest.current_state, "a");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("discardJournal: returns not_found for an unknown txnId", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    const result = discardJournal(runDir, "nope-txn");
+    assert.deepEqual(result, { discarded: false, reason: "not_found" });
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+// ─── replayJournal ──────────────────────────────────────────────────────
+
+function plantReadyJournal(runDir, runId) {
+  // Simulate a crash that landed after "ready_to_finalise" but before any
+  // rename. We stage one manifest.json + one trace file into the journal
+  // dir, write the ready manifest, and leave the final files in their
+  // pre-crash state.
+  const txnId = "test-txn-001";
+  const txnDir = join(runDir, ".journal", txnId);
+  mkdirSync(join(txnDir, "fsm-trace"), { recursive: true });
+  const stagedManifest = {
+    run_id: runId,
+    status: "in_progress",
+    current_state: "replayed-state",
+  };
+  writeFileSync(join(txnDir, "manifest.json"), JSON.stringify(stagedManifest, null, 2));
+  writeFileSync(
+    join(txnDir, "fsm-trace", "0001-exit-a.yaml"),
+    "phase: exit\nstate: a\nsequence: 1\n",
+  );
+  writeFileSync(
+    join(txnDir, "journal.json"),
+    JSON.stringify(
+      {
+        txn_id: txnId,
+        status: "ready_to_finalise",
+        run_dir: runDir,
+        staged_files: [
+          { relPath: "manifest.json" },
+          { relPath: "fsm-trace/0001-exit-a.yaml" },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  return txnId;
+}
+
+test("replayJournal: finalises a ready_to_finalise journal idempotently", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    const txnId = plantReadyJournal(runDir, runId);
+    const first = replayJournal(runDir, txnId);
+    assert.equal(first.replayed, true);
+    assert.equal(first.finalised.length, 2);
+    const manifest = readManifest(runId, opts);
+    assert.equal(manifest.current_state, "replayed-state");
+    assert.ok(existsSync(join(runDir, "fsm-trace", "0001-exit-a.yaml")));
+    // Journal dir cleaned.
+    assert.equal(existsSync(journalRoot(runDir)), false);
+    // Second replay finds nothing to do and reports cleanly.
+    const second = replayJournal(runDir, txnId);
+    assert.equal(second.replayed, false);
+    assert.equal(second.reason, "no_manifest");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("replayJournal: refuses to finalise a pending journal", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    const txnId = "pending-txn-001";
+    const txnDir = join(runDir, ".journal", txnId);
+    mkdirSync(txnDir, { recursive: true });
+    writeFileSync(
+      join(txnDir, "journal.json"),
+      JSON.stringify({ txn_id: txnId, status: "pending", staged_files: [] }),
+    );
+    const result = replayJournal(runDir, txnId);
+    assert.equal(result.replayed, false);
+    assert.equal(result.reason, "status_pending");
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -343,6 +343,30 @@ test("transaction.stage: rejects backslashes (Windows traversal)", () => {
   }
 });
 
+test("discardJournal: rejects a txnId containing path separators", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(() => discardJournal(runDir, "../../oops"), /single safe filesystem segment/);
+    assert.throws(() => discardJournal(runDir, "foo/bar"), /single safe filesystem segment/);
+    assert.throws(() => discardJournal(runDir, ".."), /single safe filesystem segment/);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("replayJournal: rejects a txnId containing path separators", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(() => replayJournal(runDir, "../../escape"), /single safe filesystem segment/);
+    assert.throws(() => replayJournal(runDir, "foo\\bar"), /single safe filesystem segment/);
+    assert.throws(() => replayJournal(runDir, "C:foo"), /single safe filesystem segment/);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
 test("replayJournal: rejects relPaths with traversal from a crafted manifest", () => {
   const store = tmpStore();
   try {

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -29,7 +29,6 @@ import {
   publicJournalProjection,
   readManifest,
   replayJournal,
-  runDirPath,
   withJournal,
   writeManifest,
 } from "../../scripts/lib/fsm-storage.mjs";

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -418,6 +418,26 @@ test("withJournal: rejects fn returning a manual Promise", () => {
   }
 });
 
+test("transaction.addStaged: rejects a stagedPath that diverges from canonical", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(
+      () =>
+        withJournal(runDir, (txn) => {
+          // Pass an arbitrary stagedPath that does NOT equal
+          // join(txnDir, relPath). The canonical-equality check
+          // refuses; a malicious helper cannot register a path the
+          // rename loop would later move into runDir.
+          txn.addStaged("manifest.json", "/tmp/somewhere-else.json");
+        }),
+      /must equal canonical/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
 // ─── appendTraceFile in-transaction return shape ────────────────────────
 
 test("appendTraceFile (transaction): returned path points at the staged file, final_path at its destination", () => {

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -500,6 +500,41 @@ test("withJournal: refuses to rename into a symlinked subdir that escapes runDir
   }
 });
 
+test("withJournal: deep relPath with escaping ancestor symlink creates NO directories outside runDir", () => {
+  const store = tmpStore();
+  const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-escape-"));
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    // Symlink runDir/workers -> escapeRoot/out, then attempt to stage
+    // a DEEP relPath ("workers/sub/nested/payload.json") whose parents
+    // do not yet exist on disk. Without the pre-flight check,
+    // mkdirSync({recursive:true}) would happily create `sub/nested/`
+    // inside escapeRoot/out before assertWithin throws. The
+    // pre-flight on the nearest existing ancestor catches the symlink
+    // at the `workers` level and refuses BEFORE any mkdir runs.
+    rmSync(join(runDir, "workers"), { recursive: true, force: true });
+    mkdirSync(join(escapeRoot, "out"), { recursive: true });
+    symlinkSync(join(escapeRoot, "out"), join(runDir, "workers"));
+    assert.throws(
+      () =>
+        withJournal(runDir, (txn) => {
+          // Stage at the canonical path (under txnDir, no escape there).
+          const relPath = "workers/sub/nested/payload.json";
+          const stagedPath = txn.stage(relPath);
+          writeFileSync(stagedPath, "{}");
+          txn.addStaged(relPath, stagedPath);
+        }),
+      /resolves to .* which is outside/,
+    );
+    // Critical assertion: escapeRoot/out remains EMPTY. No `sub/` or
+    // `sub/nested/` was created outside runDir.
+    assert.deepEqual(readdirSync(join(escapeRoot, "out")), []);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+    rmSync(escapeRoot, { recursive: true, force: true });
+  }
+});
+
 test("replayJournal: refuses to rename into a symlinked subdir that escapes runDir", () => {
   const store = tmpStore();
   const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-escape-"));

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -419,6 +419,132 @@ test("withJournal: rejects fn returning a manual Promise", () => {
   }
 });
 
+test("transaction.staged: returned snapshot is frozen and decoupled from internal state", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    let snapshotBefore;
+    let snapshotAfter;
+    withJournal(runDir, (txn) => {
+      writeManifest(
+        runId,
+        { run_id: runId, status: "in_progress", current_state: "b" },
+        { ...opts, transaction: txn },
+      );
+      snapshotBefore = txn.staged;
+      // Snapshot is frozen — push throws.
+      assert.throws(() => snapshotBefore.push({ relPath: "../../escape" }));
+      // Adding another staged entry via the proper API doesn't
+      // mutate the previously-returned snapshot (it was a copy).
+      appendTraceFile(
+        runId,
+        { phase: "exit", state: "a", data: {} },
+        { ...opts, transaction: txn },
+      );
+      snapshotAfter = txn.staged;
+      assert.equal(snapshotBefore.length, 1);
+      assert.equal(snapshotAfter.length, 2);
+    });
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("transaction.addStaged: rejects duplicate relPath", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    assert.throws(
+      () =>
+        withJournal(runDir, (txn) => {
+          const stagedPath = txn.stage("foo.json");
+          writeFileSync(stagedPath, "{}");
+          txn.addStaged("foo.json", stagedPath);
+          // Second registration of the same relPath must throw.
+          txn.addStaged("foo.json", stagedPath);
+        }),
+      /already staged/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("transaction.hasStaged: returns true iff relPath has been added", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    withJournal(runDir, (txn) => {
+      assert.equal(txn.hasStaged("manifest.json"), false);
+      writeManifest(
+        runId,
+        { run_id: runId, status: "in_progress", current_state: "b" },
+        { ...opts, transaction: txn },
+      );
+      assert.equal(txn.hasStaged("manifest.json"), true);
+      assert.equal(txn.hasStaged("nope.json"), false);
+    });
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("replayJournal: throws when staged source is missing AND destination is missing", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    const txnId = "partial-cleanup-001";
+    const txnDir = join(runDir, ".journal", txnId);
+    mkdirSync(txnDir, { recursive: true });
+    // Use a relPath that is NOT created by makeRun's setup. Neither
+    // the staged source under <txnDir>/fsm-trace/0042-... nor the
+    // final destination under <runDir>/fsm-trace/0042-... exists.
+    writeFileSync(
+      join(txnDir, "journal.json"),
+      JSON.stringify({
+        txn_id: txnId,
+        status: "ready_to_finalise",
+        staged_files: [{ relPath: "fsm-trace/0042-exit-zzz.yaml" }],
+      }),
+    );
+    assert.throws(
+      () => replayJournal(runDir, txnId),
+      /staged source for .* is missing AND the destination does not exist/,
+    );
+    // Journal still on disk — operator can inspect.
+    assert.equal(journalState(runDir).hasJournal, true);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+test("replayJournal: tolerates already-finalised entries when destination exists (idempotent re-run)", () => {
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    const txnId = "already-finalised-001";
+    const txnDir = join(runDir, ".journal", txnId);
+    mkdirSync(txnDir, { recursive: true });
+    // manifest.json already exists at the final path (makeRun wrote
+    // it). The journal lists manifest.json but the staged copy is
+    // missing — this is the legitimate "already finalised" case.
+    writeFileSync(
+      join(txnDir, "journal.json"),
+      JSON.stringify({
+        txn_id: txnId,
+        status: "ready_to_finalise",
+        staged_files: [{ relPath: "manifest.json" }],
+      }),
+    );
+    const result = replayJournal(runDir, txnId);
+    assert.equal(result.replayed, true);
+    assert.equal(result.finalised.length, 1);
+    assert.equal(result.finalised[0].already, true);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
 test("transaction.addStaged: rejects a stagedPath that diverges from canonical", () => {
   const store = tmpStore();
   try {

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -17,6 +17,8 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { symlinkSync } from "node:fs";
+
 import {
   appendTraceFile,
   buildRunId,
@@ -413,6 +415,102 @@ test("withJournal: rejects fn returning a manual Promise", () => {
     );
   } finally {
     rmSync(store, { recursive: true, force: true });
+  }
+});
+
+// ─── appendTraceFile in-transaction return shape ────────────────────────
+
+test("appendTraceFile (transaction): returned path points at the staged file, final_path at its destination", () => {
+  const store = tmpStore();
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    let recorded;
+    withJournal(runDir, (txn) => {
+      recorded = appendTraceFile(
+        runId,
+        { phase: "exit", state: "a", data: { outputs: {} } },
+        { ...opts, transaction: txn },
+      );
+      // While the transaction is open, the file lives at staged path.
+      assert.equal(recorded.staged, true);
+      assert.ok(existsSync(recorded.path), "staged file should exist on disk");
+      assert.equal(existsSync(recorded.final_path), false, "final not in place yet");
+      assert.notEqual(recorded.path, recorded.final_path);
+    });
+    // After the journal finalises, the final path exists and the
+    // staged path is gone.
+    assert.equal(existsSync(recorded.path), false);
+    assert.ok(existsSync(recorded.final_path));
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
+// ─── symlink-escape guards ──────────────────────────────────────────────
+
+test("withJournal: refuses to rename into a symlinked subdir that escapes runDir", () => {
+  const store = tmpStore();
+  // The escape target lives OUTSIDE the storage root so a successful
+  // rename would land bytes in `escape/`. With the guard, the rename is
+  // refused and the journal stays on disk.
+  const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-escape-"));
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    // Replace runDir/workers with a symlink pointing outside the run
+    // dir BEFORE the journal finalises.
+    rmSync(join(runDir, "workers"), { recursive: true, force: true });
+    mkdirSync(join(escapeRoot, "out"), { recursive: true });
+    symlinkSync(join(escapeRoot, "out"), join(runDir, "workers"));
+    assert.throws(
+      () =>
+        withJournal(runDir, (txn) => {
+          const stagedPath = txn.stage("workers/payload.json");
+          writeFileSync(stagedPath, "{}");
+          txn.addStaged("workers/payload.json", stagedPath);
+        }),
+      /resolves to .* which is outside/,
+    );
+    // The escape target should be empty (rename refused).
+    assert.deepEqual(readdirSync(join(escapeRoot, "out")), []);
+    // Journal stays on disk for inspection.
+    assert.equal(journalState(runDir).hasJournal, true);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+    rmSync(escapeRoot, { recursive: true, force: true });
+  }
+});
+
+test("replayJournal: refuses to rename into a symlinked subdir that escapes runDir", () => {
+  const store = tmpStore();
+  const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-escape-"));
+  try {
+    const { runId, runDir, opts } = makeRun(store);
+    // Plant a ready_to_finalise journal with one staged file in
+    // workers/. Then replace runDir/workers with a symlink to outside
+    // before calling replay.
+    const txnId = "symlink-escape-001";
+    const txnDir = join(runDir, ".journal", txnId);
+    mkdirSync(join(txnDir, "workers"), { recursive: true });
+    writeFileSync(join(txnDir, "workers", "payload.json"), "{}");
+    writeFileSync(
+      join(txnDir, "journal.json"),
+      JSON.stringify({
+        txn_id: txnId,
+        status: "ready_to_finalise",
+        staged_files: [{ relPath: "workers/payload.json" }],
+      }),
+    );
+    rmSync(join(runDir, "workers"), { recursive: true, force: true });
+    mkdirSync(join(escapeRoot, "out"), { recursive: true });
+    symlinkSync(join(escapeRoot, "out"), join(runDir, "workers"));
+    assert.throws(
+      () => replayJournal(runDir, txnId),
+      /resolves to .* which is outside/,
+    );
+    assert.deepEqual(readdirSync(join(escapeRoot, "out")), []);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+    rmSync(escapeRoot, { recursive: true, force: true });
   }
 });
 

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -801,6 +801,31 @@ test("withJournal: refuses to rename into a symlinked subdir that escapes runDir
 
 // ─── `.journal` root symlink rejection (containment) ────────────────────
 
+test("journalState: refuses when .journal is a BROKEN symlink (no-follow detection)", () => {
+  // existsSync follows symlinks and returns false for a dangling
+  // link, which would have made journalState silently report
+  // hasJournal:false despite a real filesystem anomaly. With
+  // lstatSync-based detection the broken symlink is treated as
+  // present, and the containment guard then throws a structured
+  // error so the operator can fix the run dir.
+  const store = tmpStore();
+  try {
+    const { runDir } = makeRun(store);
+    // Create a symlink to a target that does not exist.
+    symlinkSync("/tmp/does-not-exist-xyz-123", join(runDir, ".journal"));
+    assert.throws(
+      () => journalState(runDir),
+      // Either the containment error (if assertWithin reaches realpathSync
+      // on a broken link, the realpathSync throws ENOENT — which is
+      // surfaced) or the containment-mismatch error. Both are
+      // structured failures, not a "no journal" false negative.
+      /resolves to|ENOENT/,
+    );
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+  }
+});
+
 test("journalState: refuses when .journal itself is a symlink escaping runDir", () => {
   const store = tmpStore();
   const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-symlinked-root-"));

--- a/tests/unit/fsm-journal.test.js
+++ b/tests/unit/fsm-journal.test.js
@@ -12,12 +12,11 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-import { symlinkSync } from "node:fs";
 
 import {
   appendTraceFile,
@@ -621,6 +620,67 @@ test("withJournal: refuses to rename into a symlinked subdir that escapes runDir
     assert.deepEqual(readdirSync(join(escapeRoot, "out")), []);
     // Journal stays on disk for inspection.
     assert.equal(journalState(runDir).hasJournal, true);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+    rmSync(escapeRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── `.journal` root symlink rejection (containment) ────────────────────
+
+test("journalState: refuses when .journal itself is a symlink escaping runDir", () => {
+  const store = tmpStore();
+  const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-symlinked-root-"));
+  try {
+    const { runDir } = makeRun(store);
+    mkdirSync(join(escapeRoot, "fake-journal-root"), { recursive: true });
+    symlinkSync(join(escapeRoot, "fake-journal-root"), join(runDir, ".journal"));
+    assert.throws(() => journalState(runDir), /resolves to .* which is outside/);
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+    rmSync(escapeRoot, { recursive: true, force: true });
+  }
+});
+
+test("discardJournal: refuses when .journal itself is a symlink escaping runDir", () => {
+  const store = tmpStore();
+  const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-symlinked-root-"));
+  try {
+    const { runDir } = makeRun(store);
+    mkdirSync(join(escapeRoot, "fake-journal-root", "some-txn"), { recursive: true });
+    symlinkSync(join(escapeRoot, "fake-journal-root"), join(runDir, ".journal"));
+    assert.throws(
+      () => discardJournal(runDir, "some-txn"),
+      /resolves to .* which is outside/,
+    );
+    // The escape target must still exist (no rmSync ran on it).
+    assert.ok(existsSync(join(escapeRoot, "fake-journal-root", "some-txn")));
+  } finally {
+    rmSync(store, { recursive: true, force: true });
+    rmSync(escapeRoot, { recursive: true, force: true });
+  }
+});
+
+test("replayJournal: refuses when .journal itself is a symlink escaping runDir", () => {
+  const store = tmpStore();
+  const escapeRoot = mkdtempSync(join(tmpdir(), "fsm-journal-symlinked-root-"));
+  try {
+    const { runDir } = makeRun(store);
+    const escapeTxnDir = join(escapeRoot, "fake-journal-root", "evil-txn");
+    mkdirSync(escapeTxnDir, { recursive: true });
+    writeFileSync(
+      join(escapeTxnDir, "journal.json"),
+      JSON.stringify({
+        txn_id: "evil-txn",
+        status: "ready_to_finalise",
+        staged_files: [],
+      }),
+    );
+    symlinkSync(join(escapeRoot, "fake-journal-root"), join(runDir, ".journal"));
+    assert.throws(
+      () => replayJournal(runDir, "evil-txn"),
+      /resolves to .* which is outside/,
+    );
   } finally {
     rmSync(store, { recursive: true, force: true });
     rmSync(escapeRoot, { recursive: true, force: true });

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -628,6 +628,56 @@ test("fsm-resume: rejects --journal followed by another flag", () => {
   assert.match(result.stderr, /--journal requires a value/);
 });
 
+test("fsm-resume: --journal discard works without --fsm-path (only --storage-root + --run-id needed)", () => {
+  // Per the recovery contract, --journal discard / --journal replay
+  // should require ONLY storageRoot + runId. The previous implementation
+  // ran resolveSettings unconditionally, which forces fsmPath, blocking
+  // recovery in setups without a .fsmrc.json + without --fsm-path.
+  const tmp = setupFixture();
+  try {
+    // Drive the run so a run dir exists.
+    const next = runScript("fsm-next.mjs", [
+      "--new-run",
+      "--repo", "ctxr-dev/fsm",
+      "--base-sha", "b",
+      "--head-sha", "h",
+      "--session-id", "test-session",
+      ...commonArgs(tmp),
+    ]);
+    assert.equal(next.status, 0);
+    const runId = JSON.parse(next.stdout).run_id;
+
+    // Plant a journal under the run dir.
+    const inspect = JSON.parse(
+      runScript("fsm-inspect.mjs", ["--run-id", runId, ...commonArgs(tmp)]).stdout,
+    );
+    const txnDir = join(inspect.run_dir_path, ".journal", "no-fsm-path-001");
+    mkdirSync(txnDir, { recursive: true });
+    writeFileSync(
+      join(txnDir, "journal.json"),
+      JSON.stringify({
+        txn_id: "no-fsm-path-001",
+        status: "pending",
+        staged_files: [],
+      }),
+    );
+
+    // Pass ONLY --run-id, --journal discard, and --storage-root — no
+    // --fsm-path. The recovery short-circuit must succeed.
+    const result = runScript("fsm-resume.mjs", [
+      "--run-id", runId,
+      "--journal", "discard",
+      "--storage-root", join(tmp, "store"),
+    ]);
+    assert.equal(result.status, 0, `expected success, got stderr=${result.stderr}`);
+    const body = JSON.parse(result.stdout);
+    assert.equal(body.journal_action, "discard");
+    assert.equal(body.discarded, true);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("fsm-resume: --journal discard works when the FSM YAML is missing", () => {
   // Recovery only needs storageRoot + runId. An operator should be
   // able to discard an incomplete commit even if the FSM YAML has

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -628,6 +628,62 @@ test("fsm-resume: rejects --journal followed by another flag", () => {
   assert.match(result.stderr, /--journal requires a value/);
 });
 
+test("fsm-resume: --journal discard works when the FSM YAML is missing", () => {
+  // Recovery only needs storageRoot + runId. An operator should be
+  // able to discard an incomplete commit even if the FSM YAML has
+  // since been renamed / deleted, which would otherwise make
+  // loadFsm() blow up before the recovery short-circuit is reached.
+  const tmp = setupFixture();
+  try {
+    // Start a run so a run dir + manifest exist.
+    const next = runScript("fsm-next.mjs", [
+      "--new-run",
+      "--repo", "ctxr-dev/fsm",
+      "--base-sha", "b",
+      "--head-sha", "h",
+      "--session-id", "test-session",
+      ...commonArgs(tmp),
+    ]);
+    assert.equal(next.status, 0, `fsm-next failed: ${next.stderr}`);
+    const runId = JSON.parse(next.stdout).run_id;
+
+    // Plant a journal directly under the run dir.
+    const inspect = JSON.parse(
+      runScript("fsm-inspect.mjs", [
+        "--run-id", runId,
+        ...commonArgs(tmp),
+      ]).stdout,
+    );
+    const txnDir = join(inspect.run_dir_path, ".journal", "planted-txn-001");
+    mkdirSync(txnDir, { recursive: true });
+    writeFileSync(
+      join(txnDir, "journal.json"),
+      JSON.stringify({
+        txn_id: "planted-txn-001",
+        status: "pending",
+        staged_files: [],
+      }),
+    );
+
+    // Now NUKE the FSM YAML so loadFsm() would throw if it ran.
+    rmSync(join(tmp, "fsm.yaml"), { force: true });
+
+    // Recovery still works because the short-circuit runs BEFORE
+    // loadFsm.
+    const discardResult = runScript("fsm-resume.mjs", [
+      "--run-id", runId,
+      "--journal", "discard",
+      ...commonArgs(tmp),
+    ]);
+    assert.equal(discardResult.status, 0, `discard failed: ${discardResult.stderr}`);
+    const body = JSON.parse(discardResult.stdout);
+    assert.equal(body.journal_action, "discard");
+    assert.equal(body.discarded, true);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 // ─── final sanity: the runner file is present in scripts/.
 test("fsm-resume.mjs file is present in scripts/", () => {
   // Sanity: file exists at the canonical path.

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -628,6 +628,27 @@ test("fsm-resume: rejects --journal followed by another flag", () => {
   assert.match(result.stderr, /--journal requires a value/);
 });
 
+test("fsm-resume: --journal recovery returns run_not_found when the run dir does not exist", () => {
+  // An operator that mistypes a run-id (or points at the wrong
+  // storage root) should NOT get an ambiguous {ok:true,
+  // result:"no_journal_present"} payload — that masks the typo.
+  // Distinguish "wrong inputs" from "right inputs, nothing to do".
+  const tmp = setupFixture();
+  try {
+    const result = runScript("fsm-resume.mjs", [
+      "--run-id", "20260101-000000-deadbee",
+      "--journal", "discard",
+      "--storage-root", join(tmp, "store"),
+    ]);
+    assert.notEqual(result.status, 0);
+    const body = JSON.parse(result.stdout);
+    assert.equal(body.error, "run_not_found");
+    assert.equal(body.run_id, "20260101-000000-deadbee");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("fsm-resume: --journal discard works without --fsm-path (only --storage-root + --run-id needed)", () => {
   // Per the recovery contract, --journal discard / --journal replay
   // should require ONLY storageRoot + runId. The previous implementation

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -576,7 +576,7 @@ test("fsm-resume: rejects missing --run-id", () => {
   }
 });
 
-test("fsm-resume: rejects missing --from-state", () => {
+test("fsm-resume: rejects missing --from-state and missing --journal", () => {
   const tmp = setupFixture();
   try {
     const result = runScript("fsm-resume.mjs", [
@@ -584,7 +584,13 @@ test("fsm-resume: rejects missing --from-state", () => {
       ...commonArgs(tmp),
     ]);
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /--from-state is required/);
+    // Post-A7, callers must pass either --from-state (rewind to a prior
+    // entered state) or --journal {discard|replay} (recover an incomplete
+    // commit). Either is acceptable; missing both is the error.
+    assert.match(
+      result.stderr,
+      /either --from-state or --journal <discard\|replay> is required/,
+    );
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -628,6 +628,26 @@ test("fsm-resume: rejects --journal followed by another flag", () => {
   assert.match(result.stderr, /--journal requires a value/);
 });
 
+test("fsm-resume: --journal recovery emits malformed_run_id for a bad run-id", () => {
+  // parseRunId throws on anything not matching YYYYMMDD-HHMMSS-<7hex>.
+  // Operator recovery should surface this as a structured payload,
+  // NOT a stack trace from runDirPath.
+  const tmp = setupFixture();
+  try {
+    const result = runScript("fsm-resume.mjs", [
+      "--run-id", "not-a-valid-run-id",
+      "--journal", "discard",
+      "--storage-root", join(tmp, "store"),
+    ]);
+    assert.notEqual(result.status, 0);
+    const body = JSON.parse(result.stdout);
+    assert.equal(body.error, "malformed_run_id");
+    assert.equal(body.run_id, "not-a-valid-run-id");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("fsm-resume: --journal recovery returns run_not_found when the run dir does not exist", () => {
   // An operator that mistypes a run-id (or points at the wrong
   // storage root) should NOT get an ambiguous {ok:true,

--- a/tests/unit/fsm-resume.test.js
+++ b/tests/unit/fsm-resume.test.js
@@ -602,6 +602,32 @@ test("fsm-resume: rejects unknown argument", () => {
   assert.match(result.stderr, /unknown argument/);
 });
 
+test("fsm-resume: rejects --journal without a value", () => {
+  // Edge case: `fsm-resume --journal` with no following action used to
+  // silently parse `journalAction = undefined` and then fall through to
+  // the generic "either --from-state or --journal ..." error, which
+  // misleads the user (they did pass --journal). The parser now
+  // requires a value for every flag.
+  const result = runScript("fsm-resume.mjs", [
+    "--run-id", "20260101-000000-1234567",
+    "--journal",
+  ]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--journal requires a value/);
+});
+
+test("fsm-resume: rejects --journal followed by another flag", () => {
+  // Same shape as the previous: if the value happens to look like
+  // another flag, treat it as a missing value rather than silently
+  // consuming it as the action.
+  const result = runScript("fsm-resume.mjs", [
+    "--run-id", "20260101-000000-1234567",
+    "--journal", "--from-state", "a",
+  ]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--journal requires a value/);
+});
+
 // ─── final sanity: the runner file is present in scripts/.
 test("fsm-resume.mjs file is present in scripts/", () => {
   // Sanity: file exists at the canonical path.


### PR DESCRIPTION
## Summary

- Closes A7 from the FSM-library plan: every `fsm-commit` runs inside a journal-style transaction (`withJournal`) so the commit becomes a true single atomic step (every file lands or none do).
- Crash recovery: a SIGKILL between "ready_to_finalise" and the rename loop leaves a recoverable journal on disk. `fsm-next --resume` and `fsm-commit` both refuse to advance while a journal is present (`incomplete_commit_detected`). `fsm-resume --journal {discard|replay}` is the explicit recovery path. `fsm-inspect` surfaces the journal state.
- 14 new tests (10 unit + 4 integration, including a real SIGKILL during a synchronous busy-wait pause window injected via `FSM_TEST_PAUSE_BEFORE_FINALISE`). Full suite: 205/205 green.

## What changed

- `scripts/lib/fsm-storage.mjs`: new exports `withJournal`, `journalState`, `discardJournal`, `replayJournal`. `appendTraceFile`, `readManifest`, `writeManifest` now honour an `opts.transaction` that routes writes through the journal staging area; sequence accounting still works across staged + on-disk trace files in one commit.
- `scripts/lib/fsm-engine.mjs`: `updateManifest` threads `opts.transaction` through to `readManifest` + `writeManifest`.
- `scripts/lib/fsm-aggregator.mjs`: `aggregateLoopOutputs` + `aggregateAcrossStates` honour `transaction` so the loop-terminate aggregate writes participate in the same atomic commit as the exit trace.
- `scripts/fsm-commit.mjs`: restructured around `withJournal`. Every multi-write branch (loop iter continue, loop iter terminate + aggregate, post-validation fault, output schema violation, no-transition fault, terminal completion, advance) now runs inside one transaction. Brief computation moved AFTER finalisation so disk-read counters (`countLoopIterations`, `runEnv`) observe the just-written records.
- `scripts/fsm-next.mjs`: `--resume` detects a pre-existing journal and refuses with structured `incomplete_commit_detected` (carries the `recovery` commands the operator should run).
- `scripts/fsm-resume.mjs`: new `--journal {discard|replay}` mode that does NOT require `--from-state`. `discard` rolls back, `replay` finalises a `ready_to_finalise` journal idempotently.
- `scripts/fsm-inspect.mjs`: output now includes a `journal` field (`{ present, txn_id, status, staged, recovery }`).
- `package.json`: scripts split into `test`/`test:unit`/`test:integration`.
- `CHANGELOG.md`: new file with the A7 entry under `[Unreleased]`.

## Test plan

- [x] `npm run test:unit` → 201/201 green (includes 10 new `fsm-journal.test.js`).
- [x] `npm run test:integration` → 4/4 green (`tests/integration/atomic-tx.test.js`):
  - successful commit leaves no journal residue,
  - SIGKILL during the pause window leaves a `ready_to_finalise` journal; `fsm-inspect` surfaces it; `fsm-next --resume` refuses with `incomplete_commit_detected`; `fsm-resume --journal replay` finalises and the manifest then reflects the advance,
  - SIGKILL + `--journal discard` rolls back to the pre-commit manifest,
  - `fsm-commit` refuses to start when a journal is already on disk.
- [x] Manual end-to-end loop FSM walk via existing fixture still works (verified by `fsm-runtime.test.js` + `fsm-loop.test.js`).