### PR TITLE
feat(w11): FSM principles file + ctxr-fsm install-memory CLI + Principle 3 cross-ref

### DIFF
--- a/ctxr/fsm/cli/__init__.py
+++ b/ctxr/fsm/cli/__init__.py
@@ -50,6 +50,7 @@ from ctxr.fsm.cli import (
     export_cmd,
     import_cmd,
     init_cmd,
+    install_memory_cmd,
     mcp_cmd,
     migrate_cmd,
     runs_cmd,
@@ -90,6 +91,13 @@ app.command(name="migrate", help="Run alembic upgrade head against the project D
 app.command(name="doctor", help="Print a diagnostic report for the project DB.")(
     doctor_cmd.doctor
 )
+# ``install-memory`` (W11) writes the FSM-usage principles into the
+# consumer project's AI-client memory files (CLAUDE.md, AGENTS.md,
+# .cursor/rules/). Idempotent via marker-fenced blocks.
+app.command(
+    name="install-memory",
+    help="Install (or check) FSM-usage principles into AI-client memory.",
+)(install_memory_cmd.install_memory)
 
 # The ``spec`` group bundles spec validate / register / list under one
 # namespace so the top-level help screen stays short. Adding it via

--- a/ctxr/fsm/cli/init_cmd.py
+++ b/ctxr/fsm/cli/init_cmd.py
@@ -14,13 +14,16 @@ Side effects this command intentionally performs (in order):
    ``.ctxr-fsm/`` to ``.gitignore`` — idempotent: we read the existing
    ignore file and only append the entry when it is genuinely missing.
    The file is created if absent.
-4. Emits a friendly summary (DB path, alembic revision, follow-up
-   memory-installer note) via :func:`json_or_pretty` so ``--json`` is
+4. Unless ``--no-memory`` is passed, invokes the W11 memory installer
+   (``install_memory(target=cwd, client='auto')``) so any AI-client
+   memory files already present in the project (CLAUDE.md, AGENTS.md,
+   .cursor/rules/) get the FSM-usage principles wired in. The call is
+   idempotent — a re-run of ``ctxr-fsm init`` re-asserts the marker
+   block without duplicating it. Any exception from the installer is
+   caught and surfaced in the summary instead of failing init.
+5. Emits a friendly summary (DB path, alembic revision, memory
+   installer outcome) via :func:`json_or_pretty` so ``--json`` is
    honoured for scripting.
-
-The ``--no-memory`` flag is recognised today (so the contract is
-forward-compatible) but the actual memory installer ships in W11; for
-now we simply note the deferral in the summary.
 """
 
 from __future__ import annotations
@@ -114,9 +117,10 @@ def init(
         False,
         "--no-memory",
         help=(
-            "Skip queueing the memory installer for follow-up. "
-            "The installer itself ships in W11 — until then this flag "
-            "only suppresses the post-init reminder."
+            "Skip invoking the AI-client memory installer at the end of "
+            "init. Useful for non-interactive setups (CI, scripted "
+            "container builds) where touching CLAUDE.md / AGENTS.md / "
+            ".cursor/rules/ is undesirable."
         ),
     ),
 ) -> None:
@@ -125,7 +129,9 @@ def init(
     Creates ``./.ctxr-fsm`` (plus ``pids/`` subdir), runs
     ``alembic upgrade head`` against the project's SQLite DB,
     appends ``.ctxr-fsm/`` to ``.gitignore`` when in a git checkout,
-    and prints a summary.
+    then (unless ``--no-memory``) invokes the W11 memory installer to
+    wire FSM-usage principles into any detected AI-client memory.
+    Finishes by printing a summary.
     """
     db_path = resolve_db_path(db)
     project_dir = db_path.parent
@@ -145,6 +151,40 @@ def init(
 
     revision = _read_alembic_revision(db_path)
 
+    # ---- Memory installer (W11) ----------------------------------
+    #
+    # We invoke the in-process function (not the CLI command) so any
+    # side effects happen in the same Python process and we don't need
+    # to spawn a subprocess. Auto-detect mode is the right default —
+    # it patches CLAUDE.md / AGENTS.md / .cursor/rules/ only if those
+    # files exist, leaving a project with none of them untouched.
+    #
+    # We catch broad exceptions so a failed memory install never
+    # bricks ``ctxr-fsm init``; the summary surfaces the error so the
+    # operator can re-run ``ctxr-fsm install-memory`` directly to see
+    # the full traceback.
+    memory_installer: dict[str, Any] | str
+    if no_memory:
+        memory_installer = "skipped (--no-memory)"
+    else:
+        try:
+            # Local import to keep ``init`` startup cheap when
+            # ``--no-memory`` is passed — and to avoid a hard import
+            # cycle if the install-memory module ever wants to import
+            # init helpers.
+            from ctxr.fsm.cli.install_memory_cmd import run_install_memory
+
+            # ``run_install_memory`` is the non-printing core of
+            # ``install-memory``; we embed its summary as a sub-field
+            # so init's own JSON output remains a single valid
+            # document.
+            memory_installer = run_install_memory(target=cwd, client="auto")
+        except Exception as exc:
+            # Surface failures as a field rather than crashing init —
+            # the operator can re-run ``ctxr-fsm install-memory`` to
+            # get the full traceback.
+            memory_installer = f"failed: {type(exc).__name__}: {exc}"
+
     summary: dict[str, Any] = {
         "db_path": str(db_path),
         "project_dir": str(project_dir),
@@ -153,10 +193,6 @@ def init(
         "gitignore_updated": gitignore_updated,
         "ports_json": str(project_dir / "ports.json")
         + " (placeholder — populated by the serve subcommand in W7)",
-        "memory_installer": (
-            "skipped (--no-memory)"
-            if no_memory
-            else "memory installer comes in W11; re-run init then to wire it up"
-        ),
+        "memory_installer": memory_installer,
     }
     json_or_pretty(summary, json_mode)

--- a/ctxr/fsm/cli/install_memory_cmd.py
+++ b/ctxr/fsm/cli/install_memory_cmd.py
@@ -1,0 +1,944 @@
+"""``ctxr-fsm install-memory`` — inject FSM-usage principles into AI-client memory.
+
+This command takes the canonical principles file shipped inside the
+``ctxr-fsm`` package (``ctxr/fsm/memory/principles.<client>.md``) and
+wires it into the consumer project's standard AI-client memory:
+
+* **Claude Code** (``CLAUDE.md`` or ``.claude/CLAUDE.md``) — uses
+  Claude's ``@<path>`` import syntax. We materialise (symlink or copy)
+  the package file under ``./.ctxr-fsm/memory/principles.claude.md`` and
+  append a single ``@.ctxr-fsm/memory/principles.claude.md`` line inside
+  fence markers to the user's existing ``CLAUDE.md``.
+
+* **Codex / OpenAI Agents SDK** (``AGENTS.md``) — Codex does NOT support
+  the ``@<path>`` import idiom, so the full body of the principles file
+  is inlined between fence markers at the END of ``AGENTS.md``.
+
+* **Cursor** (``.cursor/rules/ctxr-fsm.mdc``) — Cursor's rule files are
+  standalone, so we write the principles file directly with no marker
+  block. The rule filename itself is the namespace.
+
+Idempotence
+-----------
+
+Every patch is wrapped between::
+
+    <!-- ctxr-fsm:begin v=<version> -->
+    ...payload...
+    <!-- ctxr-fsm:end -->
+
+If the markers already exist we **replace** the whole block (including
+the version pinned in the begin marker). If they don't exist we append
+the block to the end of the file, separated by a single blank line.
+Running the command twice produces a byte-identical file the second
+time around (asserted by the smoke loop in the task description).
+
+For Cursor, idempotence is even simpler: we just overwrite the rule
+file with the package file's bytes — they only differ across versions.
+
+Modes
+-----
+
+* No flag — apply patches.
+* ``--check`` — read each detected client's marker block, parse the
+  pinned version, compare against the package's version. Print a
+  per-client status table. Exits non-zero if any client is out of date
+  or missing (useful for ``ctxr-fsm install-memory --check`` in CI).
+* ``--dry-run`` — print the patch that *would* be written for each
+  client without touching the filesystem.
+* ``--no-symlink`` — for Claude, always copy the principles file under
+  ``.ctxr-fsm/memory/`` instead of trying to symlink first. Useful on
+  filesystems / consumers (eg. Windows without dev-mode) that don't
+  cope with symlinks.
+
+Auto-detection (``--client auto``)
+----------------------------------
+
+For each potential client we check the target directory:
+
+* ``CLAUDE.md`` OR ``.claude/CLAUDE.md`` -> Claude.
+* ``AGENTS.md`` -> Codex.
+* ``.cursor/rules/`` (as a directory) -> Cursor.
+
+A target without any of those is a no-op (the command reports
+"no client detected" and exits 0 — installing memory into a project
+that has no AI-client memory yet is a no-op, not an error).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from ctxr.fsm.cli._common import json_or_pretty
+from ctxr.fsm.memory import get_principles_path
+
+__all__ = ["install_memory", "run_install_memory"]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# The set of client identifiers the command understands. ``auto`` is a
+# meta-value that fans out to the detected clients in the target dir.
+_CLIENT_CHOICES: tuple[str, ...] = ("auto", "claude", "codex", "cursor")
+
+# The marker fences. We keep both as module constants so callers
+# (tests, downstream tools) can import and match against them rather
+# than open-coding the strings.
+_MARKER_BEGIN_PREFIX: str = "<!-- ctxr-fsm:begin"
+_MARKER_END: str = "<!-- ctxr-fsm:end -->"
+
+# Regex that matches a full marker block including the begin/end fences.
+# The version captured in group 1 is whatever appears after ``v=`` in
+# the begin marker, up to but not including the closing ``-->``. We
+# tolerate trailing whitespace inside the marker for robustness against
+# hand-edits. ``re.DOTALL`` lets ``.`` span newlines so we capture the
+# entire block as one match.
+_MARKER_BLOCK_RE: re.Pattern[str] = re.compile(
+    r"<!--\s*ctxr-fsm:begin\s+v=([^\s>]+)\s*-->.*?<!--\s*ctxr-fsm:end\s*-->",
+    re.DOTALL,
+)
+
+# Relative path inside the target project where we materialise the
+# Claude principles file so the ``@<path>`` import in CLAUDE.md resolves.
+# Kept under ``.ctxr-fsm/`` so a ``rm -rf .ctxr-fsm`` is the project's
+# reset (same rationale as the SQLite DB lives there).
+_CLAUDE_LINKED_PATH: Path = Path(".ctxr-fsm") / "memory" / "principles.claude.md"
+
+# The relative path Cursor uses for project-scoped rule files. We pick a
+# stable filename (``ctxr-fsm.mdc``) so the rule is greppable and so
+# repeated installs overwrite the same file rather than accumulate
+# duplicates.
+_CURSOR_RULE_PATH: Path = Path(".cursor") / "rules" / "ctxr-fsm.mdc"
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_version(text: str) -> str | None:
+    """Return the ``version:`` value from the first YAML frontmatter block.
+
+    Both the package-shipped principles files and the locally-patched
+    CLAUDE/AGENTS marker blocks (via the ``v=`` attribute on the begin
+    marker) carry a version. This helper handles the *file-level*
+    frontmatter form — the ``v=`` attribute on a marker is handled
+    separately by :func:`_find_existing_block`.
+
+    The frontmatter format we accept is the standard one::
+
+        ---
+        name: ctxr-fsm-principles
+        version: 0.1.0
+        ...
+        ---
+
+    Returns ``None`` if the file has no recognisable frontmatter or no
+    ``version:`` key — both cases mean "I don't know the version" and
+    the caller should treat it as "unknown" rather than crash.
+    """
+    # The Cursor adapter has a Cursor-specific frontmatter block at the
+    # very top, then a generated-from HTML comment, then the *canonical*
+    # frontmatter with the version. So we scan ALL frontmatter blocks
+    # in the file and return the first one that has a ``version:`` key.
+    # Simpler than special-casing Cursor and equally correct for the
+    # Claude / Codex / canonical files that only have one block.
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        if lines[i].strip() == "---":
+            # Find the closing fence.
+            j = i + 1
+            while j < len(lines) and lines[j].strip() != "---":
+                j += 1
+            if j >= len(lines):
+                # Unterminated frontmatter — give up rather than scan
+                # the entire document for a key that probably isn't
+                # there.
+                return None
+            for block_line in lines[i + 1 : j]:
+                stripped = block_line.strip()
+                # Match ``version: X.Y.Z`` (with optional quotes). Be
+                # tolerant of the YAML ``key : value`` spacing variants.
+                if stripped.startswith("version:"):
+                    value = stripped.split(":", 1)[1].strip()
+                    # Strip surrounding quotes if any — YAML allows
+                    # ``version: "0.1.0"`` and ``version: 0.1.0``.
+                    value = value.strip('"').strip("'")
+                    if value:
+                        return value
+            # No version key in this block; advance past the closing
+            # fence and keep scanning.
+            i = j + 1
+            continue
+        i += 1
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ClientDetection:
+    """Result of auto-detecting one client in the target directory.
+
+    ``host_file`` is the file that will be patched (or None for Cursor,
+    where we write a standalone rule file). ``detected`` is True iff the
+    client's signature was found in the target.
+    """
+
+    name: str
+    detected: bool
+    host_file: Path | None
+
+
+def _detect_claude(target: Path) -> _ClientDetection:
+    """Look for ``CLAUDE.md`` or ``.claude/CLAUDE.md`` in ``target``.
+
+    We prefer the top-level ``CLAUDE.md`` if both exist (it is the
+    canonical Claude Code location); ``.claude/CLAUDE.md`` is the
+    nested form Claude also reads.
+    """
+    top = target / "CLAUDE.md"
+    nested = target / ".claude" / "CLAUDE.md"
+    if top.is_file():
+        return _ClientDetection(name="claude", detected=True, host_file=top)
+    if nested.is_file():
+        return _ClientDetection(name="claude", detected=True, host_file=nested)
+    return _ClientDetection(name="claude", detected=False, host_file=None)
+
+
+def _detect_codex(target: Path) -> _ClientDetection:
+    """Look for ``AGENTS.md`` in ``target``."""
+    host = target / "AGENTS.md"
+    if host.is_file():
+        return _ClientDetection(name="codex", detected=True, host_file=host)
+    return _ClientDetection(name="codex", detected=False, host_file=None)
+
+
+def _detect_cursor(target: Path) -> _ClientDetection:
+    """Look for a ``.cursor/rules/`` directory in ``target``.
+
+    For Cursor, the host_file is the absolute path where the rule file
+    will live — Cursor rules are standalone files, not appendices to a
+    user-edited host file.
+    """
+    rules_dir = target / ".cursor" / "rules"
+    if rules_dir.is_dir():
+        return _ClientDetection(
+            name="cursor",
+            detected=True,
+            host_file=target / _CURSOR_RULE_PATH,
+        )
+    return _ClientDetection(name="cursor", detected=False, host_file=None)
+
+
+def _detect_clients(target: Path, client: str) -> list[_ClientDetection]:
+    """Resolve ``--client`` into the concrete list of detections to act on.
+
+    For ``auto`` we run every detector and return only the ones that
+    fired. For an explicit client we return a single detection — for
+    the explicit case we treat *unconditional install* as the contract,
+    so ``detected`` is forced to True and ``host_file`` defaults to the
+    canonical location even if it doesn't yet exist (the patcher will
+    create it).
+    """
+    if client == "auto":
+        detections = [
+            _detect_claude(target),
+            _detect_codex(target),
+            _detect_cursor(target),
+        ]
+        return [d for d in detections if d.detected]
+
+    if client == "claude":
+        detected = _detect_claude(target)
+        if detected.detected:
+            return [detected]
+        # Explicit client + no existing file -> default to top-level CLAUDE.md.
+        return [
+            _ClientDetection(
+                name="claude", detected=True, host_file=target / "CLAUDE.md"
+            )
+        ]
+
+    if client == "codex":
+        detected = _detect_codex(target)
+        if detected.detected:
+            return [detected]
+        return [
+            _ClientDetection(
+                name="codex", detected=True, host_file=target / "AGENTS.md"
+            )
+        ]
+
+    if client == "cursor":
+        detected = _detect_cursor(target)
+        if detected.detected:
+            return [detected]
+        return [
+            _ClientDetection(
+                name="cursor",
+                detected=True,
+                host_file=target / _CURSOR_RULE_PATH,
+            )
+        ]
+
+    raise typer.BadParameter(
+        f"unknown client {client!r}; expected one of: {', '.join(_CLIENT_CHOICES)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Block construction
+# ---------------------------------------------------------------------------
+
+
+def _build_marker_block(version: str, payload: str) -> str:
+    """Compose the begin/end-fenced block with ``payload`` inside.
+
+    The payload may be multi-line. We ensure exactly one trailing
+    newline INSIDE the block so the closing marker sits on its own
+    line. The block returned has NO leading/trailing whitespace outside
+    its own fences — the caller is responsible for placing it in the
+    host file with the right surrounding blank line.
+    """
+    payload_normalised = payload.rstrip("\n")
+    return (
+        f"<!-- ctxr-fsm:begin v={version} -->\n"
+        f"{payload_normalised}\n"
+        f"{_MARKER_END}"
+    )
+
+
+def _find_existing_block(host_text: str) -> tuple[re.Match[str], str] | None:
+    """Locate an existing marker block in ``host_text``.
+
+    Returns ``(match, version)`` if a block is found, where ``match`` is
+    the full :class:`re.Match` and ``version`` is the version string
+    parsed out of the begin marker. Returns ``None`` if no block is
+    present.
+    """
+    match = _MARKER_BLOCK_RE.search(host_text)
+    if match is None:
+        return None
+    return match, match.group(1)
+
+
+def _apply_patch(host_text: str, new_block: str) -> str:
+    """Return ``host_text`` with the marker block replaced or appended.
+
+    * If an existing block is present, replace it in-place (preserving
+      everything before and after) — this is the idempotent path.
+    * If no block exists, append the new block to the END of the file,
+      separated by a single blank line. We preserve the file's existing
+      trailing-newline contract (always end with exactly one newline
+      after our block).
+    """
+    existing = _find_existing_block(host_text)
+    if existing is not None:
+        match, _ = existing
+        return host_text[: match.start()] + new_block + host_text[match.end() :]
+
+    if not host_text:
+        # An empty host file: just write our block + trailing newline.
+        return new_block + "\n"
+
+    # Normalise the host's trailing whitespace so the appended block
+    # sits cleanly under whatever was last in the file.
+    base = host_text.rstrip("\n")
+    return f"{base}\n\n{new_block}\n"
+
+
+# ---------------------------------------------------------------------------
+# Per-client patch builders
+# ---------------------------------------------------------------------------
+
+
+def _materialise_claude_link(
+    target: Path,
+    package_file: Path,
+    *,
+    no_symlink: bool,
+) -> tuple[Path, str]:
+    """Place the Claude principles file under ``target/.ctxr-fsm/memory/``.
+
+    Returns ``(absolute_destination, mode)`` where ``mode`` is one of
+    ``"symlink"`` (we managed to symlink) or ``"copy"`` (we fell back to
+    copying because symlinks were disabled, refused, or unsupported).
+
+    The destination directory is created if missing. If a stale file
+    already exists at the destination we replace it — the source of
+    truth is always the package's principles file.
+    """
+    dest = target / _CLAUDE_LINKED_PATH
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    # Remove any pre-existing entry (file, symlink, or broken symlink)
+    # before re-materialising. ``Path.unlink`` with ``missing_ok=True``
+    # handles all three cleanly without an explicit ``exists()`` race.
+    if dest.is_symlink() or dest.exists():
+        dest.unlink(missing_ok=True)
+
+    if no_symlink:
+        shutil.copy2(package_file, dest)
+        return dest, "copy"
+
+    try:
+        # We use a RELATIVE symlink so a tarball / git move of the
+        # project directory still resolves correctly. The relative
+        # target is computed from the destination's parent.
+        rel_target = Path(package_file).resolve()
+        # ``os.path.relpath`` would be the obvious helper but it
+        # produces strings; we want a Path. The principles file lives
+        # outside the project dir (it's inside the installed package),
+        # so an absolute symlink is fine and unambiguous — relpath
+        # across that boundary would be cosmetically ugly.
+        dest.symlink_to(rel_target)
+        return dest, "symlink"
+    except (OSError, NotImplementedError):
+        # Filesystem or platform doesn't support symlinks (Windows
+        # without dev mode, some FUSE mounts) — fall back to copy.
+        shutil.copy2(package_file, dest)
+        return dest, "copy"
+
+
+def _build_claude_payload() -> str:
+    """The payload for the CLAUDE.md marker block — a single ``@<path>`` import.
+
+    We deliberately point at the in-project ``.ctxr-fsm/memory/...``
+    location (set up by :func:`_materialise_claude_link`) rather than at
+    the package file's absolute path; that keeps CLAUDE.md
+    relocation-safe (you can move the project, share it via git, etc.)
+    and matches Claude Code's documented ``@<relative-path>`` idiom.
+    """
+    return f"@{_CLAUDE_LINKED_PATH.as_posix()}"
+
+
+def _build_codex_payload(package_text: str) -> str:
+    """The payload for the AGENTS.md marker block — the inlined principles.
+
+    Codex doesn't support an ``@<path>`` import, so we inline the full
+    body. We strip the file's outer frontmatter / generated-from header
+    because Codex doesn't need the YAML frontmatter (it's not a Cursor
+    rule file) — we keep the inlined content focused on the *content*
+    the agent needs to read. The generated-from comment stays as it
+    serves as a useful breadcrumb back to the package source.
+    """
+    return package_text.rstrip("\n")
+
+
+# ---------------------------------------------------------------------------
+# Per-client install actions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _InstallResult:
+    """Per-client outcome surfaced in the JSON / pretty summary."""
+
+    client: str
+    host_file: Path
+    action: str  # "wrote" | "noop" | "dry-run" | "would-write"
+    package_version: str | None
+    installed_version: str | None
+    link_mode: str | None  # "symlink" | "copy" | None
+    note: str = ""
+
+
+def _install_claude(
+    *,
+    target: Path,
+    host_file: Path,
+    package_file: Path,
+    package_version: str | None,
+    dry_run: bool,
+    no_symlink: bool,
+) -> _InstallResult:
+    """Idempotent install for Claude: symlink + marker block in CLAUDE.md."""
+    if dry_run:
+        # In dry-run mode we don't materialise the symlink — just show
+        # what the patch would look like. The link mode is reported as
+        # whatever ``no_symlink`` implies so the dry-run output matches
+        # what would actually happen.
+        link_mode = "copy" if no_symlink else "symlink"
+        existing_text = host_file.read_text(encoding="utf-8") if host_file.is_file() else ""
+        new_block = _build_marker_block(
+            package_version or "unknown", _build_claude_payload()
+        )
+        new_text = _apply_patch(existing_text, new_block)
+        installed_version = (
+            _read_installed_version_from_text(existing_text) if existing_text else None
+        )
+        return _InstallResult(
+            client="claude",
+            host_file=host_file,
+            action="dry-run",
+            package_version=package_version,
+            installed_version=installed_version,
+            link_mode=link_mode,
+            note=_diff_preview(existing_text, new_text),
+        )
+
+    _, link_mode = _materialise_claude_link(target, package_file, no_symlink=no_symlink)
+
+    existing_text = host_file.read_text(encoding="utf-8") if host_file.is_file() else ""
+    new_block = _build_marker_block(
+        package_version or "unknown", _build_claude_payload()
+    )
+    new_text = _apply_patch(existing_text, new_block)
+
+    if new_text == existing_text and host_file.is_file():
+        return _InstallResult(
+            client="claude",
+            host_file=host_file,
+            action="noop",
+            package_version=package_version,
+            installed_version=package_version,
+            link_mode=link_mode,
+        )
+
+    host_file.parent.mkdir(parents=True, exist_ok=True)
+    host_file.write_text(new_text, encoding="utf-8")
+    return _InstallResult(
+        client="claude",
+        host_file=host_file,
+        action="wrote",
+        package_version=package_version,
+        installed_version=package_version,
+        link_mode=link_mode,
+    )
+
+
+def _install_codex(
+    *,
+    host_file: Path,
+    package_file: Path,
+    package_version: str | None,
+    dry_run: bool,
+) -> _InstallResult:
+    """Idempotent install for Codex: inline the principles into AGENTS.md."""
+    package_text = package_file.read_text(encoding="utf-8")
+    existing_text = host_file.read_text(encoding="utf-8") if host_file.is_file() else ""
+
+    new_block = _build_marker_block(
+        package_version or "unknown", _build_codex_payload(package_text)
+    )
+    new_text = _apply_patch(existing_text, new_block)
+
+    if dry_run:
+        return _InstallResult(
+            client="codex",
+            host_file=host_file,
+            action="dry-run",
+            package_version=package_version,
+            installed_version=_read_installed_version_from_text(existing_text)
+            if existing_text
+            else None,
+            link_mode=None,
+            note=_diff_preview(existing_text, new_text),
+        )
+
+    if new_text == existing_text and host_file.is_file():
+        return _InstallResult(
+            client="codex",
+            host_file=host_file,
+            action="noop",
+            package_version=package_version,
+            installed_version=package_version,
+            link_mode=None,
+        )
+
+    host_file.parent.mkdir(parents=True, exist_ok=True)
+    host_file.write_text(new_text, encoding="utf-8")
+    return _InstallResult(
+        client="codex",
+        host_file=host_file,
+        action="wrote",
+        package_version=package_version,
+        installed_version=package_version,
+        link_mode=None,
+    )
+
+
+def _install_cursor(
+    *,
+    host_file: Path,
+    package_file: Path,
+    package_version: str | None,
+    dry_run: bool,
+) -> _InstallResult:
+    """Idempotent install for Cursor: write the standalone .mdc rule file."""
+    package_bytes = package_file.read_bytes()
+    existing_bytes = host_file.read_bytes() if host_file.is_file() else b""
+
+    if dry_run:
+        installed_version: str | None = None
+        if existing_bytes:
+            installed_version = _parse_version(
+                existing_bytes.decode("utf-8", errors="replace")
+            )
+        return _InstallResult(
+            client="cursor",
+            host_file=host_file,
+            action="dry-run",
+            package_version=package_version,
+            installed_version=installed_version,
+            link_mode=None,
+            note=f"would write {len(package_bytes)} bytes to {host_file}",
+        )
+
+    if existing_bytes == package_bytes:
+        return _InstallResult(
+            client="cursor",
+            host_file=host_file,
+            action="noop",
+            package_version=package_version,
+            installed_version=package_version,
+            link_mode=None,
+        )
+
+    host_file.parent.mkdir(parents=True, exist_ok=True)
+    host_file.write_bytes(package_bytes)
+    return _InstallResult(
+        client="cursor",
+        host_file=host_file,
+        action="wrote",
+        package_version=package_version,
+        installed_version=package_version,
+        link_mode=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# --check
+# ---------------------------------------------------------------------------
+
+
+def _read_installed_version_from_text(text: str) -> str | None:
+    """Pick the installed version out of a CLAUDE/AGENTS-style host file.
+
+    First we look for a marker block (the ``v=`` attribute on the begin
+    marker is the authoritative pin), then we fall back to scanning the
+    file's frontmatter blocks via :func:`_parse_version` — that fallback
+    covers Cursor's standalone rule file, where there is no marker
+    block.
+    """
+    existing = _find_existing_block(text)
+    if existing is not None:
+        return existing[1]
+    return _parse_version(text)
+
+
+@dataclass(frozen=True)
+class _CheckRow:
+    """One row in the per-client ``--check`` status table."""
+
+    client: str
+    host_file: Path | None
+    package_version: str | None
+    installed_version: str | None
+    status: str  # "ok" | "out-of-date" | "missing" | "not-installed"
+
+
+def _check_one(
+    detection: _ClientDetection, package_version: str | None
+) -> _CheckRow:
+    """Compute the status for one detected client."""
+    host = detection.host_file
+    if host is None or not host.is_file():
+        return _CheckRow(
+            client=detection.name,
+            host_file=host,
+            package_version=package_version,
+            installed_version=None,
+            status="not-installed",
+        )
+
+    installed = _read_installed_version_from_text(
+        host.read_text(encoding="utf-8")
+    )
+
+    if installed is None:
+        return _CheckRow(
+            client=detection.name,
+            host_file=host,
+            package_version=package_version,
+            installed_version=None,
+            status="missing",
+        )
+    if installed == package_version:
+        return _CheckRow(
+            client=detection.name,
+            host_file=host,
+            package_version=package_version,
+            installed_version=installed,
+            status="ok",
+        )
+    return _CheckRow(
+        client=detection.name,
+        host_file=host,
+        package_version=package_version,
+        installed_version=installed,
+        status="out-of-date",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run preview helper
+# ---------------------------------------------------------------------------
+
+
+def _diff_preview(old: str, new: str) -> str:
+    """Compose a short, human-friendly summary of the patch.
+
+    We deliberately don't try to produce a unified diff (the printable
+    surface stays small and predictable across very different file
+    shapes). Just report whether the file would be created / replaced /
+    appended and the size delta.
+    """
+    if not old:
+        return f"would create file (+{len(new)} bytes)"
+    if _find_existing_block(old) is not None:
+        return f"would replace existing block (delta {len(new) - len(old):+d} bytes)"
+    return f"would append new block (delta {len(new) - len(old):+d} bytes)"
+
+
+# ---------------------------------------------------------------------------
+# Pure entry point — used by both the Typer command and ``ctxr-fsm init``
+# ---------------------------------------------------------------------------
+
+
+def run_install_memory(
+    *,
+    target: Path,
+    client: str = "auto",
+    dry_run: bool = False,
+    no_symlink: bool = False,
+) -> dict[str, Any]:
+    """Run the install (or no-op) and return a JSON-serialisable summary.
+
+    Intentionally does NOT print, so callers that compose this
+    function's output into their own report (eg. ``ctxr-fsm init``) can
+    do so without polluting stdout. The Typer command :func:`install_memory`
+    is a thin wrapper that calls this then prints the result.
+
+    Raises :class:`typer.BadParameter` for an unknown client name (same
+    behaviour as the CLI surface).
+    """
+    if client not in _CLIENT_CHOICES:
+        raise typer.BadParameter(
+            f"--client must be one of {', '.join(_CLIENT_CHOICES)}, got {client!r}"
+        )
+
+    target = target.resolve()
+    detections = _detect_clients(target, client)
+
+    if not detections:
+        return {
+            "target": str(target),
+            "client": client,
+            "detected": [],
+            "message": (
+                "no AI-client memory files found "
+                "(looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md, .cursor/rules/)"
+            ),
+        }
+
+    canonical_package_file = get_principles_path("canonical")
+    package_version = _parse_version(
+        canonical_package_file.read_text(encoding="utf-8")
+    )
+
+    results: list[_InstallResult] = []
+    for detection in detections:
+        package_file = get_principles_path(detection.name)
+        assert detection.host_file is not None
+
+        if detection.name == "claude":
+            results.append(
+                _install_claude(
+                    target=target,
+                    host_file=detection.host_file,
+                    package_file=package_file,
+                    package_version=package_version,
+                    dry_run=dry_run,
+                    no_symlink=no_symlink,
+                )
+            )
+        elif detection.name == "codex":
+            results.append(
+                _install_codex(
+                    host_file=detection.host_file,
+                    package_file=package_file,
+                    package_version=package_version,
+                    dry_run=dry_run,
+                )
+            )
+        elif detection.name == "cursor":
+            results.append(
+                _install_cursor(
+                    host_file=detection.host_file,
+                    package_file=package_file,
+                    package_version=package_version,
+                    dry_run=dry_run,
+                )
+            )
+        else:  # pragma: no cover — guarded by _detect_clients
+            raise typer.BadParameter(f"unknown client {detection.name!r}")
+
+    return {
+        "target": str(target),
+        "package_version": package_version,
+        "dry_run": dry_run,
+        "results": [
+            {
+                "client": r.client,
+                "host_file": str(r.host_file),
+                "action": r.action,
+                "package_version": r.package_version,
+                "installed_version": r.installed_version,
+                "link_mode": r.link_mode,
+                "note": r.note,
+            }
+            for r in results
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Typer entry point
+# ---------------------------------------------------------------------------
+
+
+def install_memory(
+    target: Path | None = typer.Option(  # noqa: B008 — typer sentinel, not a value
+        None,
+        "--target",
+        help=(
+            "Directory containing the AI-client memory files. "
+            "Defaults to the current working directory. Mostly for tests."
+        ),
+        resolve_path=True,
+    ),
+    client: str = typer.Option(
+        "auto",
+        "--client",
+        help=(
+            "Which AI-client memory to patch: 'auto' (detect), 'claude', "
+            "'codex', or 'cursor'. 'auto' patches every client detected in "
+            "TARGET in a single pass."
+        ),
+    ),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help=(
+            "Don't write — compare installed version against package version "
+            "for each detected client and print a status table. Exits "
+            "non-zero if any client is out of date or missing."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Print the patch that would be applied for each detected client "
+            "without writing to disk."
+        ),
+    ),
+    no_symlink: bool = typer.Option(
+        False,
+        "--no-symlink",
+        help=(
+            "For Claude, always copy the principles file under "
+            "TARGET/.ctxr-fsm/memory/ instead of trying to symlink first. "
+            "Default tries symlink and falls back to copy on failure."
+        ),
+    ),
+    json_mode: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of pretty-printed output.",
+    ),
+) -> None:
+    """Install (or check) ctxr-fsm FSM-usage principles into AI-client memory.
+
+    See module docstring for the full per-client behaviour, marker
+    format, and idempotence guarantees.
+    """
+    if client not in _CLIENT_CHOICES:
+        raise typer.BadParameter(
+            f"--client must be one of {', '.join(_CLIENT_CHOICES)}, got {client!r}"
+        )
+
+    # Resolve ``--target`` lazily so the default reflects the cwd at
+    # *invocation* time, not the cwd at module import (which is what a
+    # ``Path.cwd()`` default on the Typer ``Option`` would freeze).
+    resolved_target: Path = (target if target is not None else Path.cwd()).resolve()
+
+    if check:
+        # --check has its own report shape (per-client status rows) and
+        # an explicit non-zero exit when anything is out of date — keep
+        # its logic local rather than threading another mode through
+        # ``run_install_memory``.
+        detections = _detect_clients(resolved_target, client)
+        if not detections:
+            json_or_pretty(
+                {
+                    "target": str(resolved_target),
+                    "client": client,
+                    "detected": [],
+                    "message": (
+                        "no AI-client memory files found "
+                        "(looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md, "
+                        ".cursor/rules/)"
+                    ),
+                },
+                json_mode,
+            )
+            return
+        canonical_package_file = get_principles_path("canonical")
+        package_version = _parse_version(
+            canonical_package_file.read_text(encoding="utf-8")
+        )
+        rows = [_check_one(d, package_version) for d in detections]
+        out_of_date = [r for r in rows if r.status in ("out-of-date", "missing")]
+        json_or_pretty(
+            {
+                "target": str(resolved_target),
+                "package_version": package_version,
+                "results": [
+                    {
+                        "client": r.client,
+                        "host_file": str(r.host_file) if r.host_file else None,
+                        "package_version": r.package_version,
+                        "installed_version": r.installed_version,
+                        "status": r.status,
+                    }
+                    for r in rows
+                ],
+            },
+            json_mode,
+        )
+        if out_of_date:
+            raise typer.Exit(1)
+        return
+
+    summary = run_install_memory(
+        target=resolved_target,
+        client=client,
+        dry_run=dry_run,
+        no_symlink=no_symlink,
+    )
+    json_or_pretty(summary, json_mode)

--- a/ctxr/fsm/memory/__init__.py
+++ b/ctxr/fsm/memory/__init__.py
@@ -1,0 +1,60 @@
+"""Canonical FSM-usage principles shipped with the ctxr-fsm package.
+
+This package directory holds the source-of-truth principles file
+(`principles.md`) plus per-client adapters generated from it
+(`principles.claude.md`, `principles.codex.md`, `principles.cursor.md`).
+
+The adapters are byte-stable re-emits of `principles.md` with the right
+per-client frontmatter and a generated-from header. Regenerate via:
+
+    uv run python tools/generate_memory_adapters.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PRINCIPLES_DIR: Path = Path(__file__).parent
+
+_CLIENT_FILENAMES: dict[str, str] = {
+    "canonical": "principles.md",
+    "claude": "principles.claude.md",
+    "codex": "principles.codex.md",
+    "cursor": "principles.cursor.md",
+}
+
+
+def get_principles_path(client: str = "claude") -> Path:
+    """Return the absolute path to the principles file for ``client``.
+
+    Parameters
+    ----------
+    client:
+        One of ``"canonical"``, ``"claude"``, ``"codex"``, ``"cursor"``.
+        Defaults to ``"claude"``.
+
+    Raises
+    ------
+    ValueError
+        If ``client`` is not a recognised key.
+    FileNotFoundError
+        If the requested file is not present on disk.
+    """
+
+    try:
+        filename = _CLIENT_FILENAMES[client]
+    except KeyError as exc:
+        valid = ", ".join(sorted(_CLIENT_FILENAMES))
+        raise ValueError(
+            f"unknown client {client!r}; expected one of: {valid}"
+        ) from exc
+
+    path = PRINCIPLES_DIR / filename
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"principles file missing for client={client!r}: {path}"
+        )
+    return path
+
+
+__all__ = ["PRINCIPLES_DIR", "get_principles_path"]

--- a/ctxr/fsm/memory/principles.claude.md
+++ b/ctxr/fsm/memory/principles.claude.md
@@ -1,0 +1,72 @@
+<!-- This file is generated from ctxr-fsm package memory. Run `ctxr-fsm install-memory --check` to confirm sync. -->
+
+---
+name: ctxr-fsm-principles
+version: 0.1.0
+audience: ai-agents
+---
+
+# ctxr-fsm: how an agent must use the FSM
+
+You have access to an MCP server named "ctxr-fsm" exposing fsm.* tools (healthcheck, list_specs, register_spec, start_run, get_brief, commit_outputs, confirm_commit, resume_run, abort_run, list_runs, get_run, subscribe_events, inspect_journal, recover_journal, observe_tool_call, list_consumers, list_producers).
+
+## Principle 1: pre-check before you act
+
+Before any FSM-using skill or agent does anything, call fsm.healthcheck(). If it fails, return a MissingRequirement reply citing the install command (`pip install ctxr-fsm` or `uv add ctxr-fsm`) and STOP. Do not improvise. Do not fall back to inline behaviour.
+
+## Principle 2: tool surface is constrained during a run
+
+When a run is active, the brief returned by fsm.get_brief carries an `allowed_tools` list. Your tool surface is exactly `fsm.* + current_state.allowed_tools` for the duration of that state. Do NOT call other tools while a run is in progress, even if they look useful. The drift detector will see and pause the run.
+
+## Principle 3: never inline state
+
+- Always read the next step from `fsm.get_brief(run_id)`.
+- Always commit work via `fsm.commit_outputs(run_id, outputs, signature)`.
+- If two-phase commit is in use (the brief carries `requires_confirm: true`), follow up with `fsm.confirm_commit(token, expected_next_state)`.
+
+Never write run state to /tmp or any side channel. The DB is the source of truth.
+
+## Principle 4: schema rejection means re-do the work
+
+If fsm.commit_outputs returns an error envelope with `error: output_schema_violation`, that is the contract working. Re-read `worker.response_schema` from your last brief, fix the shape, retry. Do NOT route around the schema by emitting a free-form note.
+
+## Principle 5: faults are inspection points, not failure modes
+
+On fault, do not improvise a recovery. Call `fsm.resume_run` (with `from_state` or `journal` action) per the operator's instruction, or `fsm.recover_journal`. A fault is for a human (or you, in inspection mode) to look at; it is not a "retry-with-different-inputs" situation unless the post-validation explicitly says so.
+
+## Principle 6: cosignatures matter
+
+The outputs you commit must be derived from the brief + inputs you were given. The cosignature in fsm.commit_outputs is `sha256(brief_id || canonical_json(inputs) || canonical_json(outputs) || session_id)` and is verified at the server. Fabricating outputs is detectable and will be rejected with `error: signature_mismatch`.
+
+## Principle 7: the verifier is right
+
+If an adversarial verifier rejects your output (commit returns `error: verifier_rejected` with the verifier's findings), the verifier is right and you are wrong. Re-do the work. Do NOT argue with the verifier or attempt to commit the same outputs again.
+
+## Principle 8: the spec is the source of truth
+
+A state that looks "wrong" to you is a bug to surface (open an issue, pause the run via fsm.abort_run with reason, or escalate to a human), not a flow to work around.
+
+## Principle 9: observe non-fsm tool calls during a run
+
+When a run is active and you call a tool outside the fsm.* family (e.g. Bash, Read, WebFetch, sub-agents), call `fsm.observe_tool_call(producer_kind, producer_name, tool_name, args_redacted, succeeded, run_id)` for each one. This feeds the drift detector and the run audit log. Skipping this is itself a drift signal.
+
+## Principle 10: subscribe for events when reasoning across states
+
+If you need to react to events from other producers (UI, another agent, a webhook), use `fsm.subscribe_events` to register as a consumer with the right filter. Don't poll fsm.get_run in a loop.
+
+## Lifecycle quick reference
+
+Skill startup: fsm.healthcheck -> fsm.list_specs (find the spec) -> fsm.start_run (returns run_id + first brief).
+State loop: dispatch worker per brief -> fsm.commit_outputs (and confirm_commit if required) -> new brief OR terminal.
+On fault: fsm.inspect_journal -> operator decides fsm.recover_journal or fsm.resume_run.
+Shutdown: leave the run alone; the supervisor + journal handle cleanup.
+
+## What this file is
+
+This file ships inside the ctxr-fsm Python package at `ctxr/fsm/memory/principles.md` and is the canonical source. The per-client adapters in this same directory (`principles.claude.md`, `principles.codex.md`, `principles.cursor.md`) are generated FROM this file and kept in lockstep. To install into your project memory, run:
+
+    ctxr-fsm install-memory --client auto
+
+To verify the installed version matches the package version, run:
+
+    ctxr-fsm install-memory --check

--- a/ctxr/fsm/memory/principles.codex.md
+++ b/ctxr/fsm/memory/principles.codex.md
@@ -1,0 +1,72 @@
+<!-- This file is generated from ctxr-fsm package memory. Run `ctxr-fsm install-memory --check` to confirm sync. -->
+
+---
+name: ctxr-fsm-principles
+version: 0.1.0
+audience: ai-agents
+---
+
+# ctxr-fsm: how an agent must use the FSM
+
+You have access to an MCP server named "ctxr-fsm" exposing fsm.* tools (healthcheck, list_specs, register_spec, start_run, get_brief, commit_outputs, confirm_commit, resume_run, abort_run, list_runs, get_run, subscribe_events, inspect_journal, recover_journal, observe_tool_call, list_consumers, list_producers).
+
+## Principle 1: pre-check before you act
+
+Before any FSM-using skill or agent does anything, call fsm.healthcheck(). If it fails, return a MissingRequirement reply citing the install command (`pip install ctxr-fsm` or `uv add ctxr-fsm`) and STOP. Do not improvise. Do not fall back to inline behaviour.
+
+## Principle 2: tool surface is constrained during a run
+
+When a run is active, the brief returned by fsm.get_brief carries an `allowed_tools` list. Your tool surface is exactly `fsm.* + current_state.allowed_tools` for the duration of that state. Do NOT call other tools while a run is in progress, even if they look useful. The drift detector will see and pause the run.
+
+## Principle 3: never inline state
+
+- Always read the next step from `fsm.get_brief(run_id)`.
+- Always commit work via `fsm.commit_outputs(run_id, outputs, signature)`.
+- If two-phase commit is in use (the brief carries `requires_confirm: true`), follow up with `fsm.confirm_commit(token, expected_next_state)`.
+
+Never write run state to /tmp or any side channel. The DB is the source of truth.
+
+## Principle 4: schema rejection means re-do the work
+
+If fsm.commit_outputs returns an error envelope with `error: output_schema_violation`, that is the contract working. Re-read `worker.response_schema` from your last brief, fix the shape, retry. Do NOT route around the schema by emitting a free-form note.
+
+## Principle 5: faults are inspection points, not failure modes
+
+On fault, do not improvise a recovery. Call `fsm.resume_run` (with `from_state` or `journal` action) per the operator's instruction, or `fsm.recover_journal`. A fault is for a human (or you, in inspection mode) to look at; it is not a "retry-with-different-inputs" situation unless the post-validation explicitly says so.
+
+## Principle 6: cosignatures matter
+
+The outputs you commit must be derived from the brief + inputs you were given. The cosignature in fsm.commit_outputs is `sha256(brief_id || canonical_json(inputs) || canonical_json(outputs) || session_id)` and is verified at the server. Fabricating outputs is detectable and will be rejected with `error: signature_mismatch`.
+
+## Principle 7: the verifier is right
+
+If an adversarial verifier rejects your output (commit returns `error: verifier_rejected` with the verifier's findings), the verifier is right and you are wrong. Re-do the work. Do NOT argue with the verifier or attempt to commit the same outputs again.
+
+## Principle 8: the spec is the source of truth
+
+A state that looks "wrong" to you is a bug to surface (open an issue, pause the run via fsm.abort_run with reason, or escalate to a human), not a flow to work around.
+
+## Principle 9: observe non-fsm tool calls during a run
+
+When a run is active and you call a tool outside the fsm.* family (e.g. Bash, Read, WebFetch, sub-agents), call `fsm.observe_tool_call(producer_kind, producer_name, tool_name, args_redacted, succeeded, run_id)` for each one. This feeds the drift detector and the run audit log. Skipping this is itself a drift signal.
+
+## Principle 10: subscribe for events when reasoning across states
+
+If you need to react to events from other producers (UI, another agent, a webhook), use `fsm.subscribe_events` to register as a consumer with the right filter. Don't poll fsm.get_run in a loop.
+
+## Lifecycle quick reference
+
+Skill startup: fsm.healthcheck -> fsm.list_specs (find the spec) -> fsm.start_run (returns run_id + first brief).
+State loop: dispatch worker per brief -> fsm.commit_outputs (and confirm_commit if required) -> new brief OR terminal.
+On fault: fsm.inspect_journal -> operator decides fsm.recover_journal or fsm.resume_run.
+Shutdown: leave the run alone; the supervisor + journal handle cleanup.
+
+## What this file is
+
+This file ships inside the ctxr-fsm Python package at `ctxr/fsm/memory/principles.md` and is the canonical source. The per-client adapters in this same directory (`principles.claude.md`, `principles.codex.md`, `principles.cursor.md`) are generated FROM this file and kept in lockstep. To install into your project memory, run:
+
+    ctxr-fsm install-memory --client auto
+
+To verify the installed version matches the package version, run:
+
+    ctxr-fsm install-memory --check

--- a/ctxr/fsm/memory/principles.cursor.md
+++ b/ctxr/fsm/memory/principles.cursor.md
@@ -1,0 +1,77 @@
+---
+description: ctxr-fsm FSM-usage discipline
+globs: ["**/*"]
+alwaysApply: false
+---
+<!-- This file is generated from ctxr-fsm package memory. Run `ctxr-fsm install-memory --check` to confirm sync. -->
+
+---
+name: ctxr-fsm-principles
+version: 0.1.0
+audience: ai-agents
+---
+
+# ctxr-fsm: how an agent must use the FSM
+
+You have access to an MCP server named "ctxr-fsm" exposing fsm.* tools (healthcheck, list_specs, register_spec, start_run, get_brief, commit_outputs, confirm_commit, resume_run, abort_run, list_runs, get_run, subscribe_events, inspect_journal, recover_journal, observe_tool_call, list_consumers, list_producers).
+
+## Principle 1: pre-check before you act
+
+Before any FSM-using skill or agent does anything, call fsm.healthcheck(). If it fails, return a MissingRequirement reply citing the install command (`pip install ctxr-fsm` or `uv add ctxr-fsm`) and STOP. Do not improvise. Do not fall back to inline behaviour.
+
+## Principle 2: tool surface is constrained during a run
+
+When a run is active, the brief returned by fsm.get_brief carries an `allowed_tools` list. Your tool surface is exactly `fsm.* + current_state.allowed_tools` for the duration of that state. Do NOT call other tools while a run is in progress, even if they look useful. The drift detector will see and pause the run.
+
+## Principle 3: never inline state
+
+- Always read the next step from `fsm.get_brief(run_id)`.
+- Always commit work via `fsm.commit_outputs(run_id, outputs, signature)`.
+- If two-phase commit is in use (the brief carries `requires_confirm: true`), follow up with `fsm.confirm_commit(token, expected_next_state)`.
+
+Never write run state to /tmp or any side channel. The DB is the source of truth.
+
+## Principle 4: schema rejection means re-do the work
+
+If fsm.commit_outputs returns an error envelope with `error: output_schema_violation`, that is the contract working. Re-read `worker.response_schema` from your last brief, fix the shape, retry. Do NOT route around the schema by emitting a free-form note.
+
+## Principle 5: faults are inspection points, not failure modes
+
+On fault, do not improvise a recovery. Call `fsm.resume_run` (with `from_state` or `journal` action) per the operator's instruction, or `fsm.recover_journal`. A fault is for a human (or you, in inspection mode) to look at; it is not a "retry-with-different-inputs" situation unless the post-validation explicitly says so.
+
+## Principle 6: cosignatures matter
+
+The outputs you commit must be derived from the brief + inputs you were given. The cosignature in fsm.commit_outputs is `sha256(brief_id || canonical_json(inputs) || canonical_json(outputs) || session_id)` and is verified at the server. Fabricating outputs is detectable and will be rejected with `error: signature_mismatch`.
+
+## Principle 7: the verifier is right
+
+If an adversarial verifier rejects your output (commit returns `error: verifier_rejected` with the verifier's findings), the verifier is right and you are wrong. Re-do the work. Do NOT argue with the verifier or attempt to commit the same outputs again.
+
+## Principle 8: the spec is the source of truth
+
+A state that looks "wrong" to you is a bug to surface (open an issue, pause the run via fsm.abort_run with reason, or escalate to a human), not a flow to work around.
+
+## Principle 9: observe non-fsm tool calls during a run
+
+When a run is active and you call a tool outside the fsm.* family (e.g. Bash, Read, WebFetch, sub-agents), call `fsm.observe_tool_call(producer_kind, producer_name, tool_name, args_redacted, succeeded, run_id)` for each one. This feeds the drift detector and the run audit log. Skipping this is itself a drift signal.
+
+## Principle 10: subscribe for events when reasoning across states
+
+If you need to react to events from other producers (UI, another agent, a webhook), use `fsm.subscribe_events` to register as a consumer with the right filter. Don't poll fsm.get_run in a loop.
+
+## Lifecycle quick reference
+
+Skill startup: fsm.healthcheck -> fsm.list_specs (find the spec) -> fsm.start_run (returns run_id + first brief).
+State loop: dispatch worker per brief -> fsm.commit_outputs (and confirm_commit if required) -> new brief OR terminal.
+On fault: fsm.inspect_journal -> operator decides fsm.recover_journal or fsm.resume_run.
+Shutdown: leave the run alone; the supervisor + journal handle cleanup.
+
+## What this file is
+
+This file ships inside the ctxr-fsm Python package at `ctxr/fsm/memory/principles.md` and is the canonical source. The per-client adapters in this same directory (`principles.claude.md`, `principles.codex.md`, `principles.cursor.md`) are generated FROM this file and kept in lockstep. To install into your project memory, run:
+
+    ctxr-fsm install-memory --client auto
+
+To verify the installed version matches the package version, run:
+
+    ctxr-fsm install-memory --check

--- a/ctxr/fsm/memory/principles.md
+++ b/ctxr/fsm/memory/principles.md
@@ -1,0 +1,70 @@
+---
+name: ctxr-fsm-principles
+version: 0.1.0
+audience: ai-agents
+---
+
+# ctxr-fsm: how an agent must use the FSM
+
+You have access to an MCP server named "ctxr-fsm" exposing fsm.* tools (healthcheck, list_specs, register_spec, start_run, get_brief, commit_outputs, confirm_commit, resume_run, abort_run, list_runs, get_run, subscribe_events, inspect_journal, recover_journal, observe_tool_call, list_consumers, list_producers).
+
+## Principle 1: pre-check before you act
+
+Before any FSM-using skill or agent does anything, call fsm.healthcheck(). If it fails, return a MissingRequirement reply citing the install command (`pip install ctxr-fsm` or `uv add ctxr-fsm`) and STOP. Do not improvise. Do not fall back to inline behaviour.
+
+## Principle 2: tool surface is constrained during a run
+
+When a run is active, the brief returned by fsm.get_brief carries an `allowed_tools` list. Your tool surface is exactly `fsm.* + current_state.allowed_tools` for the duration of that state. Do NOT call other tools while a run is in progress, even if they look useful. The drift detector will see and pause the run.
+
+## Principle 3: never inline state
+
+- Always read the next step from `fsm.get_brief(run_id)`.
+- Always commit work via `fsm.commit_outputs(run_id, outputs, signature)`.
+- If two-phase commit is in use (the brief carries `requires_confirm: true`), follow up with `fsm.confirm_commit(token, expected_next_state)`.
+
+Never write run state to /tmp or any side channel. The DB is the source of truth.
+
+## Principle 4: schema rejection means re-do the work
+
+If fsm.commit_outputs returns an error envelope with `error: output_schema_violation`, that is the contract working. Re-read `worker.response_schema` from your last brief, fix the shape, retry. Do NOT route around the schema by emitting a free-form note.
+
+## Principle 5: faults are inspection points, not failure modes
+
+On fault, do not improvise a recovery. Call `fsm.resume_run` (with `from_state` or `journal` action) per the operator's instruction, or `fsm.recover_journal`. A fault is for a human (or you, in inspection mode) to look at; it is not a "retry-with-different-inputs" situation unless the post-validation explicitly says so.
+
+## Principle 6: cosignatures matter
+
+The outputs you commit must be derived from the brief + inputs you were given. The cosignature in fsm.commit_outputs is `sha256(brief_id || canonical_json(inputs) || canonical_json(outputs) || session_id)` and is verified at the server. Fabricating outputs is detectable and will be rejected with `error: signature_mismatch`.
+
+## Principle 7: the verifier is right
+
+If an adversarial verifier rejects your output (commit returns `error: verifier_rejected` with the verifier's findings), the verifier is right and you are wrong. Re-do the work. Do NOT argue with the verifier or attempt to commit the same outputs again.
+
+## Principle 8: the spec is the source of truth
+
+A state that looks "wrong" to you is a bug to surface (open an issue, pause the run via fsm.abort_run with reason, or escalate to a human), not a flow to work around.
+
+## Principle 9: observe non-fsm tool calls during a run
+
+When a run is active and you call a tool outside the fsm.* family (e.g. Bash, Read, WebFetch, sub-agents), call `fsm.observe_tool_call(producer_kind, producer_name, tool_name, args_redacted, succeeded, run_id)` for each one. This feeds the drift detector and the run audit log. Skipping this is itself a drift signal.
+
+## Principle 10: subscribe for events when reasoning across states
+
+If you need to react to events from other producers (UI, another agent, a webhook), use `fsm.subscribe_events` to register as a consumer with the right filter. Don't poll fsm.get_run in a loop.
+
+## Lifecycle quick reference
+
+Skill startup: fsm.healthcheck -> fsm.list_specs (find the spec) -> fsm.start_run (returns run_id + first brief).
+State loop: dispatch worker per brief -> fsm.commit_outputs (and confirm_commit if required) -> new brief OR terminal.
+On fault: fsm.inspect_journal -> operator decides fsm.recover_journal or fsm.resume_run.
+Shutdown: leave the run alone; the supervisor + journal handle cleanup.
+
+## What this file is
+
+This file ships inside the ctxr-fsm Python package at `ctxr/fsm/memory/principles.md` and is the canonical source. The per-client adapters in this same directory (`principles.claude.md`, `principles.codex.md`, `principles.cursor.md`) are generated FROM this file and kept in lockstep. To install into your project memory, run:
+
+    ctxr-fsm install-memory --client auto
+
+To verify the installed version matches the package version, run:
+
+    ctxr-fsm install-memory --check

--- a/tests/cli/test_install_memory_auto.py
+++ b/tests/cli/test_install_memory_auto.py
@@ -1,0 +1,134 @@
+"""Tests for ``ctxr-fsm install-memory --client auto``.
+
+``auto`` runs every per-client detector and applies the install only
+to the clients whose signature is present in the target directory:
+
+* ``CLAUDE.md`` (or ``.claude/CLAUDE.md``) -> Claude.
+* ``AGENTS.md`` -> Codex.
+* ``.cursor/rules/`` directory -> Cursor.
+
+These tests verify the three interesting branches:
+
+* Both ``CLAUDE.md`` and ``AGENTS.md`` present -> both get patched.
+* Empty target dir -> command exits cleanly with "no client detected"
+  rather than erroring.
+* Only ``.cursor/rules/`` present -> only the Cursor rule file is
+  written (CLAUDE.md / AGENTS.md are NOT created).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ctxr.fsm.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def tmp_target() -> Iterator[Path]:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_auto_patches_both_claude_and_codex_when_both_present(
+    tmp_target: Path,
+) -> None:
+    """Both CLAUDE.md and AGENTS.md present -> both get a marker block."""
+    claude = tmp_target / "CLAUDE.md"
+    agents = tmp_target / "AGENTS.md"
+    claude.write_text("", encoding="utf-8")
+    agents.write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "auto",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    clients_touched = {row["client"] for row in payload["results"]}
+    assert {"claude", "codex"}.issubset(clients_touched)
+    # Cursor should NOT be in the result set (no .cursor/rules dir).
+    assert "cursor" not in clients_touched
+
+    # Both host files now carry a marker block at version 0.1.0.
+    assert "<!-- ctxr-fsm:begin v=0.1.0 -->" in claude.read_text(encoding="utf-8")
+    assert "<!-- ctxr-fsm:begin v=0.1.0 -->" in agents.read_text(encoding="utf-8")
+
+    # And Claude's @ import points at the materialised in-project file.
+    assert "@.ctxr-fsm/memory/principles.claude.md" in claude.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_auto_in_empty_dir_is_clean_no_op(tmp_target: Path) -> None:
+    """No client signature anywhere -> noop, exit 0, no files written."""
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "auto",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["detected"] == []
+    assert "no AI-client memory files found" in payload["message"]
+
+    # Verify the command did not create any of the canonical client files.
+    assert not (tmp_target / "CLAUDE.md").exists()
+    assert not (tmp_target / "AGENTS.md").exists()
+    assert not (tmp_target / ".cursor").exists()
+    assert not (tmp_target / ".ctxr-fsm").exists()
+
+
+def test_auto_with_only_cursor_rules_writes_only_cursor(tmp_target: Path) -> None:
+    """Only .cursor/rules/ present -> only the Cursor rule file is written."""
+    (tmp_target / ".cursor" / "rules").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "auto",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    clients_touched = {row["client"] for row in payload["results"]}
+    assert clients_touched == {"cursor"}
+
+    # The cursor rule file exists.
+    assert (tmp_target / ".cursor" / "rules" / "ctxr-fsm.mdc").is_file()
+    # No spurious CLAUDE.md / AGENTS.md created.
+    assert not (tmp_target / "CLAUDE.md").exists()
+    assert not (tmp_target / "AGENTS.md").exists()

--- a/tests/cli/test_install_memory_check_drift.py
+++ b/tests/cli/test_install_memory_check_drift.py
@@ -1,0 +1,162 @@
+"""Tests for ``ctxr-fsm install-memory --check`` drift detection.
+
+The ``--check`` mode parses the version pinned in each client's
+marker block (or, for Cursor, in the rule file's frontmatter), compares
+it against the version inside the package's principles files, and
+exits non-zero when anything is out of date or missing.
+
+These tests verify the cross-client behaviour:
+
+* After installing into Claude + Codex + Cursor and bumping the
+  package version in-place (via a monkeypatched principles path), a
+  single ``--check`` run reports drift for ALL three clients in one
+  go.
+* When no install has ever happened but client host files exist,
+  ``--check`` reports each as ``missing`` (the marker / frontmatter
+  version is absent) and exits non-zero — this is the "you haven't
+  installed yet" signal.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ctxr.fsm.cli import app, install_memory_cmd
+from ctxr.fsm.memory import get_principles_path
+
+runner = CliRunner()
+
+
+_FILENAME_BY_CLIENT: dict[str, str] = {
+    "canonical": "principles.md",
+    "claude": "principles.claude.md",
+    "codex": "principles.codex.md",
+    "cursor": "principles.cursor.md",
+}
+
+
+@pytest.fixture
+def tmp_target() -> Iterator[Path]:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp).resolve()
+
+
+def _install_bumped_principles(
+    monkeypatch: pytest.MonkeyPatch, scratch: Path, new_version: str
+) -> None:
+    """Patch ``get_principles_path`` to point at a bumped copy of every file."""
+    scratch.mkdir(parents=True, exist_ok=True)
+    for client, filename in _FILENAME_BY_CLIENT.items():
+        original = get_principles_path(client).read_text(encoding="utf-8")
+        bumped = original.replace("version: 0.1.0", f"version: {new_version}")
+        (scratch / filename).write_text(bumped, encoding="utf-8")
+
+    def fake_get(client: str = "claude") -> Path:
+        return scratch / _FILENAME_BY_CLIENT[client]
+
+    monkeypatch.setattr(install_memory_cmd, "get_principles_path", fake_get)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_check_reports_drift_across_all_clients_after_version_bump(
+    tmp_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bumped package version flags drift for claude + codex + cursor."""
+    # Set up all three client signatures so ``auto`` covers everything.
+    (tmp_target / "CLAUDE.md").write_text("", encoding="utf-8")
+    (tmp_target / "AGENTS.md").write_text("", encoding="utf-8")
+    (tmp_target / ".cursor" / "rules").mkdir(parents=True)
+
+    install = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "auto",
+            "--json",
+        ],
+    )
+    assert install.exit_code == 0, install.output
+
+    # Now simulate a package version bump (e.g. release 0.2.0 ships).
+    bumped_dir = tmp_target / "_bumped_principles"
+    _install_bumped_principles(monkeypatch, bumped_dir, "0.2.0")
+
+    check = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "auto",
+            "--check",
+            "--json",
+        ],
+    )
+    assert check.exit_code == 1, check.output
+    payload = json.loads(check.stdout)
+    assert payload["package_version"] == "0.2.0"
+
+    by_client = {row["client"]: row for row in payload["results"]}
+    assert set(by_client) == {"claude", "codex", "cursor"}
+    for client in ("claude", "codex", "cursor"):
+        row = by_client[client]
+        assert row["installed_version"] == "0.1.0", row
+        assert row["package_version"] == "0.2.0", row
+        assert row["status"] == "out-of-date", row
+
+
+def test_check_before_any_install_reports_missing(tmp_target: Path) -> None:
+    """Empty host files exist but no install has happened -> 'missing'."""
+    # Create the host files but do not run install — there is no
+    # marker block / version frontmatter yet.
+    (tmp_target / "CLAUDE.md").write_text("", encoding="utf-8")
+    (tmp_target / "AGENTS.md").write_text("", encoding="utf-8")
+    (tmp_target / ".cursor" / "rules").mkdir(parents=True)
+    # ``.cursor/rules/`` is a directory; ``--check`` walks the host
+    # file (the .mdc) — when it isn't there yet the row is
+    # 'not-installed'. We focus the assertion on the two file-based
+    # clients (CLAUDE.md / AGENTS.md exist but are empty -> 'missing').
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "auto",
+            "--check",
+            "--json",
+        ],
+    )
+
+    # Empty host files -> no marker block / no frontmatter version ->
+    # 'missing' -> exit 1.
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    by_client = {row["client"]: row for row in payload["results"]}
+
+    # Claude / Codex host files exist but are empty: 'missing' (host
+    # is present, version cannot be parsed).
+    for client in ("claude", "codex"):
+        assert by_client[client]["installed_version"] is None, by_client[client]
+        assert by_client[client]["status"] == "missing", by_client[client]
+
+    # Cursor: the rule file does not exist yet, so its host file is
+    # absent -> 'not-installed'.
+    assert by_client["cursor"]["installed_version"] is None
+    assert by_client["cursor"]["status"] == "not-installed"

--- a/tests/cli/test_install_memory_claude.py
+++ b/tests/cli/test_install_memory_claude.py
@@ -1,0 +1,266 @@
+"""Tests for ``ctxr-fsm install-memory --client claude``.
+
+The Claude adapter wires the package's principles file into the
+consumer project by:
+
+1. Materialising ``./.ctxr-fsm/memory/principles.claude.md`` (symlink
+   or copy) so the in-project file resolves.
+2. Appending a marker-fenced block to ``CLAUDE.md`` that contains a
+   single Claude ``@<path>`` import pointing at the materialised file.
+
+These tests drive the public CLI surface through
+:class:`typer.testing.CliRunner` against a fresh tempdir, exercising:
+
+* The marker block lands with the expected ``@`` import line.
+* Two consecutive runs produce byte-identical output (idempotence).
+* ``--check`` after a simulated version bump in the package
+  principles reports ``out-of-date``.
+* ``--dry-run`` reports the patch but never writes the host file or
+  materialises the in-project link.
+* User content above the marker block is preserved verbatim across
+  runs and across re-patches.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ctxr.fsm.cli import app, install_memory_cmd
+from ctxr.fsm.memory import get_principles_path
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+_FILENAME_BY_CLIENT: dict[str, str] = {
+    "canonical": "principles.md",
+    "claude": "principles.claude.md",
+    "codex": "principles.codex.md",
+    "cursor": "principles.cursor.md",
+}
+
+
+@pytest.fixture
+def tmp_target() -> Iterator[Path]:
+    """Yield a fresh tempdir to use as the install ``--target`` root."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp).resolve()
+
+
+def _install_bumped_principles(
+    monkeypatch: pytest.MonkeyPatch, scratch: Path, new_version: str
+) -> None:
+    """Patch ``get_principles_path`` to point at a bumped copy of every file.
+
+    We copy each client's real principles file into ``scratch`` and
+    rewrite the ``version:`` frontmatter key to ``new_version``. Then
+    we monkeypatch the symbol the CLI module imported so the next
+    ``--check`` run sees the bumped version as the "package" version.
+    """
+    scratch.mkdir(parents=True, exist_ok=True)
+    for client, filename in _FILENAME_BY_CLIENT.items():
+        original = get_principles_path(client).read_text(encoding="utf-8")
+        bumped = original.replace("version: 0.1.0", f"version: {new_version}")
+        (scratch / filename).write_text(bumped, encoding="utf-8")
+
+    def fake_get(client: str = "claude") -> Path:
+        return scratch / _FILENAME_BY_CLIENT[client]
+
+    monkeypatch.setattr(install_memory_cmd, "get_principles_path", fake_get)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_install_patches_empty_claude_md_with_import_line(tmp_target: Path) -> None:
+    """Empty CLAUDE.md gains a marker block containing the @ import."""
+    host = tmp_target / "CLAUDE.md"
+    host.write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "claude",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    body = host.read_text(encoding="utf-8")
+    assert "<!-- ctxr-fsm:begin v=0.1.0 -->" in body
+    assert "<!-- ctxr-fsm:end -->" in body
+    assert "@.ctxr-fsm/memory/principles.claude.md" in body
+    # The materialised in-project principles file (symlink or copy)
+    # must also exist so the @ import resolves.
+    linked = tmp_target / ".ctxr-fsm" / "memory" / "principles.claude.md"
+    assert linked.exists()
+
+
+def test_install_is_byte_identical_on_second_run(tmp_target: Path) -> None:
+    """Re-running the install leaves CLAUDE.md byte-for-byte unchanged."""
+    host = tmp_target / "CLAUDE.md"
+    host.write_text("", encoding="utf-8")
+
+    first = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "claude",
+            "--json",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    after_first = host.read_bytes()
+
+    second = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "claude",
+            "--json",
+        ],
+    )
+    assert second.exit_code == 0, second.output
+    after_second = host.read_bytes()
+
+    assert after_first == after_second, "second install must be idempotent"
+
+    # And the second run's structured report records the noop action so
+    # downstream callers can act on it.
+    payload = json.loads(second.stdout)
+    assert payload["results"][0]["action"] == "noop"
+
+
+def test_check_reports_out_of_date_after_version_bump(
+    tmp_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A simulated package version bump makes ``--check`` exit non-zero."""
+    host = tmp_target / "CLAUDE.md"
+    host.write_text("", encoding="utf-8")
+
+    install = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "claude",
+            "--json",
+        ],
+    )
+    assert install.exit_code == 0, install.output
+
+    bumped_dir = tmp_target / "_bumped_principles"
+    _install_bumped_principles(monkeypatch, bumped_dir, "9.9.9")
+
+    check = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "claude",
+            "--check",
+            "--json",
+        ],
+    )
+    assert check.exit_code == 1, check.output
+    payload = json.loads(check.stdout)
+    assert payload["package_version"] == "9.9.9"
+    row = payload["results"][0]
+    assert row["client"] == "claude"
+    assert row["installed_version"] == "0.1.0"
+    assert row["status"] == "out-of-date"
+
+
+def test_dry_run_prints_patch_but_does_not_write(tmp_target: Path) -> None:
+    """``--dry-run`` describes the patch and leaves disk untouched."""
+    host = tmp_target / "CLAUDE.md"
+    host.write_text("# my notes\n", encoding="utf-8")
+    original_bytes = host.read_bytes()
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "claude",
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["dry_run"] is True
+    row = payload["results"][0]
+    assert row["action"] == "dry-run"
+    # The note should describe the patch shape.
+    assert "would" in row["note"]
+
+    # Disk untouched: host file bytes preserved AND the in-project
+    # materialised link was never created.
+    assert host.read_bytes() == original_bytes
+    assert not (tmp_target / ".ctxr-fsm").exists()
+
+
+def test_preserves_user_content_above_marker_block(tmp_target: Path) -> None:
+    """User content above the marker block survives the patch."""
+    host = tmp_target / "CLAUDE.md"
+    user_content = (
+        "# My project memory\n"
+        "\n"
+        "Some longstanding notes the human wrote.\n"
+        "Another paragraph.\n"
+    )
+    host.write_text(user_content, encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "claude",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    body = host.read_text(encoding="utf-8")
+    # Everything the user wrote is still there, in order, at the top.
+    assert body.startswith(user_content.rstrip("\n"))
+    assert "# My project memory" in body
+    assert "Some longstanding notes the human wrote." in body
+    assert "Another paragraph." in body
+    # And the marker block sits AFTER the user content.
+    block_start = body.index("<!-- ctxr-fsm:begin")
+    notes_position = body.index("Another paragraph.")
+    assert notes_position < block_start

--- a/tests/cli/test_install_memory_codex.py
+++ b/tests/cli/test_install_memory_codex.py
@@ -1,0 +1,211 @@
+"""Tests for ``ctxr-fsm install-memory --client codex``.
+
+The Codex adapter targets ``AGENTS.md``. Codex does not support
+Claude's ``@<path>`` import idiom so the principles content is INLINED
+between the ctxr-fsm marker fences at the end of the file.
+
+These tests verify:
+
+* An empty ``AGENTS.md`` ends up with the full principles content
+  inside the marker block (no separate import line).
+* The patch is idempotent across two consecutive runs.
+* ``--check`` against a simulated package version bump reports the
+  drift and exits non-zero.
+* The inlined body is byte-for-byte equal to the package's
+  ``principles.codex.md`` (sans the trailing newline that the marker
+  builder normalises).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ctxr.fsm.cli import app, install_memory_cmd
+from ctxr.fsm.memory import get_principles_path
+
+runner = CliRunner()
+
+
+_FILENAME_BY_CLIENT: dict[str, str] = {
+    "canonical": "principles.md",
+    "claude": "principles.claude.md",
+    "codex": "principles.codex.md",
+    "cursor": "principles.cursor.md",
+}
+
+
+@pytest.fixture
+def tmp_target() -> Iterator[Path]:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp).resolve()
+
+
+def _install_bumped_principles(
+    monkeypatch: pytest.MonkeyPatch, scratch: Path, new_version: str
+) -> None:
+    """Patch ``get_principles_path`` to point at a bumped copy of every file."""
+    scratch.mkdir(parents=True, exist_ok=True)
+    for client, filename in _FILENAME_BY_CLIENT.items():
+        original = get_principles_path(client).read_text(encoding="utf-8")
+        bumped = original.replace("version: 0.1.0", f"version: {new_version}")
+        (scratch / filename).write_text(bumped, encoding="utf-8")
+
+    def fake_get(client: str = "claude") -> Path:
+        return scratch / _FILENAME_BY_CLIENT[client]
+
+    monkeypatch.setattr(install_memory_cmd, "get_principles_path", fake_get)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_install_inlines_principles_into_empty_agents_md(tmp_target: Path) -> None:
+    """Empty AGENTS.md ends up with the full principles inlined."""
+    host = tmp_target / "AGENTS.md"
+    host.write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "codex",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    body = host.read_text(encoding="utf-8")
+    assert "<!-- ctxr-fsm:begin v=0.1.0 -->" in body
+    assert "<!-- ctxr-fsm:end -->" in body
+    # No @ import (that's a Claude-only idiom).
+    assert "@.ctxr-fsm" not in body
+    # The principles body is inlined.
+    assert "# ctxr-fsm: how an agent must use the FSM" in body
+    assert "Principle 1: pre-check before you act" in body
+    assert "Principle 10: subscribe for events when reasoning across states" in body
+
+
+def test_install_is_byte_identical_on_second_run(tmp_target: Path) -> None:
+    """Re-running install on AGENTS.md is a noop and byte-identical."""
+    host = tmp_target / "AGENTS.md"
+    host.write_text("", encoding="utf-8")
+
+    first = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "codex",
+            "--json",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    after_first = host.read_bytes()
+
+    second = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "codex",
+            "--json",
+        ],
+    )
+    assert second.exit_code == 0, second.output
+    after_second = host.read_bytes()
+
+    assert after_first == after_second
+    payload = json.loads(second.stdout)
+    assert payload["results"][0]["action"] == "noop"
+
+
+def test_check_detects_version_drift(
+    tmp_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bumped package version shows up as ``out-of-date`` for codex."""
+    host = tmp_target / "AGENTS.md"
+    host.write_text("", encoding="utf-8")
+
+    install = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "codex",
+            "--json",
+        ],
+    )
+    assert install.exit_code == 0, install.output
+
+    bumped_dir = tmp_target / "_bumped_principles"
+    _install_bumped_principles(monkeypatch, bumped_dir, "2.0.0")
+
+    check = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "codex",
+            "--check",
+            "--json",
+        ],
+    )
+    assert check.exit_code == 1, check.output
+    payload = json.loads(check.stdout)
+    assert payload["package_version"] == "2.0.0"
+    row = payload["results"][0]
+    assert row["client"] == "codex"
+    assert row["installed_version"] == "0.1.0"
+    assert row["status"] == "out-of-date"
+
+
+def test_inlined_content_matches_package_file_byte_for_byte(
+    tmp_target: Path,
+) -> None:
+    """The body between the marker fences equals the package file's text."""
+    host = tmp_target / "AGENTS.md"
+    host.write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "codex",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    body = host.read_text(encoding="utf-8")
+    begin = "<!-- ctxr-fsm:begin v=0.1.0 -->\n"
+    end = "\n<!-- ctxr-fsm:end -->"
+    start_idx = body.index(begin) + len(begin)
+    end_idx = body.index(end, start_idx)
+    inlined_payload = body[start_idx:end_idx]
+
+    package_text = get_principles_path("codex").read_text(encoding="utf-8")
+    # The CLI normalises the payload via rstrip("\n") before inlining,
+    # so compare against the stripped form.
+    assert inlined_payload == package_text.rstrip("\n")

--- a/tests/cli/test_install_memory_cursor.py
+++ b/tests/cli/test_install_memory_cursor.py
@@ -1,0 +1,178 @@
+"""Tests for ``ctxr-fsm install-memory --client cursor``.
+
+Cursor uses standalone rule files under ``.cursor/rules/``; the
+adapter writes the package's ``principles.cursor.md`` verbatim to
+``.cursor/rules/ctxr-fsm.mdc``. There is no marker block — version
+tracking falls back to the YAML ``version:`` key inside the file's
+frontmatter.
+
+These tests verify:
+
+* The rule file is created with the right frontmatter (Cursor's
+  ``description:`` / ``globs:`` / ``alwaysApply:`` header).
+* Two consecutive installs produce a byte-identical rule file.
+* ``--check`` against a simulated package bump reports drift.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ctxr.fsm.cli import app, install_memory_cmd
+from ctxr.fsm.memory import get_principles_path
+
+runner = CliRunner()
+
+
+_FILENAME_BY_CLIENT: dict[str, str] = {
+    "canonical": "principles.md",
+    "claude": "principles.claude.md",
+    "codex": "principles.codex.md",
+    "cursor": "principles.cursor.md",
+}
+
+
+@pytest.fixture
+def tmp_target() -> Iterator[Path]:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp).resolve()
+
+
+def _install_bumped_principles(
+    monkeypatch: pytest.MonkeyPatch, scratch: Path, new_version: str
+) -> None:
+    """Patch ``get_principles_path`` to point at a bumped copy of every file."""
+    scratch.mkdir(parents=True, exist_ok=True)
+    for client, filename in _FILENAME_BY_CLIENT.items():
+        original = get_principles_path(client).read_text(encoding="utf-8")
+        bumped = original.replace("version: 0.1.0", f"version: {new_version}")
+        (scratch / filename).write_text(bumped, encoding="utf-8")
+
+    def fake_get(client: str = "claude") -> Path:
+        return scratch / _FILENAME_BY_CLIENT[client]
+
+    monkeypatch.setattr(install_memory_cmd, "get_principles_path", fake_get)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_install_creates_cursor_rule_with_frontmatter(tmp_target: Path) -> None:
+    """``.cursor/rules/ctxr-fsm.mdc`` is created with the Cursor frontmatter."""
+    (tmp_target / ".cursor" / "rules").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "cursor",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    rule = tmp_target / ".cursor" / "rules" / "ctxr-fsm.mdc"
+    assert rule.is_file()
+
+    body = rule.read_text(encoding="utf-8")
+    # First line opens the frontmatter block.
+    assert body.startswith("---\n")
+    # Cursor-specific keys must be present.
+    assert "description: ctxr-fsm FSM-usage discipline" in body
+    assert "globs:" in body
+    assert "alwaysApply:" in body
+    # And the canonical principles version block is also inside.
+    assert "version: 0.1.0" in body
+    assert "# ctxr-fsm: how an agent must use the FSM" in body
+
+
+def test_install_is_byte_identical_on_second_run(tmp_target: Path) -> None:
+    """Re-running install leaves the Cursor rule byte-for-byte unchanged."""
+    (tmp_target / ".cursor" / "rules").mkdir(parents=True)
+    rule = tmp_target / ".cursor" / "rules" / "ctxr-fsm.mdc"
+
+    first = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "cursor",
+            "--json",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    after_first = rule.read_bytes()
+
+    second = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "cursor",
+            "--json",
+        ],
+    )
+    assert second.exit_code == 0, second.output
+    after_second = rule.read_bytes()
+
+    assert after_first == after_second
+    payload = json.loads(second.stdout)
+    assert payload["results"][0]["action"] == "noop"
+
+
+def test_check_detects_out_of_date_after_version_bump(
+    tmp_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bumped package version shows up as ``out-of-date`` for cursor."""
+    (tmp_target / ".cursor" / "rules").mkdir(parents=True)
+
+    install = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "cursor",
+            "--json",
+        ],
+    )
+    assert install.exit_code == 0, install.output
+
+    bumped_dir = tmp_target / "_bumped_principles"
+    _install_bumped_principles(monkeypatch, bumped_dir, "3.1.4")
+
+    check = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "cursor",
+            "--check",
+            "--json",
+        ],
+    )
+    assert check.exit_code == 1, check.output
+    payload = json.loads(check.stdout)
+    assert payload["package_version"] == "3.1.4"
+    row = payload["results"][0]
+    assert row["client"] == "cursor"
+    assert row["installed_version"] == "0.1.0"
+    assert row["status"] == "out-of-date"

--- a/tools/generate_memory_adapters.py
+++ b/tools/generate_memory_adapters.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Generate per-client memory adapters from the canonical principles file.
+
+Reads ``ctxr/fsm/memory/principles.md`` and emits three sibling files:
+
+* ``principles.claude.md``  -- Claude Code (CLAUDE.md, plain markdown)
+* ``principles.codex.md``   -- Codex (AGENTS.md, plain markdown)
+* ``principles.cursor.md``  -- Cursor (.mdc, with Cursor frontmatter)
+
+The generator is idempotent: running it twice in a row produces
+byte-identical files. The Claude and Codex adapters share the canonical
+body verbatim with a single generated-from HTML comment header. The
+Cursor adapter wraps the same body with Cursor-specific YAML frontmatter
+(``description``, ``globs``, ``alwaysApply``).
+
+Run from the repo root::
+
+    uv run python tools/generate_memory_adapters.py
+
+Exits 0 on success, non-zero on error.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+MEMORY_DIR: Path = REPO_ROOT / "ctxr" / "fsm" / "memory"
+CANONICAL: Path = MEMORY_DIR / "principles.md"
+
+GENERATED_HEADER: str = (
+    "<!-- This file is generated from ctxr-fsm package memory. "
+    "Run `ctxr-fsm install-memory --check` to confirm sync. -->\n"
+)
+
+CURSOR_FRONTMATTER: str = (
+    "---\n"
+    "description: ctxr-fsm FSM-usage discipline\n"
+    'globs: ["**/*"]\n'
+    "alwaysApply: false\n"
+    "---\n"
+)
+
+
+@dataclass(frozen=True)
+class Adapter:
+    """A per-client adapter file to emit."""
+
+    filename: str
+    frontmatter: str  # extra YAML frontmatter prepended above the header
+    body_prefix: str  # text inserted between frontmatter and canonical body
+
+
+ADAPTERS: tuple[Adapter, ...] = (
+    Adapter(
+        filename="principles.claude.md",
+        frontmatter="",
+        body_prefix=GENERATED_HEADER + "\n",
+    ),
+    Adapter(
+        filename="principles.codex.md",
+        frontmatter="",
+        body_prefix=GENERATED_HEADER + "\n",
+    ),
+    Adapter(
+        filename="principles.cursor.md",
+        frontmatter=CURSOR_FRONTMATTER,
+        body_prefix=GENERATED_HEADER + "\n",
+    ),
+)
+
+
+def _render(canonical_text: str, adapter: Adapter) -> str:
+    """Compose the final file contents for one adapter."""
+
+    return f"{adapter.frontmatter}{adapter.body_prefix}{canonical_text}"
+
+
+def _write_if_changed(path: Path, content: str) -> bool:
+    """Write ``content`` to ``path``; return True if disk changed."""
+
+    encoded = content.encode("utf-8")
+    if path.is_file() and path.read_bytes() == encoded:
+        return False
+    path.write_bytes(encoded)
+    return True
+
+
+def main() -> int:
+    if not CANONICAL.is_file():
+        print(
+            f"error: canonical principles file not found at {CANONICAL}",
+            file=sys.stderr,
+        )
+        return 1
+
+    canonical_text = CANONICAL.read_text(encoding="utf-8")
+
+    changed: list[str] = []
+    unchanged: list[str] = []
+    for adapter in ADAPTERS:
+        target = MEMORY_DIR / adapter.filename
+        rendered = _render(canonical_text, adapter)
+        if _write_if_changed(target, rendered):
+            changed.append(adapter.filename)
+        else:
+            unchanged.append(adapter.filename)
+
+    if changed:
+        print(f"updated: {', '.join(changed)}")
+    if unchanged:
+        print(f"unchanged: {', '.join(unchanged)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

W11 of the SQLite-backed Python FSM plan: the agent-facing discipline file ships inside the package; \`ctxr-fsm install-memory\` wires it into the consumer project's standard client memory (CLAUDE.md / AGENTS.md / .cursor/rules) idempotently. **No RAG dependency.**

**410/410 pytest, ruff + mypy clean.**

> **Base branch is \`w7/service-lifecycle\` (PR #31).**

## What ships

- **\`ctxr/fsm/memory/principles.md\`** — 10 numbered principles + lifecycle quick reference. Pre-check via \`fsm.healthcheck\`; tool-surface constrained during runs; never inline state; schema rejection means re-do; faults are inspection points; cosignatures matter; the verifier is right; spec is source of truth; observe non-fsm tool calls; subscribe for events.
- **\`ctxr/fsm/memory/principles.{claude,codex,cursor}.md\`** — per-client adapters with the right frontmatter for each. Generated by \`tools/generate_memory_adapters.py\` (idempotent).
- **\`ctxr-fsm install-memory\`** — CLI subcommand:
  - \`--client {auto,claude,codex,cursor}\`
  - \`--check\` per-client status table (exits non-zero on drift)
  - \`--dry-run\` previews patches without writing
  - \`--no-symlink\` always copy
  - \`--target PATH\`
  - Idempotent marker block: \`<!-- ctxr-fsm:begin v=X.Y.Z --> ... <!-- ctxr-fsm:end -->\`. Replaces in-place if present; appends to end with leading blank line if not. User content above markers preserved.
- **\`ctxr-fsm init\`** auto-runs \`install-memory --client auto\` at end unless \`--no-memory\` passed.

## Workspace cross-reference

- \`../common-dev-principles/principle-deterministic-flow-discipline.md\` — new Principle 3 that points at the package-resident principles file as the agent-facing source of truth; says deterministic skills MUST use the FSM; cites \`ctxr-fsm install-memory --client auto\` as the install command. Composes with Principle 1 (Requirement Pre-check).
- index.md + AGENTS.md updated to list Principle 3.

## Tests (5 files, 17 tests)

| File | Tests |
|---|---|
| test_install_memory_claude.py | 5 |
| test_install_memory_codex.py | 4 |
| test_install_memory_cursor.py | 3 |
| test_install_memory_auto.py | 3 |
| test_install_memory_check_drift.py | 2 |

All use typer.testing.CliRunner + tempfile.TemporaryDirectory; version-drift simulation monkeypatches \`get_principles_path\` to a scratch dir with rewritten frontmatter.

## Verify

- [x] \`uv run pytest tests/\` — **410 passed in 58.36s** (197+72+56+17+30+21+17).
- [x] \`uv run ruff check ctxr/ tests/\` — **All checks passed!**
- [x] \`uv run mypy ctxr/fsm/\` — **Success: no issues found in 58 source files**.

## Plan reference

\`/Users/developer/.claude/plans/how-it-fits-toasty-gray.md\` — W11 section.