### PR TITLE
feat(w4): ctxr.fsm.mcp — MCP server (Anthropic Python SDK) with 17 fsm.* tools

### DIFF
--- a/ctxr/fsm/cli/__init__.py
+++ b/ctxr/fsm/cli/__init__.py
@@ -20,11 +20,16 @@ Command surface (W3 scope)
 * ``import`` — re-insert a run from a JSON dump (with ``--replace``
   for clobber semantics).
 
+Implemented (W4)
+----------------
+
+* ``mcp`` — Model Context Protocol server. Boots the FastMCP
+  instance over stdio (default) or HTTP-SSE.
+
 Stubbed commands (filled in later workstreams)
 ----------------------------------------------
 
 * ``serve`` — long-running orchestrator (W7).
-* ``mcp`` — Model Context Protocol server (W4).
 * ``api`` — FastAPI HTTP / SSE surface (W5).
 * ``ui`` — local UI launcher (W6 / W7).
 
@@ -117,17 +122,23 @@ app.command(
 # Stubs for future workstreams
 # ---------------------------------------------------------------------------
 
-# These four commands appear in --help today so the surface is
-# stable, but each one delegates to a sibling stub module that prints
-# a deferral message and exits non-zero. Moving the bodies out of this
-# file means a later workstream (W4/W5/W6/W7) can flesh them out
-# without touching the top-level wiring at all.
+# These commands appear in --help today so the surface is stable.
+# The ``mcp`` body is the real W4 implementation; the others remain
+# stubs (each delegates to a sibling module that prints a deferral
+# message and exits non-zero) until the workstream that owns them
+# lands. Moving the bodies out of this file means a later workstream
+# (W5/W6/W7) can flesh them out without touching the top-level wiring
+# at all.
 app.command(name="serve", help="(Stub) long-running orchestrator — ships in W7.")(
     serve_cmd.serve
 )
-app.command(name="mcp", help="(Stub) Model Context Protocol server — ships in W4.")(
-    mcp_cmd.mcp
-)
+# ``mcp`` is the W4 entry point — boots the FastMCP server over the
+# selected transport. The help string mentions both transports so
+# operators see the shape on ``ctxr-fsm --help`` without drilling in.
+app.command(
+    name="mcp",
+    help="Run the Model Context Protocol server (stdio or http transport).",
+)(mcp_cmd.mcp)
 app.command(name="api", help="(Stub) FastAPI HTTP / SSE surface — ships in W5.")(
     api_cmd.api
 )

--- a/ctxr/fsm/cli/mcp_cmd.py
+++ b/ctxr/fsm/cli/mcp_cmd.py
@@ -1,50 +1,132 @@
-"""``ctxr-fsm mcp`` — stub for the Model Context Protocol server.
+"""``ctxr-fsm mcp`` — boot the Model Context Protocol server.
 
-W3 placeholder for what W4 fills in. We accept the eventual transport
-flag (``--transport stdio|http``) today so any operator scripts that
-pin the invocation continue to work unchanged when the real server
-lands; validation is identical to what W4 will perform, so a value
-accepted today is guaranteed to be accepted tomorrow.
+This is the W4 implementation that replaces the W3 stub. The command
+is intentionally a thin shim: it parses CLI arguments, then hands
+control to :func:`ctxr.fsm.mcp.server.main`, which owns the actual
+boot sequence (DB resolution, project open, logging setup, signal
+handlers, transport loop).
 
-See ``ctxr/fsm/cli/serve_cmd.py`` for the broader rationale on shipping
-command shapes ahead of their implementations.
+Why so thin
+-----------
+
+Two reasons:
+
+1. **Testability.** Keeping the CLI shim trivial lets the W4 server
+   tests exercise :func:`main` directly (with a temp DB, in-process)
+   without spawning ``ctxr-fsm mcp`` as a subprocess. The shim itself
+   only needs a smoke test that ``--help`` documents the right flags.
+
+2. **Embedding parity.** Notebooks and third-party orchestrators
+   import :func:`ctxr.fsm.mcp.server.main` (or even the bare
+   ``ctxr.fsm.mcp.mcp`` instance) and never touch the CLI. Having the
+   CLI do anything more than argument plumbing would split the boot
+   sequence into two copies that could drift.
+
+Transport semantics
+-------------------
+
+* ``--transport stdio`` (the default): the process becomes the MCP
+  server, reading JSON-RPC frames on stdin and writing them on stdout,
+  until the client closes the pipe or SIGINT / SIGTERM arrives. This
+  is the canonical Claude Code path — the host launches the binary
+  and speaks MCP over the resulting pipes.
+* ``--transport http``: FastMCP's SSE transport binds
+  ``--host`` / ``--port`` and the process blocks on the underlying
+  uvicorn loop. Port ``0`` (the default) lets the OS pick an
+  ephemeral port, which is handy for local-loop scripts and tests
+  where the caller reads the bound port out-of-band; production
+  deployments should pass an explicit non-zero port.
+
+``--db`` honours the same layered precedence as every other
+subcommand (``--db`` > ``$CTXR_FSM_DB`` > ``./.ctxr-fsm/fsm.db``) —
+the env-var leg is wired by Typer through :data:`DB_OPTION`.
+
+A note on validation
+--------------------
+
+The transport set (``stdio``, ``http``) is enforced here, mirroring
+the W3 stub's contract so any operator script pinned against the
+stub keeps working unchanged. ``--port`` accepts ``0`` (special-cased
+to "OS-picked ephemeral port") through ``65535``; the lower bound is
+``0`` rather than ``1`` precisely so the "let the OS pick" default
+remains expressible from the CLI.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import typer
+
+from ctxr.fsm.cli._common import DB_OPTION
 
 __all__ = ["mcp"]
 
 
 # Allowed values for the ``--transport`` flag. Pinned as a tuple of
-# literals so the W4 implementer can grep one place to widen the set
-# (e.g. adding ``sse`` or ``websocket``) without hunting for stringly-
-# typed checks.
+# literals so adding a new transport (e.g. ``websocket``) is a one-
+# line change and there is exactly one place to grep for the contract.
 _VALID_TRANSPORTS: tuple[str, ...] = ("stdio", "http")
 
 
 def mcp(
+    db: Path | None = DB_OPTION,
     transport: str = typer.Option(
         "stdio",
         "--transport",
         help=(
             "MCP transport: 'stdio' (the canonical client-launched "
-            "stdio framing) or 'http' (long-poll HTTP). The full server "
-            "ships in W4; today this flag is validated but otherwise unused."
+            "framing, default) or 'http' (FastMCP's SSE transport on "
+            "the host/port below)."
+        ),
+    ),
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        help=(
+            "Bind address for the HTTP transport. Ignored for stdio. "
+            "Defaults to localhost so the dev loop is safe-by-default; "
+            "production deployments should set this explicitly."
+        ),
+    ),
+    port: int = typer.Option(
+        0,
+        "--port",
+        min=0,
+        max=65535,
+        help=(
+            "TCP port for the HTTP transport (0-65535; 0 = let the OS "
+            "pick a free ephemeral port). Ignored for stdio."
         ),
     ),
 ) -> None:
-    """Stub for the W4 MCP server.
+    """Run the ctxr-fsm MCP server until the transport returns.
 
-    Validates ``--transport`` against the documented set, then emits
-    the structured deferral message on stderr and exits with code ``1``.
+    For ``--transport stdio`` (the default) the process becomes the
+    MCP server until the client closes the pipe or SIGINT / SIGTERM
+    arrives. For ``--transport http`` the process blocks on the
+    underlying uvicorn / SSE loop until the same signals arrive.
     """
     if transport not in _VALID_TRANSPORTS:
+        # Use Typer's standard validation rendering so the UX matches
+        # any other bad-flag error (exit code 2, usage banner).
         raise typer.BadParameter(
             f"--transport must be one of {_VALID_TRANSPORTS!r} "
             f"(got {transport!r})"
         )
 
-    typer.echo("MCP server lands in W4. Stub.", err=True)
-    raise typer.Exit(1)
+    # Local import so the CLI module stays cheap to import even when
+    # the user never invokes ``mcp`` — pulling in FastMCP + uvicorn
+    # at every ``ctxr-fsm`` startup would add a noticeable warm-up
+    # cost to every other subcommand.
+    from ctxr.fsm.mcp.server import main as _server_main
+
+    # ``transport`` is already narrowed to the literal set above; pass
+    # it through verbatim. ``db`` is forwarded as-is so the server's
+    # own ``resolve_db_path`` applies the canonical precedence.
+    _server_main(
+        transport=transport,  # type: ignore[arg-type]
+        db_path=db,
+        host=host,
+        port=port,
+    )

--- a/ctxr/fsm/mcp/__init__.py
+++ b/ctxr/fsm/mcp/__init__.py
@@ -1,0 +1,62 @@
+"""``ctxr.fsm.mcp`` — Model Context Protocol server for the FSM substrate.
+
+This package exposes the SQLite-backed FSM (W2) and its core engine
+(W1) through an MCP server. The server is the W12 enforcement
+substrate: it surfaces :attr:`State.allowed_tools`, returns
+:class:`CommitToken` from two-phase ``commit_outputs``, accepts
+cosignatures, and observes tool calls. W4 is the **plumbing** wave —
+schema validation and basic commit semantics — and intentionally does
+NOT yet enforce the hard rules; W12 wires those.
+
+Module layout
+-------------
+
+* :mod:`ctxr.fsm.mcp.server` — the entry point (``main()``) plus
+  transport selection. The CLI's ``ctxr-fsm mcp`` subcommand thunks
+  here.
+* :mod:`ctxr.fsm.mcp._state` — process-wide :class:`Project` handle
+  shared between every tool body.
+* :mod:`ctxr.fsm.mcp._errors` — structured error envelope (the
+  legacy JS contract).
+* :mod:`ctxr.fsm.mcp.tools` — re-exports every ``@mcp.tool()``-
+  decorated function. Importing this module is what *registers* the
+  tools on the FastMCP instance, so the package ``__init__`` does
+  the import for its side effect.
+
+The :data:`mcp` instance is exported at package scope so external
+embedders (notebooks, third-party orchestrators) can ``from
+ctxr.fsm.mcp import mcp`` and mount it as a sub-app, run alternate
+transports, or attach extra tools without reaching into the server
+entry point.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+__all__ = ["mcp"]
+
+
+# The single FastMCP instance. Module-level so the ``@mcp.tool()``
+# decorators in :mod:`ctxr.fsm.mcp.tools` can find it at import time
+# without threading the server through a fixture.
+#
+# ``instructions`` is surfaced to MCP clients in the ``initialize``
+# response — it is the first thing an LLM-driven client sees about the
+# server, so we keep it short and action-oriented (what the server is
+# + how to use it) rather than describing internals.
+mcp: FastMCP = FastMCP(
+    name="ctxr-fsm",
+    instructions=(
+        "SQLite-backed FSM substrate. Use fsm.* tools to drive "
+        "deterministic state machines for agent workflows."
+    ),
+)
+
+
+# Import the tools module for its decorator side effects. This must
+# happen AFTER ``mcp`` is constructed because the decorators reach for
+# the live instance. Local import to avoid the top-of-file cycle that
+# would otherwise be created (tools imports _state, which is fine, but
+# tools also imports back from this package to grab ``mcp``).
+from ctxr.fsm.mcp import tools as _tools  # noqa: E402, F401  (side-effect import)

--- a/ctxr/fsm/mcp/_errors.py
+++ b/ctxr/fsm/mcp/_errors.py
@@ -1,0 +1,76 @@
+"""Structured error envelopes returned by MCP tools.
+
+The legacy JavaScript MCP server in ``legacy-js/`` returns errors as
+``{"error": "<snake_case_code>", ...}`` objects rather than throwing
+JSON-RPC errors so clients can handle them as first-class tool
+results. We keep the same contract for the Python rewrite so any
+existing client that already speaks the legacy shape works unchanged
+against the new server.
+
+Every tool wraps its body in ``try/except`` and on failure returns an
+:class:`McpToolError` (or a dict produced by :func:`as_error`) rather
+than letting the exception propagate to FastMCP — propagating would
+produce a JSON-RPC error frame, which is a different code path that
+older clients did not have to handle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "McpToolError",
+    "as_error",
+]
+
+
+class McpToolError(BaseModel):
+    """Structured error returned by an MCP tool.
+
+    Attributes:
+        error: Snake-case error code (e.g. ``"spec_not_found"``,
+            ``"invalid_state"``). Stable across versions so clients can
+            branch on it; new codes are additive.
+        detail: Optional human-readable message giving more context.
+            Safe to surface to end users / log lines.
+        payload: Optional structured data attached to the error (for
+            example the validation report for ``schema_validation_failed``).
+            Schema is per-error-code; clients that don't recognise the
+            code should treat this as an opaque blob.
+    """
+
+    error: str = Field(..., description="Snake-case error code.")
+    detail: str | None = Field(
+        default=None,
+        description="Optional human-readable explanation.",
+    )
+    payload: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional structured payload attached to the error.",
+    )
+
+
+def as_error(
+    code: str,
+    detail: str | None = None,
+    **payload: Any,
+) -> McpToolError:
+    """Construct an :class:`McpToolError` from positional fields and kwargs.
+
+    ``code`` is the snake-case error tag (mandatory). ``detail`` is the
+    human-readable message. Any remaining keyword arguments are bundled
+    into the ``payload`` dict — the ``**kw`` shape lets the call site
+    read as ``as_error("invalid_state", state_id="x", expected="ready")``
+    without manually constructing a dict.
+
+    Passing zero keyword arguments leaves ``payload`` as ``None`` rather
+    than an empty dict, so the serialised JSON omits the field entirely
+    in the common case where there is nothing extra to attach.
+    """
+    return McpToolError(
+        error=code,
+        detail=detail,
+        payload=payload or None,
+    )

--- a/ctxr/fsm/mcp/_state.py
+++ b/ctxr/fsm/mcp/_state.py
@@ -1,0 +1,77 @@
+"""Process-wide singletons for the MCP server.
+
+The :class:`~mcp.server.fastmcp.FastMCP` instance lives at module scope
+in :mod:`ctxr.fsm.mcp` so the ``@mcp.tool()`` decorators in tool
+modules can find it at import time. Tools, however, also need access
+to the open :class:`~ctxr.fsm.sqlite.Project` handle, which is *not*
+known until the server boots and opens the database file.
+
+This module is the bridge: :func:`set_project` is called once by
+:func:`ctxr.fsm.mcp.server.main` after the project is opened, and
+every tool body calls :func:`get_project` to obtain it. Tests reach
+for :func:`reset_project` between cases to ensure isolation.
+
+Why module-level state instead of a context-var or a per-request
+dependency? FastMCP's stdio transport is single-process and tools are
+plain functions — there is no request context to pin a context-var to,
+and there is exactly one ``Project`` per server lifetime. A simple
+module-global is the smallest thing that works.
+"""
+
+from __future__ import annotations
+
+from ctxr.fsm.sqlite import Project
+
+__all__ = [
+    "get_project",
+    "reset_project",
+    "set_project",
+]
+
+
+# The active Project handle. Initialised to ``None`` so calls before
+# the server is configured raise loudly via :func:`get_project` rather
+# than silently operating on a stale handle.
+_project: Project | None = None
+
+
+def set_project(project: Project) -> None:
+    """Bind ``project`` as the singleton handle every tool will use.
+
+    Called exactly once by the MCP server entry point after
+    :meth:`Project.open` succeeds. Re-binding is permitted (tests use
+    this to swap in an in-memory project) but the caller is responsible
+    for closing the previous project — this helper does not own the
+    lifecycle of either value.
+    """
+    global _project
+    _project = project
+
+
+def get_project() -> Project:
+    """Return the bound :class:`Project`, raising if none is bound.
+
+    Raises :class:`RuntimeError` instead of returning ``None`` so that
+    every tool body can assume a live project without needing a guard
+    clause; any misuse (calling a tool before ``set_project`` runs) is
+    surfaced immediately with a precise message rather than turning
+    into a ``NoneType has no attribute`` further down the stack.
+    """
+    if _project is None:
+        raise RuntimeError(
+            "ctxr.fsm.mcp project handle is not set — "
+            "call set_project(Project.open(...)) before invoking tools."
+        )
+    return _project
+
+
+def reset_project() -> None:
+    """Clear the bound project handle (intended for tests).
+
+    Does not call :meth:`Project.close` because the test fixture that
+    set the project is responsible for tearing it down; this helper
+    only resets the binding so subsequent calls to :func:`get_project`
+    raise as if the server had never been configured.
+    """
+    global _project
+    _project = None

--- a/ctxr/fsm/mcp/server.py
+++ b/ctxr/fsm/mcp/server.py
@@ -1,0 +1,214 @@
+"""Entry point for the ``ctxr-fsm mcp`` server.
+
+This module owns the *boot sequence* for the MCP server:
+
+1. Resolve the SQLite database path using the same layered precedence
+   the CLI uses (``--db`` > ``$CTXR_FSM_DB`` > ``./.ctxr-fsm/fsm.db``).
+2. Open a :class:`Project` against that path (running migrations
+   transparently so a brand-new database boots without operator
+   intervention).
+3. Bind the open project onto the process-wide handle via
+   :func:`set_project` so every tool body can fetch it.
+4. Install a stderr-only logging configuration — MCP stdio uses
+   **stdout** for the JSON-RPC framing, so any print/log that escapes
+   to stdout corrupts the protocol stream.
+5. Install signal handlers so SIGINT / SIGTERM close the project
+   cleanly (releasing the SQLite file lock) instead of leaking the
+   engine.
+6. Hand control to FastMCP's transport loop — stdio (the default,
+   client-launched) or HTTP-SSE.
+
+Why duplicate ``resolve_db_path`` logic from the CLI? We want
+``ctxr.fsm.mcp`` to be importable without pulling Typer into memory
+(the CLI module imports ``typer`` at top level, which would force a
+hard ``typer`` dependency on every MCP consumer). The duplicated
+helper is small, well-commented, and trivially kept in sync with the
+canonical CLI version.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+from pathlib import Path
+from types import FrameType
+from typing import Literal
+
+from ctxr.fsm.mcp import mcp
+from ctxr.fsm.mcp._state import reset_project, set_project
+from ctxr.fsm.sqlite import Project
+
+__all__ = ["main", "resolve_db_path"]
+
+
+# Logger used by the boot sequence itself. Per-tool logging happens
+# inside the tool modules — keeping the entry-point logger separate
+# makes it easy to grep "mcp.server" in the journal for startup /
+# shutdown events without the per-call chatter.
+_LOG = logging.getLogger("ctxr.fsm.mcp.server")
+
+
+# Mirrors :data:`ctxr.fsm.cli._common._DEFAULT_DB_RELATIVE`. Duplicated
+# (rather than imported) so the MCP server does not transitively depend
+# on the Typer-heavy CLI module — see the module docstring.
+_DEFAULT_DB_RELATIVE: Path = Path(".ctxr-fsm") / "fsm.db"
+_DB_ENV_VAR: str = "CTXR_FSM_DB"
+
+
+def resolve_db_path(db_opt: Path | None) -> Path:
+    """Apply the project's layered precedence to produce a concrete DB path.
+
+    Precedence (highest first):
+
+    1. The explicit ``db_opt`` argument (e.g. ``--db``).
+    2. ``$CTXR_FSM_DB`` from the process environment.
+    3. ``./.ctxr-fsm/fsm.db`` relative to the current working directory.
+
+    Identical contract to :func:`ctxr.fsm.cli._common.resolve_db_path`;
+    kept independent so the MCP package does not transitively depend on
+    the Typer-based CLI module.
+    """
+    if db_opt is not None:
+        return db_opt.expanduser().resolve()
+    env_value = os.environ.get(_DB_ENV_VAR)
+    if env_value:
+        return Path(env_value).expanduser().resolve()
+    return (Path.cwd() / _DEFAULT_DB_RELATIVE).resolve()
+
+
+def _configure_stderr_logging() -> None:
+    """Install a logging configuration that writes only to stderr.
+
+    The MCP stdio transport uses **stdout** for JSON-RPC framing — a
+    stray ``print()`` or default ``logging.StreamHandler`` (which
+    defaults to stderr in modern Python, but historically defaulted to
+    stdout under some configurations) corrupts the protocol stream and
+    the client disconnects with a parse error. We pin the handler to
+    ``sys.stderr`` explicitly so no future Python version change can
+    flip the default underneath us.
+
+    ``force=True`` lets us reconfigure even if some imported module
+    already called ``logging.basicConfig`` — a common gotcha in
+    embedded scenarios.
+    """
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        force=True,
+    )
+
+
+def _install_signal_handlers(project: Project) -> None:
+    """Hook SIGINT / SIGTERM to close ``project`` before exit.
+
+    FastMCP's stdio loop already responds to SIGINT by stopping the
+    event loop, but it does not know about our :class:`Project` so we
+    add a tiny shim that closes the engine (releasing the SQLite file
+    lock) and clears the global handle before re-raising the default
+    behaviour by raising :class:`SystemExit`.
+
+    ``SIGTERM`` is handled symmetrically so containerised deployments
+    that send SIGTERM during graceful shutdown also close the engine
+    cleanly.
+
+    On Windows ``SIGTERM`` does not exist; the registration is wrapped
+    in a try/except so an import on Windows does not blow up — the
+    SIGINT registration is enough on that platform.
+    """
+
+    def _shutdown(signum: int, _frame: FrameType | None) -> None:
+        _LOG.info("received signal %s, closing project and exiting", signum)
+        try:
+            project.close()
+        finally:
+            reset_project()
+        # Use exit code 0 — receiving SIGTERM is a normal lifecycle
+        # event, not an error. The MCP client will reconnect / restart
+        # us as it sees fit.
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGINT, _shutdown)
+    try:
+        signal.signal(signal.SIGTERM, _shutdown)
+    except (AttributeError, ValueError):
+        # SIGTERM is not available on Windows (AttributeError) or when
+        # we're not running in the main thread (ValueError). Both are
+        # acceptable degradations: SIGINT alone covers the interactive
+        # case, and container orchestrators on Windows have their own
+        # shutdown signalling we don't intercept.
+        _LOG.debug("SIGTERM handler not installed (unsupported on this platform)")
+
+
+def main(
+    transport: Literal["stdio", "http"] = "stdio",
+    db_path: Path | None = None,
+    host: str = "127.0.0.1",
+    port: int = 0,
+) -> None:
+    """Boot the MCP server and block until the transport returns.
+
+    Parameters
+    ----------
+    transport:
+        ``"stdio"`` (default, the canonical MCP client-launched
+        framing) or ``"http"`` for the SSE transport. The HTTP path is
+        an operator escape hatch — Claude Code itself always uses
+        stdio.
+    db_path:
+        Optional explicit database path; if ``None``, falls back to
+        :func:`resolve_db_path` (env-var, then project default).
+    host, port:
+        Listen address for the HTTP transport. Ignored for ``stdio``.
+        Default ``port=0`` lets the OS pick an ephemeral port, which
+        is mostly useful for tests and developer-loop scripts; production
+        deployments should pass an explicit port.
+    """
+    _configure_stderr_logging()
+
+    resolved_db = resolve_db_path(db_path)
+    _LOG.info("opening ctxr.fsm project at %s", resolved_db)
+
+    # ``migrate=True`` upgrades a stale schema in place so a brand-new
+    # database boots without an operator running ``ctxr-fsm migrate``
+    # first. The migration is idempotent.
+    project = Project.open(resolved_db, migrate=True)
+    set_project(project)
+
+    _install_signal_handlers(project)
+
+    try:
+        if transport == "stdio":
+            _LOG.info("starting MCP server on stdio")
+            mcp.run()
+        elif transport == "http":
+            # FastMCP's SSE transport is configured via constructor
+            # kwargs (host / port) and selected by passing ``"sse"``
+            # to ``run()``. We expose ``"http"`` to the caller as the
+            # friendlier name and translate here. The host/port are
+            # applied via the underlying settings — FastMCP reads them
+            # from ``self.settings.host`` and ``self.settings.port``
+            # which we set explicitly so a per-call host/port wins
+            # over whatever the constructor default was.
+            mcp.settings.host = host
+            mcp.settings.port = port
+            _LOG.info("starting MCP server on http://%s:%s (sse)", host, port)
+            mcp.run(transport="sse")
+        else:
+            # Defensive — Literal narrows at the type level but a
+            # runtime caller (e.g. a typo from the CLI shim) could
+            # still squeeze through.
+            raise ValueError(
+                f"unknown transport {transport!r}; expected 'stdio' or 'http'"
+            )
+    finally:
+        # Cover the path where ``mcp.run`` returns normally (e.g.
+        # client closed the stdio pipe) — the signal handlers cover
+        # the SIGINT/SIGTERM path.
+        _LOG.info("MCP transport returned, closing project")
+        try:
+            project.close()
+        finally:
+            reset_project()

--- a/ctxr/fsm/mcp/tools.py
+++ b/ctxr/fsm/mcp/tools.py
@@ -1,0 +1,29 @@
+"""MCP tool registrations.
+
+This module is imported by :mod:`ctxr.fsm.mcp` for the side effect of
+registering every ``@mcp.tool()``-decorated function on the package's
+FastMCP instance. The actual tool implementations land in the next
+phase of W4; for now this file is intentionally empty so the W4
+bootstrap (server entry point, error contract, project handle) can
+land independently and the smoke test (``from ctxr.fsm.mcp import mcp``)
+proves the wiring is sound before any tool surface is committed.
+
+When tools are added, prefer one sub-module per logical group (e.g.
+``tools_runs.py``, ``tools_states.py``, ``tools_commit.py``) and
+re-export from this aggregator so the package keeps a single, stable
+"import this for decorator side effects" entry point.
+"""
+
+from __future__ import annotations
+
+# Importing each sub-module runs its ``@mcp.tool()`` decorators, which
+# is the side-effect that registers the tools onto the FastMCP instance
+# in :mod:`ctxr.fsm.mcp`. Keep this list alphabetical so additions are
+# easy to review.
+from ctxr.fsm.mcp import (
+    tools_events,  # noqa: F401  (side-effect import)
+    tools_meta,  # noqa: F401  (side-effect import)
+    tools_runs,  # noqa: F401  (side-effect import)
+)
+
+__all__: list[str] = []

--- a/ctxr/fsm/mcp/tools_events.py
+++ b/ctxr/fsm/mcp/tools_events.py
@@ -1,0 +1,592 @@
+"""Event-bus, journal-inspection, and registry MCP tools.
+
+This module owns the *observability slice* of the W4 plumbing wave:
+clients use these tools to tail events emitted by the FSM runtime,
+peek at the journal's pre-commit ledger, recover a half-written txn,
+and enumerate the bus's producers / consumers. Every tool here is
+read-mostly — :func:`recover_journal` is the only mutator, and even it
+only acts on a single journal-txn row whose lifecycle the engine has
+abandoned.
+
+Tool surface
+------------
+
+* ``fsm.subscribe_events`` — long-polling event subscription. The MCP
+  SDK's tool calls are unary (request → single response) so we do not
+  stream; instead each call registers / refreshes the consumer, waits
+  up to ``timeout_seconds`` for new events, and returns a batch. The
+  follow-up call uses the same ``consumer_name`` (idempotent
+  registration) and naturally resumes where the previous call left off
+  because every yielded event is ack'd before it is returned.
+* ``fsm.inspect_journal`` — a flat read of
+  :meth:`JournalRepo.inspect`; returns the newest unfinalised txn for
+  a run (or ``null`` if the run is quiescent).
+* ``fsm.recover_journal`` — operator hatch for the case where the
+  engine crashed mid-commit: ``"discard"`` drops the staged writes
+  (effective rollback) and ``"replay"`` re-marks the txn finalised
+  (effective roll-forward). W4 is plumbing only — we do NOT yet
+  attempt to materialise the staged writes, just transition the txn
+  lifecycle so the engine on next boot sees a clean slate.
+* ``fsm.list_consumers`` / ``fsm.list_producers`` — registry dumps
+  for the dev-loop and for any UI that wants to render the bus
+  topology.
+
+Stdout discipline
+-----------------
+MCP stdio uses **stdout** for the JSON-RPC framing — every log line
+in this module goes to stderr via the module-level :data:`_LOG`
+(``logging`` is configured stderr-only by
+:func:`ctxr.fsm.mcp.server._configure_stderr_logging`). Tool bodies
+NEVER ``print()``.
+
+Error contract
+--------------
+Each tool body is wrapped in ``try/except``: on failure we return an
+:class:`McpToolError` envelope (the legacy JS contract) rather than
+letting the exception escape to FastMCP — propagation would surface
+as a JSON-RPC error frame, which is a different code path older
+clients did not have to handle. The success-vs-error discriminator
+is the presence of the ``"error"`` key in the structured tool
+output (FastMCP wraps both arms of a ``Union[...]`` return type
+under ``{"result": ...}`` — clients branch on
+``result.error is not None``).
+
+Enforcement note
+----------------
+W4 is the *plumbing* wave. These tools surface the bus and journal
+substrate; they do NOT yet impose the hard W12 invariants (token
+lifetimes, consumer auth, recovery-policy quorums). Wiring is
+exhaustive; enforcement is deferred so the schema can be exercised
+before it is locked down.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ctxr.fsm.mcp import mcp
+from ctxr.fsm.mcp._errors import McpToolError, as_error
+from ctxr.fsm.mcp._state import get_project
+from ctxr.fsm.sqlite.repos_events import Consumer, Event, Producer
+from ctxr.fsm.sqlite.repos_locks_journal import JournalTxn
+
+__all__ = [
+    "EventBatch",
+    "JournalRecovered",
+    "JournalState",
+    "inspect_journal",
+    "list_consumers",
+    "list_producers",
+    "recover_journal",
+    "subscribe_events",
+]
+
+
+# Logger pinned to this module's name so the journal of a running
+# server can be grep'd for ``ctxr.fsm.mcp.tools_events`` to isolate
+# the bus-observability path from the rest of the server chatter.
+_LOG = logging.getLogger("ctxr.fsm.mcp.tools_events")
+
+
+# Subscription poll cadence inside :func:`subscribe_events`. We avoid
+# importing the SQLite-layer default (``DEFAULT_POLL_INTERVAL_SECONDS``)
+# directly because this is a different decision: the MCP long-poll
+# trades a slightly slower cadence for cheaper SQLite hits, since the
+# total wait is bounded by the caller-supplied ``timeout_seconds``.
+_SUBSCRIBE_POLL_INTERVAL_SECONDS: float = 0.1
+
+# Default ``consumer.kind`` for subscriptions registered through MCP.
+# Distinct from the engine's own ``"engine"`` / ``"verifier"`` kinds so
+# operators can tell "this consumer is an MCP client tailing events"
+# apart from "this consumer is part of the FSM runtime" in
+# :func:`list_consumers` dumps.
+_MCP_CONSUMER_KIND: str = "mcp_subscriber"
+
+
+# Soft cap on ``max_events`` so a misconfigured client cannot ask for
+# a million rows in one round-trip. The cap is generous (1000) — the
+# typical UI-side tail asks for 50 — but bounded so the server's
+# memory footprint per call is predictable.
+_MAX_EVENTS_HARD_CAP: int = 1000
+
+
+# ---------------------------------------------------------------------------
+# Tool input / output models
+# ---------------------------------------------------------------------------
+
+
+class EventBatch(BaseModel):
+    """A batch of events returned by :func:`subscribe_events`.
+
+    Attributes
+    ----------
+    events:
+        Events delivered in this poll cycle, in producer-emit order
+        (``EventTable.created_at`` ascending, which on UUIDv7-keyed
+        rows is also the insertion order). Empty list when the
+        long-poll timed out with nothing to deliver — that is a
+        normal "still alive" response, not an error.
+    next_cursor:
+        Opaque cursor for the next call. Currently always ``None``
+        because the underlying ``EventDeliveriesRepo`` maintains the
+        per-consumer cursor server-side via the delivery rows; the
+        field is reserved so a future revision can add an explicit
+        client-held cursor without breaking the wire contract.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    events: list[Event] = Field(default_factory=list)
+    next_cursor: str | None = Field(
+        default=None,
+        description=(
+            "Reserved for future use; the bus tracks the cursor "
+            "server-side via per-consumer delivery rows so callers "
+            "do not need to thread one through today."
+        ),
+    )
+
+
+class JournalState(BaseModel):
+    """The journal-inspection view returned by :func:`inspect_journal`.
+
+    The repo's :meth:`JournalRepo.inspect` already returns ``None``
+    when there is no unfinalised txn, but the MCP wire contract
+    prefers a structured shape over a literal null so clients can
+    branch on a field rather than on the absence of a value.
+
+    Attributes
+    ----------
+    run_id:
+        The run whose journal was inspected, echoed back for
+        correlation when a UI dispatches many inspect calls in
+        parallel.
+    txn:
+        The newest unfinalised journal txn, or ``None`` if the run
+        is quiescent (every prior txn already finalised, or no txn
+        ever opened).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    run_id: str
+    txn: JournalTxn | None = None
+
+
+class JournalRecovered(BaseModel):
+    """The structured outcome of a :func:`recover_journal` call.
+
+    Attributes
+    ----------
+    run_id:
+        Echo of the input ``run_id`` so a client dispatching a fleet
+        of recovery calls can route the response without keeping
+        per-request state.
+    action:
+        The recovery action that was applied — ``"discard"`` deletes
+        the staged-write ledger row (effective rollback) and
+        ``"replay"`` re-marks the txn ``finalised`` (effective
+        roll-forward).
+    txn_id:
+        The journal-txn id that was acted upon, or ``None`` when
+        the run had no unfinalised txn to recover (in which case
+        the call is a structured no-op rather than an error).
+    previous_status:
+        The status of the txn *before* the recovery action ran. A
+        sanity-check field for the audit trail; the engine's
+        recovery policy logs this on every successful recovery.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    run_id: str
+    action: Literal["discard", "replay"]
+    txn_id: str | None = None
+    previous_status: (
+        Literal["pending", "ready_to_finalise", "finalised"] | None
+    ) = None
+
+
+# ---------------------------------------------------------------------------
+# fsm.subscribe_events
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.subscribe_events",
+    description=(
+        "Long-poll the FSM event bus for up to `max_events` events "
+        "within `timeout_seconds`. The same `consumer_name` resumes "
+        "where the previous call stopped — registration is idempotent."
+    ),
+)
+def subscribe_events(
+    consumer_name: Annotated[
+        str,
+        Field(
+            min_length=1,
+            description=(
+                "Durable identity for this subscription. Re-using the "
+                "same name on a subsequent call resumes the cursor."
+            ),
+        ),
+    ],
+    kinds: Annotated[
+        list[str] | None,
+        Field(
+            default=None,
+            description=(
+                "Optional list of `EventKind` string values to filter "
+                "on. None means deliver every kind."
+            ),
+        ),
+    ] = None,
+    filter_run_id: Annotated[
+        UUID | None,
+        Field(
+            default=None,
+            description=(
+                "Optional run-id to scope the subscription to a single "
+                "run. None means every run."
+            ),
+        ),
+    ] = None,
+    max_events: Annotated[
+        int,
+        Field(
+            ge=1,
+            le=_MAX_EVENTS_HARD_CAP,
+            description=(
+                "Maximum number of events to return in this batch. "
+                "Hard-capped server-side."
+            ),
+        ),
+    ] = 50,
+    timeout_seconds: Annotated[
+        float,
+        Field(
+            gt=0.0,
+            le=60.0,
+            description=(
+                "Maximum wall-clock seconds the server will wait for "
+                "events to appear before returning an empty batch."
+            ),
+        ),
+    ] = 5.0,
+) -> EventBatch | McpToolError:
+    """Long-poll for bus events, returning at most ``max_events``.
+
+    On the first call we register (or refresh) the consumer with the
+    bus; subsequent calls with the same ``consumer_name`` are
+    idempotent on the consumer row and resume the cursor because every
+    delivered event is ack'd before being returned.
+
+    Returns an empty :class:`EventBatch` on timeout — that's a
+    structured "still alive, nothing new" response and is NOT an
+    error.
+    """
+    try:
+        project = get_project()
+        filter_run_id_str = str(filter_run_id) if filter_run_id is not None else None
+
+        # Register / refresh the consumer up front so the bus knows
+        # our filters before the first poll. Re-registering is
+        # idempotent at (kind, name) and updates the filters in
+        # place — see ConsumersRepo.register.
+        with project.session_factory() as session, session.begin():
+            consumer = project.consumers.register(
+                session,
+                kind=_MCP_CONSUMER_KIND,
+                name=consumer_name,
+                filter_kind=kinds,
+                filter_run_id=filter_run_id_str,
+            )
+        consumer_id = consumer.id
+
+        deadline = time.monotonic() + timeout_seconds
+        collected: list[Event] = []
+
+        # Long-poll loop. Each cycle pulls a bounded batch, ack's
+        # every row inside the same txn (at-least-once semantics —
+        # a crash between pull and ack would re-deliver on the next
+        # call), and either returns immediately if we hit the cap or
+        # naps until the next cycle.
+        while True:
+            remaining = max_events - len(collected)
+            if remaining <= 0:
+                break
+
+            with project.session_factory() as session, session.begin():
+                pending = project.event_deliveries.pending_for(
+                    session,
+                    consumer_id=consumer_id,
+                    limit=remaining,
+                )
+                if pending:
+                    for ewd in pending:
+                        project.event_deliveries.mark_delivered(
+                            session,
+                            event_id=ewd.event.id,
+                            consumer_id=consumer_id,
+                        )
+                        project.event_deliveries.ack(
+                            session,
+                            event_id=ewd.event.id,
+                            consumer_id=consumer_id,
+                        )
+                    project.consumers.touch_last_seen(session, consumer_id)
+
+            # Project the bus-side EventWithDelivery rows down to the
+            # plain Event value-object the client cares about. Doing
+            # the projection outside the txn keeps the transaction
+            # short.
+            for ewd in pending:
+                collected.append(ewd.event)
+
+            if collected:
+                # First non-empty cycle wins: return immediately rather
+                # than waiting for the full timeout. This matches the
+                # "long-poll" idiom — the timeout is a *ceiling* on how
+                # long the server may wait, not a fixed delay.
+                break
+
+            now = time.monotonic()
+            if now >= deadline:
+                # Timed out with nothing to deliver — structured empty
+                # batch is the contract, not an error.
+                break
+
+            # Take a short nap, but never sleep past the deadline so
+            # the response is bounded by ``timeout_seconds`` even
+            # when the configured poll interval would overshoot.
+            nap = min(_SUBSCRIBE_POLL_INTERVAL_SECONDS, deadline - now)
+            if nap > 0:
+                time.sleep(nap)
+
+        _LOG.debug(
+            "subscribe_events consumer=%s delivered=%d",
+            consumer_name,
+            len(collected),
+        )
+        return EventBatch(events=collected, next_cursor=None)
+    except KeyboardInterrupt:
+        # Never swallow KeyboardInterrupt — let the server's signal
+        # handler shut down cleanly.
+        raise
+    except Exception as exc:
+        _LOG.exception("subscribe_events failed for consumer %s", consumer_name)
+        return as_error(
+            "subscribe_events_failed",
+            detail=str(exc),
+            consumer_name=consumer_name,
+        )
+
+
+# ---------------------------------------------------------------------------
+# fsm.inspect_journal
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.inspect_journal",
+    description=(
+        "Return the newest unfinalised journal txn for the given run, "
+        "or null when the run is quiescent. Read-only."
+    ),
+)
+def inspect_journal(
+    run_id: Annotated[
+        UUID,
+        Field(description="The run whose journal you want to peek at."),
+    ],
+) -> JournalState | McpToolError:
+    """Return the newest pending / ready-to-finalise journal txn for ``run_id``.
+
+    Thin wrapper around :meth:`JournalRepo.inspect`. The repo returns
+    ``None`` when nothing is in flight; we project that into a
+    :class:`JournalState` with ``txn=None`` so the wire shape is
+    consistent (clients always get an object, never a literal null
+    at the tool-result level).
+    """
+    try:
+        project = get_project()
+        run_id_str = str(run_id)
+        with project.session_factory() as session:
+            txn = project.journal.inspect(session, run_id=run_id_str)
+        return JournalState(run_id=run_id_str, txn=txn)
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("inspect_journal failed for run %s", run_id)
+        return as_error(
+            "inspect_journal_failed",
+            detail=str(exc),
+            run_id=str(run_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# fsm.recover_journal
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.recover_journal",
+    description=(
+        "Recover the newest unfinalised journal txn for a run. "
+        "`discard` rolls it back; `replay` rolls it forward to "
+        "`finalised`. Returns a structured no-op if nothing is in flight."
+    ),
+)
+def recover_journal(
+    run_id: Annotated[
+        UUID,
+        Field(description="The run whose journal needs recovering."),
+    ],
+    action: Annotated[
+        Literal["discard", "replay"],
+        Field(
+            description=(
+                "`discard` deletes the staged-write row (rollback). "
+                "`replay` transitions the txn to `finalised` "
+                "(roll-forward — W4 plumbing only; the engine itself "
+                "is what re-materialises staged writes on next boot)."
+            ),
+        ),
+    ],
+) -> JournalRecovered | McpToolError:
+    """Roll the newest unfinalised journal txn for ``run_id`` forward or back.
+
+    The operation is best-effort + idempotent: if no unfinalised
+    txn exists, we return a structured no-op (``txn_id=None``)
+    rather than raising — the engine's recovery loop calls this in
+    a tight loop and the absence of a recoverable row is the
+    common "already clean" outcome.
+
+    W4 caveat: ``"replay"`` only *transitions the txn status* to
+    ``finalised``; it does not re-execute the staged writes. The
+    next-boot engine is what actually re-materialises them. This
+    keeps the plumbing wave honest about what is and is not
+    enforced yet — W12 will wire the actual roll-forward
+    semantics.
+    """
+    try:
+        project = get_project()
+        run_id_str = str(run_id)
+        with project.session_factory() as session, session.begin():
+            txn = project.journal.inspect(session, run_id=run_id_str)
+            if txn is None:
+                # No-op success: nothing in flight to recover.
+                return JournalRecovered(
+                    run_id=run_id_str,
+                    action=action,
+                    txn_id=None,
+                    previous_status=None,
+                )
+
+            previous_status = txn.status
+            if action == "discard":
+                project.journal.discard(session, txn_id=txn.id)
+            else:  # action == "replay"
+                # Only ``ready_to_finalise`` rows are legal to
+                # roll forward — a still-``pending`` row has no
+                # staged writes to finalise. We refuse with a
+                # structured error rather than silently doing the
+                # wrong thing.
+                if txn.status != "ready_to_finalise":
+                    return as_error(
+                        "journal_replay_not_ready",
+                        detail=(
+                            "Cannot replay a journal txn whose status "
+                            f"is {txn.status!r}; only "
+                            "'ready_to_finalise' is replayable."
+                        ),
+                        run_id=run_id_str,
+                        txn_id=txn.id,
+                        current_status=txn.status,
+                    )
+                project.journal.finalise(session, txn_id=txn.id)
+
+        _LOG.info(
+            "recover_journal run=%s action=%s txn=%s prev_status=%s",
+            run_id_str,
+            action,
+            txn.id,
+            previous_status,
+        )
+        return JournalRecovered(
+            run_id=run_id_str,
+            action=action,
+            txn_id=txn.id,
+            previous_status=previous_status,
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception(
+            "recover_journal failed for run %s action %s", run_id, action
+        )
+        return as_error(
+            "recover_journal_failed",
+            detail=str(exc),
+            run_id=str(run_id),
+            action=action,
+        )
+
+
+# ---------------------------------------------------------------------------
+# fsm.list_consumers / fsm.list_producers
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.list_consumers",
+    description=(
+        "Return every registered event-bus consumer (engine "
+        "subscribers, MCP tail clients, verifiers, …)."
+    ),
+)
+def list_consumers() -> list[Consumer] | McpToolError:
+    """Enumerate every consumer registered on the event bus.
+
+    Ordered by ``id`` (UUIDv7) which approximates registration order.
+    Returned as a plain list so the FastMCP structured-output wrapping
+    is just ``{"result": [...]}``.
+    """
+    try:
+        project = get_project()
+        with project.session_factory() as session:
+            return project.consumers.list(session)
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("list_consumers failed")
+        return as_error("list_consumers_failed", detail=str(exc))
+
+
+@mcp.tool(
+    name="fsm.list_producers",
+    description=(
+        "Return every registered event-bus producer (the FSM runtime, "
+        "workers, verifiers, the CLI)."
+    ),
+)
+def list_producers() -> list[Producer] | McpToolError:
+    """Enumerate every producer registered on the event bus.
+
+    Same shape and ordering rationale as :func:`list_consumers`.
+    """
+    try:
+        project = get_project()
+        with project.session_factory() as session:
+            return project.producers.list(session)
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("list_producers failed")
+        return as_error("list_producers_failed", detail=str(exc))

--- a/ctxr/fsm/mcp/tools_meta.py
+++ b/ctxr/fsm/mcp/tools_meta.py
@@ -1,0 +1,625 @@
+"""Meta + bootstrap MCP tools: ``fsm.healthcheck``, ``fsm.list_specs``,
+``fsm.register_spec``, ``fsm.observe_tool_call``.
+
+This module groups the four "meta" tools that every MCP client needs
+before it can drive a run:
+
+* :func:`fsm_healthcheck` (``fsm.healthcheck``) — the read-only probe
+  that satisfies the common-dev *Principle 1* pre-check: a skill calls
+  this first to confirm the FSM server is up, the schema is current,
+  and the package version matches what it expects. The shape
+  intentionally mirrors what ``ctxr-fsm doctor`` surfaces (DB path,
+  SQLite version, alembic head) so an operator inspecting the JSON has
+  the same facts in both places.
+
+* :func:`fsm_list_specs` (``fsm.list_specs``) — enumerate the FSM
+  specifications registered against this database. Used by the UI and
+  by orchestrators that need to pick a spec to run; intentionally a
+  trimmed summary (no full ``definition`` body) so the response stays
+  small even when a project has hundreds of versions.
+
+* :func:`fsm_register_spec` (``fsm.register_spec``) — accept a JSON
+  spec, parse it through :meth:`FsmSpec.model_validate_json`, run the
+  cross-cutting :func:`validate_fsm_spec` checks, and persist via
+  :meth:`Project.register_spec` only if every check passes. Invalid
+  specs are *refused* with a structured ``schema_validation_failed``
+  / ``invalid_spec_definition`` error envelope so clients can branch on
+  the failure rather than parsing free-text.
+
+* :func:`fsm_observe_tool_call` (``fsm.observe_tool_call``) — the
+  agent-side hook for layer 7 (drift detection). The contract is
+  documented at length in the tool's docstring: every non-``fsm.*``
+  tool the agent invokes during an active run should be reported here
+  so the drift aggregator sees the timeline. W4 only *records* the
+  observation (tool_calls row + ``tool_call_observed`` event); the W12
+  enforcement wave will read those rows to compute drift scores.
+
+Error contract
+--------------
+
+Every tool wraps its body in ``try/except`` and on failure returns the
+legacy ``{"error": "<snake_case>", ...}`` envelope as an
+:class:`~ctxr.fsm.mcp._errors.McpToolError` Pydantic model. That keeps
+the wire shape identical to the legacy JS server (which clients already
+speak) and means the tool never leaks a JSON-RPC error frame to clients
+that were built against the old error contract.
+
+Stdout discipline
+-----------------
+
+MCP stdio uses *stdout* for JSON-RPC framing; any log line that escapes
+to stdout corrupts the protocol stream. We therefore use the module-
+scope :data:`_LOG` (configured to stderr by the boot sequence) for
+every diagnostic line and rely on the absence of ``print(...)`` here
+to keep stdout clean.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import uuid as _uuid_std
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select, text
+
+from ctxr.fsm import __version__ as _PACKAGE_VERSION  # noqa: N812
+from ctxr.fsm.core.models import EventKind, FsmSpec
+from ctxr.fsm.core.spec import validate_fsm_spec
+from ctxr.fsm.mcp import mcp
+from ctxr.fsm.mcp._errors import McpToolError, as_error
+from ctxr.fsm.mcp._state import get_project
+from ctxr.fsm.sqlite.models_core import FsmSpecTable, ProjectTable
+
+__all__ = [
+    "HealthcheckResult",
+    "ObserveResult",
+    "SpecRegisteredPayload",
+    "SpecSummary",
+    "fsm_healthcheck",
+    "fsm_list_specs",
+    "fsm_observe_tool_call",
+    "fsm_register_spec",
+]
+
+
+# Per-tool diagnostic logger. The boot sequence pins logging to stderr
+# (see :func:`ctxr.fsm.mcp.server._configure_stderr_logging`) so the
+# JSON-RPC framing on stdout is never corrupted.
+_LOG = logging.getLogger("ctxr.fsm.mcp.tools_meta")
+
+
+# Pydantic value-objects are frozen so a tool's return value is treated
+# as an immutable snapshot of the server state at call time. ``extra=
+# "forbid"`` keeps the wire shape closed — clients depending on a
+# specific field cannot be silently broken by a typo in a new field.
+_VO_CFG = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models — typed contract for tool inputs / outputs
+# ---------------------------------------------------------------------------
+
+
+class HealthcheckResult(BaseModel):
+    """Read-only probe payload returned by :func:`fsm_healthcheck`.
+
+    Mirrors the subset of ``ctxr-fsm doctor`` fields that a *Principle
+    1* pre-check needs to assert a usable environment:
+
+    * ``status`` is always ``"ok"`` on success — clients should branch
+      on the presence/absence of an ``error`` key, not on ``status``,
+      so the literal string is reserved for the happy path.
+    * ``db_path`` is the resolved absolute path of the SQLite file the
+      server is bound to. Useful when an operator wants to know which
+      database a long-running stdio server is actually writing to.
+    * ``sqlite_version`` is the version reported by the underlying
+      ``sqlite3`` library (which the CPython build bundles and which
+      can drift from the system ``sqlite3`` CLI). Surfaced because
+      JSON1 / generated-column support hinges on it.
+    * ``alembic_revision`` is the current head as recorded in the
+      ``alembic_version`` table. ``None`` when the table is missing
+      (which means migrations have never been run — a real bug at this
+      point because the server boots with ``migrate=True``, but we
+      surface ``None`` rather than crash so the pre-check can report
+      it).
+    * ``package_version`` is the installed ``ctxr.fsm`` version so
+      clients can fail fast on a version mismatch.
+    """
+
+    model_config = _VO_CFG
+
+    status: str = Field(default="ok", description="Always 'ok' on success.")
+    db_path: str = Field(description="Absolute path of the bound SQLite database.")
+    sqlite_version: str = Field(description="SQLite library version (sqlite3.sqlite_version).")
+    alembic_revision: str | None = Field(
+        default=None,
+        description="Current alembic head; None if alembic_version is absent.",
+    )
+    package_version: str = Field(description="Installed ctxr.fsm package version.")
+
+
+class SpecSummary(BaseModel):
+    """A trimmed row from ``fsm_specs`` joined with its project's slug.
+
+    Returned by :func:`fsm_list_specs` in place of the full
+    :class:`~ctxr.fsm.sqlite.RegisteredSpec` so the wire payload stays
+    bounded even for projects with hundreds of versions. Callers that
+    need the full ``definition`` body should fetch it via a follow-up
+    spec-detail tool (W5+) or via the database directly.
+    """
+
+    model_config = _VO_CFG
+
+    id: str = Field(description="Row PK of the fsm_specs entry (UUIDv7 string).")
+    project_id: str = Field(description="Row PK of the owning project row.")
+    project_slug: str = Field(description="Human-readable slug of the owning project.")
+    slug: str = Field(description="The FSM's own id, used as the natural slug.")
+    version: int = Field(description="Monotonic version within (project_id, slug).")
+    hash: str = Field(description="SHA-256 content hash of the canonical spec JSON.")
+    created_at: str = Field(description="ISO-8601 timestamp of the registration.")
+
+
+class SpecRegisteredPayload(BaseModel):
+    """Return value of :func:`fsm_register_spec`.
+
+    Mirrors the legacy JS contract: only the *identity* of the
+    registered row (``spec_id``, ``hash``, ``version``) plus a boolean
+    flag indicating whether a new row was minted vs. an existing
+    byte-identical row was returned.
+
+    The full ``RegisteredSpec`` is intentionally *not* embedded — the
+    client already has the definition (it just sent it in) and the
+    summary fields are all it needs for follow-up calls.
+    """
+
+    model_config = _VO_CFG
+
+    spec_id: str = Field(description="Row PK of the registered fsm_specs entry.")
+    hash: str = Field(description="SHA-256 canonical hash of the spec.")
+    version: int = Field(description="Version assigned within (project, slug).")
+    slug: str = Field(description="The FSM id used as the natural slug.")
+    project_id: str = Field(description="Row PK of the owning project.")
+    project_slug: str = Field(description="Human-readable slug of the owning project.")
+    created: bool = Field(
+        description="True iff a new row was inserted; False on hash-dedup match."
+    )
+
+
+class ObserveResult(BaseModel):
+    """Return value of :func:`fsm_observe_tool_call`.
+
+    ``recorded`` is always ``True`` on the happy path — the field is
+    kept so the wire shape remains a positive acknowledgement that the
+    drift aggregator (W12) will see the call on its next sweep.
+
+    ``tool_call_id`` and ``event_id`` are surfaced so a debugger or a
+    test can correlate the observation across the ``tool_calls`` and
+    ``events`` tables without an extra round-trip.
+    """
+
+    model_config = _VO_CFG
+
+    recorded: bool = Field(default=True, description="Always True on success.")
+    tool_call_id: str = Field(description="Row PK of the inserted tool_calls row.")
+    event_id: str = Field(description="Row PK of the emitted tool_call_observed event.")
+    producer_id: str = Field(description="Row PK of the upserted producer.")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _alembic_revision_for(engine: Any) -> str | None:
+    """Return the current ``alembic_version.version_num`` for ``engine``.
+
+    Mirrors the helper in :mod:`ctxr.fsm.cli.doctor_cmd` so the two
+    surfaces report the same value. We swallow exceptions deliberately:
+    the table is missing on a freshly-created (un-migrated) database
+    and the caller treats ``None`` as "migrations never ran" rather
+    than as a hard error — a healthcheck that crashes on a missing
+    table is far less useful than one that surfaces the gap.
+    """
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(text("SELECT version_num FROM alembic_version")).first()
+    except Exception:
+        return None
+    if row is None:
+        return None
+    return str(row[0])
+
+
+def _engine_db_path(engine: Any) -> str:
+    """Return a human-readable path for the SQLite engine's database.
+
+    SQLAlchemy ``Engine.url`` is a structured object whose
+    ``.database`` attribute is the path the driver was opened against.
+    For SQLite that is either an absolute filesystem path or one of
+    the in-memory sentinels (``:memory:`` / empty string). We coerce
+    to ``str`` so the JSON shape stays stable regardless of which
+    case applies.
+    """
+    db = engine.url.database
+    if db is None or db == "":
+        return ":memory:"
+    return str(db)
+
+
+# ---------------------------------------------------------------------------
+# fsm.healthcheck
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.healthcheck",
+    description=(
+        "Read-only probe: returns server status, DB path, SQLite version, "
+        "alembic head, and the ctxr.fsm package version. Used by skill "
+        "pre-checks (common-dev Principle 1) to confirm the FSM substrate "
+        "is reachable and current."
+    ),
+)
+def fsm_healthcheck() -> HealthcheckResult | McpToolError:
+    """Probe the live MCP server and return a structured snapshot.
+
+    The tool is the canonical pre-check every skill runs before issuing
+    any mutating call. It is intentionally cheap — one ``SELECT
+    version_num FROM alembic_version`` plus a couple of attribute
+    reads — so it can be polled in tight loops without measurable
+    overhead.
+
+    Returns an :class:`HealthcheckResult` on success or a structured
+    :class:`McpToolError` on failure. The most common failure is
+    ``project_not_bound`` (the server booted but ``set_project`` was
+    never called), surfaced as a hint for the operator that the boot
+    sequence is incomplete.
+    """
+    try:
+        project = get_project()
+        engine = project.engine
+        db_path = _engine_db_path(engine)
+        # ``sqlite3.sqlite_version`` is the C library version the
+        # Python build links against — the canonical thing to report
+        # in a healthcheck because feature support (JSON1, generated
+        # columns, partial indexes) hinges on it.
+        sqlite_version = sqlite3.sqlite_version
+        alembic_revision = _alembic_revision_for(engine)
+
+        return HealthcheckResult(
+            status="ok",
+            db_path=db_path,
+            sqlite_version=sqlite_version,
+            alembic_revision=alembic_revision,
+            package_version=_PACKAGE_VERSION,
+        )
+    except KeyboardInterrupt:  # pragma: no cover - operator-driven interrupt
+        raise
+    except RuntimeError as exc:
+        # ``get_project`` raises RuntimeError when the project handle
+        # is unset — surface that as the dedicated ``project_not_bound``
+        # code so clients can distinguish "server is up but not
+        # configured" from "server is down".
+        _LOG.exception("fsm.healthcheck: project handle not bound")
+        return as_error("project_not_bound", detail=str(exc))
+    except Exception as exc:
+        _LOG.exception("fsm.healthcheck: unexpected error")
+        return as_error("internal_error", detail=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# fsm.list_specs
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.list_specs",
+    description=(
+        "List every FSM specification registered against this database, "
+        "across all projects, as trimmed summaries (id, project_id, "
+        "project_slug, slug, version, hash, created_at). The full "
+        "definition body is intentionally omitted."
+    ),
+)
+def fsm_list_specs() -> list[SpecSummary] | McpToolError:
+    """Enumerate registered specs as trimmed summaries.
+
+    Joins :class:`FsmSpecTable` with :class:`ProjectTable` so each
+    row carries the human-readable ``project_slug`` alongside the
+    surrogate ``project_id``. Sorted by ``(project_slug, slug,
+    version)`` ascending so a client paging through the list sees a
+    deterministic, human-readable order without an extra sort step.
+
+    Returns a possibly-empty list of :class:`SpecSummary` on success
+    or a structured :class:`McpToolError` on failure.
+    """
+    try:
+        project = get_project()
+        # We join on the project FK to pull the slug in a single query —
+        # the alternative (per-spec round-trip to projects) is N+1 and
+        # noticeable once a database has a few dozen specs.
+        stmt = (
+            select(
+                FsmSpecTable.id,
+                FsmSpecTable.project_id,
+                ProjectTable.slug.label("project_slug"),
+                FsmSpecTable.slug,
+                FsmSpecTable.version,
+                FsmSpecTable.hash,
+                FsmSpecTable.created_at,
+            )
+            .join(ProjectTable, FsmSpecTable.project_id == ProjectTable.id)
+            .order_by(
+                ProjectTable.slug.asc(),
+                FsmSpecTable.slug.asc(),
+                FsmSpecTable.version.asc(),
+            )
+        )
+        with project.session_factory() as session:
+            rows = session.execute(stmt).all()
+
+        return [
+            SpecSummary(
+                id=row.id,
+                project_id=row.project_id,
+                project_slug=row.project_slug,
+                slug=row.slug,
+                version=row.version,
+                hash=row.hash,
+                created_at=row.created_at,
+            )
+            for row in rows
+        ]
+    except KeyboardInterrupt:  # pragma: no cover
+        raise
+    except RuntimeError as exc:
+        _LOG.exception("fsm.list_specs: project handle not bound")
+        return as_error("project_not_bound", detail=str(exc))
+    except Exception as exc:
+        _LOG.exception("fsm.list_specs: unexpected error")
+        return as_error("internal_error", detail=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# fsm.register_spec
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.register_spec",
+    description=(
+        "Parse a JSON-encoded FsmSpec, run cross-cutting validation "
+        "(reachability, dangling transitions, loop done_field, predicate "
+        "parsability), and register it under the given project. Invalid "
+        "specs are refused with a structured error envelope; "
+        "byte-identical re-registrations are idempotent (created=False)."
+    ),
+)
+def fsm_register_spec(
+    definition_json: str,
+    project_slug: str = "default",
+) -> SpecRegisteredPayload | McpToolError:
+    """Register the supplied FSM spec under ``project_slug``.
+
+    The flow is strictly:
+
+    1. Parse ``definition_json`` via
+       :meth:`FsmSpec.model_validate_json`. A Pydantic ValidationError
+       surfaces as ``invalid_spec_definition`` with the structured
+       error payload attached so clients can render per-field
+       complaints.
+    2. Run :func:`validate_fsm_spec` for the cross-cutting checks
+       (reachability, dangling transitions, loop done-field shape,
+       predicate parsability). A failure surfaces as
+       ``schema_validation_failed`` with the full
+       :class:`FsmValidationResult` attached.
+    3. Delegate to :meth:`Project.register_spec` for the actual
+       insert-or-dedupe.
+
+    On success returns a :class:`SpecRegisteredPayload` carrying the
+    new (or matched) spec's id, hash, version, and the
+    project / slug pair plus the ``created`` flag.
+    """
+    try:
+        # ── (1) Pydantic schema validation ────────────────────────────
+        try:
+            spec = FsmSpec.model_validate_json(definition_json)
+        except Exception as exc:
+            # Pydantic's ValidationError has a stable ``.errors()`` API
+            # but it's not the only thing that can land here (raw JSON
+            # decode errors, encoding errors); coerce uniformly.
+            errors_payload: list[Any]
+            getter = getattr(exc, "errors", None)
+            if callable(getter):
+                try:
+                    errors_payload = list(getter())
+                except Exception:  # pragma: no cover - defensive
+                    errors_payload = [str(exc)]
+            else:
+                errors_payload = [str(exc)]
+            _LOG.info("fsm.register_spec: pydantic validation failed")
+            return as_error(
+                "invalid_spec_definition",
+                detail="failed to parse FsmSpec from definition_json",
+                errors=errors_payload,
+            )
+
+        # ── (2) Cross-cutting structural validation ───────────────────
+        validation = validate_fsm_spec(spec)
+        if not validation.valid:
+            _LOG.info(
+                "fsm.register_spec: structural validation failed (%d errors)",
+                len(validation.errors),
+            )
+            # ``model_dump(mode='json')`` keeps tuples as lists so the
+            # JSON shape on the wire is stable.
+            return as_error(
+                "schema_validation_failed",
+                detail="FsmSpec failed cross-cutting validation",
+                validation=validation.model_dump(mode="json"),
+            )
+
+        # ── (3) Persist via the project facade ────────────────────────
+        project = get_project()
+        result = project.register_spec(spec, project_slug=project_slug)
+
+        return SpecRegisteredPayload(
+            spec_id=result.spec.id,
+            hash=result.spec.hash,
+            version=result.spec.version,
+            slug=result.spec.slug,
+            project_id=result.spec.project_id,
+            project_slug=project_slug,
+            created=result.created,
+        )
+    except KeyboardInterrupt:  # pragma: no cover
+        raise
+    except RuntimeError as exc:
+        _LOG.exception("fsm.register_spec: project handle not bound")
+        return as_error("project_not_bound", detail=str(exc))
+    except Exception as exc:
+        _LOG.exception("fsm.register_spec: unexpected error")
+        return as_error("internal_error", detail=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# fsm.observe_tool_call
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.observe_tool_call",
+    description=(
+        "Record an agent-side tool invocation so the W12 drift detector "
+        "can observe layer-7 activity. The agent SHOULD call this for "
+        "every non-fsm.* tool call made during an active run, passing "
+        "the producer kind/name, the tool name, redacted arguments, and "
+        "the success flag. W4 only records the observation; W12 wires "
+        "enforcement."
+    ),
+)
+def fsm_observe_tool_call(
+    producer_kind: str,
+    producer_name: str,
+    tool_name: str,
+    args_redacted: dict[str, Any],
+    succeeded: bool = True,
+    run_id: UUID | None = None,
+) -> ObserveResult | McpToolError:
+    """Record a tool-call observation + emit a ``tool_call_observed`` event.
+
+    Contract for callers
+    --------------------
+
+    The agent (or any orchestrator driving the FSM) is expected to
+    invoke this tool *for every non-``fsm.*`` tool call it makes
+    during an active run*. The arguments must be redacted at the
+    caller — this server does not know which keys carry secrets and
+    will persist whatever it is handed verbatim. ``succeeded`` is the
+    boolean outcome the agent observed; the server does not attempt
+    to verify it.
+
+    ``producer_kind`` / ``producer_name`` identify the source of the
+    call (typically ``("agent", "<agent-name>")`` or
+    ``("worker", "<role>")``). The pair is upserted into the
+    ``producers`` table so re-using the same identity across calls
+    re-uses the same producer id; that is what lets the drift
+    aggregator (W12) group calls by source.
+
+    ``run_id`` is optional — a ``None`` value records a "run-less"
+    observation, which the drift aggregator already filters out of its
+    run-scoped queries. UUIDs are accepted as the typed ``uuid.UUID``
+    over the wire and coerced to text for storage so the persistence
+    layer never gains a datetime / uuid round-trip dependency.
+
+    Side effects
+    ------------
+
+    Inside a single transaction:
+
+    1. The ``(producer_kind, producer_name)`` producer is upserted.
+    2. A row is inserted into ``tool_calls`` with the redacted args
+       and the success flag.
+    3. A ``tool_call_observed`` event is emitted on the bus so any
+       subscriber (the W12 drift aggregator, the UI live tail, …)
+       sees the observation on its next poll.
+
+    All three writes participate in one ``Session.begin()`` block so
+    a crash between any two of them leaves the database consistent.
+    """
+    try:
+        project = get_project()
+
+        # Coerce UUID → 36-char text once, up front, so the storage
+        # layer never has to think about uuid types. None stays None
+        # so the column accepts NULL for run-less observations.
+        run_id_text: str | None = str(run_id) if run_id is not None else None
+
+        with project.session_factory() as session, session.begin():
+            producer = project.producers.upsert(
+                session,
+                kind=producer_kind,
+                name=producer_name,
+            )
+
+            tool_call = project.tool_calls.record(
+                session,
+                run_id=run_id_text,
+                producer_id=producer.id,
+                tool_name=tool_name,
+                args_redacted=args_redacted or {},
+                succeeded=succeeded,
+            )
+
+            # Emit the layer-7 event so subscribers (W12 drift
+            # aggregator, dashboards) see this observation in their
+            # next poll. Payload mirrors the persisted shape so a
+            # downstream consumer never has to cross-reference the
+            # ``tool_calls`` table just to read the tool name.
+            event = project.events.emit(
+                session,
+                producer_id=producer.id,
+                kind=EventKind.tool_call_observed.value,
+                payload={
+                    "tool_call_id": tool_call.id,
+                    "tool_name": tool_name,
+                    "producer_kind": producer_kind,
+                    "producer_name": producer_name,
+                    "succeeded": bool(succeeded),
+                    "args_redacted": args_redacted or {},
+                },
+                run_id=run_id_text,
+            )
+
+        return ObserveResult(
+            recorded=True,
+            tool_call_id=tool_call.id,
+            event_id=event.id,
+            producer_id=producer.id,
+        )
+    except KeyboardInterrupt:  # pragma: no cover
+        raise
+    except RuntimeError as exc:
+        _LOG.exception("fsm.observe_tool_call: project handle not bound")
+        return as_error("project_not_bound", detail=str(exc))
+    except ValueError as exc:
+        # ``UUID`` coercion would have happened in FastMCP's input
+        # validation, but downstream value-validation (e.g. an empty
+        # ``producer_name``) can still raise here. Surface as the
+        # ``invalid_argument`` code so clients can distinguish bad
+        # input from server-side bugs.
+        _LOG.info("fsm.observe_tool_call: invalid argument")
+        return as_error("invalid_argument", detail=str(exc))
+    except Exception as exc:
+        _LOG.exception("fsm.observe_tool_call: unexpected error")
+        return as_error("internal_error", detail=str(exc))
+
+
+# Re-export the stdlib UUID module under a private name so future
+# extensions can adopt it (e.g. ``observe_tool_call`` accepting a
+# str-and-uuid union) without touching the import list. Marked
+# unused-by-linter via ``_`` prefix; not part of ``__all__``.
+_uuid_module = _uuid_std

--- a/ctxr/fsm/mcp/tools_runs.py
+++ b/ctxr/fsm/mcp/tools_runs.py
@@ -1,0 +1,1168 @@
+"""MCP tools that drive the FSM run lifecycle.
+
+This module registers the ``fsm.*`` tools that an MCP client uses to
+start, brief, advance, resume, abort, list, and inspect FSM runs. The
+implementations are intentionally *plumbing-only* for W4: they validate
+inputs, drive the pure engine in :mod:`ctxr.fsm.core.engine`, and
+persist results through the W2 :class:`Project` facade. The hard
+enforcement layer (two-phase commit tokens, cosignatures, off-allowlist
+tool observation, drift pausing) is W12 — this module ships the
+return-shape plumbing for those features (``CommitToken`` field on
+``CommitResult``, ``confirm_commit`` tool) but stubs the actual
+enforcement so the surface is stable before W12 wires it.
+
+Design contract
+---------------
+
+* Every tool input is a Pydantic model declared in this file; every
+  output is a Pydantic model (also declared here, except where the
+  engine already returns one — :class:`Brief` is re-used as-is).
+* Every tool body is wrapped in ``try/except`` and on failure returns
+  an :class:`McpToolError`-shaped envelope (see :mod:`ctxr.fsm.mcp._errors`)
+  instead of letting the exception propagate. Propagating would turn
+  into a JSON-RPC error frame, which is a different code path that
+  older clients do not have to handle.
+* All logging goes to stderr — MCP stdio uses stdout for the JSON-RPC
+  framing. The server entry-point pins the root logger to
+  ``sys.stderr``; we just call ``logging.getLogger(__name__)`` here.
+* The :class:`Project` handle is fetched via :func:`get_project` once
+  per tool call (cheap — it's a module-global lookup); we do NOT cache
+  it on this module because tests reset the binding between cases.
+* No subprocess. No network. Every state change is a Python call into
+  the W2 repos.
+
+Why one module per tool group (``tools_runs.py``) instead of one per
+tool? The eight tools here all share the same helpers (spec
+reconstruction, current-state lookup, env materialisation, brief
+construction) and operate on the same handful of repos. Splitting them
+further would force every helper to be either re-implemented or
+imported across module boundaries for no real benefit.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+
+from ctxr.fsm.core.engine import advance as engine_advance
+from ctxr.fsm.core.engine import build_brief
+from ctxr.fsm.core.models import (
+    Brief,
+    EventKind,
+    FsmSpec,
+    PostValidationResultEntry,
+    RunCtx,
+    TransitionEvaluation,
+)
+from ctxr.fsm.mcp import mcp
+from ctxr.fsm.mcp._errors import McpToolError, as_error
+from ctxr.fsm.mcp._state import get_project
+from ctxr.fsm.sqlite import Project
+from ctxr.fsm.sqlite.models_core import RunTable, StateTable, TransitionTable
+from ctxr.fsm.sqlite.repos_core import RunSummary, _iso_now_ms
+from ctxr.fsm.sqlite.repos_locks_journal import JournalTxn, Lock
+
+__all__ = [
+    "AbortResult",
+    "AbortRunInput",
+    "CommitOutputsInput",
+    "CommitResult",
+    "ConfirmCommitInput",
+    "ConfirmResult",
+    "GetBriefInput",
+    "GetRunInput",
+    "ListRunsInput",
+    "ResumeResult",
+    "ResumeRunInput",
+    "RunDetail",
+    "RunStartedPayload",
+    "StartRunInput",
+]
+
+
+# Module logger. The server entry-point configures the root logger to
+# write to stderr (``_configure_stderr_logging``); we just pull a child
+# of it here so log lines carry the ``ctxr.fsm.mcp.tools_runs`` name and
+# never leak onto stdout.
+_LOG = logging.getLogger(__name__)
+
+
+# Producer identity used when this module emits engine-attributed
+# events (state_entered, transition_taken, run_completed, …). Mirrors
+# the identity used by :meth:`Project.start_run` and the CLI so the
+# audit trail attributes every lifecycle emit to one logical producer
+# regardless of which surface drove it.
+_ENGINE_PRODUCER_KIND: str = "engine"
+_ENGINE_PRODUCER_NAME: str = "fsm.runtime"
+
+
+# ---------------------------------------------------------------------------
+# Tool input / output models
+# ---------------------------------------------------------------------------
+
+
+# We keep the I/O models flat and strict-but-friendly: ``strict=True``
+# rejects accidental int/str confusion, ``extra="ignore"`` on inputs
+# lets the MCP client send forward-compatible extra fields without the
+# tool blowing up. Outputs are extra="forbid" to keep the wire format
+# minimal and self-documenting.
+_IN_CFG = ConfigDict(strict=False, extra="ignore", populate_by_name=True)
+_OUT_CFG = ConfigDict(strict=False, extra="forbid", populate_by_name=True)
+
+
+class StartRunInput(BaseModel):
+    """Arguments for :func:`fsm_start_run`."""
+
+    model_config = _IN_CFG
+
+    spec_id: uuid.UUID = Field(
+        ..., description="UUID of a registered FSM spec to start a run for."
+    )
+    args: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form arguments threaded into the run env at start.",
+    )
+
+
+class RunStartedPayload(BaseModel):
+    """Return value of :func:`fsm_start_run`."""
+
+    model_config = _OUT_CFG
+
+    run_id: uuid.UUID
+    brief: Brief
+    fsm_spec_hash: str
+
+
+class GetBriefInput(BaseModel):
+    """Arguments for :func:`fsm_get_brief`."""
+
+    model_config = _IN_CFG
+
+    run_id: uuid.UUID
+
+
+class CommitOutputsInput(BaseModel):
+    """Arguments for :func:`fsm_commit_outputs`."""
+
+    model_config = _IN_CFG
+
+    run_id: uuid.UUID
+    outputs: dict[str, Any]
+    signature: str | None = Field(
+        default=None,
+        description=(
+            "Optional commit signature. Recorded as-is in W4; cryptographic "
+            "verification is wired in W12 alongside the cosignature surface."
+        ),
+    )
+
+
+class CommitToken(BaseModel):
+    """Slim mirror of :class:`ctxr.fsm.core.models.CommitToken` for the wire.
+
+    The core type carries the same fields; redeclaring it here keeps the
+    MCP module self-contained (so the generated tool schema does not
+    pull in a parallel core import) and lets W12 evolve the token shape
+    without touching every MCP consumer's generated bindings.
+    """
+
+    model_config = _OUT_CFG
+
+    token: uuid.UUID
+    run_id: uuid.UUID
+    state_id: str
+    expected_next_state: str
+    expires_at: datetime
+
+
+class CommitResult(BaseModel):
+    """Discriminated result returned by :func:`fsm_commit_outputs`.
+
+    ``kind`` mirrors the engine's :class:`EngineAdvanceResult` taxonomy
+    but with one rename: the engine's ``"advance"`` becomes ``"advanced"``
+    here to match the JS legacy MCP contract. ``"loop_continue"``
+    likewise becomes ``"loop_continued"``.
+
+    For W4 ``token`` is always ``None``; W12 will mint a
+    :class:`CommitToken` and require the client to call
+    :func:`fsm_confirm_commit` before the next brief is materialised.
+    """
+
+    model_config = _OUT_CFG
+
+    kind: Literal["advanced", "terminal", "fault", "loop_continued"]
+    brief: Brief | None = None
+    next_state: str | None = None
+    iteration_n: int | None = None
+    verdict: Any = None
+    reason: str | None = None
+    errors: list[str] = Field(default_factory=list)
+    evaluations: list[TransitionEvaluation] = Field(default_factory=list)
+    post_validations: list[PostValidationResultEntry] = Field(default_factory=list)
+    token: CommitToken | None = None
+
+
+class ConfirmCommitInput(BaseModel):
+    """Arguments for :func:`fsm_confirm_commit`."""
+
+    model_config = _IN_CFG
+
+    token: uuid.UUID
+    expected_next_state: str
+
+
+class ConfirmResult(BaseModel):
+    """Return value of :func:`fsm_confirm_commit`.
+
+    W4 always returns ``confirmed=True``; the real two-phase commit
+    semantics land in W12. ``note`` documents that for any caller that
+    is reading the surface today expecting hard enforcement.
+    """
+
+    model_config = _OUT_CFG
+
+    confirmed: bool
+    note: str | None = None
+
+
+class ResumeRunInput(BaseModel):
+    """Arguments for :func:`fsm_resume_run`."""
+
+    model_config = _IN_CFG
+
+    run_id: uuid.UUID
+    from_state: str | None = None
+    journal: Literal["discard", "replay"] | None = None
+
+
+class ResumeResult(BaseModel):
+    """Return value of :func:`fsm_resume_run`.
+
+    Mirrors the CLI's ``ctxr-fsm run resume`` JSON payload exactly so a
+    script that reads either surface can hand the result through one
+    parser. ``engine_resume`` is a human-readable note pointing at the
+    W12 deferral.
+    """
+
+    model_config = _OUT_CFG
+
+    run_id: uuid.UUID
+    from_state: str | None = None
+    journal_action: str | None = None
+    journal_txn_id: str | None = None
+    engine_resume: str = (
+        "engine-driven resume comes in a later workstream (W12)"
+    )
+
+
+class AbortRunInput(BaseModel):
+    """Arguments for :func:`fsm_abort_run`."""
+
+    model_config = _IN_CFG
+
+    run_id: uuid.UUID
+    reason: str | None = None
+
+
+class AbortResult(BaseModel):
+    """Return value of :func:`fsm_abort_run`."""
+
+    model_config = _OUT_CFG
+
+    run_id: uuid.UUID
+    previous_status: str
+    new_status: str = "aborted"
+    ended_at: str
+    reason: str | None = None
+
+
+class ListRunsInput(BaseModel):
+    """Arguments for :func:`fsm_list_runs`."""
+
+    model_config = _IN_CFG
+
+    filter_status: str | None = None
+    since: str | None = None
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+class GetRunInput(BaseModel):
+    """Arguments for :func:`fsm_get_run`."""
+
+    model_config = _IN_CFG
+
+    run_id: uuid.UUID
+
+
+class RunDetail(BaseModel):
+    """Return value of :func:`fsm_get_run`.
+
+    A read-only bundle of every "show me this run" projection. Fields
+    map 1:1 onto the CLI's ``ctxr-fsm run show`` JSON output so the two
+    surfaces stay aligned.
+    """
+
+    model_config = _OUT_CFG
+
+    manifest: dict[str, Any]
+    state_tree: dict[str, Any] | None = None
+    events: list[dict[str, Any]] = Field(default_factory=list)
+    journal: dict[str, Any] | None = None
+    locks: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_engine_producer(project: Project) -> str:
+    """Upsert the engine producer and return its id.
+
+    Mirrors the lazy upsert performed by :meth:`Project.start_run` and
+    the CLI so every lifecycle emit from this module is attributed to
+    the same logical producer (``kind='engine'``, ``name='fsm.runtime'``)
+    as the events that started / advanced the run.
+    """
+    with project.session_factory() as session, session.begin():
+        producer = project.producers.upsert(
+            session,
+            kind=_ENGINE_PRODUCER_KIND,
+            name=_ENGINE_PRODUCER_NAME,
+        )
+    return producer.id
+
+
+def _load_fsm_spec(project: Project, registered_spec_id: str) -> FsmSpec | None:
+    """Reconstruct an :class:`FsmSpec` from the row identified by id.
+
+    The W2 substrate stores the spec as a canonical JSON ``definition``
+    column; we reload it via Pydantic so the engine sees the same
+    object shape it would see if the caller had constructed the spec
+    in-process. Returns ``None`` when the spec row is missing.
+    """
+    with project.session_factory() as session:
+        registered = project.specs.get(session, registered_spec_id)
+    if registered is None:
+        return None
+    return FsmSpec.model_validate(registered.definition)
+
+
+def _current_state_id(run_manifest: Any, spec: FsmSpec) -> str:
+    """Return the run's current FSM state id, falling back to ``spec.entry``.
+
+    The runs table tracks ``current_state`` as a nullable TEXT column;
+    on a fresh run (before any state has been entered) it is ``None``,
+    in which case the entry state from the spec is the right answer.
+    Older runs from before the W4 bookkeeping landed may also leave it
+    ``None`` mid-flight — falling back to the entry state is the
+    conservative behaviour (worst case the brief targets the entry
+    state and the operator notices the staleness).
+    """
+    if run_manifest.current_state:
+        return str(run_manifest.current_state)
+    return spec.entry
+
+
+def _materialise_env(project: Project, run_manifest: Any) -> dict[str, Any]:
+    """Reconstruct the run env from the run's args + emitted exit traces.
+
+    The engine wants an env dict keyed by name. W2 stores the run-level
+    seed args on the run row and outputs on per-state-entry rows; we
+    merge them here so a brief built for the current state sees inputs
+    from every prior exit.
+
+    Iteration order: ``args`` first (lowest precedence), then state
+    exits in ``entry_seq`` order so later outputs shadow earlier ones
+    with the same key. The behaviour mirrors what the CLI / engine do
+    in-memory when driving a run end-to-end.
+    """
+    env: dict[str, Any] = dict(run_manifest.args or {})
+    with project.session_factory() as session:
+        for state_entry in project.states.list_by_run(session, run_manifest.id):
+            if state_entry.outputs:
+                env.update(state_entry.outputs)
+    return env
+
+
+def _persist_state_entry(
+    project: Project,
+    *,
+    run_id: str,
+    state_id: str,
+    inputs: dict[str, Any],
+    producer_id: str,
+    iteration_n: int | None = None,
+) -> str:
+    """Create a state-entry row, update ``runs.current_state``, emit the event.
+
+    Returns the new state-entry row's PK so the caller can use it as the
+    ``from_state_pk`` for the *next* transition row. The work happens
+    inside one transaction so a crash mid-way leaves the run consistent.
+    """
+    with project.session_factory() as session, session.begin():
+        next_seq = project.states.next_entry_seq(session, run_id)
+        state_row = project.states.create(
+            session,
+            run_id=run_id,
+            state_id=state_id,
+            inputs=inputs,
+            entry_seq=next_seq,
+        )
+
+        # Update the runs.current_state pointer + bump last_update_at.
+        # No dedicated repo method exists for "set current_state", so we
+        # mutate the ORM row directly; the @atomic block makes the write
+        # visible together with the new state-entry row.
+        run_row = session.get(RunTable, run_id)
+        if run_row is not None:
+            run_row.current_state = state_id
+            run_row.last_update_at = _iso_now_ms()
+            session.add(run_row)
+
+        project.events.emit(
+            session,
+            producer_id=producer_id,
+            kind=EventKind.state_entered.value,
+            payload={
+                "run_id": run_id,
+                "state_id": state_id,
+                "entry_seq": next_seq,
+                "iteration_n": iteration_n,
+            },
+            run_id=run_id,
+        )
+    return state_row.id
+
+
+def _record_state_exit(
+    project: Project,
+    *,
+    run_id: str,
+    state_pk: str,
+    outputs: dict[str, Any],
+    producer_id: str,
+) -> None:
+    """Mark a state entry as exited, persist its outputs, emit the event."""
+    with project.session_factory() as session, session.begin():
+        project.states.mark_exited(session, state_pk, outputs)
+        project.events.emit(
+            session,
+            producer_id=producer_id,
+            kind=EventKind.state_exited.value,
+            payload={"run_id": run_id, "state_pk": state_pk},
+            run_id=run_id,
+        )
+
+
+def _record_transition(
+    project: Project,
+    *,
+    run_id: str,
+    from_state_pk: str,
+    to_state_id: str,
+    kind: str,
+    predicate: str | None,
+    predicate_result: bool | None,
+    producer_id: str,
+) -> None:
+    """Insert a transitions row + emit ``transition_taken``."""
+    with project.session_factory() as session, session.begin():
+        project.transitions.create(
+            session,
+            run_id=run_id,
+            from_state_pk=from_state_pk,
+            to_state_id=to_state_id,
+            kind=kind,
+            predicate=predicate,
+            predicate_result=predicate_result,
+        )
+        project.events.emit(
+            session,
+            producer_id=producer_id,
+            kind=EventKind.transition_taken.value,
+            payload={
+                "run_id": run_id,
+                "from_state_pk": from_state_pk,
+                "to_state_id": to_state_id,
+                "kind": kind,
+                "predicate": predicate,
+                "predicate_result": predicate_result,
+            },
+            run_id=run_id,
+        )
+
+
+def _current_state_pk(project: Project, run_id: str, state_id: str) -> str | None:
+    """Return the row PK of the *most recent* entry for ``state_id``.
+
+    Used by ``commit_outputs`` to know which state-entry row to
+    ``mark_exited`` and which row's PK to use as ``from_state_pk`` on
+    the outgoing transition. We pick the latest by ``entry_seq DESC``
+    so a re-entered state's prior visits are not accidentally mutated.
+    """
+    with project.session_factory() as session:
+        stmt = (
+            select(StateTable)
+            .where(StateTable.run_id == run_id)
+            .where(StateTable.state_id == state_id)
+            .order_by(StateTable.entry_seq.desc())
+            .limit(1)
+        )
+        row = session.execute(stmt).scalar_one_or_none()
+    return row.id if row is not None else None
+
+
+def _lock_to_dict(lock: Lock | None) -> dict[str, Any] | None:
+    """Project a :class:`Lock` value object into the wire dict.
+
+    Returns ``None`` when the lock is not held. The datetimes are
+    rendered as ISO strings so the JSON survives a round-trip without
+    needing per-field decoders on the client.
+    """
+    if lock is None:
+        return None
+    return {
+        "run_id": lock.run_id,
+        "holder_session_id": lock.holder_session_id,
+        "acquired_at": lock.acquired_at.isoformat(),
+        "expires_at": lock.expires_at.isoformat(),
+        "is_stale": lock.is_stale,
+    }
+
+
+def _journal_to_dict(txn: JournalTxn | None) -> dict[str, Any] | None:
+    """Project a :class:`JournalTxn` into the wire dict (or ``None``)."""
+    if txn is None:
+        return None
+    return {
+        "id": txn.id,
+        "run_id": txn.run_id,
+        "status": txn.status,
+        "staged_writes": list(txn.staged_writes),
+        "started_at": txn.started_at.isoformat(),
+        "ready_at": txn.ready_at.isoformat() if txn.ready_at else None,
+        "finalised_at": txn.finalised_at.isoformat() if txn.finalised_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="fsm.start_run",
+    description=(
+        "Start a new FSM run against a registered spec. Returns the new "
+        "run id, the brief for the entry state, and the spec hash recorded "
+        "against the run."
+    ),
+)
+def fsm_start_run(input: StartRunInput) -> RunStartedPayload | McpToolError:
+    """Implement the ``fsm.start_run`` tool.
+
+    Flow:
+    1. Resolve the registered spec; 404-style error if missing.
+    2. Reconstruct the :class:`FsmSpec` so the engine has a real object
+       to introspect.
+    3. Call :meth:`Project.start_run` to mint the run row, register the
+       engine producer, and emit ``run_started``.
+    4. Persist the entry-state row (W4 bookkeeping the engine itself
+       does not perform yet), update ``runs.current_state``, and emit
+       ``state_entered``.
+    5. Build the first :class:`Brief` from the entry state and the
+       run's seed args.
+    """
+    try:
+        project = get_project()
+        spec_id_str = str(input.spec_id)
+
+        spec = _load_fsm_spec(project, spec_id_str)
+        if spec is None:
+            return as_error(
+                "spec_not_found",
+                detail=f"no registered spec with id {spec_id_str!r}",
+                spec_id=spec_id_str,
+            )
+
+        run = project.start_run(spec_id=spec_id_str, args=dict(input.args))
+        producer_id = _ensure_engine_producer(project)
+
+        # Materialise the entry state's inputs from args + emit
+        # state_entered so the audit trail shows the entry.
+        entry_state = spec.get_state(spec.entry)
+        worker = entry_state.worker or (
+            entry_state.loop.worker if entry_state.loop is not None else None
+        )
+        entry_inputs: dict[str, Any] = {}
+        if worker is not None:
+            entry_inputs = {name: input.args.get(name) for name in worker.inputs}
+
+        _persist_state_entry(
+            project,
+            run_id=run.id,
+            state_id=entry_state.id,
+            inputs=entry_inputs,
+            producer_id=producer_id,
+        )
+
+        # Build the first brief. ``env`` here is just the seed args —
+        # there are no prior state exits to merge in yet.
+        brief = build_brief(
+            spec,
+            entry_state,
+            env=dict(input.args),
+            run_id=uuid.UUID(run.id),
+        )
+
+        return RunStartedPayload(
+            run_id=uuid.UUID(run.id),
+            brief=brief,
+            fsm_spec_hash=run.fsm_spec_hash,
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("fsm.start_run failed")
+        return as_error("internal_error", detail=str(exc))
+
+
+@mcp.tool(
+    name="fsm.get_brief",
+    description=(
+        "Return the current Brief for an in-flight run. Builds the brief "
+        "from the run's current state and merged env (args + prior state "
+        "exit outputs)."
+    ),
+)
+def fsm_get_brief(input: GetBriefInput) -> Brief | McpToolError:
+    """Implement ``fsm.get_brief`` — build the brief for the current state."""
+    try:
+        project = get_project()
+        run_id_str = str(input.run_id)
+
+        run = project.get_run(run_id_str)
+        if run is None:
+            return as_error(
+                "run_not_found",
+                detail=f"no run with id {run_id_str!r}",
+                run_id=run_id_str,
+            )
+
+        spec = _load_fsm_spec(project, run.fsm_spec_id)
+        if spec is None:
+            return as_error(
+                "spec_not_found",
+                detail=f"run references missing spec {run.fsm_spec_id!r}",
+                spec_id=run.fsm_spec_id,
+            )
+
+        current_state_id = _current_state_id(run, spec)
+        try:
+            state = spec.get_state(current_state_id)
+        except KeyError:
+            return as_error(
+                "invalid_state",
+                detail=(
+                    f"run.current_state {current_state_id!r} is not present "
+                    "in spec.states"
+                ),
+                state=current_state_id,
+            )
+
+        env = _materialise_env(project, run)
+        brief = build_brief(spec, state, env=env, run_id=uuid.UUID(run.id))
+        return brief
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("fsm.get_brief failed")
+        return as_error("internal_error", detail=str(exc))
+
+
+@mcp.tool(
+    name="fsm.commit_outputs",
+    description=(
+        "Commit worker outputs for the run's current state. Drives the pure "
+        "engine to validate, decide loop continuation, run post-validations, "
+        "and resolve the outgoing transition. Persists the resulting state "
+        "transition (W4 plumbing; W12 wraps this with two-phase commit)."
+    ),
+)
+def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError:
+    """Implement ``fsm.commit_outputs`` — single-phase advance for W4.
+
+    Persistence rules applied here:
+    * ``advanced``: exit the current state, record the transition, enter
+      the next state, return the next brief.
+    * ``loop_continued``: leave the current state-entry row alone, return
+      the iteration's brief (no exit yet).
+    * ``terminal``: exit the current state, update the run to
+      ``completed`` with verdict, emit ``run_completed``.
+    * ``fault``: leave the current state-entry row alone, emit
+      ``validation_failed`` so the audit trail captures the diagnostic.
+
+    Returns a :class:`CommitResult` discriminated on ``kind``.
+    """
+    try:
+        project = get_project()
+        run_id_str = str(input.run_id)
+
+        run = project.get_run(run_id_str)
+        if run is None:
+            return as_error(
+                "run_not_found",
+                detail=f"no run with id {run_id_str!r}",
+                run_id=run_id_str,
+            )
+
+        spec = _load_fsm_spec(project, run.fsm_spec_id)
+        if spec is None:
+            return as_error(
+                "spec_not_found",
+                detail=f"run references missing spec {run.fsm_spec_id!r}",
+                spec_id=run.fsm_spec_id,
+            )
+
+        current_state_id = _current_state_id(run, spec)
+        try:
+            spec.get_state(current_state_id)
+        except KeyError:
+            return as_error(
+                "invalid_state",
+                detail=(
+                    f"run.current_state {current_state_id!r} is not present "
+                    "in spec.states"
+                ),
+                state=current_state_id,
+            )
+
+        env = _materialise_env(project, run)
+        ctx = RunCtx(
+            run_id=uuid.UUID(run.id),
+            fsm_id=spec.id,
+            current_state=current_state_id,
+            env=env,
+        )
+
+        result = engine_advance(spec, ctx, dict(input.outputs))
+        producer_id = _ensure_engine_producer(project)
+        from_pk = _current_state_pk(project, run.id, current_state_id)
+
+        if result.kind == "fault":
+            # Audit-trail the failure so subscribers see it on the bus;
+            # do NOT mark the state exited — the worker is expected to
+            # retry or the operator to intervene.
+            with project.session_factory() as session, session.begin():
+                project.events.emit(
+                    session,
+                    producer_id=producer_id,
+                    kind=EventKind.validation_failed.value,
+                    payload={
+                        "run_id": run.id,
+                        "state": current_state_id,
+                        "reason": result.reason,
+                        "errors": list(result.errors),
+                        "post_validations": [
+                            entry.model_dump(mode="json")
+                            for entry in result.post_validations
+                        ],
+                    },
+                    run_id=run.id,
+                )
+            return CommitResult(
+                kind="fault",
+                reason=result.reason,
+                errors=list(result.errors),
+                evaluations=list(result.evaluations),
+                post_validations=list(result.post_validations),
+            )
+
+        if result.kind == "loop_continue":
+            # The loop body wants another iteration. Hand back the next
+            # brief; the state-entry row stays open until the loop
+            # actually terminates.
+            return CommitResult(
+                kind="loop_continued",
+                brief=result.brief,
+                iteration_n=result.iteration_n,
+            )
+
+        if result.kind == "terminal":
+            # Mark the current state exited with its outputs, flip the
+            # run to ``completed`` with the engine's verdict, emit
+            # ``run_completed``.
+            if from_pk is not None:
+                _record_state_exit(
+                    project,
+                    run_id=run.id,
+                    state_pk=from_pk,
+                    outputs=dict(input.outputs),
+                    producer_id=producer_id,
+                )
+            now = _iso_now_ms()
+            with project.session_factory() as session, session.begin():
+                project.runs.update_status(
+                    session,
+                    run_id=run.id,
+                    status="completed",
+                    ended_at=now,
+                    verdict=str(result.verdict) if result.verdict is not None else None,
+                )
+                project.events.emit(
+                    session,
+                    producer_id=producer_id,
+                    kind=EventKind.run_completed.value,
+                    payload={
+                        "run_id": run.id,
+                        "verdict": result.verdict,
+                        "ended_at": now,
+                    },
+                    run_id=run.id,
+                )
+            return CommitResult(
+                kind="terminal",
+                verdict=result.verdict,
+                evaluations=list(result.evaluations),
+            )
+
+        # result.kind == "advance"
+        # Find the winning transition's guard kind / predicate text from
+        # the evaluations trace so the transitions row is faithful.
+        winning_eval: TransitionEvaluation | None = None
+        for ev in result.evaluations:
+            if ev.result and ev.to == result.next_state:
+                winning_eval = ev
+                break
+
+        if from_pk is not None:
+            _record_state_exit(
+                project,
+                run_id=run.id,
+                state_pk=from_pk,
+                outputs=dict(input.outputs),
+                producer_id=producer_id,
+            )
+            _record_transition(
+                project,
+                run_id=run.id,
+                from_state_pk=from_pk,
+                to_state_id=result.next_state or "",
+                kind=(winning_eval.kind if winning_eval else "always") or "always",
+                predicate=(winning_eval.expression if winning_eval else None),
+                # ``always`` / ``otherwise`` carry no predicate_result;
+                # everything else gets the boolean evaluation outcome.
+                predicate_result=(
+                    None
+                    if winning_eval is None
+                    or winning_eval.kind in {"always", "otherwise"}
+                    else bool(winning_eval.result)
+                ),
+                producer_id=producer_id,
+            )
+
+        # Enter the next state and bump runs.current_state.
+        next_state_id = result.next_state or ""
+        next_state = spec.get_state(next_state_id)
+        next_worker = next_state.worker or (
+            next_state.loop.worker if next_state.loop is not None else None
+        )
+        merged_env = {**env, **dict(input.outputs)}
+        next_inputs: dict[str, Any] = {}
+        if next_worker is not None:
+            next_inputs = {name: merged_env.get(name) for name in next_worker.inputs}
+        _persist_state_entry(
+            project,
+            run_id=run.id,
+            state_id=next_state_id,
+            inputs=next_inputs,
+            producer_id=producer_id,
+        )
+
+        return CommitResult(
+            kind="advanced",
+            brief=result.brief,
+            next_state=result.next_state,
+            evaluations=list(result.evaluations),
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("fsm.commit_outputs failed")
+        return as_error("internal_error", detail=str(exc))
+
+
+@mcp.tool(
+    name="fsm.confirm_commit",
+    description=(
+        "Confirm a previously-issued commit token. W4 stub: always returns "
+        "confirmed=True. W12 wires the real two-phase commit semantics."
+    ),
+)
+def fsm_confirm_commit(input: ConfirmCommitInput) -> ConfirmResult | McpToolError:
+    """Implement ``fsm.confirm_commit`` — W4 stub for the W12 surface.
+
+    The tool exists so MCP clients can already wire the two-call commit
+    flow today; the actual token-issue / token-consume path lands in
+    W12. We accept any token + expected_next_state and return
+    ``confirmed=True`` plus a note documenting the deferral.
+    """
+    try:
+        # Touch the args so a linter cannot flag them as unused; the
+        # tool's contract is "accept these and return confirmed=True"
+        # in W4, but we still validate that the inputs Pydantic-parsed.
+        _ = input.token
+        _ = input.expected_next_state
+        return ConfirmResult(
+            confirmed=True,
+            note=(
+                "two-phase commit semantics are W12; commit_outputs is "
+                "currently single-phase and confirm_commit is a stub."
+            ),
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("fsm.confirm_commit failed")
+        return as_error("internal_error", detail=str(exc))
+
+
+@mcp.tool(
+    name="fsm.resume_run",
+    description=(
+        "Resume a paused/faulted run. W4 ships the journal bookkeeping + "
+        "emits run_resumed; engine-driven resume itself comes in W12."
+    ),
+)
+def fsm_resume_run(input: ResumeRunInput) -> ResumeResult | McpToolError:
+    """Implement ``fsm.resume_run`` — mirrors the CLI ``run resume``."""
+    try:
+        project = get_project()
+        run_id_str = str(input.run_id)
+
+        run = project.get_run(run_id_str)
+        if run is None:
+            return as_error(
+                "run_not_found",
+                detail=f"no run with id {run_id_str!r}",
+                run_id=run_id_str,
+            )
+
+        producer_id = _ensure_engine_producer(project)
+        journal_action: str | None = None
+        journal_txn_id: str | None = None
+
+        with project.session_factory() as session, session.begin():
+            existing = project.journal.inspect(session, run_id=run.id)
+            journal_txn_id = existing.id if existing is not None else None
+
+            if input.journal == "discard" and existing is not None:
+                project.journal.discard(session, txn_id=existing.id)
+                journal_action = "discarded"
+            elif input.journal == "replay" and existing is not None:
+                # Replay-into-engine lands in W12; here we only record
+                # the operator's intent so the event stream tells the
+                # full story when the engine wakes back up.
+                journal_action = "replay_requested"
+            elif input.journal is not None:
+                journal_action = "noop_no_journal"
+
+            project.events.emit(
+                session,
+                producer_id=producer_id,
+                kind=EventKind.run_resumed.value,
+                payload={
+                    "run_id": run.id,
+                    "from_state": input.from_state,
+                    "journal_action": journal_action,
+                    "journal_txn_id": journal_txn_id,
+                    "engine_resume_pending": True,
+                },
+                run_id=run.id,
+            )
+
+        return ResumeResult(
+            run_id=uuid.UUID(run.id),
+            from_state=input.from_state,
+            journal_action=journal_action,
+            journal_txn_id=journal_txn_id,
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("fsm.resume_run failed")
+        return as_error("internal_error", detail=str(exc))
+
+
+@mcp.tool(
+    name="fsm.abort_run",
+    description=(
+        "Mark a run as aborted and emit run_aborted. Refuses runs already "
+        "in a terminal state (completed / aborted)."
+    ),
+)
+def fsm_abort_run(input: AbortRunInput) -> AbortResult | McpToolError:
+    """Implement ``fsm.abort_run`` — atomic update + run_aborted emit."""
+    try:
+        project = get_project()
+        run_id_str = str(input.run_id)
+
+        run = project.get_run(run_id_str)
+        if run is None:
+            return as_error(
+                "run_not_found",
+                detail=f"no run with id {run_id_str!r}",
+                run_id=run_id_str,
+            )
+        if run.status in {"completed", "aborted"}:
+            return as_error(
+                "invalid_state_transition",
+                detail=(
+                    f"run {run_id_str!r} is already in terminal status "
+                    f"{run.status!r}; refusing to abort"
+                ),
+                previous_status=run.status,
+            )
+
+        producer_id = _ensure_engine_producer(project)
+        now = _iso_now_ms()
+
+        with project.session_factory() as session, session.begin():
+            updated = project.runs.update_status(
+                session,
+                run_id=run.id,
+                status="aborted",
+                ended_at=now,
+            )
+            if updated is None:
+                return as_error(
+                    "run_not_found",
+                    detail=f"run {run_id_str!r} disappeared mid-abort",
+                    run_id=run_id_str,
+                )
+
+            project.events.emit(
+                session,
+                producer_id=producer_id,
+                kind=EventKind.run_aborted.value,
+                payload={
+                    "run_id": run.id,
+                    "reason": input.reason,
+                    "previous_status": run.status,
+                    "ended_at": now,
+                },
+                run_id=run.id,
+            )
+
+        return AbortResult(
+            run_id=uuid.UUID(run.id),
+            previous_status=run.status,
+            new_status="aborted",
+            ended_at=now,
+            reason=input.reason,
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("fsm.abort_run failed")
+        return as_error("internal_error", detail=str(exc))
+
+
+@mcp.tool(
+    name="fsm.list_runs",
+    description=(
+        "List runs, optionally filtered by status and since-timestamp. "
+        "Returns slim RunSummary value objects; use fsm.get_run for the "
+        "full per-run picture."
+    ),
+)
+def fsm_list_runs(input: ListRunsInput) -> list[RunSummary] | McpToolError:
+    """Implement ``fsm.list_runs`` — mirrors the CLI ``runs ls`` shortcuts.
+
+    Routing rules match the CLI exactly: ``incomplete`` and ``resumable``
+    are special keywords that hit dedicated repo methods; any other
+    status falls through to ``by_status``; no status hits ``latest``.
+    """
+    try:
+        project = get_project()
+        with project.session_factory() as session:
+            if input.filter_status is None:
+                rows = project.runs.latest(session, limit=input.limit)
+            elif input.filter_status == "incomplete":
+                rows = project.runs.incomplete(session)
+            elif input.filter_status == "resumable":
+                rows = project.runs.resumable(session)
+            else:
+                rows = project.runs.by_status(session, input.filter_status)
+
+        # ``--since`` is a lexicographic ISO comparison — the repo
+        # writes timestamps with a stable suffix so string ordering ==
+        # chronological ordering.
+        if input.since is not None:
+            rows = [row for row in rows if row.last_update_at >= input.since]
+        return rows[: input.limit]
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("fsm.list_runs failed")
+        return as_error("internal_error", detail=str(exc))
+
+
+@mcp.tool(
+    name="fsm.get_run",
+    description=(
+        "Return the full per-run report: manifest, state tree, last 50 "
+        "events, journal, locks."
+    ),
+)
+def fsm_get_run(input: GetRunInput) -> RunDetail | McpToolError:
+    """Implement ``fsm.get_run`` — assemble the full run picture."""
+    try:
+        project = get_project()
+        run_id_str = str(input.run_id)
+
+        run = project.get_run(run_id_str)
+        if run is None:
+            return as_error(
+                "run_not_found",
+                detail=f"no run with id {run_id_str!r}",
+                run_id=run_id_str,
+            )
+
+        with project.session_factory() as session:
+            tree = project.runs.state_tree(session, run.id)
+            event_rows = list(project.runs.events(session, run.id))
+            journal = project.journal.inspect(session, run_id=run.id)
+            lock = project.locks.inspect(session, run_id=run.id)
+
+        recent_events = event_rows[-50:]
+
+        return RunDetail(
+            manifest=run.model_dump(mode="json"),
+            state_tree=(
+                tree.model_dump(mode="json") if tree is not None else None
+            ),
+            events=[event.model_dump(mode="json") for event in recent_events],
+            journal=_journal_to_dict(journal),
+            locks=_lock_to_dict(lock),
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        _LOG.exception("fsm.get_run failed")
+        return as_error("internal_error", detail=str(exc))
+
+
+# Defensive: keep a small unused-import dam so static-analysis can't
+# silently strip the TransitionTable import that we may want to use in
+# follow-up iterations. The actual runtime cost is zero (TYPE_CHECKING
+# would also work, but plain import keeps mypy / pyright honest about
+# the module's existence at runtime).
+_ = TransitionTable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,21 @@ module = [
 ]
 disable_error_code = ["arg-type", "attr-defined", "union-attr", "call-overload", "call-arg"]
 
+[[tool.mypy.overrides]]
+# MCP tool modules occasionally drop below the repository layer to issue
+# ad-hoc SQLAlchemy ``select(...).where(Table.col == ...)`` queries — the
+# ``_current_state_pk`` helper in tools_runs.py and the joined spec-summary
+# listing in tools_meta.py both need them. They run into the same
+# descriptor-as-value typing friction described in the repository override
+# block above (column attributes typed as their Python value rather than
+# ``InstrumentedAttribute[T]``). Suppress ONLY the codes that friction
+# produces — every other surface in these files stays strictly typed.
+module = [
+    "ctxr.fsm.mcp.tools_runs",
+    "ctxr.fsm.mcp.tools_meta",
+]
+disable_error_code = ["arg-type", "attr-defined", "call-overload"]
+
 [tool.pytest.ini_options]
 addopts = "-ra -q --strict-markers"
 testpaths = ["tests"]

--- a/tests/cli/test_cli_stubs.py
+++ b/tests/cli/test_cli_stubs.py
@@ -105,35 +105,78 @@ def test_serve_stub_rejects_invalid_mode_flag() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ``mcp`` — MCP server stub (W4)
+# ``mcp`` — MCP server (W4, now implemented)
 # ---------------------------------------------------------------------------
+#
+# These tests used to assert on the W3 stub's deferral message. W4
+# replaced the stub with a real boot path that takes over the process
+# until the transport returns, so we can no longer ``invoke(app, ["mcp"])``
+# from a unit test — that would actually start the FastMCP stdio loop
+# and block. Instead we exercise the surface via ``--help`` (which the
+# Typer runner can render without entering any tool body) and assert
+# that every documented flag (``--transport``, ``--host``, ``--port``)
+# is listed. Real end-to-end coverage of the boot sequence is a W4
+# integration test that drives the server in a subprocess with a
+# wire-level MCP client; that lives outside this stub-shaped file.
 
 
-def test_mcp_stub_exits_nonzero_with_deferral_message() -> None:
-    """``ctxr-fsm mcp`` must defer to W4 and exit non-zero."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        _project_db(tmpdir)
-        result = runner.invoke(app, ["mcp"])
+def test_mcp_help_lists_transport_host_and_port_options() -> None:
+    """``ctxr-fsm mcp --help`` documents the W4 flag surface."""
+    result = runner.invoke(app, ["mcp", "--help"])
 
-    assert result.exit_code != 0
-    assert "MCP server lands in W4" in result.stderr
+    # ``--help`` always exits 0 — anything else means a registration
+    # regression (e.g. the import in cli/__init__.py was dropped).
+    assert result.exit_code == 0, (
+        f"`mcp --help` must exit 0 (got {result.exit_code}); "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    # Each flag must be visible by name so operator scripts and the
+    # docs site can reliably parse the help text. We assert on the
+    # long-form name with the leading double-dash because Typer's
+    # rich help renderer can wrap descriptions but always prints the
+    # flag token verbatim on its own line.
+    assert "--transport" in result.stdout
+    assert "--host" in result.stdout
+    assert "--port" in result.stdout
+
+    # ``--db`` is shared across every subcommand — also documented here
+    # so callers see the full surface in one screen. Asserting on it
+    # too pins the wiring against an accidental drop of ``DB_OPTION``.
+    assert "--db" in result.stdout
 
 
-def test_mcp_stub_accepts_valid_transport_flag() -> None:
-    """``--transport http`` reaches the stub body."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        _project_db(tmpdir)
-        result = runner.invoke(app, ["mcp", "--transport", "http"])
+def test_mcp_rejects_invalid_transport_flag() -> None:
+    """An out-of-set ``--transport`` value fails Typer validation.
 
-    assert result.exit_code == 1
-    assert "lands in W4" in result.stderr
-
-
-def test_mcp_stub_rejects_invalid_transport_flag() -> None:
-    """An out-of-set ``--transport`` value fails Typer validation."""
+    The transport allowlist (``stdio``, ``http``) is enforced up-front
+    in the CLI shim, before the server's heavyweight boot sequence
+    runs, so this test can safely invoke the command without ever
+    entering the FastMCP loop.
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         _project_db(tmpdir)
         result = runner.invoke(app, ["mcp", "--transport", "websocket"])
+
+    # ``typer.BadParameter`` renders through Click's usage-error path,
+    # which exits with code 2. We assert "non-zero, not 1" so the
+    # distinction between validation failure (2) and any future stub-
+    # style deferral (1) stays explicit.
+    assert result.exit_code != 0
+    assert result.exit_code != 1
+
+
+def test_mcp_rejects_out_of_range_port() -> None:
+    """``--port`` outside 0-65535 fails Typer's bound check.
+
+    We allow ``port=0`` (let the OS pick a free ephemeral port) so the
+    lower bound is ``0``, not ``1``; the upper bound is the canonical
+    TCP maximum. Going past either trips Typer's range validation
+    before the server boots.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _project_db(tmpdir)
+        result = runner.invoke(app, ["mcp", "--port", "70000"])
 
     assert result.exit_code != 0
     assert result.exit_code != 1
@@ -220,8 +263,11 @@ def test_ui_stub_rejects_out_of_range_port() -> None:
 @pytest.mark.parametrize(
     ("subcommand", "marker"),
     [
+        # Stub commands carry an explicit "ships in W{N}" marker in
+        # their registered help line. ``mcp`` is now the real W4
+        # implementation, so its top-level help string no longer
+        # advertises a workstream — see the dedicated case below.
         ("serve", "W7"),
-        ("mcp", "W4"),
         ("api", "W5"),
         ("ui", "W6"),
     ],
@@ -243,3 +289,21 @@ def test_all_stubs_registered_and_visible_in_help(
     # ships in the per-command help line registered in the app factory.
     assert subcommand in result.stdout
     assert marker in result.stdout
+
+
+def test_mcp_registered_and_visible_in_help() -> None:
+    """The real ``mcp`` command must appear on the top-level help screen.
+
+    Mirrors :func:`test_all_stubs_registered_and_visible_in_help` for
+    the now-implemented W4 command — the parametrised case above can't
+    cover it because ``mcp``'s help line no longer carries a workstream
+    marker. Asserting on the subcommand name plus the word "Protocol"
+    pins both the registration and the documented purpose.
+    """
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "mcp" in result.stdout
+    # "Protocol" appears in the registered help text and is a stable,
+    # distinctive token — far less likely to false-match than "MCP"
+    # which could collide with another command's description.
+    assert "Protocol" in result.stdout

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,16 @@
+"""Integration tests for ctxr.fsm.
+
+Tests in this package exercise the substrate end-to-end through public
+entry points (CLI, MCP server, HTTP API) rather than calling the
+internal Python API directly. They are deliberately slower than the
+unit tests under ``tests/unit/`` — expect seconds, not milliseconds —
+because each test spins up the real subprocess / transport stack.
+
+Sub-packages:
+
+* :mod:`tests.integration.sqlite` — end-to-end lifecycle exercises
+  that touch the SQLite repositories through ``Project``.
+* :mod:`tests.integration.mcp` — MCP server handshake / tool surface
+  tests; spawn ``ctxr-fsm mcp`` as a subprocess and drive it over the
+  stdio JSON-RPC transport using the official ``mcp`` SDK client.
+"""

--- a/tests/integration/mcp/__init__.py
+++ b/tests/integration/mcp/__init__.py
@@ -1,0 +1,15 @@
+"""Integration tests for the W4 ``ctxr-fsm mcp`` server.
+
+These tests spawn ``ctxr-fsm mcp`` as a real subprocess and drive it
+through the official ``mcp`` Python SDK's stdio client. They cover the
+wire-level behaviour of every ``fsm.*`` tool — the equivalent unit
+tests live next door under ``tests/unit/mcp`` and exercise the tool
+bodies in-process; these integration tests confirm the JSON-RPC framing,
+FastMCP registration, and stdio plumbing all line up end-to-end.
+
+Each test gets an isolated ``tempfile.TemporaryDirectory`` SQLite path
+so there is no cross-test contamination. Tests are intentionally slower
+than the unit suite (subprocess spawn + MCP initialize handshake) — a
+single tool round-trip is in the 5-15s range — so they should run
+sparingly in the inner dev loop and always in CI.
+"""

--- a/tests/integration/mcp/test_mcp_abort_resume.py
+++ b/tests/integration/mcp/test_mcp_abort_resume.py
@@ -1,0 +1,404 @@
+"""End-to-end integration tests for ``fsm.abort_run`` and ``fsm.resume_run``.
+
+These tests exercise the MCP server **over its actual transport** — they
+spawn ``uv run ctxr-fsm mcp --db <tmp>`` as a subprocess, hand-shake the
+JSON-RPC framing through the official MCP Python SDK's stdio client, and
+assert the side-effects against the SQLite substrate after the server
+exits.
+
+Why subprocess-level coverage matters
+-------------------------------------
+
+The W4 plumbing is reached by clients **only** through the stdio
+transport. In-process tests against the tool functions can pass while
+the transport-level boot sequence (logging-to-stderr, project binding,
+signal handlers, FastMCP's input-model unwrap) silently regresses. The
+two abort / resume tests both:
+
+* spawn the server fresh against a per-test ``tempfile.TemporaryDirectory``
+  so there is zero shared state between cases;
+* open an :class:`mcp.ClientSession` over the stdio pipes, ``initialize``
+  the protocol, and invoke ``fsm.abort_run`` / ``fsm.resume_run`` exactly
+  the way Claude Code would;
+* re-open the SQLite DB after the client session exits to inspect what
+  landed on disk through the public :class:`Project` facade — the same
+  contract every other lifecycle test uses.
+
+Test cost
+---------
+
+Each test spawns a Python subprocess (``uv run ctxr-fsm mcp``) and runs
+the alembic migration on its way up. Expect 5-15 seconds per test on a warm
+machine; the suite is therefore parked under ``tests/integration/mcp``
+and is excluded from the fast inner-loop ``pytest -x tests/unit`` run by
+file-tree convention.
+
+MCP SDK API used
+----------------
+
+* ``mcp.ClientSession`` — the standard client-side façade.
+* ``mcp.client.stdio.stdio_client`` — async context manager that yields
+  ``(read_stream, write_stream)`` plumbed to the child's stdio.
+* ``mcp.client.stdio.StdioServerParameters`` — the subprocess descriptor.
+* ``session.call_tool(name, arguments={"input": {...}})`` — FastMCP wraps
+  the tool's Pydantic input model under a single ``input`` key in the
+  generated tool schema; we mirror that here.
+
+Return shape: ``CallToolResult.structuredContent`` is a JSON object of
+the form ``{"result": <pydantic-model-dump>}`` for tools that return a
+single Pydantic model. We assert against that nested ``result`` blob
+because it is the stable, self-describing contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+from ctxr.fsm.core.models import EventKind, FsmSpec, State, Transition
+from ctxr.fsm.sqlite import Project
+
+# ---------------------------------------------------------------------------
+# Spec + DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_spec(spec_id: str = "abort_resume_demo") -> FsmSpec:
+    """Build the minimal valid two-state FSM used by every test in this file.
+
+    Shape: ``a`` (entry) → ``b`` (terminal). None of the tests actually
+    drive a transition — they only need a run row to exist so the
+    abort / resume tools have something to act on — but a registered spec
+    still has to pass the cross-cutting structural validator, which is why
+    we provide a single ``always`` edge instead of leaving state ``a``
+    isolated.
+    """
+    return FsmSpec(
+        id=spec_id,
+        version=1,
+        entry="a",
+        states=[
+            State(
+                id="a",
+                purpose="entry state",
+                transitions=[Transition(to="b", when="always")],
+            ),
+            State(
+                id="b",
+                purpose="terminal state",
+                transitions=[],
+            ),
+        ],
+    )
+
+
+def _seed_run(db: Path) -> str:
+    """Bootstrap the project DB at ``db`` and return a fresh run id.
+
+    Opens the project in-process (the same way the CLI does), registers
+    the demo spec, and calls :meth:`Project.start_run` so the on-disk DB
+    already carries a run row by the time the MCP subprocess boots
+    against the same file. Returning just the id keeps the helper neutral
+    about which other rows the caller may want to seed alongside it
+    (journal txns, for instance).
+    """
+    with Project.open(db, migrate=True, echo=False) as project:
+        registered = project.register_spec(_make_spec())
+        run = project.start_run(registered.spec.id, args={})
+        return run.id
+
+
+def _seed_run_with_pending_journal(db: Path) -> tuple[str, str]:
+    """Seed a run with a ``pending`` journal txn open against it.
+
+    Returns ``(run_id, journal_txn_id)``. The ``--journal discard`` test
+    needs both: the run id to address the tool call, and the txn id so it
+    can assert the pre-state actually had a row before invoking the tool.
+    """
+    with Project.open(db, migrate=True, echo=False) as project:
+        registered = project.register_spec(_make_spec())
+        run = project.start_run(registered.spec.id, args={})
+        with project.session_factory() as session, session.begin():
+            txn = project.journal.open(session, run_id=run.id)
+            txn_id = txn.id
+        return run.id, txn_id
+
+
+def _read_run_status(db: Path, run_id: str) -> tuple[str, str | None]:
+    """Return ``(status, ended_at)`` for ``run_id`` from the on-disk DB.
+
+    Re-opens the project read-only-ish (no transaction begun) so the
+    assertion observes exactly whatever the MCP server committed.
+    """
+    with Project.open(db, migrate=False, echo=False) as project:
+        run = project.get_run(run_id)
+        assert run is not None, f"run {run_id!r} vanished between writes"
+        return run.status, run.ended_at
+
+
+def _read_event_kinds(db: Path, run_id: str) -> list[str]:
+    """Return every event kind recorded against ``run_id``, in seq order."""
+    with (
+        Project.open(db, migrate=False, echo=False) as project,
+        project.session_factory() as session,
+    ):
+        events = list(project.runs.events(session, run_id))
+    return [event.kind for event in events]
+
+
+def _read_last_event_payload(db: Path, run_id: str) -> dict[str, Any]:
+    """Return the payload of the most-recent event recorded on ``run_id``."""
+    with (
+        Project.open(db, migrate=False, echo=False) as project,
+        project.session_factory() as session,
+    ):
+        events = list(project.runs.events(session, run_id))
+    assert events, f"no events recorded on run {run_id!r}"
+    return dict(events[-1].payload)
+
+
+def _read_journal_txn(db: Path, run_id: str) -> Any:
+    """Return ``JournalRepo.inspect(run_id)`` (or ``None``) for assertions.
+
+    ``inspect`` returns the newest unfinalised txn for the run, so this
+    is the correct lens for "did the pending row survive the call?".
+    """
+    with (
+        Project.open(db, migrate=False, echo=False) as project,
+        project.session_factory() as session,
+    ):
+        return project.journal.inspect(session, run_id=run_id)
+
+
+# ---------------------------------------------------------------------------
+# MCP client helpers
+# ---------------------------------------------------------------------------
+
+
+def _server_params(db: Path) -> StdioServerParameters:
+    """Build the subprocess descriptor for ``uv run ctxr-fsm mcp --db <db>``.
+
+    ``uv run`` is the project's canonical launcher — it both selects the
+    correct Python interpreter and ensures the venv is in sync without
+    forcing the test process to know where ``.venv/bin/python`` lives.
+    We do **not** pass ``--transport stdio`` explicitly because stdio is
+    the default; the explicit argument would couple the test to the CLI
+    surface unnecessarily.
+    """
+    return StdioServerParameters(
+        command="uv",
+        args=["run", "ctxr-fsm", "mcp", "--db", str(db)],
+    )
+
+
+async def _with_session(
+    db: Path,
+    body: Callable[[ClientSession], Awaitable[Any]],
+) -> Any:
+    """Spawn the MCP server, hand ``body`` an initialised client session.
+
+    Single-call wrapper so test bodies stay flat: they get a connected,
+    handshaked :class:`ClientSession` and only have to author the
+    ``call_tool`` invocations. The async context managers handle process
+    lifecycle (terminate on exit) and transport teardown (flush + close
+    stdio pipes).
+    """
+    params = _server_params(db)
+    async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
+        await session.initialize()
+        return await body(session)
+
+
+def _structured_result(result: Any) -> dict[str, Any]:
+    """Unwrap the canonical ``{"result": ...}`` envelope from a tool call.
+
+    FastMCP serialises a tool that returns a single Pydantic model into
+    ``CallToolResult.structuredContent == {"result": <model.model_dump()>}``.
+    Tests assert against the inner dict, so this helper makes that
+    explicit and gives a clear failure when the shape changes.
+    """
+    assert result.isError is False, (
+        f"tool call returned an error: {result.content!r}"
+    )
+    sc = result.structuredContent
+    assert isinstance(sc, dict), f"missing structuredContent on {result!r}"
+    assert "result" in sc, f"structuredContent missing 'result' key: {sc!r}"
+    inner = sc["result"]
+    assert isinstance(inner, dict), f"unexpected result shape: {inner!r}"
+    return inner
+
+
+# ---------------------------------------------------------------------------
+# fsm.abort_run
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_abort_run_flips_status_and_emits_event() -> None:
+    """``fsm.abort_run`` over MCP flips status → aborted and emits the event.
+
+    Mirrors the CLI's ``run abort`` happy-path test but exercises the
+    full stdio transport: we open a client session against a fresh
+    subprocess, invoke the tool with ``run_id`` + ``reason``, and then
+    re-open the DB to confirm both the manifest flip and the
+    ``run_aborted`` event landed exactly once.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "fsm.db"
+        run_id = _seed_run(db)
+
+        # Sanity check: the run starts in_progress with no ended_at.
+        pre_status, pre_ended_at = _read_run_status(db, run_id)
+        assert pre_status == "in_progress"
+        assert pre_ended_at is None
+
+        async def body(session: ClientSession) -> dict[str, Any]:
+            result = await session.call_tool(
+                "fsm.abort_run",
+                arguments={
+                    "input": {"run_id": run_id, "reason": "user cancelled"}
+                },
+            )
+            return _structured_result(result)
+
+        payload = asyncio.run(_with_session(db, body))
+
+        # ── Tool payload ────────────────────────────────────────────────
+        assert payload["run_id"] == run_id
+        assert payload["previous_status"] == "in_progress"
+        assert payload["new_status"] == "aborted"
+        assert payload["reason"] == "user cancelled"
+        assert payload["ended_at"]  # ISO-8601 string, non-empty
+
+        # ── Manifest reflects the abort ─────────────────────────────────
+        post_status, post_ended_at = _read_run_status(db, run_id)
+        assert post_status == "aborted"
+        assert post_ended_at is not None and post_ended_at != ""
+        # The payload's ended_at must match what the substrate persisted.
+        assert payload["ended_at"] == post_ended_at
+
+        # ── Event log carries exactly one run_aborted ───────────────────
+        kinds = _read_event_kinds(db, run_id)
+        assert kinds.count(EventKind.run_aborted.value) == 1
+        # And it is the last event on the timeline.
+        assert kinds[-1] == EventKind.run_aborted.value
+        # The very first event is still the run_started recorded by
+        # Project.start_run during seeding.
+        assert kinds[0] == EventKind.run_started.value
+
+        # The event payload mirrors the tool result.
+        event_payload = _read_last_event_payload(db, run_id)
+        assert event_payload["run_id"] == run_id
+        assert event_payload["reason"] == "user cancelled"
+        assert event_payload["previous_status"] == "in_progress"
+        assert event_payload["ended_at"] == post_ended_at
+
+
+# ---------------------------------------------------------------------------
+# fsm.resume_run — --from-state X
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_resume_run_from_state_returns_w12_deferral() -> None:
+    """``fsm.resume_run`` with ``from_state`` surfaces the W12 stub message.
+
+    W4 ships only the bookkeeping for engine-driven resume; the actual
+    replay-into-engine path lands in W12. The tool's contract is that
+    every response carries an ``engine_resume`` field whose value
+    explicitly names the deferral so scripts and humans both see that
+    the engine has not picked the run back up. We assert that the
+    deferral string mentions ``W12`` (the stable marker every other
+    surface — CLI, docs, source — uses for the same deferral).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "fsm.db"
+        run_id = _seed_run(db)
+
+        async def body(session: ClientSession) -> dict[str, Any]:
+            result = await session.call_tool(
+                "fsm.resume_run",
+                arguments={
+                    "input": {"run_id": run_id, "from_state": "a"}
+                },
+            )
+            return _structured_result(result)
+
+        payload = asyncio.run(_with_session(db, body))
+
+        assert payload["run_id"] == run_id
+        assert payload["from_state"] == "a"
+        # No --journal flag was passed and there's no pre-existing
+        # journal row, so journal_action stays None.
+        assert payload["journal_action"] is None
+        # Load-bearing assertion: the deferral message must call out W12.
+        assert "W12" in payload["engine_resume"], (
+            f"expected W12 deferral in engine_resume, got: "
+            f"{payload['engine_resume']!r}"
+        )
+
+        # A run_resumed event must land regardless of the engine-resume
+        # deferral, so subscribers see the operator's intent.
+        kinds = _read_event_kinds(db, run_id)
+        assert EventKind.run_resumed.value in kinds
+
+
+# ---------------------------------------------------------------------------
+# fsm.resume_run — --journal discard
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_resume_run_journal_discard_removes_pending_row() -> None:
+    """``fsm.resume_run`` with ``journal='discard'`` removes the pending row.
+
+    Pre-condition: the run has a ``pending`` journal txn open against it.
+    Action: invoke the resume tool with ``journal='discard'``.
+    Post-condition: :meth:`JournalRepo.inspect` returns ``None`` and the
+    tool payload reports ``journal_action='discarded'`` plus the id of
+    the txn that was removed (so a caller can correlate the action with
+    the row it touched).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "fsm.db"
+        run_id, txn_id = _seed_run_with_pending_journal(db)
+
+        # Pre-state sanity check: a pending journal row really does
+        # exist with the expected status.
+        pre = _read_journal_txn(db, run_id)
+        assert pre is not None
+        assert pre.id == txn_id
+        assert pre.status == "pending"
+
+        async def body(session: ClientSession) -> dict[str, Any]:
+            result = await session.call_tool(
+                "fsm.resume_run",
+                arguments={
+                    "input": {"run_id": run_id, "journal": "discard"}
+                },
+            )
+            return _structured_result(result)
+
+        payload = asyncio.run(_with_session(db, body))
+
+        assert payload["run_id"] == run_id
+        assert payload["journal_action"] == "discarded"
+        assert payload["journal_txn_id"] == txn_id
+        # The deferral marker is still present — the resume tool always
+        # surfaces it regardless of which sub-action fired.
+        assert "W12" in payload["engine_resume"]
+
+        # ── The pending row must be gone after discard ──────────────────
+        post = _read_journal_txn(db, run_id)
+        assert post is None, (
+            f"journal row {txn_id!r} was not discarded; still present as "
+            f"{post!r}"
+        )
+
+        # A run_resumed event must still be on the timeline so the
+        # audit log captures the operator's action.
+        kinds = _read_event_kinds(db, run_id)
+        assert EventKind.run_resumed.value in kinds

--- a/tests/integration/mcp/test_mcp_handshake.py
+++ b/tests/integration/mcp/test_mcp_handshake.py
@@ -1,0 +1,241 @@
+"""End-to-end MCP handshake tests for the ``ctxr-fsm mcp`` server.
+
+These tests spawn ``ctxr-fsm mcp --db <tmp>`` as a real subprocess
+and drive it through the official MCP Python SDK's stdio client
+(``mcp.client.stdio.stdio_client`` + ``mcp.ClientSession``). They lock
+two wire contracts independently from the in-process unit tests:
+
+1. The MCP ``initialize`` handshake completes successfully and the
+   advertised :class:`~mcp.types.ServerCapabilities` includes a
+   non-empty ``tools`` capability. Without this, MCP clients refuse to
+   call any tool — so this is the smallest possible smoke test that
+   proves the FastMCP wiring is sound.
+
+2. ``tools/list`` returns every ``fsm.*`` tool the W4 wave promised.
+   The expected set is enumerated below; new tools added in later
+   waves should append to the set so a missing registration fails the
+   suite at the source of the regression (the ``tools/list`` round
+   trip) rather than later when a downstream test tries to invoke a
+   ghost tool.
+
+Implementation notes
+--------------------
+
+* MCP SDK API used: ``StdioServerParameters(command=..., args=...)``
+  →  ``async with stdio_client(params) as (read, write):`` →
+  ``async with ClientSession(read, write) as session:`` →
+  ``await session.initialize()`` / ``await session.list_tools()``.
+  This matches the public surface documented for the 1.x SDK line and
+  is what the SDK's own examples use.
+
+* Why ``asyncio.run`` instead of a ``pytest-asyncio`` fixture? The
+  surrounding repo has no ``asyncio_mode = "auto"`` pytest config, so
+  we keep each test a sync function that drives a single
+  ``asyncio.run(...)`` call. This avoids depending on the plugin's
+  event-loop scope semantics and keeps the test trivially
+  reproducible at the REPL (you can copy the inner coroutine into a
+  Python shell and run it directly).
+
+* Each test creates its own ``TemporaryDirectory`` so the SQLite file
+  is isolated. The server boots with ``migrate=True`` so the empty
+  database is auto-upgraded to the current alembic head — no test
+  setup needs to ``alembic upgrade head`` first.
+
+* The subprocess is launched as ``uv run ctxr-fsm mcp --db <tmp>`` so
+  the test honours the project's tooling contract (no manual venv
+  activation, the same command operators would copy from the README).
+  We pass ``cwd`` explicitly to insulate the test from whatever
+  directory pytest was invoked from.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+# The complete set of MCP tools the W4 wave promises. Any new tool
+# added to ``ctxr.fsm.mcp`` should be appended here so a missing
+# decorator-side-effect registration trips this test immediately
+# instead of failing further downstream when something tries to call
+# the unregistered name.
+#
+# Names use the canonical ``fsm.<verb>`` namespace so the MCP client
+# never has to guess whether a tool came from this server.
+EXPECTED_TOOLS: frozenset[str] = frozenset(
+    {
+        # tools_meta.py
+        "fsm.healthcheck",
+        "fsm.list_specs",
+        "fsm.register_spec",
+        "fsm.observe_tool_call",
+        # tools_runs.py
+        "fsm.start_run",
+        "fsm.get_brief",
+        "fsm.commit_outputs",
+        "fsm.confirm_commit",
+        "fsm.resume_run",
+        "fsm.abort_run",
+        "fsm.list_runs",
+        "fsm.get_run",
+        # tools_events.py
+        "fsm.subscribe_events",
+        "fsm.inspect_journal",
+        "fsm.recover_journal",
+        "fsm.list_consumers",
+        "fsm.list_producers",
+    }
+)
+
+
+# Generous timeout for the full spawn + handshake + tools/list round
+# trip. The dominant cost is the ``uv run`` import-time penalty on a
+# cold cache (FastMCP + SQLAlchemy + Alembic pulled in for every fresh
+# Python process); 60 s leaves plenty of slack for slow CI runners
+# without masking a genuinely hung handshake.
+HANDSHAKE_TIMEOUT_S: float = 60.0
+
+
+def _server_params(db_path: Path) -> StdioServerParameters:
+    """Build the stdio-client launch parameters.
+
+    ``uv run`` is the project's canonical "run this command inside the
+    managed venv" wrapper — invoking it (rather than the
+    ``.venv/bin/ctxr-fsm`` script directly) keeps the test honest about
+    the operator-facing command and means it works on a clean checkout
+    where ``.venv`` may not yet exist.
+
+    The repo root is computed from ``__file__`` so the test runs
+    correctly regardless of the directory pytest was launched from.
+    """
+
+    repo_root = Path(__file__).resolve().parents[3]
+    return StdioServerParameters(
+        command="uv",
+        args=["run", "ctxr-fsm", "mcp", "--db", str(db_path)],
+        cwd=str(repo_root),
+    )
+
+
+async def _handshake_and_list(db_path: Path) -> tuple[object, list[object]]:
+    """Run the full ``initialize`` + ``tools/list`` round trip.
+
+    Returns the raw ``InitializeResult`` and the list of ``Tool``
+    objects so the individual tests can make their own assertions
+    without re-establishing the connection (which is the slow part).
+    """
+
+    params = _server_params(db_path)
+    async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
+        init_result = await session.initialize()
+        list_result = await session.list_tools()
+        return init_result, list_result.tools
+
+
+def _run_handshake(db_path: Path) -> tuple[object, list[object]]:
+    """Synchronous wrapper around :func:`_handshake_and_list`.
+
+    Centralises the ``asyncio.run`` + ``asyncio.wait_for`` boilerplate
+    so each test body stays a flat sequence of assertions. The wrapper
+    raises :class:`asyncio.TimeoutError` if the handshake exceeds
+    :data:`HANDSHAKE_TIMEOUT_S` — a deliberate fail-loud signal that
+    the server is hung rather than the test silently waiting forever.
+    """
+
+    async def _wrapped() -> tuple[object, list[object]]:
+        return await asyncio.wait_for(
+            _handshake_and_list(db_path), timeout=HANDSHAKE_TIMEOUT_S
+        )
+
+    return asyncio.run(_wrapped())
+
+
+def test_initialize_advertises_tools_capability() -> None:
+    """``initialize`` must succeed and advertise the ``tools`` capability.
+
+    MCP clients gate every ``tools/*`` call on the server's advertised
+    capabilities — if ``capabilities.tools`` is ``None`` the client
+    will refuse to send ``tools/list`` even when the server has tools
+    registered. This test therefore asserts the *advertisement*, not
+    just the presence of the tools themselves (covered by the sibling
+    test below).
+
+    We also pin a couple of identity fields (``serverInfo.name`` and
+    ``protocolVersion``) so a regression that flips the FastMCP
+    instance's name or forgets to negotiate a protocol version is
+    caught here instead of in a downstream client.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        init_result, _tools = _run_handshake(db_path)
+
+        # ``capabilities.tools`` is an Optional[ToolsCapability]; the
+        # *presence* of the object (vs. ``None``) is what tells clients
+        # they may call ``tools/list``. We don't care about the inner
+        # ``listChanged`` flag — FastMCP defaults it sensibly.
+        assert init_result.capabilities.tools is not None, (
+            "MCP server must advertise the 'tools' capability so clients "
+            "may call tools/list; capabilities.tools was None"
+        )
+
+        # Identity guard: a typo in the FastMCP constructor name would
+        # silently break every client that looks the server up by name
+        # (mcp.json registries do exactly that).
+        assert init_result.serverInfo.name == "ctxr-fsm", (
+            f"unexpected MCP serverInfo.name {init_result.serverInfo.name!r}; "
+            "expected 'ctxr-fsm'"
+        )
+
+        # protocolVersion is a free-form string negotiated by the SDK;
+        # we only assert it is set so a future SDK upgrade that forgets
+        # to negotiate a version fails loudly.
+        assert init_result.protocolVersion, "protocolVersion must be a non-empty string"
+
+
+def test_tools_list_contains_every_expected_fsm_tool() -> None:
+    """``tools/list`` must return every ``fsm.*`` tool W4 promised.
+
+    The assertion is a *superset* check rather than equality so future
+    waves can add tools without breaking this test — but every tool in
+    :data:`EXPECTED_TOOLS` MUST be present. A missing tool means a
+    decorator side-effect registration was lost (typically the
+    ``from ctxr.fsm.mcp import tools_X`` import got dropped from the
+    aggregator).
+
+    We deliberately compare names only — the tool schemas are a
+    separate contract validated by the per-tool integration tests.
+    Comparing only names also keeps this test resilient to harmless
+    docstring / description tweaks.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        _init_result, tools = _run_handshake(db_path)
+
+        listed = {t.name for t in tools}
+        missing = EXPECTED_TOOLS - listed
+        assert not missing, (
+            f"MCP server is missing expected fsm.* tools: {sorted(missing)}; "
+            f"listed tools were: {sorted(listed)}"
+        )
+
+        # Sanity guard: every tool the server lists must live under the
+        # ``fsm.`` namespace. A stray non-namespaced tool would collide
+        # with whatever other servers a client has mounted and is
+        # almost certainly a bug.
+        non_namespaced = {n for n in listed if not n.startswith("fsm.")}
+        assert not non_namespaced, (
+            f"MCP server registered non-namespaced tools (must start "
+            f"with 'fsm.'): {sorted(non_namespaced)}"
+        )
+
+
+if __name__ == "__main__":
+    # Allow ``python tests/integration/mcp/test_mcp_handshake.py`` as a
+    # quick manual smoke. Pytest is still the canonical entry point.
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/integration/mcp/test_mcp_healthcheck.py
+++ b/tests/integration/mcp/test_mcp_healthcheck.py
@@ -1,0 +1,262 @@
+"""End-to-end test for the ``fsm.healthcheck`` MCP tool.
+
+This integration test boots ``ctxr-fsm mcp`` as a real subprocess via
+the official MCP Python SDK's stdio client (``mcp.client.stdio``) and
+issues a ``fsm.healthcheck`` call across the JSON-RPC pipe. Asserting
+on the wire-level response — rather than calling the tool function
+directly — gives us coverage of:
+
+* the CLI shim (``ctxr-fsm mcp`` -> ``ctxr.fsm.cli.mcp_cmd.mcp``);
+* the server boot sequence (``Project.open`` + ``set_project``
+  + logging-to-stderr + signal handlers);
+* the FastMCP tool registration (the ``@mcp.tool(name="fsm.healthcheck")``
+  decorator must actually expose the tool over stdio);
+* the structured-output round-trip (Pydantic models -> JSON-RPC
+  ``structuredContent`` -> Pydantic re-parse in the client).
+
+These tests are significantly slower than the in-process unit tests
+(subprocess spawn + MCP initialize handshake + SQLite migration on a
+brand-new DB) — expect 5-15s per case — so they are kept narrow and
+deliberately small in number. The matching in-process unit tests cover
+the tool body's branching exhaustively.
+
+MCP SDK API used
+----------------
+
+* ``mcp.client.stdio.StdioServerParameters`` — describes the child
+  process (command + args + cwd + env). Used keyword-only here per the
+  SDK 1.27 signature.
+* ``mcp.client.stdio.stdio_client`` — async context manager yielding
+  the ``(read_stream, write_stream)`` pair, spawning the subprocess
+  and tearing it down on exit.
+* ``mcp.ClientSession`` — wraps the stream pair into a JSON-RPC
+  session; we call ``initialize()`` once and then drive ``call_tool``
+  to invoke ``fsm.healthcheck``.
+
+Output shape: ``ClientSession.call_tool`` returns
+``mcp.types.CallToolResult``. For FastMCP-decorated tools that return a
+Pydantic model, the structured payload arrives under
+``CallToolResult.structuredContent["result"]`` (a dict with the model
+fields). The unstructured ``content`` list also carries the same data
+as a single ``TextContent`` JSON-encoded blob — we assert on the
+structured form because it is the typed contract clients are expected
+to consume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+# The integration loop spawns a subprocess that runs Alembic migrations
+# against a brand-new SQLite file and then completes the MCP initialize
+# handshake; on cold caches that can comfortably take 10-15 seconds.
+# We bound each tool round-trip with a generous async timeout so a hung
+# subprocess fails the suite loudly instead of hanging CI indefinitely.
+_TOOL_CALL_TIMEOUT_SECONDS: float = 30.0
+
+
+def _server_params(db_path: Path) -> StdioServerParameters:
+    """Build the ``StdioServerParameters`` for a per-test ctxr-fsm mcp run.
+
+    We invoke through ``uv run`` so the subprocess picks up the project's
+    virtualenv and lockfile-pinned dependencies (matching what an
+    operator would type at the shell). The DB path is passed via the
+    ``--db`` flag so the server's ``resolve_db_path`` precedence is
+    exercised exactly as a real client would exercise it.
+
+    The child inherits the parent's environment so any locally-set
+    ``UV_*`` / ``PYTHONPATH`` overrides are preserved — important for
+    running these tests inside the developer-loop virtualenv as well as
+    in CI's clean shell. We do NOT pass ``cwd`` explicitly so the child
+    starts in the project root (the test runner's cwd), which keeps the
+    ``uv`` invocation aligned with the project's ``uv.lock``.
+    """
+    return StdioServerParameters(
+        command="uv",
+        args=["run", "ctxr-fsm", "mcp", "--db", str(db_path)],
+        env=dict(os.environ),
+    )
+
+
+async def _call_healthcheck(db_path: Path) -> dict[str, Any]:
+    """Spawn the MCP server, call ``fsm.healthcheck``, and return the dict.
+
+    The structured payload sits at ``CallToolResult.structuredContent``
+    under the ``"result"`` key — FastMCP wraps a single typed return
+    value in that envelope so the JSON-RPC ``structuredContent`` field
+    is always an object even when the tool returns a list or a scalar.
+
+    On any tool-level error (``isError=True``) we still return the
+    structured payload so the test body can render a helpful failure
+    message; the assertion that ``isError is False`` lives in the
+    caller.
+    """
+    async with (
+        stdio_client(_server_params(db_path)) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        result = await asyncio.wait_for(
+            session.call_tool("fsm.healthcheck", {}),
+            timeout=_TOOL_CALL_TIMEOUT_SECONDS,
+        )
+
+    # ``structuredContent`` is the typed envelope; ``content`` is the
+    # plain-text fallback FastMCP also emits for clients that do not
+    # yet consume the structured form. We return both so the assertion
+    # on the structured shape can fall back to a clear diagnostic if
+    # the structured envelope is unexpectedly missing.
+    return {
+        "isError": bool(result.isError),
+        "structuredContent": result.structuredContent,
+        "content": [
+            {"type": item.type, "text": getattr(item, "text", None)}
+            for item in result.content
+        ],
+    }
+
+
+def _extract_healthcheck_payload(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Pull the ``HealthcheckResult`` dict out of a CallToolResult envelope.
+
+    FastMCP wraps a Pydantic return value as
+    ``structuredContent = {"result": <model dict>}``. We assert on the
+    presence of that wrapper here (with a helpful message) so the test
+    body downstream can focus on field-level assertions instead of
+    juggling the envelope shape.
+    """
+    structured = envelope["structuredContent"]
+    assert structured is not None, (
+        f"fsm.healthcheck did not return a structuredContent envelope; "
+        f"got isError={envelope['isError']!r}, content={envelope['content']!r}"
+    )
+    assert "result" in structured, (
+        f"fsm.healthcheck structuredContent missing 'result' wrapper key; "
+        f"got keys={list(structured)!r}"
+    )
+    payload = structured["result"]
+    assert isinstance(payload, dict), (
+        f"fsm.healthcheck 'result' should be a dict; got {type(payload).__name__}"
+    )
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_healthcheck_returns_status_ok() -> None:
+    """``fsm.healthcheck`` returns ``status=="ok"`` on a fresh DB.
+
+    The server boots against a brand-new SQLite file (so the Alembic
+    upgrade runs as part of ``Project.open(..., migrate=True)``), and
+    we expect the healthcheck to report a happy, fully-initialised
+    server. Asserting on ``status`` first gives the cleanest
+    diagnostic when the round-trip fails for any reason — a non-"ok"
+    status means the tool body returned an error envelope, which the
+    next assertion would obscure.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "fsm.db"
+        envelope = asyncio.run(_call_healthcheck(db_path))
+
+    assert envelope["isError"] is False, (
+        f"fsm.healthcheck returned isError=True; envelope={envelope!r}"
+    )
+
+    payload = _extract_healthcheck_payload(envelope)
+    assert payload.get("status") == "ok", (
+        f"expected status='ok', got payload={payload!r}"
+    )
+
+
+def test_healthcheck_db_path_matches_db_flag() -> None:
+    """``fsm.healthcheck`` echoes back the same DB path we passed to ``--db``.
+
+    ``resolve_db_path`` canonicalises the path with ``Path.resolve()``,
+    which on macOS prepends ``/private`` to anything under ``/tmp``.
+    We therefore compare against ``db_path.resolve()`` rather than the
+    raw ``db_path`` we constructed, so the test stays correct on every
+    platform (macOS, Linux CI runners, container layers with symlinks
+    in the temp tree).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "fsm.db"
+        envelope = asyncio.run(_call_healthcheck(db_path))
+
+    assert envelope["isError"] is False, (
+        f"fsm.healthcheck returned isError=True; envelope={envelope!r}"
+    )
+
+    payload = _extract_healthcheck_payload(envelope)
+    reported = payload.get("db_path")
+    assert reported is not None, (
+        f"fsm.healthcheck payload missing 'db_path' field; payload={payload!r}"
+    )
+
+    # Compare resolved paths — the server canonicalises via Path.resolve(),
+    # so a literal string compare against str(db_path) would fail on macOS
+    # where /tmp is a symlink to /private/tmp. ``Path(...).resolve()`` on
+    # both sides normalises the representation regardless of host quirks.
+    assert Path(reported).resolve() == db_path.resolve(), (
+        f"reported db_path {reported!r} does not match --db argument "
+        f"{db_path!s} (resolved: {db_path.resolve()!s})"
+    )
+
+
+def test_healthcheck_reports_alembic_revision_and_package_version() -> None:
+    """The healthcheck surfaces the alembic head and the package version.
+
+    ``Project.open(..., migrate=True)`` runs the Alembic upgrade as part
+    of the boot sequence, so the very first call against a fresh DB
+    should already report a non-``None`` revision. ``package_version``
+    must always be the installed ``ctxr.fsm`` version — a non-empty
+    string so client-side version pinning has something to compare.
+
+    This case is folded into the same suite as the basic status check
+    because the SDK round-trip dominates the runtime: amortising the
+    handshake cost across the two assertions keeps the integration
+    suite cheap to run.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "fsm.db"
+        envelope = asyncio.run(_call_healthcheck(db_path))
+
+    assert envelope["isError"] is False, (
+        f"fsm.healthcheck returned isError=True; envelope={envelope!r}"
+    )
+
+    payload = _extract_healthcheck_payload(envelope)
+
+    # Alembic head — must be present because the server boots with
+    # ``migrate=True``. ``None`` here would mean the upgrade silently
+    # failed to populate the ``alembic_version`` table.
+    revision = payload.get("alembic_revision")
+    assert isinstance(revision, str) and revision, (
+        f"expected non-empty alembic_revision string; payload={payload!r}"
+    )
+
+    # Package version — must be the installed ctxr.fsm version. We
+    # don't pin a literal here (the package version evolves on every
+    # release) so the assertion is "non-empty string" plus a sanity
+    # check that it looks PEP-440-ish (contains a dot).
+    pkg_version = payload.get("package_version")
+    assert isinstance(pkg_version, str) and "." in pkg_version, (
+        f"expected dotted package_version string; payload={payload!r}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual debug path
+    # Allow ``python tests/integration/mcp/test_mcp_healthcheck.py`` to
+    # run the suite under pytest without remembering the full module
+    # path. Handy when iterating on the test body locally.
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/integration/mcp/test_mcp_journal_recovery.py
+++ b/tests/integration/mcp/test_mcp_journal_recovery.py
@@ -1,0 +1,368 @@
+"""Integration tests for ``fsm.inspect_journal`` and ``fsm.recover_journal``.
+
+These tests spawn a real ``ctxr-fsm mcp`` subprocess via the official MCP
+Python SDK's stdio client transport, then drive the journal-recovery
+tools end-to-end. The fixtures pre-populate the SQLite database with a
+registered spec, an in-flight run, and a journal-txn row in a known
+status BEFORE the server boots, so the tools see realistic state on
+first contact.
+
+Coverage matrix (matches the W4 brief):
+
+* ``fsm.inspect_journal`` returns the newest unfinalised txn for a run
+  when one exists. We seed a ``pending`` txn and confirm the wire
+  payload echoes its id / status / staged_writes.
+* ``fsm.recover_journal`` with ``action="discard"`` deletes the staged
+  ledger row (effective rollback). After the call we re-poll
+  ``inspect_journal`` and confirm the txn is gone.
+* ``fsm.recover_journal`` with ``action="replay"`` finalises a
+  ``ready_to_finalise`` txn (effective roll-forward — W4 only flips
+  the status, the engine on next boot re-materialises the writes).
+  After the call we re-poll ``inspect_journal`` and confirm the txn no
+  longer surfaces (``inspect`` only returns ``pending`` /
+  ``ready_to_finalise`` rows).
+
+MCP client API used
+-------------------
+* ``mcp.ClientSession`` — async high-level client surface.
+* ``mcp.client.stdio.stdio_client`` + ``StdioServerParameters`` —
+  spawn the server as a subprocess and yield the
+  (read_stream, write_stream) pair the ``ClientSession`` consumes.
+* ``ClientSession.initialize()`` — performs the MCP initialize
+  handshake before any tool call.
+* ``ClientSession.call_tool(name, arguments)`` — single tool round-trip;
+  returns a ``CallToolResult`` whose ``structuredContent`` field carries
+  the typed Pydantic payload (FastMCP serialises ``BaseModel`` returns
+  to ``structuredContent`` automatically).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from ctxr.fsm.core.models import FsmSpec, State, Transition
+from ctxr.fsm.sqlite import Project
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+# Generous deadline for a single MCP tool round-trip in this test module.
+# The wall-clock cost is dominated by subprocess spawn + the MCP
+# initialize handshake, not the tool body, so 30s is conservative even
+# on a slow CI runner.
+_TOOL_TIMEOUT_SECONDS: float = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db_path() -> Iterator[Path]:
+    """Yield a per-test SQLite path under a fresh ``TemporaryDirectory``.
+
+    Each test gets its own directory so the journal-row contents one
+    test seeds never bleed into another. The path is returned (not the
+    directory) because the MCP server's ``--db`` option wants a file
+    path; the parent directory is the context-managed handle.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp) / "fsm.sqlite3"
+
+
+@pytest.fixture
+def linear_two_state_spec() -> FsmSpec:
+    """A minimal two-state FSM used to mint runs whose journal we exercise.
+
+    We do not actually drive the FSM through ``commit_outputs`` in these
+    tests — we just need a registered spec so :meth:`Project.start_run`
+    can mint a run row whose ``run_id`` the journal-txn rows hang off.
+    """
+    return FsmSpec(
+        id="journal_recovery_demo",
+        version=1,
+        entry="state_a",
+        states=[
+            State(
+                id="state_a",
+                purpose="entry state",
+                transitions=[Transition(to="state_b", when="always")],
+            ),
+            State(
+                id="state_b",
+                purpose="terminal state",
+                transitions=[],
+            ),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB-priming helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_run(db_path: Path, spec: FsmSpec) -> str:
+    """Register ``spec`` and start a run on a fresh project at ``db_path``.
+
+    Returns the ``run_id`` of the newly-minted run. Opens and closes the
+    Project inline so the SQLite file lock is released before the MCP
+    server subprocess tries to open the same file.
+    """
+    with Project.open(db_path) as project:
+        registered = project.register_spec(spec)
+        run = project.start_run(spec_id=registered.spec.id, args={})
+        return run.id
+
+
+def _seed_pending_txn(db_path: Path, run_id: str) -> str:
+    """Insert a ``pending`` journal txn for ``run_id``; return the txn id.
+
+    Re-opens the project so we get a fresh session-factory; the row is
+    committed via the project's atomic begin() block before the project
+    closes.
+    """
+    with (
+        Project.open(db_path) as project,
+        project.session_factory() as session,
+        session.begin(),
+    ):
+        txn = project.journal.open(session, run_id=run_id)
+        return txn.id
+
+
+def _seed_ready_txn(db_path: Path, run_id: str) -> str:
+    """Insert a ``ready_to_finalise`` journal txn for ``run_id``.
+
+    Walks the lifecycle ``open() → mark_ready()`` so the row is in the
+    state that ``recover_journal action=replay`` will accept.
+    """
+    with (
+        Project.open(db_path) as project,
+        project.session_factory() as session,
+        session.begin(),
+    ):
+        txn = project.journal.open(session, run_id=run_id)
+        project.journal.mark_ready(
+            session,
+            txn_id=txn.id,
+            staged_writes=[{"kind": "demo", "payload": {"ok": True}}],
+        )
+        return txn.id
+
+
+def _read_journal_status(db_path: Path, run_id: str) -> str | None:
+    """Return the current status of the newest unfinalised txn for ``run_id``.
+
+    Returns ``None`` when no unfinalised txn exists — that is the
+    post-discard / post-replay shape we assert against. We re-open the
+    project after the MCP subprocess has shut down so the SQLite file
+    is fully released.
+    """
+    with Project.open(db_path) as project, project.session_factory() as session:
+        txn = project.journal.inspect(session, run_id=run_id)
+    return txn.status if txn is not None else None
+
+
+# ---------------------------------------------------------------------------
+# MCP client helpers
+# ---------------------------------------------------------------------------
+
+
+def _server_params(db_path: Path) -> StdioServerParameters:
+    """Build the stdio-spawn parameters for the ``ctxr-fsm mcp`` subprocess.
+
+    We invoke the server via ``uv run ctxr-fsm mcp --db <path>`` so the
+    project's virtualenv + entry-point script wiring is exercised
+    end-to-end. The CWD is left at the project root (uv resolves the
+    venv from there).
+    """
+    return StdioServerParameters(
+        command="uv",
+        args=["run", "ctxr-fsm", "mcp", "--db", str(db_path)],
+    )
+
+
+async def _call_tool(
+    db_path: Path,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Spawn the MCP server, call one tool, return its ``structuredContent``.
+
+    The whole lifecycle (spawn → initialize → call_tool → shutdown) is
+    bracketed inside one coroutine so the subprocess is fully torn down
+    before the function returns; the SQLite file lock is released by
+    the time the caller inspects the DB directly via
+    :func:`_read_journal_status`.
+
+    FastMCP serialises a ``BaseModel`` return value into the
+    ``structuredContent`` field of the ``CallToolResult``. The SDK
+    wraps non-dict-root return types (and *every* return type when the
+    tool's declared return is a union — e.g. ``JournalState |
+    McpToolError``) inside a ``{"result": ...}`` envelope so the
+    ``structuredContent`` field always carries a JSON object. We unwrap
+    that single-key envelope here so per-test assertions read the
+    Pydantic payload directly without each test re-implementing the
+    unwrap.
+    """
+    async with (
+        stdio_client(_server_params(db_path)) as (read_stream, write_stream),
+        ClientSession(read_stream, write_stream) as session,
+    ):
+        await session.initialize()
+        result = await session.call_tool(tool_name, arguments)
+        # ``isError`` is the SDK's transport-level error flag — a
+        # tool that returned our McpToolError envelope is NOT
+        # transport-error (it still returns a 200-equivalent), so
+        # we only assert here against actual JSON-RPC errors.
+        assert not result.isError, (
+            f"tool {tool_name!r} returned transport error: {result}"
+        )
+        assert result.structuredContent is not None, (
+            f"tool {tool_name!r} returned no structuredContent: {result}"
+        )
+        structured = dict(result.structuredContent)
+        # FastMCP wraps Union-typed returns under a single ``result``
+        # key — peel it off so callers see the raw Pydantic dict.
+        # On the rare tool that returns a bare dict (no wrapper) we
+        # leave it alone.
+        if (
+            list(structured.keys()) == ["result"]
+            and isinstance(structured["result"], dict)
+        ):
+            return dict(structured["result"])
+        return structured
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_journal_returns_pending_txn(
+    tmp_db_path: Path, linear_two_state_spec: FsmSpec
+) -> None:
+    """``fsm.inspect_journal`` surfaces a pre-seeded ``pending`` txn row.
+
+    Flow:
+    1. Pre-populate: register spec, start run, open a journal txn (which
+       is ``pending`` because we never call ``mark_ready``).
+    2. Spawn the MCP server, call ``fsm.inspect_journal`` with the
+       seeded run_id.
+    3. Assert the wire payload echoes the txn id, status, run_id, and
+       carries the empty ``staged_writes`` list.
+    """
+    run_id = _seed_run(tmp_db_path, linear_two_state_spec)
+    txn_id = _seed_pending_txn(tmp_db_path, run_id)
+
+    payload = asyncio.run(
+        asyncio.wait_for(
+            _call_tool(tmp_db_path, "fsm.inspect_journal", {"run_id": run_id}),
+            timeout=_TOOL_TIMEOUT_SECONDS,
+        )
+    )
+
+    # JournalState wire shape: {run_id, txn: {...}}
+    assert payload["run_id"] == run_id, (
+        f"inspect_journal returned wrong run_id: {payload}"
+    )
+    txn = payload["txn"]
+    assert txn is not None, (
+        f"inspect_journal returned txn=None despite seeded pending row: {payload}"
+    )
+    assert txn["id"] == txn_id, (
+        f"inspect_journal returned wrong txn_id: {txn}"
+    )
+    assert txn["run_id"] == run_id
+    assert txn["status"] == "pending"
+    # Freshly-opened pending txns carry an empty staged_writes list
+    # (canonical "[]") — assert that to lock the shape in.
+    assert txn["staged_writes"] == []
+
+
+def test_recover_journal_discard_removes_pending_txn(
+    tmp_db_path: Path, linear_two_state_spec: FsmSpec
+) -> None:
+    """``fsm.recover_journal action=discard`` deletes a ``pending`` row.
+
+    Flow:
+    1. Pre-populate: seed a ``pending`` txn against a fresh run.
+    2. Call ``fsm.recover_journal`` with ``action="discard"``.
+    3. Assert the wire payload reports ``action=discard``, echoes the
+       txn id, and notes the previous status was ``pending``.
+    4. Re-open the SQLite DB out-of-band and confirm the row is gone
+       (``journal.inspect`` returns ``None`` for this run).
+    """
+    run_id = _seed_run(tmp_db_path, linear_two_state_spec)
+    txn_id = _seed_pending_txn(tmp_db_path, run_id)
+
+    payload = asyncio.run(
+        asyncio.wait_for(
+            _call_tool(
+                tmp_db_path,
+                "fsm.recover_journal",
+                {"run_id": run_id, "action": "discard"},
+            ),
+            timeout=_TOOL_TIMEOUT_SECONDS,
+        )
+    )
+
+    assert payload["run_id"] == run_id
+    assert payload["action"] == "discard"
+    assert payload["txn_id"] == txn_id
+    assert payload["previous_status"] == "pending"
+
+    # Out-of-band verification: the row is gone, so inspect() returns
+    # None on a fresh project handle.
+    assert _read_journal_status(tmp_db_path, run_id) is None
+
+
+def test_recover_journal_replay_finalises_ready_txn(
+    tmp_db_path: Path, linear_two_state_spec: FsmSpec
+) -> None:
+    """``fsm.recover_journal action=replay`` finalises a ``ready_to_finalise`` row.
+
+    Flow:
+    1. Pre-populate: open a journal txn AND ``mark_ready`` it so the
+       row carries staged_writes and status ``ready_to_finalise``.
+    2. Call ``fsm.recover_journal`` with ``action="replay"``.
+    3. Assert the wire payload reports the replay action, echoes the
+       txn id, and notes the previous status was ``ready_to_finalise``.
+    4. Re-open the SQLite DB out-of-band and confirm ``inspect`` no
+       longer surfaces the row (it's now ``finalised``, which is
+       outside ``inspect``'s ``(pending, ready_to_finalise)`` filter).
+    """
+    run_id = _seed_run(tmp_db_path, linear_two_state_spec)
+    txn_id = _seed_ready_txn(tmp_db_path, run_id)
+
+    payload = asyncio.run(
+        asyncio.wait_for(
+            _call_tool(
+                tmp_db_path,
+                "fsm.recover_journal",
+                {"run_id": run_id, "action": "replay"},
+            ),
+            timeout=_TOOL_TIMEOUT_SECONDS,
+        )
+    )
+
+    assert payload["run_id"] == run_id
+    assert payload["action"] == "replay"
+    assert payload["txn_id"] == txn_id
+    assert payload["previous_status"] == "ready_to_finalise"
+
+    # The row is now ``finalised``, which falls outside the
+    # ``inspect`` filter, so a re-poll returns None.
+    assert _read_journal_status(tmp_db_path, run_id) is None

--- a/tests/integration/mcp/test_mcp_observe_tool_call.py
+++ b/tests/integration/mcp/test_mcp_observe_tool_call.py
@@ -1,0 +1,365 @@
+"""Integration test: ``fsm.observe_tool_call`` over the real MCP stdio transport.
+
+This test exercises the W4 plumbing for layer-7 drift observation
+end-to-end:
+
+1.  We spawn ``ctxr-fsm mcp --db <tmp>`` as a child process using the
+    official ``mcp`` Python SDK's stdio client. That is the canonical
+    MCP framing — exactly what Claude Code itself speaks — so the test
+    confirms the JSON-RPC handshake, FastMCP registration, and tool
+    dispatch all line up against a fresh database.
+
+2.  We call ``fsm.observe_tool_call`` once with a representative
+    payload (producer kind/name, tool name, redacted args, success
+    flag, optional run id) and assert that the structured response
+    carries both the inserted ``tool_calls.id`` and the emitted
+    ``tool_call_observed`` event id.
+
+3.  We then open a *separate* ``Project`` against the same SQLite file
+    (after the server has fully shut down via the stdio context
+    manager) and verify both rows are present and correlated:
+
+    * the ``tool_calls`` row exists, carries the expected tool name,
+      the redacted args, and the success flag we sent;
+    * the corresponding ``tool_call_observed`` event exists on the
+      bus and references the same ``tool_call_id`` in its payload.
+
+The ``observe_tool_call`` tool body wraps both writes in a single
+``Session.begin()`` block, so the presence of both rows is the
+observable proof that the txn was atomic — a partial commit would
+leave one row missing and the assertions would trip.
+
+MCP client API used
+-------------------
+``mcp.ClientSession`` driven over ``mcp.client.stdio.stdio_client``
+(version 1.27.2 of the ``mcp`` SDK). The same pattern is the one the
+Anthropic ``mcp`` README documents for stdio clients; we adopt it
+verbatim so future tests can copy the boilerplate.
+
+Performance note
+----------------
+A single round-trip through the spawned server (process start +
+``initialize`` handshake + tool call + clean shutdown) lands in the
+5-15 second range on a modern dev laptop. Keep that in mind before adding
+many of these — prefer in-process unit tests for tool-body coverage
+and reserve the integration tests for wire-protocol confirmations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+from ctxr.fsm.core.models import EventKind
+from ctxr.fsm.sqlite import Project
+from ctxr.fsm.sqlite.models_enforcement import ToolCallTable
+from ctxr.fsm.sqlite.models_events import EventTable
+
+# ---------------------------------------------------------------------------
+# Wire-protocol constants
+# ---------------------------------------------------------------------------
+
+# The tool name registered by ``ctxr.fsm.mcp.tools_meta.fsm_observe_tool_call``
+# (see the ``@mcp.tool(name=...)`` decorator). Pinning it as a constant keeps
+# the wire contract grep-able from the test alone.
+_OBSERVE_TOOL_NAME: str = "fsm.observe_tool_call"
+
+# Cap how long any single MCP round-trip is allowed to wait before the test
+# is considered hung. Generous on purpose — the subprocess spawn plus the
+# initialize handshake can take a few seconds on a cold cache.
+_ROUND_TRIP_TIMEOUT_SECONDS: float = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Subprocess + client driver
+# ---------------------------------------------------------------------------
+
+
+async def _drive_mcp_session(
+    db_path: Path,
+    body: Callable[[ClientSession], Awaitable[Any]],
+) -> Any:
+    """Spawn the MCP server, hand a live ``ClientSession`` to ``body``.
+
+    The body coroutine receives an *initialized* session (the MCP
+    handshake has already completed) and returns whatever the test
+    cares to assert on. We pin ``--db`` to a per-test temp file so the
+    server boots against an empty database — no cross-test state.
+
+    We deliberately use ``uv run ctxr-fsm`` rather than invoking the
+    script directly so the test inherits the same Python env / package
+    resolution rules the dev loop uses; ``uv`` re-uses the existing
+    ``.venv`` (no fresh install) so the spawn cost stays bounded.
+    """
+    params = StdioServerParameters(
+        command="uv",
+        args=["run", "ctxr-fsm", "mcp", "--db", str(db_path)],
+    )
+
+    async with (
+        stdio_client(params) as (read_stream, write_stream),
+        ClientSession(read_stream, write_stream) as session,
+    ):
+        # The handshake is mandatory before any tool call — skipping
+        # it would surface as a protocol-violation error on the
+        # very first ``call_tool`` invocation.
+        await session.initialize()
+        return await body(session)
+
+
+def _structured_payload(call_result: Any) -> dict[str, Any]:
+    """Extract the structured tool output from an MCP ``CallToolResult``.
+
+    FastMCP wraps a typed Pydantic return into ``structuredContent`` on
+    the SDK side. For tools whose return type is a ``Union[Model,
+    McpToolError]`` (every ``fsm.*`` tool here), FastMCP further wraps
+    the payload under a synthetic ``"result"`` key — that is the
+    Pydantic adapter discriminator. We unwrap it transparently so the
+    test reads the actual model fields without an extra layer.
+
+    We branch defensively because the SDK has historically also
+    serialised the same payload into the first ``content[0]``
+    ``TextContent`` block as JSON — falling back to that path keeps the
+    test robust against minor SDK revisions without losing coverage.
+    """
+
+    def _unwrap_result(d: dict[str, Any]) -> dict[str, Any]:
+        # FastMCP wraps non-BaseModel / Union returns in {"result": ...}.
+        # If we see a single "result" key whose value is itself a dict,
+        # treat that as the canonical payload.
+        if list(d.keys()) == ["result"] and isinstance(d["result"], dict):
+            return d["result"]
+        return d
+
+    structured = getattr(call_result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return _unwrap_result(structured)
+
+    # Fallback: parse the first text content block as JSON. The SDK
+    # always emits at least one content block for a successful call.
+    content = getattr(call_result, "content", None)
+    if content:
+        first = content[0]
+        text = getattr(first, "text", None)
+        if isinstance(text, str):
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise AssertionError(
+                    f"could not parse tool response text as JSON: {text!r}"
+                ) from exc
+            if isinstance(parsed, dict):
+                return _unwrap_result(parsed)
+    raise AssertionError(
+        "MCP tool result carried neither structuredContent nor a JSON text block"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_observe_tool_call_writes_row_and_event_atomically() -> None:
+    """One ``fsm.observe_tool_call`` writes both a tool_calls row and an event.
+
+    The test asserts the full chain end-to-end:
+
+    * the MCP server can be spawned, handshaked, and the tool dispatched;
+    * the tool returns a structured success payload with the two row ids
+      the W4 contract promises (``tool_call_id``, ``event_id``);
+    * after the server shuts down, inspecting the SQLite file confirms
+      both rows are present, correlated by id, and carry the data the
+      tool was called with. The atomicity of the txn is observable by
+      the fact that neither row can exist without the other on the
+      happy path — both must be there.
+    """
+    tool_name: str = "Bash"  # representative non-fsm.* tool the agent might run
+    args_redacted: dict[str, Any] = {"command": "<redacted>", "cwd": "/tmp"}
+    producer_kind: str = "agent"
+    producer_name: str = "test-agent"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.sqlite3"
+
+        async def _body(session: ClientSession) -> dict[str, Any]:
+            # Pre-flight sanity: the tool must actually be registered.
+            # If the FastMCP decorator name ever drifts, this assertion
+            # surfaces the mismatch with a clear error instead of a
+            # mysterious "unknown tool" failure on the call below.
+            tools_resp = await session.list_tools()
+            registered_names = {tool.name for tool in tools_resp.tools}
+            assert _OBSERVE_TOOL_NAME in registered_names, (
+                f"{_OBSERVE_TOOL_NAME!r} not in registered tools "
+                f"{sorted(registered_names)!r}"
+            )
+
+            call_result = await session.call_tool(
+                _OBSERVE_TOOL_NAME,
+                arguments={
+                    "producer_kind": producer_kind,
+                    "producer_name": producer_name,
+                    "tool_name": tool_name,
+                    "args_redacted": args_redacted,
+                    "succeeded": True,
+                    # run_id intentionally omitted — observation is allowed
+                    # to be "run-less" per the tool's contract.
+                },
+            )
+            assert call_result.isError is False, (
+                f"tool call surfaced as an error: {call_result!r}"
+            )
+            return _structured_payload(call_result)
+
+        # asyncio.run owns the loop lifetime for the whole subprocess
+        # exchange; once it returns, stdio_client has already torn down
+        # the child process and the SQLite file is unlocked so a fresh
+        # Project can open it for verification.
+        payload = asyncio.run(
+            asyncio.wait_for(
+                _drive_mcp_session(db_path, _body),
+                timeout=_ROUND_TRIP_TIMEOUT_SECONDS,
+            )
+        )
+
+        # ── Assertions on the tool's structured response ────────────
+        assert payload.get("recorded") is True, payload
+        tool_call_id = payload.get("tool_call_id")
+        event_id = payload.get("event_id")
+        producer_id = payload.get("producer_id")
+        assert isinstance(tool_call_id, str) and tool_call_id, payload
+        assert isinstance(event_id, str) and event_id, payload
+        assert isinstance(producer_id, str) and producer_id, payload
+
+        # ── Assertions on the persisted side-effects ────────────────
+        # Open the same DB the server wrote to; ``migrate=False`` is
+        # fine here because the server already ran the head migration
+        # when it booted.
+        with Project.open(db_path, migrate=False) as project:
+            with project.session_factory() as session:
+                tool_call_row = session.get(ToolCallTable, tool_call_id)
+                event_row = session.get(EventTable, event_id)
+
+            # The tool_calls row must exist and carry exactly what
+            # the tool was called with.
+            assert tool_call_row is not None, (
+                f"no tool_calls row found for id {tool_call_id!r}"
+            )
+            assert tool_call_row.tool_name == tool_name
+            assert tool_call_row.succeeded is True
+            assert tool_call_row.producer_id == producer_id
+            # ``args_redacted_json`` is the canonical JSON of whatever
+            # was sent; round-trip and compare structurally rather than
+            # by raw string so a future canonical-JSON tweak (key
+            # sorting, whitespace) does not break the assertion.
+            persisted_args = json.loads(tool_call_row.args_redacted_json)
+            assert persisted_args == args_redacted
+
+            # The matching event must exist on the bus and reference
+            # the same tool_call_id in its payload — that is the link
+            # the W12 drift aggregator will follow.
+            assert event_row is not None, (
+                f"no events row found for id {event_id!r}"
+            )
+            assert event_row.kind == EventKind.tool_call_observed.value
+            assert event_row.producer_id == producer_id
+            event_payload = json.loads(event_row.payload_json)
+            assert event_payload.get("tool_call_id") == tool_call_id
+            assert event_payload.get("tool_name") == tool_name
+            assert event_payload.get("producer_kind") == producer_kind
+            assert event_payload.get("producer_name") == producer_name
+            assert event_payload.get("succeeded") is True
+            assert event_payload.get("args_redacted") == args_redacted
+
+
+def test_observe_tool_call_with_run_id_persists_link() -> None:
+    """A run-scoped observation lands on ``tool_calls.run_id`` and ``events.run_id``.
+
+    The contract explicitly allows ``run_id`` to be omitted (covered by
+    the first test) *or* supplied as a UUID; this test exercises the
+    second arm and confirms the run linkage is persisted on both sides
+    of the atomic write. Drift detection (W12) reads ``run_id`` to
+    scope its queries to a single run, so the linkage is the only
+    thing that makes the observation usable in practice.
+    """
+    from ctxr.fsm.core.models import FsmSpec, State
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.sqlite3"
+
+        # We need a real run id to attach the observation to. The
+        # simplest path is to open the project in-process, register a
+        # tiny spec, and start a run — then close the project (release
+        # the file lock) before the MCP server boots against the same
+        # file.
+        with Project.open(db_path) as project:
+            spec = FsmSpec(
+                id="observe_demo",
+                version=1,
+                entry="only",
+                states=[State(id="only", purpose="single", transitions=[])],
+            )
+            registered = project.register_spec(spec)
+            run = project.start_run(registered.spec.id, args={})
+            run_id = run.id
+
+        async def _body(session: ClientSession) -> dict[str, Any]:
+            call_result = await session.call_tool(
+                _OBSERVE_TOOL_NAME,
+                arguments={
+                    "producer_kind": "agent",
+                    "producer_name": "run-scoped",
+                    "tool_name": "Edit",
+                    "args_redacted": {"path": "<redacted>"},
+                    "succeeded": False,
+                    "run_id": run_id,
+                },
+            )
+            assert call_result.isError is False, (
+                f"tool call surfaced as an error: {call_result!r}"
+            )
+            return _structured_payload(call_result)
+
+        payload = asyncio.run(
+            asyncio.wait_for(
+                _drive_mcp_session(db_path, _body),
+                timeout=_ROUND_TRIP_TIMEOUT_SECONDS,
+            )
+        )
+
+        tool_call_id = payload["tool_call_id"]
+        event_id = payload["event_id"]
+
+        with Project.open(db_path, migrate=False) as project:
+            with project.session_factory() as session:
+                tool_call_row = session.get(ToolCallTable, tool_call_id)
+                event_row = session.get(EventTable, event_id)
+
+            assert tool_call_row is not None
+            assert tool_call_row.run_id == run_id
+            assert tool_call_row.succeeded is False
+
+            assert event_row is not None
+            assert event_row.run_id == run_id
+            assert event_row.kind == EventKind.tool_call_observed.value
+            event_payload = json.loads(event_row.payload_json)
+            assert event_payload.get("succeeded") is False
+
+
+# Guard rail: pytest-asyncio is a project dev-dep but we drive asyncio.run
+# ourselves rather than mark these tests with ``@pytest.mark.asyncio``.
+# This sentinel test is here as a paper trail so a future contributor who
+# tries to convert the file to async-style fixtures knows the conscious
+# choice was made (asyncio.run keeps the lifetime of the spawned subprocess
+# bounded to a single scope, simplifying cleanup).
+def test_intentional_asyncio_run_strategy_documented() -> None:
+    """Sentinel: confirm pytest is wired and the file imports cleanly."""
+    assert pytest.__name__ == "pytest"

--- a/tests/integration/mcp/test_mcp_start_brief_commit.py
+++ b/tests/integration/mcp/test_mcp_start_brief_commit.py
@@ -1,0 +1,364 @@
+"""End-to-end MCP integration test: register_spec → start_run → commit_outputs → terminal.
+
+This test spawns the real ``ctxr-fsm mcp`` binary as a subprocess and
+drives it through the official ``mcp`` Python SDK's stdio client. The
+goal is to confirm the JSON-RPC framing, FastMCP tool registration, and
+stdio plumbing all line up end-to-end for the W4 happy path:
+
+1. Register a small two-state FSM spec via ``fsm.register_spec``.
+2. Start a run via ``fsm.start_run`` — get back ``run_id`` + the brief
+   for the entry state.
+3. Commit outputs for the entry state via ``fsm.commit_outputs`` —
+   expect ``kind="advanced"`` with the next state's brief embedded.
+4. Commit outputs for the terminal state — expect ``kind="terminal"``.
+5. Read the final picture via ``fsm.get_run`` and assert the
+   ``state_tree`` mirrors the linear walk (root ``state_a`` → child
+   ``state_b``) and the run is ``completed``.
+
+The whole flow drives two states to terminal so the substrate's
+``advanced`` and ``terminal`` branches of the commit result discriminator
+are both exercised in one run.
+
+MCP client API used
+-------------------
+
+``mcp`` 1.27.2 — ``ClientSession`` + ``stdio_client`` +
+``StdioServerParameters``. ``call_tool`` returns a ``CallToolResult``
+whose ``structuredContent`` field carries the Pydantic-typed payload
+returned by each tool body. FastMCP wraps non-dict Pydantic return
+values under a top-level ``"result"`` key on the wire; the
+:func:`_unwrap` helper below normalises both shapes so the rest of the
+test reads the same way whether or not the wrapping happened.
+
+Stdio framing means logs the server prints to stderr are invisible to
+the client; the smoke check at the top of the test confirms the
+``initialize`` handshake completes (i.e. stdout was clean JSON-RPC).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+# ---------------------------------------------------------------------------
+# Fixture spec
+# ---------------------------------------------------------------------------
+
+
+# A deliberately tiny two-state linear FSM:
+#
+#   state_a (entry, ``always`` → state_b)
+#     → state_b (no transitions == terminal)
+#
+# We use ``"always"`` guards so the predicate evaluator is not in the
+# picture — this test is about the MCP wire surface, not transition
+# semantics. The shape is intentionally identical to what
+# ``fsm.register_spec``'s ``definition_json`` argument expects after
+# ``json.dumps``: the same JSON FsmSpec.model_validate_json parses
+# in-process.
+_FIXTURE_SPEC: dict[str, Any] = {
+    "id": "mcp_demo_two_state",
+    "version": 1,
+    "entry": "state_a",
+    "states": [
+        {
+            "id": "state_a",
+            "purpose": "entry state for the MCP integration test",
+            "transitions": [{"to": "state_b", "when": "always"}],
+        },
+        {
+            "id": "state_b",
+            "purpose": "terminal state for the MCP integration test",
+            "transitions": [],
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unwrap(structured: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the tool payload, peeling FastMCP's ``{"result": ...}`` wrapper.
+
+    FastMCP serialises a Pydantic return value by dumping it under a
+    top-level ``"result"`` key when the type is a non-dict model;
+    ``dict``-typed returns land flat. We accept either shape so the
+    rest of the test does not have to special-case the wrapping.
+    """
+    assert structured is not None, "tool returned no structuredContent"
+    if list(structured.keys()) == ["result"] and isinstance(structured["result"], dict):
+        return structured["result"]
+    return structured
+
+
+@asynccontextmanager
+async def _mcp_session(db_path: Path) -> AsyncIterator[ClientSession]:
+    """Spawn ``ctxr-fsm mcp`` as a subprocess and yield an initialised session.
+
+    The subprocess is launched via ``uv run`` so the test inherits the
+    same dependency resolution as ``cd <repo> && uv run pytest`` — no
+    activation-side dependency on the developer's current
+    ``VIRTUAL_ENV``. ``cwd`` is pinned to the repo root so ``uv``
+    discovers the right project regardless of where pytest is invoked
+    from.
+
+    The double async-with (``stdio_client`` then ``ClientSession``) is
+    the canonical pattern from the SDK: the outer manager owns the
+    transport streams, the inner manager owns the session lifecycle
+    (initialize on entry, shutdown on exit).
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    params = StdioServerParameters(
+        command="uv",
+        args=[
+            "run",
+            "--project",
+            str(repo_root),
+            "ctxr-fsm",
+            "mcp",
+            "--db",
+            str(db_path),
+        ],
+    )
+    async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
+        await session.initialize()
+        yield session
+
+
+async def _drive_two_state_run_to_terminal(db_path: Path) -> dict[str, Any]:
+    """Run the full register -> start -> commit x2 -> get_run flow.
+
+    Returns a dict bundling the intermediate payloads so the synchronous
+    test function can make assertions against each step without needing
+    to be async itself.
+    """
+    async with _mcp_session(db_path) as session:
+        # --- 1. Register the fixture spec ---------------------------------
+        register_resp = await session.call_tool(
+            "fsm.register_spec",
+            {
+                "definition_json": json.dumps(_FIXTURE_SPEC),
+                "project_slug": "mcp_integration_demo",
+            },
+        )
+        assert register_resp.isError is False, (
+            f"fsm.register_spec returned an error: {register_resp}"
+        )
+        register = _unwrap(register_resp.structuredContent)
+
+        # --- 2. Start a run -----------------------------------------------
+        start_resp = await session.call_tool(
+            "fsm.start_run",
+            {
+                "input": {
+                    "spec_id": register["spec_id"],
+                    "args": {"seed": "mcp-integration"},
+                }
+            },
+        )
+        assert start_resp.isError is False, (
+            f"fsm.start_run returned an error: {start_resp}"
+        )
+        start = _unwrap(start_resp.structuredContent)
+
+        # --- 3. Commit outputs for state_a (expect advanced) --------------
+        first_commit_resp = await session.call_tool(
+            "fsm.commit_outputs",
+            {
+                "input": {
+                    "run_id": start["run_id"],
+                    "outputs": {"hello": "world"},
+                }
+            },
+        )
+        assert first_commit_resp.isError is False, (
+            f"fsm.commit_outputs (first) returned an error: {first_commit_resp}"
+        )
+        first_commit = _unwrap(first_commit_resp.structuredContent)
+
+        # --- 4. Commit outputs for state_b (expect terminal) --------------
+        second_commit_resp = await session.call_tool(
+            "fsm.commit_outputs",
+            {
+                "input": {
+                    "run_id": start["run_id"],
+                    "outputs": {"verdict": "ok"},
+                }
+            },
+        )
+        assert second_commit_resp.isError is False, (
+            f"fsm.commit_outputs (second) returned an error: {second_commit_resp}"
+        )
+        second_commit = _unwrap(second_commit_resp.structuredContent)
+
+        # --- 5. Read the final picture for state_tree assertions ----------
+        detail_resp = await session.call_tool(
+            "fsm.get_run",
+            {"input": {"run_id": start["run_id"]}},
+        )
+        assert detail_resp.isError is False, (
+            f"fsm.get_run returned an error: {detail_resp}"
+        )
+        detail = _unwrap(detail_resp.structuredContent)
+
+        return {
+            "register": register,
+            "start": start,
+            "first_commit": first_commit,
+            "second_commit": second_commit,
+            "detail": detail,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_start_brief_commit_drives_two_states_to_terminal() -> None:
+    """End-to-end MCP happy path: register, start, commit twice, inspect.
+
+    Exercises every contract from the brief in one subprocess:
+
+    * ``fsm.register_spec`` returns a created row with the right slug,
+      version, and a stable hash.
+    * ``fsm.start_run`` returns a ``run_id`` plus the brief for the
+      entry state.
+    * ``fsm.commit_outputs`` (first call) returns ``kind="advanced"``
+      with the next brief embedded.
+    * ``fsm.commit_outputs`` (second call) returns ``kind="terminal"``.
+    * ``fsm.get_run``'s ``state_tree`` reflects the linear walk
+      ``state_a → state_b``.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        result = asyncio.run(_drive_two_state_run_to_terminal(db_path))
+
+    register = result["register"]
+    start = result["start"]
+    first_commit = result["first_commit"]
+    second_commit = result["second_commit"]
+    detail = result["detail"]
+
+    # --- register_spec --------------------------------------------------
+    assert register["created"] is True, "first registration should mint a row"
+    assert register["slug"] == _FIXTURE_SPEC["id"]
+    assert register["version"] == 1
+    assert register["project_slug"] == "mcp_integration_demo"
+    # ``hash`` is the SHA-256 canonical hash — 64 hex chars.
+    assert isinstance(register["hash"], str)
+    assert len(register["hash"]) == 64
+    # ``spec_id`` is a UUIDv7 string; we only check it's non-empty and
+    # the right length, not the timestamp embedded in it.
+    assert isinstance(register["spec_id"], str)
+    assert len(register["spec_id"]) == 36
+
+    # --- start_run ------------------------------------------------------
+    assert isinstance(start["run_id"], str)
+    assert len(start["run_id"]) == 36
+    assert start["fsm_spec_hash"] == register["hash"]
+    brief = start["brief"]
+    assert brief["state"] == "state_a"
+    assert brief["fsm_id"] == _FIXTURE_SPEC["id"]
+    # The entry state declares no worker so the brief carries an empty
+    # outputs_expected list and the ``has_worker`` flag is False.
+    assert brief["has_worker"] is False
+    assert brief["has_loop"] is False
+    # Transitions on the brief should match the spec: a single
+    # always-guard transition to state_b.
+    assert len(brief["transitions"]) == 1
+    assert brief["transitions"][0]["to"] == "state_b"
+
+    # --- first commit: advanced ----------------------------------------
+    assert first_commit["kind"] == "advanced", (
+        f"expected advanced after committing state_a, got {first_commit!r}"
+    )
+    assert first_commit["next_state"] == "state_b"
+    assert first_commit["brief"] is not None
+    assert first_commit["brief"]["state"] == "state_b"
+    # The winning transition evaluation should be the ``always`` guard
+    # we declared on state_a.
+    evaluations = first_commit.get("evaluations") or []
+    assert any(
+        ev["to"] == "state_b" and ev["result"] is True for ev in evaluations
+    ), f"expected an `always→state_b` evaluation in {evaluations!r}"
+
+    # --- second commit: terminal ---------------------------------------
+    assert second_commit["kind"] == "terminal", (
+        f"expected terminal after committing state_b, got {second_commit!r}"
+    )
+    # The ``verdict`` key was passed in the outputs of the terminal
+    # commit and the engine surfaces it on the result.
+    assert second_commit.get("verdict") == "ok"
+
+    # --- get_run: manifest + state_tree --------------------------------
+    manifest = detail["manifest"]
+    assert manifest["status"] == "completed"
+    assert manifest["current_state"] == "state_b"
+    assert manifest["verdict"] == "ok"
+    assert manifest["fsm_spec_id"] == register["spec_id"]
+
+    tree = detail["state_tree"]
+    assert tree is not None, "state_tree must be present once the run is committed"
+    # Root of the tree is the entry state.
+    assert tree["state_id"] == "state_a"
+    assert tree["entry_seq"] == 1
+    assert tree["status"] == "exited"
+    # The entry state's outputs should reflect what we committed.
+    assert tree["outputs"] == {"hello": "world"}
+
+    # Exactly one child: state_b.
+    assert len(tree["children"]) == 1, (
+        f"expected a single child on state_a, got {tree['children']!r}"
+    )
+    child = tree["children"][0]
+    assert child["state_id"] == "state_b"
+    assert child["entry_seq"] == 2
+    assert child["status"] == "exited"
+    assert child["outputs"] == {"verdict": "ok"}
+    assert child["children"] == [], (
+        f"state_b is terminal — expected no children, got {child['children']!r}"
+    )
+
+    # The recent-events tail returned by fsm.get_run must include the
+    # canonical lifecycle events: start, two state_entered/state_exited
+    # pairs, a transition_taken, and a run_completed. We assert by kind
+    # rather than exact count so the test is robust to future event
+    # types being added by the substrate.
+    event_kinds = [event["kind"] for event in detail["events"]]
+    required = {
+        "run_started",
+        "state_entered",
+        "state_exited",
+        "transition_taken",
+        "run_completed",
+    }
+    assert required.issubset(set(event_kinds)), (
+        f"missing required event kinds: {sorted(required - set(event_kinds))!r}; "
+        f"observed kinds={event_kinds!r}"
+    )
+
+    # Journal must be empty — every commit finalised its transactions.
+    assert detail["journal"] is None, (
+        f"journal was not cleared on a clean run: {detail['journal']!r}"
+    )
+
+
+# A pytest marker that surfaces clearly when someone runs ``pytest -m
+# integration`` to scope to integration tests. Registering the marker
+# in ``pyproject.toml`` would silence the ``unknown marker`` warning;
+# until that lands we apply it here so the test still works under
+# ``--strict-markers`` with an inline filter.
+pytestmark = pytest.mark.filterwarnings("ignore::pytest.PytestUnknownMarkWarning")

--- a/tests/integration/mcp/test_mcp_subscribe_events.py
+++ b/tests/integration/mcp/test_mcp_subscribe_events.py
@@ -1,0 +1,501 @@
+"""Integration test: ``fsm.subscribe_events`` over the real MCP stdio transport.
+
+This test spawns ``ctxr-fsm mcp`` as a subprocess against a freshly
+migrated per-test SQLite database, drives it through the official
+``mcp`` Python SDK's stdio client, and asserts the two contracts the
+W4 brief calls out for the subscribe-events tool:
+
+1. A pre-populated run + event log delivered through a brand-new
+   consumer name returns the matching events (filtered by ``kinds``).
+2. A *second* call from the same consumer name returns only the
+   *new* events emitted after the first call — the per-consumer
+   cursor is advanced by the ack performed inside the tool body, so
+   the same name effectively resumes where it left off.
+
+Why a subprocess?
+-----------------
+
+The whole point of the MCP layer is the JSON-RPC framing over stdio.
+Exercising the tools in-process would skip that framing entirely;
+a subprocess + the SDK's :func:`stdio_client` is the only way to get
+production-equivalent coverage of the boot path (database open,
+project bind, logger pinning, FastMCP registration, decorator side
+effects, tool dispatch).
+
+Performance note
+----------------
+
+Spawning ``uv run ctxr-fsm mcp`` + completing the MCP initialize
+handshake takes a few seconds per test. The brief calls these tests
+"slower (5-15s per test)". We minimise the per-test cost by
+**pre-populating the DB on the main thread** (synchronous, in-process
+SQLite) and only starting the subprocess once that is done — the
+subprocess then only has to handle two tool calls before being torn
+down.
+
+MCP client API used
+-------------------
+
+* :class:`mcp.ClientSession` — the high-level wrapper that owns the
+  initialize handshake and ``call_tool`` dispatch.
+* :class:`mcp.client.stdio.StdioServerParameters` — declarative spec
+  for the subprocess (``command="uv"``, ``args=["run", "ctxr-fsm",
+  "mcp", "--db", str(tmp_db)]``).
+* :func:`mcp.client.stdio.stdio_client` — async context manager
+  yielding the ``(read, write)`` stream pair that
+  :class:`ClientSession` is constructed against.
+
+Tool results come back as :class:`mcp.types.CallToolResult` with
+``structuredContent`` populated (FastMCP wraps the Pydantic return
+value automatically). For tools whose return annotation is a
+``Union[A, B]`` (as ``fsm.subscribe_events`` is —
+``EventBatch | McpToolError``), FastMCP wraps the payload under a
+``"result"`` key so the JSON-Schema output contract can describe both
+arms. We branch on ``structuredContent["result"]`` rather than parsing
+the text content blocks because the structured payload is the
+documented machine contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+from ctxr.fsm.core.models import EventKind, FsmSpec, State, Transition
+from ctxr.fsm.sqlite import Project
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+# Generous client-side timeouts. The MCP stdio handshake on a cold
+# ``uv run`` typically completes within a couple of seconds on this
+# project's CI image; the higher ceiling absorbs the slower local
+# Rancher-on-macOS path without flake.
+_INIT_TIMEOUT_SECONDS: float = 30.0
+_CALL_TIMEOUT_SECONDS: float = 30.0
+
+
+# Consumer durable identity used by both calls in the test. Re-using
+# the same name is exactly how the cursor is resumed: the second call
+# refreshes the consumer in place and pulls only the deliveries that
+# became ``pending`` after the first call ack'd everything it had.
+_CONSUMER_NAME: str = "t1"
+
+
+# The subset of event kinds the subscriber filters on. Keeping it
+# narrow makes the assertions tight: we will emit a mix of kinds and
+# verify only ``state_entered`` / ``state_exited`` rows come back.
+_KINDS_FILTER: list[str] = [
+    EventKind.state_entered.value,
+    EventKind.state_exited.value,
+]
+
+
+# A short timeout for ``fsm.subscribe_events`` itself so an empty
+# batch returns quickly. The tool's contract allows up to 60s; 2s is
+# more than enough for the test's "did we get the new events?" probe.
+_SUBSCRIBE_TIMEOUT_SECONDS: float = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Pre-population helpers (run inside the test, before the subprocess boots)
+# ---------------------------------------------------------------------------
+
+
+def _build_two_state_spec() -> FsmSpec:
+    """Return a tiny two-state FSM spec used for pre-population.
+
+    Linear ``state_a`` → ``state_b``. We do not actually *drive* the
+    engine — we only need a registered spec + a run row so the events
+    we emit by hand have a valid ``run_id`` foreign key.
+    """
+    return FsmSpec(
+        id="subscribe_events_demo",
+        version=1,
+        entry="state_a",
+        states=[
+            State(
+                id="state_a",
+                purpose="entry state",
+                transitions=[Transition(to="state_b", when="always")],
+            ),
+            State(
+                id="state_b",
+                purpose="terminal state",
+                transitions=[],
+            ),
+        ],
+    )
+
+
+def _prepopulate_database(db_path: Path) -> str:
+    """Migrate the DB, register a spec, start a run, register consumer ``t1``,
+    and emit a mix of events.
+
+    Returns the ``run_id`` so the test can correlate the delivered
+    events back to the run it created.
+
+    Why register the consumer *before* emitting events?
+    --------------------------------------------------
+    ``EventsRepo.emit`` performs the fan-out *at emit time* — it
+    inserts one ``EventDeliveryTable`` row per matching consumer.
+    Consumers that register *after* an event is emitted never see it
+    because no delivery row exists for them. This is the bus's
+    documented at-least-once contract.
+
+    Pre-registering ``t1`` here means the subscribe-events tool's
+    own idempotent re-registration on first call is a no-op on the
+    delivery rows (it only updates the filter columns), so every
+    event we emit below is already queued for ``t1`` when the
+    subprocess wakes up.
+
+    A mix of kinds is emitted so the ``kinds=[state_entered,
+    state_exited]`` filter can prove it actually filters:
+
+    * ``state_entered`` x 2 (state_a entry, state_b entry) — matched
+    * ``state_exited``  x 1 (state_a exit)                — matched
+    * ``transition_taken`` x 1                            — filtered out
+
+    Plus the ``run_started`` event ``Project.start_run`` emits
+    automatically — also filtered out because its kind is not in the
+    list.
+    """
+    with Project.open(db_path, migrate=True) as project:
+        registered = project.register_spec(_build_two_state_spec())
+        spec_id = registered.spec.id
+
+        run = project.start_run(spec_id, args={"prepopulated": True})
+        run_id = run.id
+
+        # The runtime producer is upserted by ``start_run``; fetch its
+        # id so the hand-emitted events below share the same producer
+        # identity as the automatic ``run_started`` event. This matches
+        # what a real engine would do — every state-level emit is
+        # attributed to the same runtime producer.
+        with project.session_factory() as session, session.begin():
+            producer = project.producers.upsert(
+                session,
+                kind="engine",
+                name="fsm.runtime",
+            )
+            producer_id = producer.id
+
+            # Register the consumer with the same filter the subscribe
+            # call will use later. This is the critical step: the
+            # delivery rows for the events emitted below are created
+            # *at emit time* against this consumer, so the subprocess
+            # only has to pull-and-ack them — not wait for new emits.
+            project.consumers.register(
+                session,
+                kind="mcp_subscriber",
+                name=_CONSUMER_NAME,
+                filter_kind=_KINDS_FILTER,
+                filter_run_id=run_id,
+            )
+
+            # Emit four hand-crafted events plus the automatic
+            # ``run_started`` that already landed inside ``start_run``.
+            # The mix exercises the kind filter: only state_entered /
+            # state_exited should come back through subscribe_events.
+
+            project.events.emit(
+                session,
+                producer_id=producer_id,
+                kind=EventKind.state_entered.value,
+                payload={"run_id": run_id, "state": "state_a", "entry_seq": 1},
+                run_id=run_id,
+            )
+            project.events.emit(
+                session,
+                producer_id=producer_id,
+                kind=EventKind.state_exited.value,
+                payload={"run_id": run_id, "state": "state_a"},
+                run_id=run_id,
+            )
+            project.events.emit(
+                session,
+                producer_id=producer_id,
+                kind=EventKind.transition_taken.value,
+                payload={"run_id": run_id, "from": "state_a", "to": "state_b"},
+                run_id=run_id,
+            )
+            project.events.emit(
+                session,
+                producer_id=producer_id,
+                kind=EventKind.state_entered.value,
+                payload={"run_id": run_id, "state": "state_b", "entry_seq": 2},
+                run_id=run_id,
+            )
+
+    return run_id
+
+
+def _emit_post_subscribe_event(db_path: Path, run_id: str) -> None:
+    """Emit one extra ``state_exited`` event for the second subscribe call.
+
+    Re-opens the project (the previous handle was closed when its
+    context manager exited inside :func:`_prepopulate_database`).
+    The new event must match the consumer's filter so a delivery row
+    is created against the already-registered ``t1`` consumer — which
+    is precisely the row the second subscribe call should pull.
+    """
+    with (
+        Project.open(db_path, migrate=False) as project,
+        project.session_factory() as session,
+        session.begin(),
+    ):
+        producer = project.producers.upsert(
+            session,
+            kind="engine",
+            name="fsm.runtime",
+        )
+        project.events.emit(
+            session,
+            producer_id=producer.id,
+            kind=EventKind.state_exited.value,
+            payload={"run_id": run_id, "state": "state_b"},
+            run_id=run_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# MCP client helpers
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _spawn_server(db_path: Path) -> AsyncIterator[ClientSession]:
+    """Boot ``ctxr-fsm mcp`` as a subprocess and yield an initialized session.
+
+    ``uv run`` is used as the command so the subprocess picks up the
+    same project virtualenv that pytest itself is running under. The
+    explicit ``--db`` flag bypasses the env-var / default-path
+    precedence so the subprocess hits the same per-test temp file the
+    in-process pre-population used.
+
+    The ``stdio_client`` and ``ClientSession`` context managers are
+    nested explicitly (rather than via a single ``async with``) so the
+    teardown order is deterministic: the session is shut down first
+    (sending the MCP shutdown frame), then the stdio pipes are torn
+    down (closing the pipes signals the subprocess to exit). This
+    matches the SDK's documented pattern.
+    """
+    params = StdioServerParameters(
+        command="uv",
+        args=["run", "ctxr-fsm", "mcp", "--db", str(db_path)],
+    )
+    async with (
+        stdio_client(params) as (read_stream, write_stream),
+        ClientSession(read_stream, write_stream) as session,
+    ):
+        # The initialize handshake is what proves the server is
+        # actually up — every subsequent call_tool depends on it.
+        # We wrap in ``wait_for`` to fail loudly with a useful
+        # timeout error if the subprocess never speaks the protocol
+        # (e.g. an import error printed to stderr would leave us
+        # blocking on stdin forever otherwise).
+        await asyncio.wait_for(
+            session.initialize(),
+            timeout=_INIT_TIMEOUT_SECONDS,
+        )
+        yield session
+
+
+async def _call_subscribe(
+    session: ClientSession,
+    *,
+    consumer_name: str = _CONSUMER_NAME,
+    kinds: list[str] | None = None,
+    timeout_seconds: float = _SUBSCRIBE_TIMEOUT_SECONDS,
+    max_events: int = 50,
+) -> dict[str, Any]:
+    """Call ``fsm.subscribe_events`` and return its structured content.
+
+    Returns the parsed Pydantic-projected dict (FastMCP's
+    ``structuredContent`` for a Pydantic return value). We assert
+    ``isError is False`` here so any negative-path failure surfaces
+    with a clear pytest stack rather than as a downstream KeyError.
+
+    ``kinds`` is passed through verbatim; ``None`` means "every
+    kind" (the tool default).
+    """
+    arguments: dict[str, Any] = {
+        "consumer_name": consumer_name,
+        "timeout_seconds": timeout_seconds,
+        "max_events": max_events,
+    }
+    if kinds is not None:
+        arguments["kinds"] = kinds
+
+    result = await asyncio.wait_for(
+        session.call_tool("fsm.subscribe_events", arguments=arguments),
+        timeout=_CALL_TIMEOUT_SECONDS,
+    )
+
+    assert result.isError is False, (
+        f"fsm.subscribe_events returned an error: "
+        f"content={result.content!r} structured={result.structuredContent!r}"
+    )
+    assert result.structuredContent is not None, (
+        "fsm.subscribe_events returned no structuredContent — FastMCP "
+        "should always wrap a Pydantic return value into structuredContent"
+    )
+    # FastMCP wraps a ``Union[A, B]`` return annotation under the
+    # ``"result"`` key so the output JSON Schema can describe both
+    # arms. Unwrap it here so callers get the EventBatch dict
+    # directly. If the underlying tool returned an ``McpToolError``
+    # the dict will have an ``"error"`` key instead — callers branch
+    # on the field shape rather than on Python type info.
+    payload = result.structuredContent.get("result")
+    assert isinstance(payload, dict), (
+        f"expected structuredContent['result'] to be a dict, got "
+        f"{type(payload).__name__}: {result.structuredContent!r}"
+    )
+    assert "error" not in payload, (
+        f"fsm.subscribe_events returned an error envelope: {payload!r}"
+    )
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscribe_events_returns_filtered_events_then_cursor_advances() -> None:
+    """Single end-to-end test that covers both contractual properties.
+
+    The two assertions are deliberately bundled into one test because
+    they share an expensive subprocess fixture (boot + initialize +
+    teardown ~5-10s) and a shared pre-populated database. Splitting
+    them would double the wall-clock cost for no extra coverage —
+    the second assertion *cannot* run in isolation because it
+    structurally depends on the first call having advanced the cursor.
+
+    Coverage:
+
+    1. First call with ``kinds=[state_entered, state_exited]`` returns
+       exactly the three matching events from the pre-populated set
+       (two state_entered, one state_exited), in emit order, with
+       payloads intact. The ``run_started`` and ``transition_taken``
+       events are filtered out.
+    2. A *second* call with the same ``consumer_name`` after one new
+       matching event has been emitted returns only that single new
+       event — the cursor advanced because the first call ack'd
+       everything it pulled.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.sqlite3"
+
+        # Pre-populate synchronously, in-process, before the subprocess
+        # boots. The subprocess will see the registered consumer and
+        # all four hand-emitted events the moment it opens the DB.
+        run_id = _prepopulate_database(db_path)
+
+        async with _spawn_server(db_path) as session:
+            # ── First call ───────────────────────────────────────────
+            first_batch = await _call_subscribe(
+                session,
+                consumer_name=_CONSUMER_NAME,
+                kinds=_KINDS_FILTER,
+            )
+
+            assert first_batch.get("next_cursor") is None, (
+                "next_cursor is reserved and should always be None today"
+            )
+            first_events = first_batch.get("events")
+            assert isinstance(first_events, list), (
+                f"events must be a list, got {type(first_events).__name__}"
+            )
+
+            # Three matched events: two state_entered + one state_exited.
+            # transition_taken and run_started are filtered out by the
+            # kinds list above.
+            assert len(first_events) == 3, (
+                f"expected 3 filtered events, got {len(first_events)}: "
+                f"{[(e.get('kind'), e.get('payload')) for e in first_events]}"
+            )
+
+            # Every returned event must have a kind in the filter set —
+            # this is the property the kinds filter guarantees.
+            for event in first_events:
+                assert event["kind"] in _KINDS_FILTER, (
+                    f"event with disallowed kind leaked through filter: {event!r}"
+                )
+                # Every event was emitted with a run_id; the bus
+                # preserves that scoping in the delivered payload.
+                assert event["run_id"] == run_id, (
+                    f"event run_id {event['run_id']!r} != expected {run_id!r}"
+                )
+
+            # Emit-order: the first state_entered (state_a) precedes
+            # the state_exited (state_a), which precedes the second
+            # state_entered (state_b). Per-run ``seq`` is the wire-
+            # level guarantee of that ordering.
+            seqs = [event["seq"] for event in first_events]
+            assert seqs == sorted(seqs), (
+                f"events out of monotonic seq order: {seqs}"
+            )
+
+            kinds_in_order = [event["kind"] for event in first_events]
+            assert kinds_in_order == [
+                EventKind.state_entered.value,
+                EventKind.state_exited.value,
+                EventKind.state_entered.value,
+            ], (
+                f"unexpected delivery order of kinds: {kinds_in_order}"
+            )
+
+            # ── Emit one more matching event between the calls ───────
+            # Do this *outside* the subprocess (the subprocess holds
+            # its own SQLite handle but SQLite's default journal mode
+            # is WAL via Alembic's migration, so a second writer can
+            # land a row that the subprocess sees on its next poll).
+            _emit_post_subscribe_event(db_path, run_id)
+
+            # ── Second call — same consumer_name ─────────────────────
+            second_batch = await _call_subscribe(
+                session,
+                consumer_name=_CONSUMER_NAME,
+                kinds=_KINDS_FILTER,
+            )
+            second_events = second_batch.get("events")
+            assert isinstance(second_events, list), (
+                f"events must be a list, got {type(second_events).__name__}"
+            )
+
+            # The cursor advanced — only the single newly-emitted event
+            # should come back. The three events from the first call
+            # were ack'd inside the tool body and are no longer
+            # ``pending`` for ``t1``.
+            assert len(second_events) == 1, (
+                f"expected 1 new event after cursor advance, got "
+                f"{len(second_events)}: "
+                f"{[(e.get('kind'), e.get('payload')) for e in second_events]}"
+            )
+
+            new_event = second_events[0]
+            assert new_event["kind"] == EventKind.state_exited.value, (
+                f"new event kind mismatch: {new_event['kind']!r}"
+            )
+            assert new_event["run_id"] == run_id, (
+                f"new event run_id {new_event['run_id']!r} != expected {run_id!r}"
+            )
+            # The new event's seq must be strictly greater than every
+            # seq returned in the first batch — that is the bus's per-
+            # run monotonicity guarantee.
+            assert new_event["seq"] > max(seqs), (
+                f"new event seq {new_event['seq']} did not exceed "
+                f"first-batch max {max(seqs)}"
+            )


### PR DESCRIPTION
## Summary

W4 of the SQLite-backed Python FSM plan: the agent-facing MCP server. **2,800 LOC of server code + 2,500 LOC of stdio integration tests; 341/341 pytest (197+72+56+16), ruff clean, mypy clean.**

> **Base branch is \`w3/ctxr-fsm-cli\` (PR #27).** That PR must merge first.

## 17 fsm.* tools

| Group | Tools |
|---|---|
| **Meta** | \`fsm.healthcheck\`, \`fsm.list_specs\`, \`fsm.register_spec\`, \`fsm.observe_tool_call\` |
| **Runs** | \`fsm.start_run\`, \`fsm.get_brief\`, \`fsm.commit_outputs\`, \`fsm.confirm_commit\` (W4 stub; W12), \`fsm.resume_run\`, \`fsm.abort_run\`, \`fsm.list_runs\`, \`fsm.get_run\` |
| **Events + journal** | \`fsm.subscribe_events\`, \`fsm.inspect_journal\`, \`fsm.recover_journal\`, \`fsm.list_consumers\`, \`fsm.list_producers\` |

\`fsm.healthcheck\` is the Principle 1 pre-check tool — skills call it before any state-affecting tool.
\`fsm.observe_tool_call\` is the layer-7 hook for the W12 drift detector.

## Stack

- Built on official Anthropic Python MCP SDK 1.27.2 (FastMCP decorator API).
- **stdio transport by default** (Claude Code's natural channel).
- \`--transport http\` boots SSE via \`mcp.run(transport='sse')\`.
- All tool inputs/outputs are Pydantic models from \`ctxr.fsm.core.models\` (typed contract).
- Errors return a \`McpToolError\` envelope matching the legacy JS error shape.
- Logging hard-pinned to stderr so stdio framing on stdout stays clean.
- SIGINT/SIGTERM handlers close the Project gracefully.

## CLI integration

W3's \`ctxr-fsm mcp\` stub replaced with a real implementation:
\`\`\`
ctxr-fsm mcp [--db PATH] [--transport stdio|http] [--host HOST] [--port PORT]
\`\`\`

## Tests (7 files, 16 stdio integration tests)

Each test spawns the server as a subprocess via \`stdio_client(StdioServerParameters(command='uv', args=['run','ctxr-fsm','mcp','--db', <tmp>]))\`, drives \`ClientSession.initialize() + session.call_tool(...)\`, asserts on \`structuredContent['result']\`. Per-test \`TemporaryDirectory\` for SQLite isolation. ~13s total wall time.

## Verify

- [x] \`uv run pytest tests/ -q\` — **341 passed in 24.00s**.
- [x] \`uv run ruff check ctxr/ tests/\` — **All checks passed!**
- [x] \`uv run mypy ctxr/fsm/\` — **Success: no issues found in 42 source files**.

## Plan reference

\`/Users/developer/.claude/plans/how-it-fits-toasty-gray.md\` — W4 section.