### PR TITLE
docs(w9): 9 docs/*.md files + production-ready top-level README + CHANGELOG 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable changes to `ctxr-fsm` (the Python package at this repository root) are documented in this file.
+
+The format is based on [Keep a Changelog v1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The cohabiting Node.js package `@ctxr/fsm` at [`legacy-js/`](legacy-js/) keeps its own changelog under [`legacy-js/CHANGELOG.md`](legacy-js/CHANGELOG.md); entries here cover the Python rewrite only.
+
+## [Unreleased]
+
+In development toward `0.2.0`. Tracked workstreams (post-`0.1.0`):
+
+- W6 UI run-detail polish — keyboard navigation, journal-txn inspector, event-filter facets.
+- Verifier specialists — pluggable real-LLM panels beyond the default structural verifier (design-constraints judge, acceptance-criteria judge, security-review judge).
+- Per-project supervisor metrics endpoint + Prometheus scrape target.
+- W10 CI/CD — automated import-linting, manual-publish workflow polish, release-note generator wired to this file.
+- Cross-project drift dashboards in `fsm-ui`.
+
+No public API breakage planned for `0.2.0`. The 17 `fsm.*` MCP tools, the `/api/v1/` REST surface, the SQLite schema (alembic head), and the `ctxr-fsm` CLI command set are stable contracts.
+
+## [0.1.0] — 2026-05-30
+
+First public release. Establishes the full Python substrate end-to-end: pure core, SQLite persistence, three operator surfaces (MCP, REST, CLI), the UI, the supervised service lifecycle, three runnable examples, the principles-injection CLI, and the enforcement primitives. Distributed on PyPI as `ctxr-fsm` (publishes manually via `workflow_dispatch`).
+
+### Added
+
+**W1 — `ctxr.fsm.core` — pure FSM substrate.**
+Pydantic models (`FsmSpec`, `State`, `Transition`, `Worker`, `Loop`, `Predicate`, `ResponseSchema`, `VerifierSpec`, `Brief`, `WorkerOutput`, `CommitSignature`, `CommitToken`, `RunCtx`, `ValidationResult`). Pure engine (`build_brief`, `validate_output`, `resolve_transition`, `run_post_validations`, `advance`, `EngineAdvanceResult`). Loop iteration mechanics (`loop_decide`, `outputs_path_for`). Pure aggregator folds (`aggregate_loop_outputs`, `aggregate_across_states`). Spec validation + canonical hashing (`FsmSpec.validate()`, `FsmSpec.hash()`). Sandboxed predicate DSL for guards and post-validations. Adversarial verifier panel runtime. `Repository`, `EventBus`, `JournalProtocol`, `Lock` Protocols.
+
+**W2 — `ctxr.fsm.sqlite` — persistence.**
+SQLite STRICT-mode schema with WAL. Alembic migrations (runnable in-process — no `alembic` binary needed). 18 tables across `models_core.py`, `models_enforcement.py`, `models_events.py`. Repositories (`repos_core`, `repos_states`, `repos_events`, `repos_locks_journal`, `repos_enforcement`). `Project` facade as the single object higher layers use. Atomic transactions through `transactions.py` (one SQLite tx + one append-only journal entry per observable mutation). UUIDv7 PKs, ISO-8601 UTC timestamps, canonical JSON columns. Event bus, single-writer lock, drift detector.
+
+**W3 — `ctxr.fsm.cli` — `typer` console script.**
+`init`, `migrate`, `serve`, `mcp`, `api`, `ui`, `doctor`. Run commands: `runs ls`, `run show`, `run resume`, `run abort`. Spec commands: `spec validate`, `spec register`, `spec list`. Data: `export`, `import` (`schema_version: 1` JSON, atomic). `install-memory` (see W11). 56 tests. Global `--db` / `$CTXR_FSM_DB` / `./.ctxr-fsm/fsm.db` precedence, `--json` everywhere, structured exit codes (0/1/2).
+
+**W4 — `ctxr.fsm.mcp` — MCP server.**
+Anthropic Python SDK-based server exposing 17 `fsm.*` tools across four groups: meta + bootstrap (`fsm.healthcheck`, `fsm.list_specs`, `fsm.register_spec`, `fsm.observe_tool_call`); run lifecycle (`fsm.start_run`, `fsm.get_brief`, `fsm.commit_outputs`, `fsm.confirm_commit`, `fsm.resume_run`, `fsm.abort_run`, `fsm.list_runs`, `fsm.get_run`); events + journal (`fsm.subscribe_events`, `fsm.inspect_journal`, `fsm.recover_journal`, `fsm.list_consumers`, `fsm.list_producers`). Structured `McpToolError` envelope, stdio + HTTP/SSE transports, integration tests.
+
+**W5 — `ctxr.fsm.api` — FastAPI REST + SSE.**
+FastAPI app at `ctxr.fsm.api:app` mounted under `/api/v1/`. Mirrors the W4 MCP surface for HTTP clients. SSE event stream at `/events`. OpenAPI/Swagger at `/docs`, schemas at `/openapi.json`. Auth surface, admin routes, request/response models cross-validated with the MCP tool models.
+
+**W6 — `fsm-ui` — observation surface.**
+Vite + Preact + Tailwind v4 + TypeScript SPA at `ui/`. SSE consumer over the FastAPI `/events` stream. Run list, run detail, state tree, event timeline. Write actions round-trip through the same REST endpoints any other client would call.
+
+**W7 — Service lifecycle.**
+`ctxr-fsm serve` supervisor with one child per subsystem (MCP, FastAPI, Vite UI, drift daemon, healthz probe). One PID file at `.ctxr-fsm/run/supervisor.pid` prevents double-boot. Reserved ports up front, recorded in `.ctxr-fsm/run/ports.json`. Graceful drain reload (`ctxr-fsm serve reload`). `ctxr-fsm doctor` walks PID file, port file, DB migrations, journal integrity, and drift state and reports pass/fail per subsystem. Single SQLite writer enforcement; readers go through WAL.
+
+**W8 — Examples.**
+Three runnable, fully-deterministic FSM workflows under `examples/` driving the engine end-to-end with simulated worker outputs (offline, sub-second): `plan_implement_qa_fix.py` (loops, predicates, conditional branches, post-validations), `code_review_pipeline.py` (fan-out loop, cross-state aggregation, GO/CONDITIONAL/NO-GO synthesis), `research_with_retries.py` (judgement transitions, retry back-edges, journal recovery). End-to-end tests for each.
+
+**W11 — Principles + memory injection.**
+`ctxr-fsm install-memory` injects (or checks) FSM-usage principles into AI-client memory files: Claude (`CLAUDE.md` or `.claude/CLAUDE.md` via `@.ctxr-fsm/memory/principles.claude.md` import), Codex (`AGENTS.md` body inlined), Cursor (`.cursor/rules/ctxr-fsm.mdc`). Idempotent marker-block format; `--check` exits non-zero for CI gating. Cross-reference into Principle 3 of the common-dev rule set.
+
+**W12 — Enforcement primitives.**
+Four orthogonal groups across six layers:
+
+- **Capability**: `State.allowed_tools` surfacing on the brief (layer 2). Claude Code `pre-tool-use.fsm-guard.py` hook (layer 4) blocks off-allowlist calls in CC sessions.
+- **Integrity**: spec-hash lock (layer 9) pins a running workflow to its registered spec hash. Commit cosignature (layer 5) — `SHA-256` over canonical JSON of `{brief_id, inputs_hash, outputs_hash, session_id}`. Two-phase commit (layer 12) — `fsm.commit_outputs` mints a 60s-TTL `CommitToken`; `fsm.confirm_commit` consumes it and replays the journal.
+- **Adversarial**: verifier panel (layer 3). Default structural verifier (re-applies `response_schema`); `set_verifier_handler()` registers a real LLM panel; majority threshold per `VerifierSpec`.
+- **Observational**: drift detector (layer 8). Background task in the supervisor tallies signal weights per run; cumulative score strictly above `score_threshold` flips `run.status = drift_paused` exactly once. Defaults tuned so one accidental off-allowlist call is noise, three trip the pause. Kill switch via `CTXR_FSM_DRIFT_DISABLED=1`.
+
+Plus the operator playbooks in [`docs/enforcement.md`](docs/enforcement.md) and [`docs/recovery.md`](docs/recovery.md).
+
+**W9 — Documentation.**
+Production-ready top-level [`README.md`](README.md) and this changelog. Full reference set under [`docs/`](docs/): `architecture.md`, `api.md`, `data-model.md`, `mcp-tools.md`, `http-api.md`, `operating.md`, `enforcement.md`, `examples-tour.md`, `recovery.md`.
+
+### Note about the JS cohabitation
+
+The pre-rewrite Node.js package `@ctxr/fsm` continues to live at [`legacy-js/`](legacy-js/) and publishes to npm independently via `legacy-js/.github/workflows/publish.yml`. This Python `0.1.0` release does **not** change, deprecate, or replace the JS package — existing npm consumers (notably `skill-code-review`) keep working unchanged. Migrating JS consumers onto `ctxr-fsm` is tracked separately and is not a precondition for adopting either side.
+
+### Known issues / future
+
+- **W6 UI run-detail polish** — current dashboard renders run list, state tree, and event timeline; keyboard navigation, journal-txn inspector, and per-event-kind filter facets land in `0.2.0`.
+- **Verifier specialists** — `verifier.py` ships with a structural default. Real-LLM specialist panels (design-constraints judge, acceptance-criteria judge, security-review judge) ship in `0.2.0`. Register your own today via `set_verifier_handler()`.
+- **W10 CI/CD** — manual `workflow_dispatch` publish is wired and used to cut this release; full import-lint enforcement, branch-protection automation, and auto-generated release notes from this file land alongside `0.2.0`.
+- **Engine-driven resume** — `ctxr-fsm run resume` currently performs the bookkeeping half (journal discard/replay + `run_resumed` event). The engine-driven half (re-deriving the next brief from the resumed state) tracks under the W12 follow-up issue.
+- **Cross-project dashboards** — the UI scopes to one project DB at a time. Multi-project rollups land post-`0.2.0`.
+
+[Unreleased]: https://github.com/ctxr-dev/fsm/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ctxr-dev/fsm/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,71 +1,94 @@
-# fsm/
+# ctxr-fsm — SQLite-backed FSM substrate for deterministic LLM-orchestrated workflows
 
-Two roots cohabiting during the JavaScript → Python migration:
+A Python 3.12+ runtime that turns an `FsmSpec` into a crash-safe, auditable agent workflow on top of a single SQLite database. Workers (LLMs, scripts, humans) advance the run through `fsm.*` tools served over MCP, REST, or stdio; the substrate enforces what each state may do, cosigns every commit, runs an adversarial verifier panel, and quarantines runs that drift. One DB, one process tree, one observable timeline — no Redis, no queue broker, no Kubernetes.
 
-- **`./` (this root)** — the new `ctxr-fsm` Python 3.12+ library, with SQLite as the primary persistence layer, plus shipped subsystems: `ctxr.fsm.core`, `ctxr.fsm.sqlite`, `ctxr.fsm.mcp` (MCP server), `ctxr.fsm.api` (FastAPI), `fsm-ui` (Vite + Preact + Tailwind v4 SPA at `ui/`), and runnable agent-orchestration examples under `examples/`. Imported as `ctxr.fsm` via PEP 420 namespace packages (no top-level `ctxr/__init__.py`). PyPI distribution: `ctxr-fsm`. Not yet published — `0.1.0` is in active build.
-- **`./legacy-js/`** — the existing published `@ctxr/fsm` Node.js library (251 tests, A1–A9 + A7 atomic-tx journal, 0.2.0-pre). Still publishes from there via `legacy-js/.github/workflows/publish.yml` so `skill-code-review` and every other npm consumer keeps working unchanged during the rewrite. Migrating JS consumers to the new Python system is a separate plan; until that lands, the JS root is the source of truth for shipped behaviour.
+## Architecture at a glance
 
-The full plan, including all locked decisions, sequenced workstreams (W0–W12), and verification gates, lives at `/Users/developer/.claude/plans/how-it-fits-toasty-gray.md` in the developer workspace.
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                      UI (fsm-ui · Vite + Preact)                     │
+│              SSE consumer over the FastAPI event stream              │
+└──────────────────────────────────────────────────────────────────────┘
+                              ▲
+┌─────────────────┬────────────┴───────────┬──────────────────────────┐
+│  ctxr.fsm.mcp   │      ctxr.fsm.api      │      ctxr.fsm.cli        │
+│  (MCP server)   │ (FastAPI · REST + SSE) │   (typer · operator)     │
+│   17 fsm.*      │   /runs /specs /events │   init · serve · doctor  │
+│   tools         │   /admin               │   runs · spec · migrate  │
+└─────────────────┴────────────┬───────────┴──────────────────────────┘
+                               ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                          ctxr.fsm.sqlite                             │
+│   STRICT schema · alembic migrations · 18 tables · repositories      │
+│   Project facade · transactions · journal · locks · drift detector   │
+└──────────────────────────────────────────────────────────────────────┘
+                               ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                            ctxr.fsm.core                             │
+│  Pydantic models · engine (advance) · predicate DSL · loop · agg     │
+│  spec validate/hash · verifier panel · Protocols for persistence     │
+└──────────────────────────────────────────────────────────────────────┘
+```
 
-## Status
+Arrows point in the dependency direction. The core never imports SQLite; SQLite never imports MCP/API/CLI; the UI talks HTTP only. Full reference: [docs/architecture.md](docs/architecture.md).
 
-| Subsystem | State | Path |
+## Quick start
+
+```bash
+uv add ctxr-fsm                                       # or: pip install 'ctxr-fsm[all]'
+ctxr-fsm init                                         # .ctxr-fsm/fsm.db + migrations + AI-memory patch
+ctxr-fsm spec register examples.plan_implement_qa_fix:spec
+ctxr-fsm serve --mode dev                             # boots MCP + FastAPI + Vite UI
+open http://localhost:5173                            # browse the run dashboard
+```
+
+`ctxr-fsm init` is idempotent — re-run it any time to top up migrations or refresh the principles installed into `CLAUDE.md` / `AGENTS.md`. `serve --mode dev` is a single supervisor process; `ctxr-fsm doctor` prints DB facts plus per-subsystem health.
+
+## What's included
+
+| Subsystem | What it does | Doc |
 |---|---|---|
-| `legacy-js/` Node `@ctxr/fsm` | Published, frozen feature set (bug-fix only) | `legacy-js/` |
-| `ctxr.fsm.core` (Pydantic + engine) | In build (W1) | `ctxr/fsm/core/` |
-| `ctxr.fsm.sqlite` (schema + repo) | In build (W2) | `ctxr/fsm/sqlite/` |
-| `ctxr.fsm.cli` (typer) | In build (W3) | `ctxr/fsm/cli/` |
-| `ctxr.fsm.mcp` (MCP server) | In build (W4) | `ctxr/fsm/mcp/` |
-| `ctxr.fsm.api` (FastAPI) | In build (W5) | `ctxr/fsm/api/` |
-| `fsm-ui` (Vite + Preact + Tailwind v4) | In build (W6) | `ui/` |
-| Service lifecycle (supervisor) | In build (W7) | `ctxr/fsm/cli/serve.py` |
-| Examples | In build (W8) | `examples/` |
-| Principles + memory injection | In build (W11) | `ctxr/fsm/memory/` |
-| Enforcement primitives | In build (W12) | across W1/W2/W4/W7 |
+| `ctxr.fsm.core` | Pydantic spec models, pure engine (`advance`, `build_brief`), predicate DSL, loop + aggregator, spec hashing, verifier panel, Protocol surface | [docs/api.md](docs/api.md) |
+| `ctxr.fsm.sqlite` | STRICT-mode schema across 18 tables, alembic migrations, repositories, `Project` facade, single-writer lock, atomic-tx journal, drift detector | [docs/data-model.md](docs/data-model.md) |
+| `ctxr.fsm.mcp` | MCP server (stdio + HTTP/SSE) exposing 17 `fsm.*` tools — start runs, get briefs, commit + confirm outputs, subscribe to events, inspect the journal | [docs/mcp-tools.md](docs/mcp-tools.md) |
+| `ctxr.fsm.api` | FastAPI app with REST + SSE under `/api/v1/`, OpenAPI at `/docs`, auth surface, mirrors the MCP tool set for browser / HTTP clients | [docs/http-api.md](docs/http-api.md) |
+| `ctxr.fsm.cli` | `typer` console script: `init`, `migrate`, `serve`, `mcp`, `api`, `ui`, `doctor`, `runs ls`, `run show/resume/abort`, `spec validate/register/list`, `export`, `import`, `install-memory` | [docs/operating.md](docs/operating.md) |
+| `fsm-ui` | Vite + Preact + Tailwind v4 SPA in `ui/`. SSE-driven run dashboard | [docs/architecture.md](docs/architecture.md) |
+| Service lifecycle | Supervisor with one child per subsystem, reserved ports, PID singleton, graceful drain reload, `doctor` integrity sweep | [docs/operating.md](docs/operating.md) |
+| Enforcement | Spec-hash lock, commit cosignature, two-phase commit, adversarial verifier panel, drift detector, Claude Code pre-tool-use hook | [docs/enforcement.md](docs/enforcement.md) |
+| Examples | Three runnable simulated-worker workflows: plan/implement/qa/fix, code-review pipeline, research-with-retries | [docs/examples-tour.md](docs/examples-tour.md) |
+| Recovery | Operator playbook for crashes, stalled journal txns, drift quarantine, replay | [docs/recovery.md](docs/recovery.md) |
 
-## Quick start (once W0 + W1 + W2 land)
+## Why an FSM substrate?
 
-```bash
-# In your consumer project:
-uv add ctxr-fsm                      # or: pip install ctxr-fsm
-ctxr-fsm init                        # creates .ctxr-fsm/fsm.db + applies migrations + patches CLAUDE.md/AGENTS.md
-ctxr-fsm serve --mode dev            # boots MCP + FastAPI + fsm-ui dev server
-# browse http://localhost:<port>     # see the run dashboard
-```
+A bare LLM loop is a probability cloud over tool calls; an FSM is a contract. Each state declares what tools the worker may call, what shape its output must take, what predicate decides the next state, and whether an adversarial verifier panel has to second the result. The substrate then enforces that contract with a two-phase commit, a cosignature over the brief + inputs + outputs, a spec-hash lock that pins a running workflow to its declared shape, and a background drift detector that quarantines runs whose accumulated misbehaviour crosses a configurable threshold. The result is a workflow you can replay, audit, and resume — not just one you can rerun and hope. Full layer-by-layer reference: [docs/enforcement.md](docs/enforcement.md).
 
-## Legacy quick start (npm)
+## What's at `legacy-js/`
 
-```bash
-cd legacy-js && npm install
-npx @ctxr/fsm --help
-```
+The pre-rewrite Node.js package `@ctxr/fsm` lives at [`legacy-js/`](legacy-js/) and still publishes to npm from there via its own workflow. It cohabits this repository so existing JS consumers (notably `skill-code-review`) keep working unchanged while the Python rewrite stabilises; migrating JS consumers onto `ctxr-fsm` is tracked separately and is not a precondition for using either side.
 
-See `legacy-js/README.md` for the JS API surface and CLI reference.
+## Documentation
 
-## Migration plan
+- [docs/architecture.md](docs/architecture.md) — layered design, dependency rule, service topology
+- [docs/api.md](docs/api.md) — Python API reference (`ctxr.fsm.core` + `ctxr.fsm.sqlite`)
+- [docs/data-model.md](docs/data-model.md) — every SQLite table, enum vocabulary, ER diagram, journal contract
+- [docs/mcp-tools.md](docs/mcp-tools.md) — the 17 `fsm.*` MCP tools, error envelope, examples
+- [docs/http-api.md](docs/http-api.md) — REST + SSE surface, auth, OpenAPI
+- [docs/operating.md](docs/operating.md) — CLI reference, env vars, port + PID layout
+- [docs/enforcement.md](docs/enforcement.md) — spec-hash lock, cosignature, two-phase commit, verifier, drift detector, CC hook
+- [docs/examples-tour.md](docs/examples-tour.md) — walkthrough of the three runnable examples
+- [docs/recovery.md](docs/recovery.md) — crash + drift + replay operator playbook
 
-The plan file (`how-it-fits-toasty-gray.md` in the developer workspace) is the single source of truth for what lands when. The high-level sequence:
+## Quick links
 
-```
-W0  cohabitation       (you are here)
-W1  core lib           Pydantic + engine + predicates + loop + aggregator
-W2  sqlite             schema + alembic + repo + event bus + transactions
-W3  CLI                typer app + init + runs + spec + serve
-W4  MCP server         fsm.* tools incl. healthcheck + observe + confirm
-W5  FastAPI            REST + SSE
-W6  fsm-ui             Vite + Preact + Tailwind v4 SPA
-W7  service lifecycle  supervisor + ports + PIDs + reuse + live reload
-W8  examples           three runnable agent workflows
-W11 principles + install-memory CLI
-W12 enforcement        spec-hash lock + cosignature + verifier + drift detector + hook
-W9  documentation
-W10 CI/CD (manual publish only, per Principle 2)
-```
-
-## Contributing
-
-This is part of the [ctxr-dev workspace](https://github.com/ctxr-dev). New Python work lands under `ctxr/fsm/` and is driven by per-workstream branches and PRs. JS bug fixes land under `legacy-js/`. Cross-cutting changes (the two-roots layout itself) live at this top level.
+- PyPI: [`ctxr-fsm`](https://pypi.org/project/ctxr-fsm/) (publishes from this repo — manual `workflow_dispatch` only)
+- GitHub: [ctxr-dev/fsm](https://github.com/ctxr-dev/fsm) — issues, PRs, CI
+- Plan: `/Users/developer/.claude/plans/how-it-fits-toasty-gray.md` — single source of truth for workstreams (W0–W12), locked decisions, verification gates
 
 ## License
 
-MIT for both roots. See `LICENSE` (Python) and `legacy-js/LICENSE` (JS).
+MIT for both roots. See [`LICENSE`](LICENSE) (Python) and [`legacy-js/LICENSE`](legacy-js/LICENSE) (JS).
+
+## Contributors
+
+Maintained by [ctxr-dev](https://github.com/ctxr-dev). Python work lands under `ctxr/fsm/` on per-workstream branches; JS bug fixes land under `legacy-js/`. Cross-cutting changes (the cohabitation itself, the top-level README, this CHANGELOG) live at this root. PRs welcome — read [docs/architecture.md](docs/architecture.md) first so the layer boundaries stay clean.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,272 @@
+# Python API Reference
+
+The `ctxr.fsm` package exposes two layers:
+
+- **Pure core** (`ctxr.fsm.core`) — Pydantic spec primitives plus stateless engine functions. No I/O, no database, safe to import anywhere `pydantic` is installed.
+- **SQLite substrate** (`ctxr.fsm.sqlite`) — a single `Project` facade that wires a SQLAlchemy engine to every sub-repository.
+
+For higher-level surfaces see [cli.md](cli.md), [mcp.md](mcp.md), and [http.md](http.md). For the data model behind the repos see [schema.md](schema.md).
+
+## Import surface
+
+The top-level package re-exports every public name from `ctxr.fsm.core` so the common imports are flat:
+
+```python
+from ctxr.fsm import (
+    FsmSpec, State, Transition, Worker, Loop, Predicate,
+    ResponseSchema, VerifierSpec,
+    Brief, WorkerOutput, RunCtx,
+    advance, build_brief, loop_decide,
+    aggregate_loop_outputs, aggregate_across_states,
+    validate_fsm_spec, fsm_spec_hash,
+)
+from ctxr.fsm.sqlite import Project, run_migrations
+```
+
+`__version__` is published on the top-level module.
+
+```
+ctxr.fsm                  ergonomic re-exports of ctxr.fsm.core
+├── core/                  pure spec + engine (no I/O)
+├── sqlite/                Project facade + sub-repos
+├── api/                   FastAPI app (see http.md)
+├── cli/                   Click commands (see cli.md)
+└── mcp/                   MCP tool surface (see mcp.md)
+```
+
+## The Project facade
+
+`Project` is the single handle higher layers hold per database. It owns one `Engine`, one `sessionmaker`, and one instance of every sub-repository.
+
+### Lifecycle
+
+```python
+from pathlib import Path
+from ctxr.fsm.sqlite import Project
+
+with Project.open(Path("./fsm.db"), migrate=True) as proj:
+    spec_handle = proj.register_spec(my_spec, project_slug="default")
+    run = proj.start_run(spec_handle.spec.id)
+    print(run.id, run.status)
+```
+
+| Constructor | Use when |
+| --- | --- |
+| `Project.open(db_path, *, migrate=True, echo=False)` | Canonical entry point. Runs `alembic upgrade head` first when `migrate=True`. |
+| `Project.from_engine(engine, *, session_factory=None)` | Tests with a pre-built in-memory engine. |
+| `Project(engine, *, session_factory=None)` | Advanced: inject your own engine + sessionmaker. |
+| `run_migrations(db_path)` | Standalone migration (e.g. deploy script booting the API server). |
+
+### Convenience operations
+
+| Method | Returns | Notes |
+| --- | --- | --- |
+| `register_spec(spec, *, project_slug="default")` | `SpecRegistered` | Get-or-create project, then insert-or-dedupe spec. |
+| `start_run(spec_id, args=None)` | `Run` | Atomic: run row + producer upsert + `run_started` event in one txn. |
+| `get_run(run_id)` | `Run \| None` | Pass-through to `RunsRepo.get`. |
+| `subscribe(consumer_name, kinds=None, filter_run_id=None, *, poll_interval_seconds=0.25, stop_after=None)` | `Iterator[Event]` | At-least-once. Cursor persisted per consumer name. |
+| `transaction(*, run_id)` | `TransactionContext` | Engine-bound unit-of-work for `@atomic`-decorated callables. |
+| `close()` / `__exit__` | — | Idempotent. Restores the previous sessionmaker binding. |
+
+`proj.engine` and `proj.session_factory` are exposed for raw queries or explicit session management.
+
+## Sub-repository catalog
+
+Every sub-repo is a stateless class hung off the `Project`. Methods take an explicit `Session` (open one with `proj.session_factory()` or via `@atomic`) so callers stay in control of transactions.
+
+### Core lifecycle — `proj.projects`, `proj.specs`, `proj.runs`, `proj.run_sessions`
+
+| Repo | Method | Purpose |
+| --- | --- | --- |
+| `ProjectsRepo` | `create(session, *, slug)` | Insert a project row. |
+| | `get(session, id)` / `get_by_slug(session, slug)` | Lookup. |
+| | `list(session)` | All projects, slug-ordered. |
+| `SpecsRepo` | `register(session, *, spec, project_id)` | Insert-or-dedupe by `fsm_spec_hash`. |
+| | `get(session, spec_id)` / `list_versions(session, project_id, fsm_id)` | Lookup + history. |
+| `RunsRepo` | `create(session, *, project_id, spec_id, args, fsm_spec_hash)` | Seed `in_progress`. |
+| | `get(session, run_id)` | Single run. |
+| | `latest` / `incomplete` / `resumable` / `aborted` / `failed` / `completed` / `by_status` / `by_session` / `by_project` | Filtered `RunSummary` lists. |
+| | `state_tree(session, run_id)` | Nested `StateNode` (states + transitions + artifacts). |
+| | `events(session, run_id, ...)` | Event journal for a run. |
+| | `update_status(session, run_id, ...)` | Lifecycle transitions (`pause`, `resume`, `complete`, `abort`, `drift_pause`). |
+| `RunSessionsRepo` | `open(session, *, run_id, ...)` / `close(session, ...)` | Wall-clock session bookkeeping. |
+
+### State tree — `proj.states`, `proj.transitions`, `proj.worker_artifacts`, `proj.aggregates`
+
+| Repo | Highlights |
+| --- | --- |
+| `StatesRepo` | `create`, `get`, `mark_exited`, `mark_faulted`, `list_by_run`, `next_entry_seq`. |
+| `TransitionsRepo` | `create`, `by_status` (taken / pending / faulted). |
+| `WorkerArtifactsRepo` | `create`, `by_state` — one row per worker dispatch (brief + outputs + commit signature reference). |
+| `AggregatesRepo` | `create`, `get(session, run_id, field)` — materialised loop / cross-state aggregates. |
+
+### Concurrency + journal — `proj.locks`, `proj.journal`
+
+```python
+with proj.session_factory() as session, session.begin():
+    res = proj.locks.acquire(session, run_id=run.id, holder="worker-1", ttl_seconds=60)
+    if res.acquired:
+        txn = proj.journal.open(session, run_id=run.id)
+        # ... build outputs ...
+        proj.journal.mark_ready(session, txn_id=txn.id, payload={...})
+        proj.journal.finalise(session, txn_id=txn.id)
+        proj.locks.release(session, run_id=run.id, holder="worker-1")
+```
+
+| Repo | Methods |
+| --- | --- |
+| `LocksRepo` | `acquire`, `release`, `inspect` — per-run exclusive lock with TTL + staleness. |
+| `JournalRepo` | `open`, `mark_ready`, `finalise`, `discard`, `inspect` — two-phase commit envelope for worker outputs. |
+
+### Enforcement — `proj.commit_signatures`, `proj.commit_tokens`, `proj.tool_calls`, `proj.drift_signals`
+
+| Repo | Methods |
+| --- | --- |
+| `CommitSignaturesRepo` | `record`, `last_for_run` — persists `CommitSignature` envelopes. |
+| `CommitTokensRepo` | `issue`, `consume`, `expire_stale` — single-use tokens authorising a transition commit. |
+| `ToolCallsRepo` | `record`, `by_run` — observed worker tool calls (for allowlist enforcement). |
+| `DriftSignalsRepo` | `record`, `by_run`, `score_for_run` — typed drift signals + aggregate score. |
+
+See [enforcement.md](enforcement.md) for the full enforcement model.
+
+### Event bus — `proj.producers`, `proj.consumers`, `proj.events`, `proj.event_deliveries`
+
+| Repo | Methods |
+| --- | --- |
+| `ProducersRepo` | `upsert(session, *, kind, name)`, `get`, `list`. |
+| `ConsumersRepo` | `register(session, *, kind, name, filter_kind=None, filter_run_id=None)`, `get`, `list`, `touch_last_seen`. |
+| `EventsRepo` | `emit(session, *, producer_id, kind, payload, run_id=None)`, `by_producer`, `by_run`, `by_kind`. |
+| `EventDeliveriesRepo` | `pending_for`, `mark_delivered`, `ack`, `fail`. |
+
+`Project.subscribe` is the high-level wrapper that owns the polling loop; reach for these directly when building custom consumers.
+
+## Spec primitives
+
+All spec types are frozen Pydantic models with `extra="forbid"`. Construction validates eagerly.
+
+```mermaid
+classDiagram
+    class FsmSpec {
+        +str id
+        +int version
+        +str entry
+        +list~State~ states
+        +get_state(state_id) State
+    }
+    class State {
+        +str id
+        +str purpose
+        +list~str~ preconditions
+        +Worker? worker
+        +Loop? loop
+        +list~str~ outputs
+        +list~Predicate~ post_validations
+        +list~Transition~ transitions
+        +list~str~ allowed_tools
+        +VerifierSpec? verifier
+    }
+    class Transition {
+        +str to
+        +Predicate|"always"|"otherwise"|dict when
+    }
+    class Worker {
+        +str role
+        +str prompt_template
+        +list~str~ inputs
+        +ResponseSchema? response_schema
+    }
+    class Loop {
+        +Worker worker
+        +int max_iterations
+        +str done_field
+        +str? iteration_outputs_dir
+    }
+    FsmSpec "1" --> "*" State
+    State "1" --> "*" Transition
+    State --> Worker : worker
+    State --> Loop : loop
+    State --> VerifierSpec : verifier
+    Loop --> Worker
+```
+
+### Quick reference
+
+| Type | Required fields | Notes |
+| --- | --- | --- |
+| `FsmSpec` | `id`, `entry`, `states` | `entry` must be a known state id; ids unique. |
+| `State` | `id` | `id` matches `^[a-z][a-z0-9_]*$`. `worker` and `loop` are mutually exclusive. |
+| `Worker` | `role`, `prompt_template` | `response_schema` is optional but required for loop done-field validation. |
+| `Loop` | `worker`, `done_field` | `done_field` must appear in `worker.response_schema.properties`. |
+| `Predicate` | `expression` | Accepts `Predicate("a == 1")` sugar. |
+| `Transition` | `to`, `when` | `when` accepts `"always"`, `"otherwise"`, a `Predicate`, or a typed dict (`{"kind": "deterministic", "expression": ...}` / `{"kind": "judgement", "criteria": ..., "evidence_required": ...}`). |
+| `ResponseSchema` | `schema` (aliased to `schema_` in Python) | Wraps a JSON Schema dict; `model_validate_json_payload(payload)` validates with Draft 2020-12. |
+| `VerifierSpec` | `role`, `prompt_template`, `response_schema` | `parallel_count >= majority_threshold >= 1`. |
+
+### Enums (StrEnum)
+
+| Enum | Members |
+| --- | --- |
+| `RunStatus` | `in_progress`, `paused`, `faulted`, `completed`, `aborted`, `superseded`, `drift_paused`. |
+| `StateStatus` | `entered`, `exited`, `faulted`. |
+| `TransitionKind` | `always`, `otherwise`, `deterministic`, `judgement`. |
+| `EventKind` | 25 members; see [events.md](events.md). |
+| `DeliveryStatus` | `pending`, `delivered`, `acked`, `failed`. |
+| `SignalKind` | Drift taxonomy (`off_allowlist_tool_call`, `repeated_validation_failed`, …). |
+| `VerifierVerdict` | `passed`, `rejected`, `inconclusive`. |
+
+### Engine value objects
+
+`Brief`, `WorkerOutput`, `CommitSignature`, `CommitToken`, `ValidationResult`, `PostValidationResult`, `TransitionEvaluation`, `LoopDecision`, `RunCtx`, `AllowedTools` — all frozen Pydantic models. `CommitSignature.compute(...)` and `CommitToken.issue(...)` are the canonical constructors.
+
+## Stateless engine functions
+
+These live in `ctxr.fsm.core` and have no I/O. They take a spec + context + outputs and return a result.
+
+| Function | Purpose |
+| --- | --- |
+| `build_brief(spec, run_ctx, *, iteration_n=None) -> Brief` | Render the work brief for the current state / iteration. |
+| `advance(spec, run_ctx, outputs, judgement_pick=None) -> EngineAdvanceResult` | One engine step: validate outputs, evaluate transitions, return next brief or terminal verdict. |
+| `loop_decide(spec, run_ctx, outputs) -> LoopDecision` | Loop continuation check. |
+| `aggregate_loop_outputs(...)` / `aggregate_across_states(...)` | Materialise the aggregator fields workers consume. |
+| `validate_fsm_spec(spec) -> FsmValidationResult` | Static validation (referential integrity, predicate parseability). |
+| `fsm_spec_hash(spec) -> str` | Canonical SHA-256 hash used by `SpecsRepo.register`. |
+| `evaluate_expression(expr, env)` / `validate_expression(expr)` | Predicate DSL helpers. |
+| `run_verifier(...)` / `get_verifier_handler` / `set_verifier_handler` | Verifier panel plumbing. |
+
+## End-to-end: build, start, drive a run
+
+```python
+from pathlib import Path
+from ctxr.fsm import FsmSpec, State, Transition, Worker, ResponseSchema, RunCtx, advance
+from ctxr.fsm.sqlite import Project
+
+spec = FsmSpec(
+    id="hello_pipeline", entry="greet",
+    states=[
+        State(
+            id="greet",
+            worker=Worker(
+                role="greeter", prompt_template="Say hi to {name}",
+                response_schema=ResponseSchema(schema={
+                    "type": "object", "required": ["greeting"],
+                    "properties": {"greeting": {"type": "string"}},
+                }),
+            ),
+            outputs=["greeting"],
+            transitions=[Transition(to="done", when="always")],
+        ),
+        State(id="done"),
+    ],
+)
+
+with Project.open(Path("./hello.db")) as proj:
+    handle = proj.register_spec(spec)
+    run = proj.start_run(handle.spec.id, args={"name": "world"})
+
+    ctx = RunCtx(run_id=run.id, fsm_id=spec.id, current_state=spec.entry,
+                 env={"name": "world"})
+    result = advance(spec, ctx, outputs={"greeting": "hi world"})
+    print(result.kind, getattr(result, "verdict", None))
+```
+
+The same engine call is what the [CLI](cli.md), [MCP server](mcp.md), and [HTTP API](http.md) drive — only the transport differs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,192 @@
+# Architecture
+
+`ctxr-fsm` is a workstation-scale finite-state-machine runtime for agent orchestration. It is a Python 3.12+ library plus a small set of long-running services (MCP server, FastAPI server, UI dev server, supervisor) that share one SQLite database per project. Every higher layer depends only on the layers below it; nothing in the core imports SQLite, HTTP, MCP, or the UI.
+
+The full workstream plan, including locked decisions and verification gates, lives at `/Users/developer/.claude/plans/how-it-fits-toasty-gray.md`.
+
+## Layered overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                      UI (fsm-ui · Vite + Preact)                     │
+│              SSE consumer over the FastAPI event stream              │
+└──────────────────────────────────────────────────────────────────────┘
+                              ▲
+┌─────────────────┬────────────┴───────────┬──────────────────────────┐
+│  ctxr.fsm.mcp   │      ctxr.fsm.api      │      ctxr.fsm.cli        │
+│  (MCP server)   │ (FastAPI · REST + SSE) │   (typer · operator)     │
+│   17 fsm.*      │   /runs /specs /events │   init · serve · doctor  │
+│   tools         │   /admin               │   runs · spec · migrate  │
+└─────────────────┴────────────┬───────────┴──────────────────────────┘
+                               ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                          ctxr.fsm.sqlite                             │
+│   STRICT schema · alembic migrations · 18 tables · repositories      │
+│   Project facade · transactions · journal · locks · drift detector   │
+└──────────────────────────────────────────────────────────────────────┘
+                               ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                            ctxr.fsm.core                             │
+│  Pydantic models · engine (advance) · predicate DSL · loop · agg     │
+│  spec validate/hash · verifier panel · Protocols for persistence     │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Arrows point in the dependency direction. The core is dependency-light (Pydantic + jsonschema). SQLite is the only persistence backend; it satisfies the `Repository`, `EventBus`, `JournalProtocol`, and `Lock` Protocols declared in `ctxr.fsm.core.protocols`.
+
+## Layer responsibilities
+
+### `ctxr.fsm.core` — pure FSM substrate
+
+The bedrock. No I/O, no database, no network. Defines what an FSM *is* and how a single step works.
+
+| Module | Responsibility |
+|---|---|
+| `models.py` | Pydantic models, StrEnums, engine value objects (`Brief`, `WorkerOutput`, `CommitSignature`, `CommitToken`, `RunCtx`, `ValidationResult`, …) |
+| `engine.py` | Pure runtime: `build_brief`, `validate_output`, `resolve_transition`, `run_post_validations`, `advance`, `EngineAdvanceResult` |
+| `loop.py` | Loop iteration mechanics: `loop_decide`, `outputs_path_for` |
+| `aggregator.py` | Pure folds over loop/state outputs |
+| `spec.py` | `FsmSpec.validate()`, `FsmSpec.hash()` (canonical hash for spec-lock) |
+| `predicates.py` | Sandboxed DSL evaluator for guards and post-validations |
+| `verifier.py` | Adversarial verifier panel runtime |
+| `protocols.py` | Typing surface (`Repository`, `EventBus`, `JournalProtocol`, `Lock`) the SQLite layer satisfies |
+
+Importing `ctxr.fsm.core` is safe in any environment that has Pydantic. See [core.md](core.md) for the model and engine reference.
+
+```python
+from ctxr.fsm import build_brief, advance, FsmSpec
+
+spec = FsmSpec.model_validate_json(open("workflow.json").read())
+spec.validate()  # structural check
+spec_hash = spec.hash()  # canonical hash used by the spec-lock
+```
+
+### `ctxr.fsm.sqlite` — persistence
+
+The only persistence backend. SQLite in STRICT mode with WAL, alembic migrations, and 18 tables across `models_core.py`, `models_enforcement.py`, and `models_events.py`. Repositories (`repos_*.py`) expose Protocol-conforming operations. The `Project` facade in `project.py` is the single object higher layers use to talk to a project's database.
+
+Atomicity is non-negotiable. Every observable mutation goes through `transactions.py`, which serialises writes inside a sqlite transaction plus an append-only journal entry. See [persistence.md](persistence.md) and [transactions.md](transactions.md).
+
+```python
+from ctxr.fsm.sqlite import Project
+
+project = Project.open(".ctxr-fsm/fsm.db")
+with project.transaction() as tx:
+    tx.runs.update_state(run_id, new_state="reviewed")
+    tx.events.append(run_id, kind="state_entered", payload={"state": "reviewed"})
+# both rows + journal entry commit atomically, or none do
+```
+
+### `ctxr.fsm.mcp` · `ctxr.fsm.api` · `ctxr.fsm.cli` — surfaces
+
+Three peers above SQLite. Each is a thin adapter; none owns business logic.
+
+| Surface | Audience | Transport | Key files |
+|---|---|---|---|
+| `ctxr.fsm.mcp` | Claude Code / agent harnesses | MCP stdio + HTTP | `server.py`, `tools_*.py` (17 `fsm.*` tools) |
+| `ctxr.fsm.api` | UI, scripts, external HTTP clients | FastAPI REST + SSE | `server.py`, `routes_*.py` |
+| `ctxr.fsm.cli` | Operators, CI | `typer` CLI (`ctxr-fsm …`) | `init_cmd.py`, `serve_cmd.py`, `doctor_cmd.py`, … |
+
+All three open the same `Project` facade and respect the same lock + journal contract. They never bypass it. See [mcp.md](mcp.md), [api.md](api.md), [cli.md](cli.md).
+
+### `fsm-ui` — observation surface
+
+Vite + Preact + Tailwind v4 SPA in `ui/`. Consumes the FastAPI SSE stream at `/events` and renders the run dashboard. Read-mostly — write actions round-trip through the same REST endpoints any other client would call. See [ui.md](ui.md).
+
+## Cross-cutting concerns
+
+These four concerns thread through every layer above the core. They are why the system can claim "no torn state across crashes".
+
+### Events
+
+The event bus is append-only. Every state transition, worker dispatch, validation result, and lifecycle change emits one event into the `events` table. Subscribers receive the same rows via SSE (`/events`) or MCP (`fsm.events.subscribe`).
+
+```
+core.advance()  ──▶  Project.transaction()  ──▶  events.append(...)
+                                                       │
+                                                       ▼
+                                            ┌──────────┴──────────┐
+                                            │ FastAPI SSE stream  │
+                                            │ MCP subscription    │
+                                            │ UI dashboard         │
+                                            └─────────────────────┘
+```
+
+Events are produced inside the same transaction as the state mutation that caused them. There is no "fire-and-forget" path. See [events.md](events.md).
+
+### Journal
+
+Every transaction writes one row to the journal table describing the intent of the change (state-from, state-to, worker output digest, spec hash at the time). The journal is the audit trail used by:
+
+- `ctxr-fsm doctor` for integrity checks,
+- the drift detector for replay,
+- post-mortem reconstruction after a crash.
+
+The journal is the source of truth for "what did this run do, in what order". See [journal.md](journal.md).
+
+### Lock (spec-hash lock)
+
+W12 enforcement: every committed transition records the canonical hash of the `FsmSpec` it ran under. The lock table guarantees:
+
+1. **Spec immutability mid-run** — a run started under spec hash `H1` cannot advance under hash `H2`.
+2. **Cosignature requirement** — a `CommitToken` must carry signatures from the engine *and* the post-validator panel.
+3. **Two-phase commit** — `prepare → commit` separates "produced an artefact" from "applied it"; a crash between phases is detectable and recoverable.
+
+See [enforcement.md](enforcement.md).
+
+### Drift detector
+
+`ctxr.fsm.sqlite.drift` periodically replays the journal forward from a checkpoint and asserts that the resulting state matches the live row. Mismatch = drift = quarantine the run and emit a `drift_detected` event. The detector runs inside the supervisor (see below) and on demand via `ctxr-fsm doctor --drift`. See [drift.md](drift.md).
+
+## Service topology — process-per-subsystem
+
+`ctxr-fsm serve` starts a **supervisor** process that owns one child process per subsystem. Subsystems are isolated for crash containment and independent reload.
+
+```
+                       ┌────────────────────────┐
+                       │  ctxr-fsm serve        │
+                       │  (supervisor; PID file)│
+                       └────────────┬───────────┘
+                                    │ spawns + watches
+       ┌────────────────┬───────────┼───────────┬────────────────┐
+       ▼                ▼           ▼           ▼                ▼
+  ┌─────────┐    ┌──────────┐  ┌────────┐  ┌────────┐    ┌──────────┐
+  │  MCP    │    │ FastAPI  │  │ UI dev │  │ drift  │    │ healthz  │
+  │ server  │    │  server  │  │ (vite) │  │ daemon │    │ probe    │
+  └────┬────┘    └────┬─────┘  └────────┘  └───┬────┘    └──────────┘
+       │              │                        │
+       └──────────────┴────────┬───────────────┘
+                               ▼
+                       ┌───────────────┐
+                       │  fsm.db       │ (single writer, WAL readers)
+                       └───────────────┘
+```
+
+Key properties:
+
+- **One PID file** at `.ctxr-fsm/run/supervisor.pid` prevents double-boot.
+- **Reserved ports** allocated up front and recorded in `.ctxr-fsm/run/ports.json`; children inherit them.
+- **Graceful drain reload** — `ctxr-fsm serve reload` drains in-flight requests, swaps the child, then resumes traffic.
+- **Doctor** — `ctxr-fsm doctor` walks the PID file, port file, DB migrations, journal integrity, and drift state, then reports pass/fail per subsystem.
+- **Single SQLite writer** — only one process holds the write lock at a time; readers go through WAL. The supervisor enforces this by routing all writes through the MCP/API processes and never the UI.
+
+See [lifecycle.md](lifecycle.md) for the full supervisor contract.
+
+## Dependency rule
+
+```
+ui  ──▶ api ──▶ sqlite ──▶ core
+        mcp ──▶ sqlite ──▶ core
+        cli ──▶ sqlite ──▶ core
+```
+
+There are no upward imports. The core never imports SQLite; SQLite never imports MCP/API/CLI; the UI is a separate process that only talks HTTP. This is enforced by import linting in CI (W10).
+
+## Where to go next
+
+- [core.md](core.md) — model and engine reference
+- [persistence.md](persistence.md) — schema, migrations, repositories
+- [mcp.md](mcp.md) · [api.md](api.md) · [cli.md](cli.md) — surface references
+- [lifecycle.md](lifecycle.md) — supervisor, ports, PIDs, reload
+- [enforcement.md](enforcement.md) — spec-lock, cosignature, two-phase commit
+- [examples.md](examples.md) — three runnable agent workflows

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,411 @@
+# Data Model
+
+Reference for every table in the `ctxr.fsm` SQLite store, the enum vocabularies that flow through them, the event-bus shape, and the atomic-tx journal contract.
+
+All tables are **SQLite STRICT** with **UUIDv7** primary keys stored as `TEXT(36)`, ISO-8601 UTC text timestamps (`YYYY-MM-DDTHH:MM:SS.sssZ`), and JSON columns stored as canonical `TEXT`. See [storage.md](storage.md) for the persistence contract and [migrations.md](migrations.md) for alembic conventions.
+
+## ER Diagram
+
+```mermaid
+erDiagram
+    projects ||--o{ fsm_specs : owns
+    projects ||--o{ runs : hosts
+    fsm_specs ||--o{ runs : "spec used"
+    runs ||--o{ run_sessions : attaches
+    runs ||--o{ states : activates
+    runs ||--o{ transitions : records
+    runs ||--o{ worker_artifacts : produces
+    runs ||--o{ aggregates : "rolls up"
+    runs ||--|| locks : "guarded by"
+    runs ||--o{ journal_txns : brackets
+    runs ||--o{ tool_calls : observes
+    runs ||--o{ drift_signals : raises
+    runs ||--o{ commit_signatures : binds
+    runs ||--o{ commit_tokens : authorises
+    runs ||--o{ events : emits
+    states ||--o{ transitions : from
+    states ||--o{ worker_artifacts : captures
+    states ||--o{ commit_signatures : signs
+    producers ||--o{ events : emits
+    events ||--o{ event_deliveries : fanout
+    consumers ||--o{ event_deliveries : receives
+```
+
+## Core Lifecycle Tables
+
+Defined in `ctxr/fsm/sqlite/models_core.py`. These are the mutable surface backing a run.
+
+### `projects`
+
+The outermost grouping. Specs and runs live under a project.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `slug` | TEXT UNIQUE | Stable handle (e.g. `ctxr-dev`) |
+| `created_at` | TEXT | ISO-8601 UTC |
+| `metadata_json` | TEXT | Free-form JSON object |
+
+### `fsm_specs`
+
+A versioned, content-addressed FSM definition. `hash` is `fsm_spec_hash(definition)` — the spec's content identity, independent of its surrogate `id`.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `project_id` | TEXT FK → projects | CASCADE |
+| `slug` | TEXT | Natural name within project |
+| `version` | INTEGER >= 1 | Monotonic per (project, slug) |
+| `hash` | TEXT | SHA-256 of canonical spec |
+| `definition_json` | TEXT | Canonical spec JSON |
+| `created_at` | TEXT | ISO-8601 UTC |
+
+UNIQUE `(project_id, slug, version)`.
+
+### `runs`
+
+A single execution of a spec. `fsm_spec_hash` is the **hash lock** — the spec hash observed at run start, used by the engine to detect mid-run drift (see [enforcement.md](enforcement.md)).
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `project_id` | TEXT FK → projects | |
+| `fsm_spec_id` | TEXT FK → fsm_specs | |
+| `fsm_spec_hash` | TEXT | Hash lock for drift detection |
+| `status` | TEXT | `RunStatus` value |
+| `current_state` / `next_state` | TEXT? | FSM state names |
+| `verdict` | TEXT? | Terminal verdict on completion |
+| `started_at` / `ended_at` / `last_update_at` | TEXT | Lifecycle timestamps |
+| `paused_at` / `pause_reason` | TEXT? | Set when status=paused |
+| `parent_run_id` | TEXT? FK → runs | Resume/supersede lineage |
+| `resume_history_json` | TEXT | JSON array of resume points |
+| `args_json` / `metadata_json` | TEXT | Run inputs + free-form metadata |
+| `transitions_count` | INTEGER | Hot counter for read paths |
+
+### `run_sessions`
+
+A worker (or operator) attachment to a run. One row per acquire/release cycle; `released_at IS NULL` means "currently attached".
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT FK → runs | CASCADE |
+| `session_id` | TEXT | External session handle |
+| `acquired_at` / `released_at` | TEXT/TEXT? | Lifecycle |
+| `release_reason` | TEXT? | Why released |
+
+### `states`
+
+One row per state **activation**. `entry_seq` is the per-run monotonic counter that totally orders activations even when timestamps tie.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT FK → runs | CASCADE |
+| `state_id` | TEXT | FSM state name |
+| `entry_seq` | INTEGER | Per-run monotonic |
+| `entered_at` / `exited_at` | TEXT/TEXT? | Lifecycle |
+| `status` | TEXT | `StateStatus` value |
+| `inputs_json` / `outputs_json` | TEXT | Bag in/out |
+| `iteration_n` | INTEGER? | Non-NULL only inside loop states |
+
+UNIQUE `(run_id, entry_seq)`.
+
+### `transitions`
+
+A taken transition between two state entries.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT FK → runs | CASCADE |
+| `from_state_id` | TEXT FK → states | Source **entry row** |
+| `to_state_id` | TEXT | Destination **FSM state name** (may not yet exist) |
+| `kind` | TEXT | `TransitionKind` value |
+| `predicate` | TEXT? | Predicate DSL source |
+| `predicate_result` | INTEGER? | 0/1 (STRICT-safe) |
+| `decided_at` | TEXT | ISO-8601 UTC |
+
+### `worker_artifacts`
+
+Captured prompt + structured response per state entry. Multiple rows per state when running a loop.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` / `state_id` | TEXT FKs | CASCADE on run |
+| `iteration_n` | INTEGER? | Loop iteration index |
+| `prompt_text` / `prompt_hash` | TEXT | Captured prompt + SHA-256 |
+| `output_json` | TEXT | Structured worker response |
+| `validated` | INTEGER | 0/1 (STRICT-safe) |
+| `created_at` | TEXT | |
+
+### `aggregates`
+
+Persisted across-state aggregation results. `from_state_ids_json` is the lineage so results are reconstructible without re-running the aggregator.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT FK → runs | CASCADE |
+| `field` | TEXT | Bag-path the aggregate feeds |
+| `from_state_ids_json` | TEXT | JSON array of source `states.id` |
+| `merged_length` | INTEGER | Item count |
+| `items_json` | TEXT | Merged items |
+| `created_at` | TEXT | |
+
+### `locks`
+
+Advisory per-run write lock. `run_id` is **both** the PK and FK — at most one lock per run.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `run_id` | TEXT PK FK → runs | CASCADE |
+| `holder_session_id` | TEXT | Current lease holder |
+| `acquired_at` / `expires_at` | TEXT | Lease window |
+
+## Event Bus Tables
+
+Defined in `ctxr/fsm/sqlite/models_events.py`. See [event-bus.md](event-bus.md) for usage.
+
+### `producers` / `consumers`
+
+Registered subsystems on the bus. Both keyed by `(kind, name)` UNIQUE.
+
+| Producers | Consumers |
+| --- | --- |
+| `id`, `kind`, `name`, `metadata_json`, `created_at` | `id`, `kind`, `name`, `filter_kind` (CSV of EventKind), `filter_run_id` (NULL = all runs), `created_at`, `last_seen_at` |
+
+### `events`
+
+Append-only log. `seq` is per-run monotonic — enforced by a **partial UNIQUE index** `(run_id, seq) WHERE run_id IS NOT NULL`. Run-less events (e.g. `producer_registered`) carry `seq = NULL` and live on the global `created_at` timeline.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT? FK → runs | CASCADE; NULL for global events |
+| `kind` | TEXT INDEXED | `EventKind` value |
+| `producer_id` | TEXT FK → producers | |
+| `payload_json` | TEXT | Event body |
+| `created_at` | TEXT INDEXED | ISO-8601 UTC |
+| `seq` | INTEGER? | Per-run monotonic |
+
+### `event_deliveries`
+
+Per-`(event, consumer)` ledger with composite PK — the at-most-once guarantee is structural.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `event_id` | TEXT PK FK → events | CASCADE |
+| `consumer_id` | TEXT PK FK → consumers | CASCADE |
+| `delivered_at` / `acked_at` | TEXT? | Lifecycle |
+| `status` | TEXT INDEXED | `DeliveryStatus` value |
+| `attempts` | INTEGER | Retry counter |
+
+## Enforcement Tables
+
+Defined in `ctxr/fsm/sqlite/models_enforcement.py`. The auditable shell around each commit. See [enforcement.md](enforcement.md).
+
+### `journal_txns`
+
+Brackets the staged writes around a state-commit; statuses are `pending → ready_to_finalise → finalised | discarded` (see `JournalTxnStatus`).
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT FK → runs | CASCADE |
+| `status` | TEXT | `JournalTxnStatus` |
+| `staged_writes_json` | TEXT | JSON array of staged writes |
+| `started_at` / `ready_at` / `finalised_at` | TEXT/TEXT?/TEXT? | Lifecycle |
+
+### `tool_calls`
+
+Every tool invocation observed. `args_redacted_json` has secrets/credentials/blobs scrubbed by the producer.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT? FK → runs | NULL = pre-run |
+| `producer_id` | TEXT FK → producers | |
+| `tool_name` | TEXT INDEXED | |
+| `args_redacted_json` | TEXT | Scrubbed args |
+| `succeeded` | BOOLEAN | |
+| `created_at` | TEXT INDEXED | |
+
+### `drift_signals`
+
+Typed signals the drift aggregator scores against a pause threshold.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT FK → runs | CASCADE |
+| `producer_id` | TEXT FK → producers | |
+| `signal_kind` | TEXT INDEXED | `SignalKind` value |
+| `weight` | REAL | Aggregator score weight (default 1.0) |
+| `payload_json` | TEXT | Signal-specific context |
+| `created_at` | TEXT | |
+
+### `commit_signatures`
+
+SHA-256 commitment binding `inputs_hash + outputs_hash + session_id + brief_id` at commit time.
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | TEXT PK | UUIDv7 |
+| `run_id` / `state_id` | TEXT FKs | |
+| `iteration_n` | INTEGER? | Non-NULL inside loops |
+| `brief_id` | TEXT | |
+| `inputs_hash` / `outputs_hash` / `signature` | TEXT(64) | Hex SHA-256 |
+| `session_id` | TEXT | |
+| `verified` | BOOLEAN | Server recomputation matched |
+| `created_at` | TEXT | |
+
+### `commit_tokens`
+
+Short-lived single-use tokens authorising a commit. Default TTL 60 s. PK **is** the token (UUIDv7).
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `token` | TEXT PK | UUIDv7 |
+| `run_id` | TEXT FK → runs | CASCADE |
+| `state_id` | TEXT | |
+| `expected_next_state` | TEXT | Prevents replay against new state |
+| `expires_at` | TEXT INDEXED | Reaper scan target |
+| `consumed_at` | TEXT? | Set atomically with commit flush |
+
+## Index Catalogue
+
+Named indexes (composite or partial) declared in `__table_args__`:
+
+| Index | Table | Columns | Use |
+| --- | --- | --- | --- |
+| `idx_runs_status_last_update` | runs | `status, last_update_at DESC` | "What's happening now" |
+| `idx_runs_project_started` | runs | `project_id, started_at DESC` | Per-project history |
+| `idx_runs_parent` | runs | `parent_run_id` | Resume/supersede lookup |
+| `idx_fsm_specs_unique` | fsm_specs | `project_id, slug, version` UNIQUE | Natural identity |
+| `idx_run_sessions_run` | run_sessions | `run_id, session_id` | Session lookup |
+| `idx_states_run_seq` | states | `run_id, entry_seq` UNIQUE | Activation ordering |
+| `idx_transitions_run_from` | transitions | `run_id, from_state_id` | Transition timeline |
+| `idx_events_run_seq` | events | `run_id, seq` UNIQUE WHERE `run_id IS NOT NULL` | Per-run monotonicity |
+| `ix_events_run_id`, `ix_events_kind`, `ix_events_producer_id`, `ix_events_created_at` | events | single-column | Common filters |
+| `idx_event_deliveries_consumer_pending` | event_deliveries | `consumer_id, status, delivered_at` | Bus poll loop |
+| `idx_journal_run_status` | journal_txns | `run_id, status` | Recovery scan |
+| `idx_commit_signatures_run` | commit_signatures | `run_id, created_at` | Commit timeline |
+
+## Status Enums
+
+All enums are `StrEnum` (`ctxr/fsm/core/models.py`, `ctxr/fsm/core/protocols.py`). Stored as TEXT; validated at the repository boundary.
+
+```python
+class RunStatus(StrEnum):
+    in_progress = "in_progress"
+    paused = "paused"
+    faulted = "faulted"
+    completed = "completed"
+    aborted = "aborted"
+    superseded = "superseded"
+    drift_paused = "drift_paused"   # raised by the drift aggregator
+
+class StateStatus(StrEnum):
+    entered = "entered"
+    exited = "exited"
+    faulted = "faulted"
+
+class TransitionKind(StrEnum):
+    always = "always"
+    otherwise = "otherwise"
+    deterministic = "deterministic"
+    judgement = "judgement"
+
+class DeliveryStatus(StrEnum):
+    pending = "pending"
+    delivered = "delivered"
+    acked = "acked"
+    failed = "failed"
+
+class SignalKind(StrEnum):
+    off_allowlist_tool_call = "off_allowlist_tool_call"
+    repeated_validation_failed = "repeated_validation_failed"
+    signature_mismatch = "signature_mismatch"
+    verifier_rejection = "verifier_rejection"
+    output_shape_near_miss = "output_shape_near_miss"
+    idle_too_long = "idle_too_long"
+
+class VerifierVerdict(StrEnum):
+    passed = "passed"
+    rejected = "rejected"
+    inconclusive = "inconclusive"
+
+class JournalTxnStatus(StrEnum):
+    pending = "pending"
+    ready_to_finalise = "ready_to_finalise"
+    finalised = "finalised"
+    discarded = "discarded"
+
+class LockAcquisitionStatus(StrEnum):
+    acquired = "acquired"
+    contended = "contended"
+    reentrant = "reentrant"
+    taken_over = "taken_over"
+```
+
+`EventKind` is the closed taxonomy of events on the journal — full list in [event-bus.md](event-bus.md).
+
+## Event Shape
+
+Every row in `events` decodes to:
+
+```python
+{
+    "id":          "01949b9c-...",        # UUIDv7
+    "run_id":      "01949b9b-..." | None,  # None for global events
+    "kind":        "state_entered",        # EventKind value
+    "producer_id": "01949b9a-...",
+    "payload_json": { ... },               # event-kind-specific JSON
+    "seq":         42 | None,              # per-run monotonic; None when run_id is None
+    "created_at":  "2026-05-30T12:34:56.789Z",
+}
+```
+
+The bus produces one `event_deliveries` row per matching consumer; the consumer's `filter_kind` (CSV of `EventKind`) and `filter_run_id` (NULL = all runs) decide matching.
+
+## Atomic-Tx Journal Model
+
+The journal is the engine's pre-commit ledger. Every state-commit follows the same lifecycle:
+
+```
+                 ┌──────────────────┐
+                 │   state entered  │
+                 └────────┬─────────┘
+                          │ open()
+                          ▼
+                ┌────────────────────┐
+       ┌────────┤  status = pending  │◄──── staged_writes accumulate
+       │        └─────────┬──────────┘
+       │ discard()        │ mark_ready()
+       │                  ▼
+       │      ┌───────────────────────────┐
+       │      │ status = ready_to_finalise │
+       │      └─────────────┬─────────────┘
+       │                    │ finalise()  (atomic flush)
+       │                    ▼
+       │      ┌───────────────────────────┐
+       │      │     status = finalised    │
+       │      └───────────────────────────┘
+       ▼
+┌──────────────────┐
+│ status = discarded│   (recovery / abort)
+└──────────────────┘
+```
+
+Rules:
+
+- Each state-commit opens **exactly one** `journal_txns` row, bracketing all writes for that commit.
+- `staged_writes_json` accumulates while `status = pending`. The worker never touches target tables directly.
+- `mark_ready()` flips to `ready_to_finalise` once enforcement (signature verification, drift score, commit-token validation) signs off.
+- `finalise()` flushes staged writes atomically and stamps `finalised_at`. The session's surrounding `@atomic` transaction makes the flush + status update one unit of work.
+- A crash mid-commit leaves the row in `pending` or `ready_to_finalise`. The engine's recovery path (driven by `idx_journal_run_status`) finds these on startup and either replays (`ready_to_finalise`) or discards (`pending`).
+- `discarded` is terminal — the txn is closed without flushing. Useful for aborted runs and recovery.
+
+See [enforcement.md](enforcement.md) for the full commit pipeline, [recovery.md](recovery.md) for crash semantics, and `ctxr/fsm/sqlite/repos_locks_journal.py` for the repository surface (`LocksRepo`, `JournalRepo`).

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -1,0 +1,329 @@
+# Enforcement layers
+
+The FSM gives state determinism. Enforcement gives you what the FSM alone
+cannot: **a worker LLM that actually plays by the rules of the state it is
+in**. Layer-by-layer reference: what each gate catches, how to enable/disable
+it, where the tests live, plus the two-phase commit walkthrough and Claude
+Code hook install.
+
+Cross-refs: [models.md](models.md), [mcp.md](mcp.md), [drift.md](drift.md).
+
+## The four groups
+
+Enforcement layers cluster into four orthogonal responsibilities:
+
+| Group | Layers | What it constrains |
+|-------|--------|--------------------|
+| **Capability** | 2 (allowed-tools surfacing), 4 (CC hook) | What tools the worker may call inside a state |
+| **Integrity** | 5 (cosignature), 9 (spec-hash lock), 12 (two-phase commit) | That the commit *actually* matches what the worker saw and what the operator approved |
+| **Adversarial** | 3 (verifier panel) | That a second opinion agrees the outputs satisfy the brief |
+| **Observational** | 8 (drift detector) | That accrued misbehaviour eventually trips an auto-pause |
+
+They compose as a funnel: capability *before* the call, integrity *during*
+the commit, adversarial *if the state declares it*, observation *always,
+asynchronously*. A worker slipping past one layer is caught by the next.
+
+```
+worker ──tool call──▶ CC hook (4) ──▶ tool runs
+                       │
+                       │ disallowed → exit 1
+                       ▼
+worker ──fsm.commit_outputs──▶ spec-hash lock (9)
+                                cosignature (5)
+                                engine.advance
+                                verifier panel (3)
+                                ──▶ CommitToken (12)
+                                              │
+worker ──fsm.confirm_commit──▶ consume token + replay journal
+                                              │
+event bus ──▶ drift detector (8) ──▶ score > threshold → drift_paused
+```
+
+## Layer 2 — allowed-tools surfacing
+
+| | |
+|---|---|
+| **Catches** | A worker invoking a tool outside the state's declared surface. |
+| **Where** | `State.allowed_tools` → `Brief.allowed_tools`. |
+| **Enable** | Declare `allowed_tools` on the state in the FSM spec. |
+| **Disable** | Omit the field, or declare `[]` (every non-`fsm.*` call is then off-allowlist). |
+| **Tests** | `tests/integration/enforcement/test_drift_detector.py::test_classifier_*` |
+
+The brief carries the closed capability set. **Every MCP client MUST refuse
+locally**; layer 8 is a defence-in-depth backstop, not the primary gate.
+`fsm.*` tools are always allowed regardless of the list — they are how a
+worker advances the FSM.
+
+```yaml
+states:
+  - id: draft
+    allowed_tools: [Read, Grep]   # worker may call Read and Grep only
+```
+
+## Layer 4 — Claude Code pre-tool-use hook
+
+| | |
+|---|---|
+| **Catches** | A worker that ignores its brief and tries to call a non-allowlisted tool from a Claude Code session. |
+| **Where** | `.claude/hooks/pre-tool-use.fsm-guard.py` (consumer project). |
+| **Enable** | Copy the hook + register it in `.claude/settings.json`. |
+| **Disable** | Remove the marker file (`rm .ctxr-fsm/active-run.json`) or unregister the hook. |
+| **Tests** | `tests/integration/enforcement/test_claude_code_hook.py` (10 scenarios). |
+
+The hook reads `<project_root>/.ctxr-fsm/active-run.json`, maintained by
+`fsm.start_run` / `fsm.confirm_commit` / `fsm.abort_run`. Soft-fails (exit 0)
+on no marker, empty allowlist, malformed JSON, or missing `tool_name` — only
+blocks on a confident negative.
+
+### Install in a consumer project
+
+```bash
+mkdir -p .claude/hooks
+cp <ctxr-fsm-repo>/.claude/hooks/pre-tool-use.fsm-guard.py .claude/hooks/
+chmod +x .claude/hooks/pre-tool-use.fsm-guard.py
+```
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": ".claude/hooks/pre-tool-use.fsm-guard.py" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+For non-cwd layouts: `export CTXR_FSM_PROJECT_ROOT=/path/to/project`.
+
+Blocked stderr payload (Claude Code surfaces this to the agent verbatim):
+
+```json
+{"blocked": true, "tool": "Bash", "allowed": ["Read", "Grep", "fsm.*"], "reason": "tool 'Bash' not in active FSM run's allowed_tools"}
+```
+
+Full contract: [HOOK_README.md](../ctxr/fsm/memory/HOOK_README.md).
+
+## Layer 9 — spec-hash lock
+
+| | |
+|---|---|
+| **Catches** | The FSM spec being re-registered under a different shape while a run is in flight. |
+| **Where** | `ctxr/fsm/mcp/tools_runs.py::_current_spec_hash_for_run`. |
+| **Enable** | Always on. |
+| **Disable** | Not configurable. Bump the spec version and start a fresh run. |
+| **Tests** | `tests/integration/enforcement/test_spec_hash_lock.py` (3 tests). |
+
+On every `fsm.get_brief` / `fsm.commit_outputs` / `POST /runs/{id}/resume`,
+the server compares `run.fsm_spec_hash` against the latest spec hash for the
+same slug. On mismatch the run is locked to the original spec version;
+clients branch on `error == "fsm_spec_changed"` and either abort or roll
+the spec change back:
+
+```json
+{
+  "error": "fsm_spec_changed",
+  "run_hash": "sha256:…",
+  "current_hash": "sha256:…"
+}
+```
+
+## Layer 5 — commit cosignature
+
+| | |
+|---|---|
+| **Catches** | A commit whose `outputs` were tampered with between worker production and server consumption (or a worker that signed against the wrong brief / inputs). |
+| **Where** | `ctxr/fsm/core/models.py::CommitSignature.compute` + `mcp/tools_runs.py`. |
+| **Enable** | Set `CTXR_FSM_REQUIRE_COSIGNATURE=1`, OR declare `allowed_tools`, OR declare a `verifier` on the state. |
+| **Disable** | Omit the three triggers above and the cosignature stays optional. |
+| **Tests** | `tests/integration/enforcement/test_cosignature.py` (5 tests). |
+
+The signature is `SHA-256` over canonical JSON of `{brief_id, inputs_hash,
+outputs_hash, session_id}` (both inner hashes also canonical JSON SHA-256):
+
+```python
+from ctxr.fsm.core.models import CommitSignature
+
+sig = CommitSignature.compute(
+    brief_id=brief.id,
+    inputs=env,           # the materialised run env
+    outputs=worker_output,
+    session_id="agent-session-42",
+)
+# pass sig.signature as the `signature` arg of fsm.commit_outputs
+```
+
+Outcomes:
+
+| Path | Error | Event |
+|------|-------|-------|
+| Valid | — | `commit_signature_verified` |
+| Mismatched | `signature_mismatch` | `commit_signature_mismatch` |
+| Missing-but-required | `signature_required` | — |
+
+## Layer 3 — adversarial verifier panel
+
+| | |
+|---|---|
+| **Catches** | Outputs that *look* schema-valid but a second judge disagrees with. |
+| **Where** | `ctxr/fsm/core/verifier.py` + `mcp/tools_runs.py`. |
+| **Enable** | Declare `verifier: VerifierSpec` on the state. |
+| **Disable** | Omit `verifier`. The cosignature is *not* required when no verifier is set unless `allowed_tools` is also declared. |
+| **Tests** | `tests/integration/enforcement/test_verifier.py` (5 tests). |
+
+Without a registered handler, the **structural verifier** runs by default —
+re-applying the worker's `response_schema`. Every commit on a state with a
+declared `verifier` thus gets some form of independent re-check.
+
+To plug in a real LLM panel, register a process-wide handler at server boot:
+
+```python
+from ctxr.fsm.core.verifier import set_verifier_handler, VerifierVote
+
+def my_handler(verifier, brief, outputs):
+    # Dispatch verifier.parallel_count sub-agents; collect their verdicts.
+    return [
+        VerifierVote(verdict="passed", reason="design constraints met"),
+        VerifierVote(verdict="passed", reason="acceptance criteria covered"),
+        VerifierVote(verdict="rejected", reason="missing edge case"),
+    ]
+
+set_verifier_handler(my_handler)
+```
+
+Pass iff `passed_count >= verifier.majority_threshold`. Pass → `verifier_passed`
+event + token issuance proceeds. Reject → `verifier_rejected` error + event,
+no token minted, run sits on the current state until the worker retries.
+
+## Layer 12 — two-phase commit
+
+| | |
+|---|---|
+| **Catches** | Half-applied commits (crash mid-write); also forces clients to acknowledge they received the new brief before the substrate considers them committed. |
+| **Where** | `ctxr/fsm/mcp/tools_runs.py::fsm_commit_outputs` + `fsm_confirm_commit`. |
+| **Enable** | Always on. |
+| **Disable** | Not configurable. |
+| **Tests** | `tests/integration/enforcement/test_two_phase_commit*.py` (11 tests). |
+
+`fsm.commit_outputs` no longer applies state-row changes directly. It
+stages them, mints a 60s-TTL `CommitToken`, and returns. The client must
+call `fsm.confirm_commit` to actually advance the run.
+
+```
+Client                       Server
+  │                             │
+  ├─ fsm.commit_outputs ───────▶│
+  │                             ├─ spec-hash lock
+  │                             ├─ cosignature check
+  │                             ├─ engine.advance
+  │                             ├─ verifier panel (if set)
+  │                             ├─ stage writes in journal_txn
+  │                             │   status=ready_to_finalise
+  │                             ├─ mint CommitToken (TTL 60s)
+  │                             ├─ emit commit_token_issued
+  │◀─── CommitResult ───────────┤
+  │     {kind, token, next…}    │
+  │                             │
+  ├─ fsm.confirm_commit ───────▶│
+  │   {token, expected_next…}   ├─ commit_tokens.consume
+  │                             ├─ replay journal_txn
+  │                             ├─ mark journal finalised
+  │                             ├─ emit commit_token_consumed
+  │                             │        + journal_finalised
+  │◀─── ConfirmResult ──────────┤
+  │     {confirmed, next_brief} │
+```
+
+Token failure modes (each returns `commit_token_invalid` with `reason`):
+
+| Reason | Meaning |
+|--------|---------|
+| `not_found` | Token never minted (or already reaped). |
+| `already_consumed` | A previous `confirm_commit` already replayed it. |
+| `expired` | TTL elapsed. ALSO emits `commit_token_expired` for the drift detector. |
+| `state_mismatch` | `expected_next_state` differs from what the token was minted against. |
+
+## Layer 8 — drift detector
+
+| | |
+|---|---|
+| **Catches** | Cumulative misbehaviour — a worker that *occasionally* slips past the per-commit gates eventually trips the scoreboard. |
+| **Where** | `ctxr/fsm/sqlite/drift.py` (loop in `cli/lifecycle/supervisor.py`). |
+| **Enable** | Always on under `ctxr-fsm serve`. |
+| **Disable** | `CTXR_FSM_DRIFT_DISABLED=1`. |
+| **Tests** | `tests/integration/enforcement/test_drift_detector.py` (10 tests). |
+
+An async background task in the supervisor polls every `poll_interval`
+seconds, scans new events per run, classifies them into `SignalKind`,
+records `drift_signals` rows with configured weights, and emits
+`drift_signal_recorded`. When the cumulative score **strictly exceeds**
+`score_threshold`, the loop atomically flips `run.status = drift_paused`
+and emits `drift_pause_triggered` exactly once.
+
+### Default weights + thresholds
+
+| Signal | Weight | Trigger |
+|--------|--------:|---------|
+| `signature_mismatch` | 8.0 | `commit_signature_mismatch` event |
+| `verifier_rejection` | 6.0 | `verifier_rejected` event |
+| `off_allowlist_tool_call` | 5.0 | `tool_call_observed` with tool ∉ `allowed_tools` and not `fsm.*` |
+| `repeated_validation_failed` | 3.0 | 2nd-or-later `validation_failed` in a row |
+| `output_shape_near_miss` | 2.0 | Reserved for future near-miss classifier |
+| `idle_too_long` | 1.0 | No event for `window_seconds` |
+
+Defaults: `score_threshold = 10.0` (strict `>`), `window_seconds = 60.0`,
+`poll_interval = 2.0`. Tuned so one accidental `Bash` (5) is noise, two (10)
+is still under threshold, three (15) — or one signature forge + one repeated
+validation fail — trips the pause.
+
+### Tuning
+
+Pass a custom `DriftConfig` when constructing the loop:
+
+```python
+from ctxr.fsm.sqlite.drift import DriftConfig, drift_detector_loop
+
+cfg = DriftConfig(
+    score_threshold=20.0,
+    window_seconds=120.0,
+    kind_weights={
+        "off_allowlist_tool_call": 10.0,   # stricter
+        "signature_mismatch": 15.0,
+        "verifier_rejection": 8.0,
+        "repeated_validation_failed": 3.0,
+        "output_shape_near_miss": 2.0,
+        "idle_too_long": 1.0,
+    },
+)
+await drift_detector_loop(project, config=cfg, poll_interval=5.0)
+```
+
+### Kill switch
+
+```bash
+CTXR_FSM_DRIFT_DISABLED=1 ctxr-fsm serve
+```
+
+The loop logs one pre-flight line and returns immediately. Unset the var on
+the next reload to re-enable.
+
+## Putting it together
+
+A correctly-instrumented run, end-to-end:
+
+1. Operator declares `allowed_tools` + `verifier` on the state.
+2. Consumer project installs the CC hook + sets `CTXR_FSM_REQUIRE_COSIGNATURE=1`.
+3. `fsm.start_run` writes the marker; layer 4 is armed.
+4. Worker reads `brief.allowed_tools`; CC hook blocks off-allowlist calls (4+2).
+5. Worker calls `fsm.commit_outputs` with a `CommitSignature` (5).
+6. Server runs spec-hash lock (9) → signature (5) → engine → verifier (3) →
+   stages journal_txn → mints token (12).
+7. Worker calls `fsm.confirm_commit` (12); substrate replays + rewrites the marker.
+8. Drift detector tallies every event on the bus (8); misbehaviour eventually
+   trips `drift_paused`.
+
+Layers are independent — disable any one and the others still hold their line.

--- a/docs/examples-tour.md
+++ b/docs/examples-tour.md
@@ -1,0 +1,329 @@
+# Examples Tour
+
+Three runnable, fully-deterministic FSM workflows ship under
+[`fsm/examples/`](../examples/). Each script is a single Python file that
+opens an ephemeral SQLite project, registers an `FsmSpec`, and drives it
+to completion using *simulated* worker outputs so the whole tour runs
+offline in well under a second.
+
+This page walks each example end-to-end:
+
+| Example | Teaches | LOC |
+| --- | --- | --- |
+| [`plan_implement_qa_fix.py`](#1-plan_implement_qa_fix-py) | Loops, predicates, conditional branches, post-validations | ~800 |
+| [`code_review_pipeline.py`](#2-code_review_pipeline-py) | Fan-out loop, cross-state aggregation, GO/CONDITIONAL/NO-GO synthesis | ~900 |
+| [`research_with_retries.py`](#3-research_with_retries-py) | Judgement transitions, retry back-edges, journal recovery | ~900 |
+
+> Cross-references:
+> [`fsm-spec.md`](./fsm-spec.md) for the spec data model,
+> [`predicates.md`](./predicates.md) for the guard DSL,
+> [`aggregator.md`](./aggregator.md) for `aggregate_across_states`,
+> [`journal.md`](./journal.md) for the recovery semantics.
+
+## Running the tour
+
+From the `fsm/` root, after `uv sync`:
+
+```bash
+uv run python examples/plan_implement_qa_fix.py
+uv run python examples/code_review_pipeline.py
+uv run python examples/research_with_retries.py
+```
+
+No setup beyond `uv sync` — every script opens its own
+`tempfile.TemporaryDirectory()`, applies the Alembic schema in-process,
+and tears the DB down on exit. The artefact you keep is the state-tree
+and event-log printed to stdout.
+
+## 1. `plan_implement_qa_fix.py`
+
+A four-stage build/QA loop: plan the work, implement it iteratively,
+review it, fix and re-review if needed.
+
+### What it teaches
+
+- The **`Loop`** primitive with `done_field` + `max_iterations`.
+- **Conditional transitions** using the predicate DSL
+  (`verdict == 'NO-GO'` vs. `otherwise`).
+- **`post_validations`** — declared on `plan` (non-trivial:
+  `len(commitments) > 0`) and `qa` (trivially true) to demonstrate the
+  wiring runs without blocking the happy path.
+- Re-entry into a previously-visited state (`qa` is entered twice,
+  producing two distinct state-tree nodes).
+
+### FSM diagram
+
+```
+plan ─always─▶ implement [loop, max=4, done=done]
+                         │
+                         └─always─▶ qa ◀────────────┐
+                                    │               │
+                  verdict=='NO-GO' ─┤               │
+                                    │               │
+                                    ▼               │
+                                   fix ──always─────┘
+                                    │
+                            otherwise (GO)
+                                    │
+                                    ▼
+                                  done
+```
+
+### Spec excerpt
+
+```python
+qa_state = State(
+    id="qa",
+    purpose="evaluate the implementation and emit a verdict",
+    worker=Worker(role="qa", ..., response_schema=_qa_schema()),
+    outputs=["verdict", "findings"],
+    post_validations=[Predicate("len(findings) >= 0")],
+    transitions=[
+        Transition(to="fix",  when=Predicate("verdict == 'NO-GO'")),
+        Transition(to="done", when="otherwise"),
+    ],
+)
+```
+
+### Expected output
+
+```
+status     : completed
+verdict    : GO
+current    : done
+
+state_tree:
+- plan (seq=1, status=exited)
+  - implement (seq=2, status=exited)
+    - qa (seq=3, status=exited)
+      - fix (seq=4, status=exited)
+        - qa (seq=5, status=exited)
+          - done (seq=6, status=exited)
+```
+
+The two `qa` nodes (seq=3 and seq=5) are the proof that re-entry
+materialises as **distinct tree nodes** rather than mutation in place.
+
+### Adapt it to your FSM
+
+| Want to... | Change... |
+| --- | --- |
+| Add a third verdict (e.g. `WAIT`) | Add another `Transition(to=..., when=Predicate("verdict == 'WAIT'"))` *before* the `otherwise` branch. |
+| Cap fix attempts | Wrap `fix` in a `Loop(max_iterations=N, done_field=...)` and let it self-exit. |
+| Reject a bad plan instead of silently passing | Replace the trivial `qa` post-validation with a real one — failures raise `PostValidationError` and journal the run as `failed`. |
+| Run real workers | Replace `simulated_output_for(...)` with a call that dispatches `brief.worker.prompt_template` to a sub-agent and validates the response against `brief.worker.response_schema`. |
+
+## 2. `code_review_pipeline.py`
+
+Fan out N review *lenses* over a diff, collect the per-lens findings,
+synthesise a GO/CONDITIONAL/NO-GO verdict.
+
+### What it teaches
+
+- A **fan-out loop** that iterates one lens per pass:
+  `gap`, `blind-spot`, `edge-case`, `infeasibility`, `divergence`,
+  `missed-step`.
+- The **`aggregate_across_states`** helper that collapses per-iteration
+  outputs into a single list keyed by `(state_id, iteration_n)`.
+- The `aggregate:<state>.<field>` **input hint** convention that
+  surfaces the aggregator dependency in the brief.
+- A `post_validation` re-asserting the verdict shape inside the engine
+  even though the worker already produced it.
+
+### FSM diagram
+
+```
+scan_diff
+   │ always
+   ▼
+dispatch_lenses [loop, max=6, done on iter 6]
+   │ always
+   ▼
+collect_findings   (consumes aggregate:dispatch_lenses.findings)
+   │ always
+   ▼
+synthesize_verdict (applies GO / CONDITIONAL / NO-GO rule)
+   │ always
+   ▼
+done
+```
+
+### Verdict rule
+
+| Verdict | Condition |
+| --- | --- |
+| `GO` | 0 BLOCKER findings |
+| `CONDITIONAL` | Every BLOCKER has a `suggested_fix` |
+| `NO-GO` | At least one BLOCKER without a `suggested_fix` |
+
+### Aggregation excerpt
+
+The driver pre-computes the cross-state aggregate before calling
+`engine.advance` on `collect_findings` and threads it into the env:
+
+```python
+aggregated = aggregate_across_states(
+    project=project,
+    run_id=run_id,
+    source_state="dispatch_lenses",
+    field="findings",
+)
+env["aggregated_findings"] = aggregated
+```
+
+### Expected output
+
+```
+== code_review_pipeline.py ==
+status     : completed
+verdict    : CONDITIONAL
+final_state: done
+
+-- event log (17 events) --
+  #  1 run_started
+  ...
+  #  8 aggregate_built
+  ...
+  # 17 run_completed
+```
+
+The `aggregate_built` event (emitted at #8) marks the moment the
+per-lens findings were collapsed into `unified_findings`.
+
+### Adapt it to your FSM
+
+| Want to... | Change... |
+| --- | --- |
+| Add or drop lenses | Edit `LENSES` and bump `Loop.max_iterations` to match. The loop terminates on whichever fires first — `done_field` or `max_iterations`. |
+| Switch the verdict rule | Edit `synthesize_verdict`'s worker logic *and* its `post_validations` together — the validator catches drift between them. |
+| Aggregate something other than `findings` | Change the `field` argument to `aggregate_across_states` and update the consuming state's `inputs=[]`. |
+| Make verdict transitions deterministic | Split the `synthesize_verdict → done` edge into three predicate-guarded edges on `verdict == 'GO' / 'CONDITIONAL' / 'NO-GO'`. |
+
+## 3. `research_with_retries.py`
+
+A research → cite → review loop that can retry, plus a second demo that
+shows journal recovery after a simulated mid-step crash.
+
+### What it teaches
+
+- A long-running **loop** capped at `max_iterations=10` whose body sets
+  `converged=true` to exit early.
+- **`judgement` transitions** out of `review` — the engine asks the
+  caller to pick between two named branches (`publish` / `retry_research`)
+  rather than evaluating a predicate.
+- An **unconditional retry back-edge** (`retry_research → research`)
+  that re-enters the loop as a fresh state-tree subtree.
+- A second mini-demo that **injects a pending journal txn**, calls
+  `journal.inspect` + `journal.discard`, and resumes the run cleanly —
+  the same recovery path that `fsm.recover_journal('discard')` follows
+  over MCP.
+
+### FSM diagram
+
+```
+research [loop, max=10, done=converged]
+   │ always
+   ▼
+cite
+   │ always
+   ▼
+review
+   │
+   ├─ judgement(verdict=='accept') ──▶ publish (terminal)
+   │
+   └─ judgement(verdict=='retry')  ──▶ retry_research
+                                              │ always
+                                              ▼
+                                         research  (loops again)
+```
+
+### Spec excerpt — judgement guards
+
+```python
+review_state = State(
+    id="review",
+    ...
+    transitions=[
+        Transition(to="publish",
+                   when={"kind": "judgement", "pick": "accept"}),
+        Transition(to="retry_research",
+                   when={"kind": "judgement", "pick": "retry"}),
+    ],
+)
+```
+
+The driver resolves the judgement by mapping `outputs['verdict']` to
+the chosen `pick` and passing it into `engine.resolve_transition`.
+
+### Expected output
+
+```
+========================================================================
+MAIN RUN — retry-then-converge
+========================================================================
+State tree:
+- research (entry_seq=1, status=exited, iteration_n=None)
+  - cite (entry_seq=2, status=exited, iteration_n=None)
+    ...
+      - publish (entry_seq=8, status=exited, iteration_n=None)
+
+Final published location: docs/research.md
+Journal clean after main run: True
+
+RECOVERY DEMO — simulated crash + journal cleanup
+...
+recover_journal action applied: discard
+Journal clean after recovery: True
+Run status after resume: in_progress
+
+SUMMARY
+Main run final state:     publish
+Published location:       docs/research.md
+Recovery demonstrated:    True
+```
+
+### Adapt it to your FSM
+
+| Want to... | Change... |
+| --- | --- |
+| Add a third review outcome | Add a third `Transition(to=..., when={"kind": "judgement", "pick": "..."})` and teach your driver how to resolve the new `pick`. |
+| Cap total retry attempts | Wrap the `research → cite → review → retry_research` cycle in a counter visible to a predicate, or move `retry_research` itself into a `Loop`. |
+| Replace `discard` with `replay` on recovery | Call `journal.replay(...)` instead of `journal.discard(...)`; the engine will re-apply the staged txn idempotently. |
+| Stream events to an orchestrator | Subscribe to the run via the `fsm.subscribe_events` MCP tool — see [`mcp-server.md`](./mcp-server.md). |
+
+## Promoting a simulated example to a real one
+
+Every example funnels its worker outputs through a single function —
+typically `simulated_output_for(state_id, iteration_n, ...)`. To go
+from demo to production, replace **only that function's body**:
+
+```python
+def real_output_for(state_id, iteration_n, env):
+    brief = engine.build_brief(project, run_id, state_id, iteration_n)
+    rendered = render(brief.worker.prompt_template, brief.inputs)
+    response = mcp.dispatch_subagent(
+        role=brief.worker.role,
+        prompt=rendered,
+        response_schema=brief.worker.response_schema,
+    )
+    validate(response, brief.worker.response_schema)
+    return response
+```
+
+The rest of the driver loop — `engine.advance`, state-entry
+persistence, transition recording, journal finalisation — stays
+unchanged. See [`engine.md`](./engine.md) for the full `advance`
+contract.
+
+## Next steps
+
+- Skim [`principles.md`](../ctxr/fsm/memory/principles.md) for the
+  engine invariants and authoring guidelines.
+- Read [`fsm-spec.md`](./fsm-spec.md) for the full `FsmSpec` /
+  `State` / `Worker` / `Loop` reference.
+- Read [`predicates.md`](./predicates.md) for the guard DSL grammar
+  and `always` / `otherwise` semantics.
+- Read [`journal.md`](./journal.md) for crash recovery, txn lifecycle,
+  and the `inspect` / `discard` / `replay` surface.
+- Read [`mcp-server.md`](./mcp-server.md) to expose any of these
+  workflows to an external orchestrator via `subscribe_events`.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,0 +1,245 @@
+# HTTP API
+
+FastAPI app at `ctxr.fsm.api:app`. Mounted under `/api/v1/`. Mirrors the W4 MCP tool surface for REST/SSE clients — the UI, browser dashboards, third-party orchestrators that do not speak MCP.
+
+Boot via the CLI:
+
+```bash
+ctxr-fsm api --host 127.0.0.1 --port 8000 --db ./.ctxr-fsm/fsm.db
+```
+
+Or as a one-liner against the default DB (`./.ctxr-fsm/fsm.db` or `$CTXR_FSM_DB`):
+
+```bash
+uvicorn ctxr.fsm.api:app --port 8000
+```
+
+Live OpenAPI / Swagger UI: **`http://<host>:<port>/docs`**. Schemas at `/openapi.json`. Both are auth-free so a browser can render them without credentials.
+
+## Auth
+
+Two modes, decided by the presence of `CTXR_FSM_API_TOKEN` at request time (re-read per call — no restart needed on rotation):
+
+| Mode | `CTXR_FSM_API_TOKEN` | Behaviour |
+| --- | --- | --- |
+| Dev | unset / empty | Every request trusted. CORS still enforced. |
+| Production | set to a non-empty string | Every request needs `Authorization: Bearer <token>`. |
+
+In production mode:
+
+- Missing header → `401 Unauthorized` + `WWW-Authenticate: Bearer`.
+- Malformed scheme or wrong token → `403 Forbidden`.
+- Comparison is constant-time (`hmac.compare_digest`).
+
+Health probes (`/healthz`, `/readyz`) and `/docs` stay auth-free so orchestrator probes do not flap.
+
+```bash
+export CTXR_FSM_API_TOKEN=$(openssl rand -hex 32)
+curl -H "Authorization: Bearer $CTXR_FSM_API_TOKEN" \
+     http://127.0.0.1:8000/api/v1/projects/current
+```
+
+## CORS
+
+The middleware is the outermost layer (pre-flight OPTIONS answered before auth fires).
+
+Defaults: `http://localhost:5173`, `http://127.0.0.1:5173` (Vite dev server). Extend via `CTXR_FSM_API_CORS_ORIGINS` (comma-separated, exact origins only — no wildcards).
+
+```bash
+export CTXR_FSM_API_CORS_ORIGINS="https://fsm.example.com,https://ops.internal"
+```
+
+## Route catalog
+
+All routes JSON unless noted. Every `/api/v1/*` route is auth-guarded.
+
+### Health & metadata
+
+| Method | Path | Auth | Body | Response |
+| --- | --- | --- | --- | --- |
+| `GET` | `/healthz` | no | — | `HealthResponse` |
+| `GET` | `/readyz` | no | — | `ReadinessResponse` |
+| `GET` | `/api/v1/projects/current` | yes | — | `ProjectMetadata` |
+
+### Specs (registry)
+
+See [specs.md](./specs.md) for the validation pipeline.
+
+| Method | Path | Auth | Body | Response |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/specs` | yes | — | `list[SpecSummary]` |
+| `GET` | `/api/v1/specs/{slug}/versions?project_slug=` | yes | — | `list[SpecVersion]` |
+| `GET` | `/api/v1/specs/{spec_id}` | yes | — | `SpecDetail` |
+| `POST` | `/api/v1/specs` | yes | `SpecRegisterBody` | `SpecRegistered` (201) |
+
+`POST /specs` returns `422` with `{error, message, errors|validation}` on Pydantic or cross-cutting validation failure. Byte-identical re-registration is idempotent (`created=False`).
+
+### Runs
+
+See [runs.md](./runs.md) and [journal.md](./journal.md).
+
+| Method | Path | Auth | Body | Response |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/runs?status=&since=&limit=&offset=` | yes | — | `list[RunSummary]` |
+| `GET` | `/api/v1/runs/{run_id}` | yes | — | `RunDetail` |
+| `GET` | `/api/v1/runs/{run_id}/state-tree` | yes | — | `StateNode` |
+| `GET` | `/api/v1/runs/{run_id}/events?since_seq=&kinds=&limit=` | yes | — | `list[Event]` |
+| `POST` | `/api/v1/runs/{run_id}/resume` | yes | `ResumeBody` | `ResumeResult` |
+| `POST` | `/api/v1/runs/{run_id}/abort` | yes | `AbortBody` | `AbortResult` |
+| `POST` | `/api/v1/runs/{run_id}/journal/{action}` | yes | — | `JournalRecovered` |
+
+`status` accepts the literals `incomplete` / `resumable` (dispatched to `RunsRepo.incomplete` / `.resumable`) or any concrete status string. Errors:
+
+- `404` — unknown `run_id`.
+- `409` — terminal-status abort, journal replay against a still-`pending` txn, or **`fsm_spec_changed`** on resume when a newer version exists under the same slug (detail carries both hashes).
+- `400` — unknown `{action}` (only `discard` / `replay` allowed).
+
+### Events bus
+
+See [events-bus.md](./events-bus.md) and the SSE protocol below.
+
+| Method | Path | Auth | Body | Response |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/events?run_id=&since_seq=&kinds=&limit=` | yes | — | `list[Event]` |
+| `GET` | `/api/v1/events/stream?consumer_name=&kinds=&filter_run_id=` | yes | — | `text/event-stream` |
+| `GET` | `/api/v1/producers` | yes | — | `list[Producer]` |
+| `GET` | `/api/v1/consumers` | yes | — | `list[Consumer]` |
+| `POST` | `/api/v1/consumers/{consumer_id}/ack` | yes | `AckBody` | `AckResult` |
+
+`limit` is hard-capped server-side (1000 for polling reads, 2000 for `/runs/{id}/events`).
+
+### Admin / observability
+
+See [enforcement.md](./enforcement.md) for the W12 substrate behind `tool_calls` / `drift_signals` / `commit_signatures`.
+
+| Method | Path | Auth | Body | Response |
+| --- | --- | --- | --- | --- |
+| `GET` | `/api/v1/admin/journal_txns?status=&limit=` | yes | — | `list[JournalTxn]` |
+| `GET` | `/api/v1/admin/locks` | yes | — | `list[Lock]` |
+| `GET` | `/api/v1/admin/tool_calls?run_id=&limit=` | yes | — | `list[ToolCall]` |
+| `GET` | `/api/v1/admin/drift_signals?run_id=` | yes | — | `DriftSignalsResponse` |
+| `GET` | `/api/v1/admin/commit_signatures?run_id=` | yes | — | `list[CommitSignatureRecord]` |
+| `POST` | `/api/v1/admin/db/doctor` | yes | — | `DoctorReport` |
+
+## Request / response shapes
+
+Full Pydantic schemas live at `/docs`. Key bodies:
+
+```python
+class SpecRegisterBody(BaseModel):
+    definition: dict[str, Any]   # raw FsmSpec JSON, validated server-side
+    project_slug: str = "default"
+
+class ResumeBody(BaseModel):
+    from_state: str | None = None
+    journal_action: Literal["discard", "replay"] | None = None
+
+class AbortBody(BaseModel):
+    reason: str | None = None
+
+class AckBody(BaseModel):
+    event_ids: list[UUID]
+```
+
+Top-level responses:
+
+```python
+class RunDetail(BaseModel):
+    manifest: dict[str, Any]          # full Run row, JSON-dumped
+    state_tree: StateNode | None
+    events_count: int
+    journal: dict[str, Any] | None    # newest unfinalised txn or null
+    lock: dict[str, Any] | None       # active lock or null
+```
+
+## SSE event stream
+
+`GET /api/v1/events/stream` opens a long-lived `text/event-stream` connection.
+
+### Frame format
+
+```
+event: <event-name>
+data: <single-line JSON>
+
+```
+
+Two named frames:
+
+| Event name | When | `data` payload |
+| --- | --- | --- |
+| `event` | An FSM `Event` row matches the consumer's filters | `Event.model_dump_json()` (single line) |
+| `ping` | No real event has been sent for ≥ 15 s | `{}` |
+
+Frames are separated by a blank line (the trailing `\n\n` from `sse-starlette`).
+
+### Lifecycle
+
+```
+client                                   server
+  │  GET /events/stream?consumer_name=ui  │
+  │ ─────────────────────────────────────▶│  register consumer (kind=http_sse_subscriber)
+  │ ◀───── 200 text/event-stream ─────────│
+  │                                       │
+  │ ◀── event: event\ndata: {...}\n\n ────│  drains up to 100 events/cycle, ack inline
+  │ ◀── event: event\ndata: {...}\n\n ────│
+  │      ... (250 ms polls between cycles)│
+  │ ◀── event: ping\ndata: {}\n\n ────────│  every ≥ 15 s of silence
+  │                                       │
+  │ ── TCP close / disconnect ────────────▶  generator sees CancelledError → tears down
+```
+
+### Cadence & semantics
+
+- Poll cycle: **250 ms** (`_SSE_POLL_INTERVAL_SECONDS`).
+- Heartbeat: **15 s** of silence (`_SSE_HEARTBEAT_SECONDS`) — survives nginx (60 s) and Cloudflare (100 s) idle timeouts.
+- Batch cap: **100 events / cycle** (`_SSE_BATCH_LIMIT`); a burst loops without sleeping until drained.
+- Delivery is **at-least-once**: every row is `mark_delivered` + `ack`'d inside the SQLite txn that fetched it, *before* the frame leaves the server.
+
+### Reconnect
+
+The cursor is server-held — reconnect with the **same `consumer_name`** and the bus resumes from the next unacked row.
+
+```javascript
+const url = new URL("/api/v1/events/stream", location.origin);
+url.searchParams.set("consumer_name", "ui-tab-7");
+url.searchParams.set("filter_run_id", runId);
+
+const es = new EventSource(url, { withCredentials: true });
+es.addEventListener("event", (e) => render(JSON.parse(e.data)));
+es.addEventListener("ping", () => {/* keep-alive */});
+// EventSource auto-reconnects on transient drops; same consumer_name → resume.
+```
+
+`EventSource` does **not** send custom `Authorization` headers. In production mode either terminate auth at a proxy that injects the header, use a `fetch`-based SSE polyfill, or accept the token via a query parameter behind a reverse proxy. Browser-side cookies + a same-origin proxy is the recommended path.
+
+For one-shot polling without the streaming overhead, use `GET /api/v1/events?run_id=…&since_seq=…` — same data, client-held cursor.
+
+## Errors
+
+Conventional FastAPI shape:
+
+```json
+{ "detail": "no run with id 'abc'" }
+```
+
+`detail` may be a string or a structured object (W12 spec-hash lock, journal-replay refusal, validation failures). HTTP codes:
+
+| Code | When |
+| --- | --- |
+| `400` | Bad path argument (e.g. unknown journal action). |
+| `401` | Production mode, header missing. |
+| `403` | Production mode, bad / malformed token. |
+| `404` | Unknown run / spec / consumer. |
+| `409` | Refused state transition or spec-hash drift. |
+| `422` | Spec validation failed (Pydantic or cross-cutting). |
+| `500` | Internal — doctor walk failed, corrupt on-disk spec, etc. |
+
+## Cross-references
+
+- [runs.md](./runs.md) — run lifecycle + resume semantics.
+- [events-bus.md](./events-bus.md) — producers, consumers, delivery semantics.
+- [journal.md](./journal.md) — atomic-txn journal + recovery.
+- [specs.md](./specs.md) — FsmSpec validation pipeline.
+- [enforcement.md](./enforcement.md) — W12 tool calls, drift signals, commit signatures.
+- [mcp.md](./mcp.md) — parallel MCP surface against the same SQLite substrate.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,317 @@
+# MCP Tool Catalog
+
+The `ctxr-fsm mcp` server exposes **17 tools** under the `fsm.*` namespace.
+Every tool input and output is a Pydantic model; errors return a structured
+`McpToolError` envelope rather than a JSON-RPC error frame so legacy clients
+keep working unchanged.
+
+- **Meta + bootstrap** (4): `fsm.healthcheck`, `fsm.list_specs`,
+  `fsm.register_spec`, `fsm.observe_tool_call`
+- **Run lifecycle** (8): `fsm.start_run`, `fsm.get_brief`,
+  `fsm.commit_outputs`, `fsm.confirm_commit`, `fsm.resume_run`,
+  `fsm.abort_run`, `fsm.list_runs`, `fsm.get_run`
+- **Events + journal** (5): `fsm.subscribe_events`, `fsm.inspect_journal`,
+  `fsm.recover_journal`, `fsm.list_consumers`, `fsm.list_producers`
+
+See also: [Architecture](./architecture.md), [Two-phase commit](./two-phase-commit.md),
+[Events](./events.md), [Drift detection](./drift.md).
+
+## Error envelope
+
+Every tool returns either its typed result model **or** an `McpToolError`
+with fields `error` (snake_case code), `detail` (human-readable), and
+optional `payload` (per-code extras):
+
+```json
+{ "error": "spec_not_found",
+  "detail": "no registered spec with id '01HF…'",
+  "payload": { "spec_id": "01HF…" } }
+```
+
+Common codes: `project_not_bound`, `run_not_found`, `spec_not_found`,
+`invalid_state`, `fsm_spec_changed`, `signature_required`,
+`signature_mismatch`, `verifier_rejected`, `commit_token_invalid`,
+`journal_not_ready`, `server_draining`, `internal_error`.
+
+## Meta + bootstrap
+
+### `fsm.healthcheck`
+
+Read-only probe. Used by skill pre-checks (common-dev *Principle 1*) to
+confirm the server is up before any mutating call.
+
+**Input:** none.
+**Output:** `HealthcheckResult { status, db_path, sqlite_version, alembic_revision, package_version }`
+
+```json
+// response
+{
+  "status": "ok",
+  "db_path": "/var/lib/ctxr-fsm/project.db",
+  "sqlite_version": "3.45.1",
+  "alembic_revision": "0007_w12_enforcement",
+  "package_version": "0.4.0"
+}
+```
+
+Errors: `project_not_bound`, `internal_error`.
+
+### `fsm.list_specs`
+
+Enumerate registered specs as trimmed summaries (no `definition` body).
+Sorted by `(project_slug, slug, version)` ascending.
+
+**Output:** `list[SpecSummary { id, project_id, project_slug, slug, version, hash, created_at }]`
+
+### `fsm.register_spec`
+
+Parse a JSON spec, run cross-cutting validation (reachability, dangling
+transitions, loop `done_field`, predicate parsability), and persist.
+Byte-identical re-registrations are idempotent (`created=False`).
+
+**Input:** `definition_json: str`, `project_slug: str = "default"`
+**Output:** `SpecRegisteredPayload { spec_id, hash, version, slug, project_id, project_slug, created }`
+
+Errors: `invalid_spec_definition` (Pydantic), `schema_validation_failed`
+(structural — payload carries the full `FsmValidationResult`).
+
+### `fsm.observe_tool_call`
+
+Layer-7 drift signal. The agent reports every **non-`fsm.*`** tool call it
+made during an active run; W12 reads these rows to compute drift scores.
+See [Drift detection](./drift.md).
+
+**Input:** `producer_kind`, `producer_name`, `tool_name`, `args_redacted: dict`,
+`succeeded: bool = true`, `run_id: UUID | None = null`
+**Output:** `ObserveResult { recorded, tool_call_id, event_id, producer_id }`
+
+Arguments must be redacted **at the caller** — the server persists them verbatim.
+
+## Run lifecycle
+
+### `fsm.start_run`
+
+Start a fresh run against a registered spec. Mints the run row, persists the
+entry state, publishes the active-run marker for layer-4 enforcement.
+
+**Input:** `StartRunInput { spec_id: UUID, args: dict = {} }`
+**Output:** `RunStartedPayload { run_id: UUID, brief: Brief, fsm_spec_hash: str }`
+
+```json
+// example call
+{ "spec_id": "01HF…", "args": { "user_query": "…" } }
+```
+
+Errors: `spec_not_found`, `internal_error`.
+
+### `fsm.get_brief`
+
+Build the Brief for the run's current state from `args` + every prior state's
+exit outputs. Trips `fsm_spec_changed` if the spec has been re-registered
+under the same slug with a different hash (W12 spec-hash lock).
+
+**Input:** `GetBriefInput { run_id: UUID }`
+**Output:** `Brief`
+
+Errors: `run_not_found`, `spec_not_found`, `fsm_spec_changed`, `invalid_state`.
+
+### `fsm.commit_outputs`
+
+**Phase 1** of the two-phase commit. Drives the engine, runs the verifier
+panel when the state declares one, stages writes in a `journal_txn` marked
+`ready_to_finalise`, and mints a single-use `CommitToken`. The state-row +
+transition-row + manifest update are **not** applied yet — the client must
+call `fsm.confirm_commit` next.
+
+**Input:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `run_id` | `UUID` | required |
+| `outputs` | `dict[str, Any]` | worker outputs being committed |
+| `signature` | `str \| None` | layer-5 cosignature (see below) |
+| `brief_id` | `UUID \| None` | required iff `signature` set |
+| `session_id` | `str \| None` | required iff `signature` set |
+
+**Output:** `CommitResult`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | `"advanced" \| "terminal" \| "fault" \| "loop_continued"` | discriminator |
+| `brief` | `Brief?` | the *next* brief on advance / loop_continue |
+| `next_state` | `str?` | new state id on advance |
+| `iteration_n` | `int?` | loop iteration number |
+| `verdict` | `Any` | terminal verdict |
+| `reason`, `errors`, `evaluations`, `post_validations` | … | fault diagnostics |
+| `token` | `CommitToken?` | present iff not `fault` |
+| `expected_next_state` | `str?` | sentinel `"__terminal__"` for terminal |
+
+Cosignature is required when the state declares `allowed_tools`, a `verifier`,
+**or** `CTXR_FSM_REQUIRE_COSIGNATURE=1`. Compute as
+`CommitSignature.compute(brief_id, inputs, outputs, session_id)`. See
+[Commit signatures](./signatures.md).
+
+Errors: `run_not_found`, `spec_not_found`, `fsm_spec_changed`, `invalid_state`,
+`signature_required`, `signature_mismatch`, `verifier_rejected`,
+`server_draining`, `internal_error`.
+
+### `fsm.confirm_commit`
+
+**Phase 2.** Validate + consume the token, replay the staged journal txn, mark
+it finalised, emit `commit_token_consumed`, return the new manifest and next
+brief.
+
+**Input:** `ConfirmCommitInput { token: UUID, expected_next_state: str }`
+**Output:** `ConfirmResult { confirmed: bool, note?, next_brief?, manifest? }`
+
+Errors: `commit_token_invalid` (with `reason ∈ {missing, consumed, expired, state_mismatch}`),
+`journal_not_ready`, `run_not_found`, `spec_not_found`, `internal_error`.
+
+#### Two-phase commit flow
+
+```mermaid
+sequenceDiagram
+    participant W as Worker
+    participant S as MCP Server
+    participant DB as SQLite
+
+    W->>S: fsm.commit_outputs(outputs, signature?)
+    S->>S: verify signature, run engine, run verifier
+    S->>DB: open journal_txn, mark ready_to_finalise
+    S->>DB: issue commit_token (TTL 60s)
+    S-->>W: CommitResult{ token, expected_next_state }
+    Note over W: client now holds an unconfirmed advance
+    W->>S: fsm.confirm_commit(token, expected_next_state)
+    S->>DB: consume token (atomic check)
+    S->>DB: replay staged writes (state, transition, events)
+    S->>DB: finalise journal_txn
+    S-->>W: ConfirmResult{ next_brief, manifest }
+```
+
+Properties:
+
+- **Atomic**: a crash between phases leaves either a token+journal row or
+  neither — never a half-applied advance.
+- **Idempotent confirm**: re-presenting a consumed token returns
+  `commit_token_invalid { reason: "consumed" }`.
+- **Bounded**: tokens expire after 60s; an expired token emits
+  `commit_token_expired` for the drift aggregator.
+- **Verifier-gated**: a rejected verifier panel returns `verifier_rejected`
+  *without* minting a token, so a bad commit cannot advance the run.
+
+### `fsm.resume_run`
+
+Resume a paused/faulted run. W4 ships the journal bookkeeping +
+`run_resumed` event; engine-driven resume lands in W12.
+
+**Input:** `ResumeRunInput { run_id: UUID, from_state?: str, journal?: "discard" | "replay" }`
+**Output:** `ResumeResult { run_id, from_state?, journal_action?, journal_txn_id?, engine_resume }`
+
+### `fsm.abort_run`
+
+Mark a run aborted, emit `run_aborted`, clear the active-run marker.
+Refuses runs already in a terminal status (`completed` / `aborted`).
+
+**Input:** `AbortRunInput { run_id: UUID, reason?: str }`
+**Output:** `AbortResult { run_id, previous_status, new_status: "aborted", ended_at, reason? }`
+
+Errors: `run_not_found`, `invalid_state_transition`.
+
+### `fsm.list_runs`
+
+List runs, optionally filtered.
+
+**Input:** `ListRunsInput { filter_status?: str, since?: str, limit: int = 50 }`
+**Output:** `list[RunSummary]`
+
+`filter_status` accepts any literal status (`running`, `completed`, …) plus
+two special keywords: `incomplete` and `resumable`.
+
+### `fsm.get_run`
+
+Assemble the full per-run picture: manifest, state tree, last 50 events,
+journal, locks.
+
+**Input:** `GetRunInput { run_id: UUID }`
+**Output:** `RunDetail { manifest, state_tree?, events, journal?, locks? }`
+
+## Events + journal
+
+### `fsm.subscribe_events`
+
+Long-poll the event bus. The same `consumer_name` resumes the cursor on the
+next call — registration is idempotent at `(kind, name)`.
+
+**Input:**
+
+| Field | Type | Default |
+|-------|------|---------|
+| `consumer_name` | `str` (≥1) | — |
+| `kinds` | `list[str] \| None` | `null` (all) |
+| `filter_run_id` | `UUID \| None` | `null` (all runs) |
+| `max_events` | `int 1..1000` | `50` |
+| `timeout_seconds` | `float (0, 60]` | `5.0` |
+
+**Output:** `EventBatch { events: list[Event], next_cursor: null }`
+
+An empty batch on timeout is a structured "still alive" response, not an
+error. See [Events](./events.md) for the `Event` shape.
+
+### `fsm.inspect_journal`
+
+Read the newest unfinalised journal txn for a run.
+
+**Input:** `run_id: UUID`
+**Output:** `JournalState { run_id, txn: JournalTxn | null }`
+
+### `fsm.recover_journal`
+
+Operator hatch for a crash mid-commit.
+
+**Input:** `run_id: UUID`, `action: "discard" | "replay"`
+**Output:** `JournalRecovered { run_id, action, txn_id?, previous_status? }`
+
+| `action` | Effect |
+|----------|--------|
+| `discard` | drop staged writes (rollback) |
+| `replay` | mark txn `finalised` (roll-forward; W4 transitions status only, W12 wires re-materialisation) |
+
+A run with no unfinalised txn returns a structured no-op (`txn_id=null`).
+
+Errors: `journal_replay_not_ready` (pending-but-unstaged row).
+
+### `fsm.list_consumers` / `fsm.list_producers`
+
+Registry dumps for the dev loop / UI.
+
+**Output:** `list[Consumer]` / `list[Producer]` (ordered by id ≈ registration order).
+
+## Drain behaviour
+
+The server's drain lifecycle (SIGTERM, hot reload) is built around three
+guarantees:
+
+1. **Reject new work.** Once `start_drain()` flips the flag, every tool body
+   (wrapped by `@drain_aware`) returns the structured error:
+
+   ```json
+   { "error": "server_draining",
+     "detail": "MCP server is draining; retry in a moment" }
+   ```
+
+2. **Wait for the in-flight tail.** `wait_for_drain()` polls the in-flight
+   counter at 50ms cadence until it reaches zero or the budget elapses
+   (default **30s**). A clean drain adds a 250ms settle window so the FastMCP
+   transport can flush the just-completed call's response.
+
+3. **Stable stderr banners.** A `[ctxr-fsm mcp]` prefix on both the start
+   and end lines so the supervisor's log-tail regex stays simple.
+
+```
+[ctxr-fsm mcp] draining for reload (waiting up to 30s for in-flight tool calls)
+[ctxr-fsm mcp] drain complete; goodbye
+```
+
+Every `fsm.*` tool is wrapped with `@drain_aware` — clients should treat
+`server_draining` as a transient error and retry after a short backoff. See
+[Server lifecycle](./server-lifecycle.md) for the supervisor contract.

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -1,0 +1,325 @@
+# Operating ctxr-fsm
+
+CLI reference for the `ctxr-fsm` console script. Every command honours the same
+`--db` / `$CTXR_FSM_DB` / `./.ctxr-fsm/fsm.db` precedence and supports
+`--json` for machine-readable output.
+
+```
+ctxr-fsm <command> [<subcommand>] [OPTIONS]
+```
+
+See also: [architecture](architecture.md), [specs](specs.md), [runs](runs.md).
+
+## Global conventions
+
+| Flag         | Effect                                                          |
+| ------------ | --------------------------------------------------------------- |
+| `--db`, `-d` | Override the project database path.                             |
+| `--json`     | Emit a sorted, indented JSON document instead of pretty output. |
+| `--help`     | Print help for any command or subcommand.                       |
+
+DB precedence (highest first): `--db PATH` > `$CTXR_FSM_DB` > `./.ctxr-fsm/fsm.db`.
+
+Exit codes: `0` success, `1` domain failure (banner on stderr), `2` usage error.
+
+## Lifecycle commands
+
+These bring a project up, keep its schema current, and tear off diagnostics.
+
+### `init`
+
+Bootstrap a project directory.
+
+```
+ctxr-fsm init [--db PATH] [--json] [--no-memory]
+```
+
+Performs, in order:
+
+1. Creates `./.ctxr-fsm/` and `./.ctxr-fsm/pids/`.
+2. Runs `alembic upgrade head` in-process (no `alembic` binary required).
+3. Appends `.ctxr-fsm/` to `.gitignore` (idempotent) when inside a git checkout.
+4. Unless `--no-memory`, invokes `install-memory --client auto`.
+5. Prints a summary (db path, pids dir, alembic revision, memory outcome).
+
+```bash
+ctxr-fsm init
+ctxr-fsm init --no-memory --json
+```
+
+### `migrate`
+
+Run `alembic upgrade head` against the project DB and report before/after
+revisions.
+
+```
+ctxr-fsm migrate [--db PATH] [--json]
+```
+
+```bash
+ctxr-fsm migrate --json
+# { "upgraded": true, "revision_before": "ab12...", "revision_after": "cd34..." }
+```
+
+### `serve`
+
+Run the unified supervisor (MCP + API + UI in dev mode).
+
+```
+ctxr-fsm serve [--db PATH] [--mode dev|prod]
+```
+
+| Flag      | Default | Notes                                                |
+| --------- | ------- | ---------------------------------------------------- |
+| `--mode`  | `dev`   | `dev` adds watchfiles reload and the Vite UI server. |
+
+```
+                supervisor
+                    |
+        +-----------+-----------+
+        |           |           |
+       MCP         API         UI    (UI only in --mode dev)
+      (stdio /   (FastAPI)   (Vite)
+        http)
+```
+
+SIGINT / SIGTERM drain children with a 5s budget per child, then escalate to
+`kill()`.
+
+### `mcp`
+
+Boot the Model Context Protocol server. Used as a Claude Code stdio child or
+hosted over HTTP/SSE.
+
+```
+ctxr-fsm mcp [--db PATH] [--transport stdio|http] [--host HOST] [--port PORT]
+```
+
+| Flag          | Default       | Notes                                          |
+| ------------- | ------------- | ---------------------------------------------- |
+| `--transport` | `stdio`       | `http` enables FastMCP's SSE transport.        |
+| `--host`      | `127.0.0.1`   | Bind address for `http`.                       |
+| `--port`      | `0`           | `0` = pick an ephemeral port.                  |
+
+```bash
+ctxr-fsm mcp                            # stdio, for Claude Code
+ctxr-fsm mcp --transport http --port 0  # OS-picked port, logged on start
+```
+
+### `api`
+
+Boot the FastAPI HTTP / SSE server.
+
+```
+ctxr-fsm api [--db PATH] [--host HOST] [--port PORT] [--reload]
+```
+
+| Flag       | Default       | Notes                                              |
+| ---------- | ------------- | -------------------------------------------------- |
+| `--host`   | `127.0.0.1`   | Bind explicitly for non-loopback exposure.         |
+| `--port`   | `0`           | `0` = OS-picked port (handy for tests and dev).    |
+| `--reload` | `False`       | Forwards to uvicorn's auto-reload watcher.         |
+
+### `ui`
+
+Boot the Vite dev server for the UI subproject.
+
+```
+ctxr-fsm ui [--port PORT] [--api-port PORT] [--no-install]
+```
+
+| Flag           | Default | Notes                                                  |
+| -------------- | ------- | ------------------------------------------------------ |
+| `--port`       | `5173`  | Vite's canonical port.                                 |
+| `--api-port`   | `8765`  | Exported as `VITE_API_PORT`; rewires the proxy target. |
+| `--no-install` | `False` | Skip lazy `npm install` on first run.                  |
+
+### `doctor`
+
+Diagnostic dump: DB facts plus supervisor health.
+
+```
+ctxr-fsm doctor [--db PATH] [--json]
+```
+
+Reports DB path & size, SQLite version, PRAGMAs, alembic revision, per-table
+row counts, journal status breakdown, lock count, and for each managed
+subsystem (`mcp`, `api`, `ui`): port, pid, `pid_alive`, `probe_url`, and the
+`/healthz` body.
+
+```bash
+ctxr-fsm doctor --json | jq '.supervisor.subsystems.api'
+```
+
+## Run commands
+
+`runs` (plural) groups cross-run queries; `run` (singular) groups per-run
+commands.
+
+### `runs ls`
+
+```
+ctxr-fsm runs ls [--status STATUS] [--since ISO8601] [--limit N] [--db PATH] [--json]
+```
+
+`--status` accepts any single status (`in_progress`, `paused`, `faulted`,
+`completed`, `aborted`) plus the keywords `incomplete` and `resumable`.
+Defaults to most-recently-updated.
+
+```bash
+ctxr-fsm runs ls --status incomplete --limit 5
+```
+
+### `run show`
+
+```
+ctxr-fsm run show <RUN_ID> [--db PATH] [--json]
+```
+
+Prints the run manifest, ASCII state tree, last 20 events, and the newest
+unfinalised journal txn (if any).
+
+```
+state tree
+  plan [completed] (seq=0)
+  ├── implement [completed] (seq=1)
+  │   └── qa [completed] (seq=2)
+  └── fix [in_progress] (seq=3)
+```
+
+### `run resume`
+
+```
+ctxr-fsm run resume <RUN_ID> [--from-state STATE] [--journal discard|replay] [--db PATH] [--json]
+```
+
+Performs the bookkeeping half of resume: optionally discards/marks the open
+journal txn, then emits a `run_resumed` event. Engine-driven resume itself
+lands in W12.
+
+### `run abort`
+
+```
+ctxr-fsm run abort <RUN_ID> [--reason TEXT] [--db PATH] [--json]
+```
+
+Atomically flips status to `aborted` and emits `run_aborted`. Refuses runs
+already in a terminal state.
+
+### `export`
+
+```
+ctxr-fsm export <RUN_ID> <OUTPUT_PATH> [--overwrite] [--db PATH] [--json]
+```
+
+Writes a `schema_version: 1` JSON document containing the run, state tree,
+events, worker artifacts, aggregates, commit signatures, and the newest
+unfinalised journal txn. Pass `-` as `OUTPUT_PATH` to stream to stdout.
+
+```bash
+ctxr-fsm export 018f...e2 ./run.json
+ctxr-fsm export 018f...e2 - | jq '.counts'
+```
+
+### `import`
+
+```
+ctxr-fsm import <INPUT_PATH> [--replace] [--db PATH] [--json]
+```
+
+Inserts a run from a JSON document produced by `export`. Refuses to clobber an
+existing run id without `--replace`. The whole operation is wrapped in one
+`@atomic` envelope so a failure rolls back cleanly. See [runs](runs.md) for
+schema details.
+
+## Spec commands
+
+Validate and register `FsmSpec` objects from a `<module>:<attribute>` import
+path.
+
+### `spec validate`
+
+```
+ctxr-fsm spec validate <SPEC_IMPORT_PATH> [--json]
+```
+
+In-memory validation only; the DB is never opened. Non-zero exit on failure
+makes this safe as a pre-commit / CI gate.
+
+```bash
+ctxr-fsm spec validate examples.plan_implement_qa_fix:spec
+```
+
+### `spec register`
+
+```
+ctxr-fsm spec register <SPEC_IMPORT_PATH> [--project-slug SLUG] [--db PATH] [--json]
+```
+
+Validates first, then persists. Reports whether a new version was minted or an
+existing content-hash matched. Default project slug is `default`.
+
+### `spec list`
+
+```
+ctxr-fsm spec list [--project-slug SLUG] [--db PATH] [--json]
+```
+
+Enumerates registered specs grouped by slug. Omit `--project-slug` to walk every
+project.
+
+## `install-memory`
+
+Inject (or check) the FSM-usage principles into AI-client memory files.
+
+```
+ctxr-fsm install-memory [--target DIR] [--client auto|claude|codex|cursor]
+                        [--check] [--dry-run] [--no-symlink] [--json]
+```
+
+| Client   | Target                                          | Idiom                                |
+| -------- | ----------------------------------------------- | ------------------------------------ |
+| Claude   | `CLAUDE.md` or `.claude/CLAUDE.md`              | `@.ctxr-fsm/memory/principles.claude.md` import inside a marker block. |
+| Codex    | `AGENTS.md`                                     | Full body inlined inside a marker block. |
+| Cursor   | `.cursor/rules/ctxr-fsm.mdc`                    | Standalone rule file (overwrites).   |
+
+Marker block format (idempotent — re-running produces a byte-identical file):
+
+```
+<!-- ctxr-fsm:begin v=0.1.0 -->
+...payload...
+<!-- ctxr-fsm:end -->
+```
+
+`--check` exits non-zero when any detected client is missing or out of date —
+suitable for CI.
+
+## Environment variables
+
+| Variable         | Used by                  | Effect                                              |
+| ---------------- | ------------------------ | --------------------------------------------------- |
+| `CTXR_FSM_DB`    | every command            | Default DB path when `--db` is not supplied.        |
+| `VITE_API_PORT`  | `ui` (child env)         | Tells the Vite proxy where the API is listening.    |
+| `PWD`            | `spec validate/register` | Prepended to `sys.path` so local modules import.    |
+
+## Port and PID files
+
+The supervisor stores lifecycle state under `<project_root>/.ctxr-fsm/`.
+
+```
+.ctxr-fsm/
+  fsm.db                    # SQLite project database
+  ports.json                # { "mcp": 8123, "api": 8765, "ui": 5173 }
+  pids/
+    mcp.pid                 # { "pid": 12345, "probe_url": "...", "acquired_at": "..." }
+    api.pid
+    ui.pid
+  active-run.json           # { "run_id": "...", "set_at": "..." } (optional)
+  memory/
+    principles.claude.md    # symlink or copy of the package principles file
+```
+
+All three documents are written via `tmp + rename` so a crash mid-write never
+leaves a half-written file. PID files are *hints*, not mutexes: callers probe
+`/healthz` and check `pid_is_alive` before reusing a slot. `ctxr-fsm doctor`
+surfaces all of this for inspection.

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -1,0 +1,286 @@
+# Recovery
+
+How `ctxr.fsm` survives crashes, races, and operator drift — and what to
+do when it doesn't.
+
+The substrate is built so that **every state-mutating unit of work is
+bracketed by a journal txn**, **every writer takes a single-writer
+lock**, and **every commit is signed against a spec hash**. When
+something goes wrong, these primitives leave forensic breadcrumbs in
+the SQLite database. This guide is the operator playbook for reading
+and acting on those breadcrumbs.
+
+See also: [atomic.md](atomic.md), [enforcement.md](enforcement.md),
+[cli.md](cli.md), [mcp.md](mcp.md), [api.md](api.md).
+
+---
+
+## The journal model
+
+Every commit attempt opens a row in `journal_txns` and walks it through
+three statuses:
+
+```
+open()        →  status=pending,           started_at=now
+mark_ready()  →  status=ready_to_finalise, ready_at=now,  staged_writes
+finalise()    →  status=finalised,         finalised_at=now
+discard()     →  row deleted
+```
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending: open()
+    pending --> ready_to_finalise: mark_ready()
+    ready_to_finalise --> finalised: finalise()
+    pending --> [*]: discard()
+    ready_to_finalise --> [*]: discard()
+    finalised --> [*]: GC
+```
+
+| Status              | Meaning                                                                 | Recoverable? |
+|---------------------|-------------------------------------------------------------------------|--------------|
+| `pending`           | Worker started, has not yet declared staged writes. No data committed.  | **Discard.**     |
+| `ready_to_finalise` | Staged writes recorded; main txn committed; finalise marker not yet set.| **Replay.**      |
+| `finalised`         | Quiescent; audit trail only.                                            | Nothing to do.   |
+
+Why two phases? The journal row is opened in its own short txn so it
+survives a main-txn abort. Without that two-step write-ahead-log
+discipline, a crash mid-commit would erase the only trace of the
+attempted work.
+
+---
+
+## When a `journal_txn` is left over
+
+A row in `pending` or `ready_to_finalise` is the universal "we crashed
+between two phases" signal. The next `@atomic`-wrapped call for the
+same run will **refuse to start** and raise `JournalRefusedError`:
+
+```
+refusing to start atomic txn for run 'abc…':
+an outstanding journal txn (id='018f…', status='pending')
+exists and must be resolved via
+`fsm run resume --journal {discard,replay}` first.
+```
+
+The operator must clear it before new work can flow.
+
+### Inspect
+
+| Surface | Command                                                       |
+|---------|---------------------------------------------------------------|
+| CLI     | `ctxr-fsm run show <run_id>` (journal section)                |
+| CLI     | `ctxr-fsm runs ls --status incomplete`                        |
+| MCP     | `fsm.inspect_journal { run_id }`                              |
+| API     | `GET /api/v1/admin/journal_txns?status=pending`               |
+| API     | `GET /api/v1/admin/journal_txns?status=ready_to_finalise`     |
+
+Sample CLI output:
+
+```
+$ ctxr-fsm run show 7c3a…
+journal
+  id=018f… status=ready_to_finalise
+  started=2026-05-29T12:34:56.789Z
+  staged_writes=3
+```
+
+### Discard vs replay
+
+| Action     | Use when                                                  | What it does                                                                  |
+|------------|-----------------------------------------------------------|-------------------------------------------------------------------------------|
+| `discard`  | Status is `pending` (no data was committed).              | Deletes the row. The run is back to "ready for fresh work".                   |
+| `replay`   | Status is `ready_to_finalise` (data committed, marker lost). | Flips the row to `finalised`. **W4: status only**; engine re-materialisation lands in W12. |
+
+```bash
+# Roll back a half-started txn.
+ctxr-fsm run resume <run_id> --journal discard
+
+# Roll forward a committed-but-unfinalised txn.
+ctxr-fsm run resume <run_id> --journal replay
+```
+
+MCP equivalent:
+
+```jsonc
+// tool: fsm.recover_journal
+{ "run_id": "7c3a…", "action": "discard" }   // or "replay"
+```
+
+A `replay` against a `pending` row is refused with
+`journal_replay_not_ready` — there are no staged writes to roll
+forward.
+
+---
+
+## Spec hash drift error
+
+When a run starts, the engine snapshots the spec's SHA-256 hash onto
+the run row (`runs.fsm_spec_hash`). On every resume / commit, the
+**spec-hash lock** (W12 layer 9) compares that snapshot against the
+*current* latest version registered under the same `(project_id,
+slug)`. A mismatch means an operator re-registered the spec mid-flight.
+
+### How it surfaces
+
+| Surface | Shape                                                                 |
+|---------|-----------------------------------------------------------------------|
+| MCP     | `{ error: "fsm_spec_changed", run_hash, current_hash }`               |
+| API     | `HTTP 409 Conflict` with the same JSON body in `detail`.              |
+| CLI     | The next `fsm run resume` propagates the MCP/API error verbatim.      |
+
+Example API response:
+
+```json
+{
+  "detail": {
+    "error": "fsm_spec_changed",
+    "detail": "FSM spec hash changed since run started",
+    "run_hash":     "9af3…b1",
+    "current_hash": "c102…7e"
+  }
+}
+```
+
+### Operator playbook
+
+1. **Compare the hashes.** `ctxr-fsm spec show <slug>` prints the
+   current registered version; `ctxr-fsm run show <id>` prints the
+   run's snapshot.
+2. **Decide intent.**
+   - The spec change was intentional and the run is stale → abort the
+     run: `ctxr-fsm run abort <id> --reason "spec rev'd"`.
+   - The spec change was a mistake → re-register the original
+     definition: `ctxr-fsm spec register <file>`; the run resumes
+     cleanly.
+3. **Never** edit `runs.fsm_spec_hash` by hand. The hash is the
+   integrity contract; rewriting it strips the audit trail.
+
+---
+
+## Stale lock takeover
+
+`locks` carries one row per actively-locked run, with a TTL
+(`expires_at`). A live row means another writer holds the run; an
+expired row means the previous writer crashed or stalled.
+
+### Inspect
+
+```bash
+# CLI — surfaced via the doctor report.
+ctxr-fsm doctor
+
+# API — every held lock, freshest first.
+curl -s http://localhost:8000/api/v1/admin/locks | jq
+```
+
+### Acquire / takeover behaviour
+
+| Pre-state                            | Acquire result                          |
+|--------------------------------------|------------------------------------------|
+| no row                               | `acquired`                               |
+| same session, any state              | `already_held_by_same_session` (heartbeat) |
+| different session, **live**          | `held`, refused                          |
+| different session, **expired**       | `replaced_stale`, taken over             |
+
+`release` is the inverse and is owner-only: a foreign session calling
+`release` gets `not_owner` and the row stays put. **Stealing a live
+lock is never a release operation** — it goes through `acquire` on a
+naturally-stale lease.
+
+### Operator playbook
+
+1. **Wait first.** Default TTL is 3600 s. If you suspect a true hang,
+   confirm via `ctxr-fsm doctor` that the holder PID is dead.
+2. **Let the next worker take over.** Any subsequent `acquire` from a
+   new session on the same run will trip the `replaced_stale` path
+   automatically. No operator action needed.
+3. **Force-clear only as last resort.** If a lock is wedged on a row
+   you know is abandoned, delete it directly:
+   ```bash
+   sqlite3 .ctxr/fsm.sqlite "DELETE FROM locks WHERE run_id = '7c3a…'"
+   ```
+   Then `ctxr-fsm run resume <id>` to re-emit the bookkeeping event.
+
+---
+
+## Drift-paused runs (W12)
+
+The W12 drift detector scores each run's event stream against a
+weighted taxonomy and auto-pauses runs whose cumulative score exceeds
+`DriftConfig.score_threshold` (default 10.0). A paused run has
+`runs.status = 'drift_paused'`.
+
+```
+flowchart LR
+    Events --> Classify --> Score
+    Score -- > threshold --> Pause[status=drift_paused]
+    Score -- <= threshold --> Continue
+```
+
+### Signal weights (defaults)
+
+| Signal kind                     | Weight | Trigger                                                  |
+|---------------------------------|-------:|----------------------------------------------------------|
+| `signature_mismatch`            | 8.0    | Cosignature mismatch on commit                           |
+| `verifier_rejection`            | 6.0    | Verifier panel rejected the worker output                |
+| `off_allowlist_tool_call`       | 5.0    | Tool not in state's `allowed_tools` (and not `fsm.*`)    |
+| `repeated_validation_failed`    | 3.0    | 2nd+ consecutive `validation_failed`                     |
+| `output_shape_near_miss`        | 2.0    | Output close to but not matching schema                  |
+| `idle_too_long`                 | 1.0    | Run idle beyond `window_seconds` (default 60s)           |
+
+### Inspect
+
+| Surface | Command                                                         |
+|---------|-----------------------------------------------------------------|
+| CLI     | `ctxr-fsm runs ls --status drift_paused`                        |
+| CLI     | `ctxr-fsm run show <run_id>` (recent events list)               |
+| API     | `GET /api/v1/admin/drift_signals?run_id=<id>` (signals + score) |
+
+Sample API response:
+
+```json
+{
+  "run_id": "7c3a…",
+  "score": 13.0,
+  "signals": [
+    { "kind": "off_allowlist_tool_call", "weight": 5.0, "payload": { "tool_name": "Bash" } },
+    { "kind": "off_allowlist_tool_call", "weight": 5.0, "payload": { "tool_name": "Bash" } },
+    { "kind": "repeated_validation_failed", "weight": 3.0 }
+  ]
+}
+```
+
+### Operator playbook
+
+1. **Read the signals.** The list tells you *why* the run paused — a
+   single off-allowlist `Bash` is noise, three is a worker that is
+   systematically ignoring the contract.
+2. **Decide.**
+   - The signals are a false positive → adjust the spec
+     (`allowed_tools`) or widen `DriftConfig.score_threshold`, then
+     `ctxr-fsm run resume <id>`.
+   - The signals are real → `ctxr-fsm run abort <id> --reason
+     "drift confirmed"` and start a fresh run with a tightened spec.
+3. **Kill switch.** Set `CTXR_FSM_DRIFT_DISABLED=1` and reload the
+   supervisor to stop the loop entirely. Use sparingly — drift
+   pausing is the last enforcement layer.
+
+---
+
+## Recovery cheat sheet
+
+| Symptom                                          | Cause                                | Action                                                          |
+|--------------------------------------------------|--------------------------------------|-----------------------------------------------------------------|
+| `JournalRefusedError` on next call               | `pending` row left over              | `run resume --journal discard`                                  |
+| `JournalRefusedError`, status `ready_to_finalise`| Commit landed, finalise marker lost  | `run resume --journal replay`                                   |
+| HTTP 409 `fsm_spec_changed`                      | Spec re-registered mid-run           | Abort the run, or re-register the original spec                 |
+| `acquire` returns `held` indefinitely            | Live lock by another session         | Wait for TTL; verify holder is dead via `doctor`                |
+| `acquire` returns `replaced_stale`               | Previous holder crashed              | Nothing — takeover is automatic                                 |
+| Run status `drift_paused`                        | Drift score above threshold          | Inspect `/admin/drift_signals`; resume or abort                 |
+| `journal_replay_not_ready`                       | `replay` on a `pending` row          | Use `discard` instead                                           |
+
+The substrate's golden rule: **never edit the journal, lock, or hash
+columns by hand**. Every recovery path above goes through a CLI / MCP
+/ API surface that emits the corresponding event so the audit trail
+stays whole.


### PR DESCRIPTION
## Summary

W9 of the SQLite-backed Python FSM plan: complete user-facing documentation. **~2,900 LOC of markdown across 11 files; zero source-code changes; full verify gauntlet still green (456 pytest + 17 vitest + ruff + mypy).**

> **Base branch is \`w12/enforcement-primitives\` (PR #34).**

## Files

| File | LOC | Coverage |
|---|---|---|
| README.md (rewrite) | 94 | Hero, architecture diagram, quick start, what's included, why an FSM substrate, what's at legacy-js/, full docs index, quick links, license |
| docs/architecture.md | 192 | Layered design + dependency rule + cross-cutting concerns + service topology |
| docs/data-model.md | 411 | 18 STRICT tables, Mermaid ER diagram, indexes, enums, event shape, journal lifecycle |
| docs/api.md | 272 | Project facade + sub-repos + Pydantic classes + 30-line end-to-end example |
| docs/mcp-tools.md | 317 | All 17 fsm.* tools, two-phase commit sequence diagram, drain behaviour |
| docs/http-api.md | 245 | FastAPI routes + auth + CORS + SSE protocol + error codes |
| docs/operating.md | 325 | ctxr-fsm CLI reference, env vars, .ctxr-fsm/ tree |
| docs/recovery.md | 286 | Journal lifecycle, operator playbook per failure mode |
| docs/enforcement.md | 329 | 4 layer groups, per-layer enable/disable, hook installation |
| docs/examples-tour.md | 329 | Walk through 3 examples with diagrams + expected output |
| CHANGELOG.md | 80 | Keep a Changelog v1.1 [Unreleased] + [0.1.0] with workstream breakdown |

## Verify

- [x] \`uv run pytest tests/\` — **456 passed** (no regression).
- [x] \`uv run ruff check ctxr/ tests/ examples/\` — **All checks passed**.
- [x] \`uv run mypy ctxr/fsm/\` — **Success: no issues found in 60 source files**.
- [x] \`cd ui && npm test\` — **17 passed**.
- [x] All 9 docs/*.md files written, non-empty, cross-linked.

## Plan reference

\`/Users/developer/.claude/plans/how-it-fits-toasty-gray.md\` — W9 section.