### PR TITLE
ci(w10): Python CI + manual PyPI publish + tag-on-main per Principle 2

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,140 @@
+# Python CI for the @ctxr/fsm package (Python side).
+#
+# Per Principle 2 (Manual publish + sibling linking), this workflow ONLY
+# lints, type-checks, runs migrations, runs tests, and builds the UI.
+# It DOES NOT publish to PyPI or npm. Publishing is always manual
+# (workflow_dispatch-only) and lives in separate workflows.
+#
+# Jobs:
+#   * lint     — ruff + mypy across the Python tree (matrix 3.12 / 3.13)
+#   * test     — alembic upgrade/downgrade smoke + pytest (matrix 3.12 / 3.13)
+#   * ui-build — Node 22: npm ci, vite build, vitest run
+#
+# NEVER touch fsm/legacy-js/ from here — that subtree owns its own JS CI.
+
+name: Python — CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint (ruff + mypy) — py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: '0.5.11'
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Sync dependencies
+        run: uv sync --all-extras --dev
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+      - name: Ruff (lint)
+        run: uv run ruff check ctxr/ tests/ examples/
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+      - name: Mypy (type-check)
+        run: uv run mypy ctxr/fsm/
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+  test:
+    name: Test (alembic + pytest) — py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: '0.5.11'
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Sync dependencies
+        run: uv sync --all-extras --dev
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+      # Alembic migrations smoke test against a throwaway SQLite DB.
+      # CTXR_FSM_DB_URL is honoured by migrations/env.py so we never
+      # touch the repo's default DB path.
+      - name: Alembic upgrade head (SQLite smoke)
+        run: |
+          mkdir -p "$RUNNER_TEMP/fsm-ci"
+          export CTXR_FSM_DB_URL="sqlite:///$RUNNER_TEMP/fsm-ci/ci.db"
+          echo "CTXR_FSM_DB_URL=$CTXR_FSM_DB_URL" >> "$GITHUB_ENV"
+          uv run alembic upgrade head
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+      - name: Alembic downgrade base (reversibility check)
+        run: uv run alembic downgrade base
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+      - name: Pytest
+        run: uv run pytest tests/ -v --tb=short
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+
+  ui-build:
+    name: UI build (Node 22)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install dependencies (npm ci)
+        run: npm ci
+
+      - name: Build (vite)
+        run: npm run build
+
+      - name: Test (vitest)
+        run: npm test

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,182 @@
+# WARNING: This workflow publishes ctxr-fsm to PyPI. It is MANUAL ONLY
+# (workflow_dispatch). It is intentionally NOT triggered by push or tag.
+# See: docs/architecture.md (manual-publish discipline) and the
+# workspace-wide Principle 2 in common-dev-principles/.
+
+name: Publish ctxr-fsm to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Semver bump'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: 'Dry run (build + upload to TestPyPI only)'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    name: Build and publish ctxr-fsm
+    runs-on: ubuntu-latest
+    # PyPI Trusted Publishing — no API token stored in the repo.
+    # The `pypi` environment is bound to ctxr-fsm on pypi.org via OIDC.
+    environment: pypi
+    permissions:
+      # Required for PyPI Trusted Publishing via OIDC.
+      id-token: write
+      # Required to push the version-bump commit and tag.
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Need full history so we can push a tag back to origin.
+          fetch-depth: 0
+          # Use the default GITHUB_TOKEN to push the bump commit + tag.
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: uv sync --all-extras --dev
+
+      # ---------------- Pre-flight checks ----------------
+      - name: Run tests
+        run: uv run pytest tests/ -q
+
+      - name: Lint with ruff
+        run: uv run ruff check ctxr/ tests/ examples/
+
+      - name: Type-check with mypy
+        run: uv run mypy ctxr/fsm/
+
+      # ---------------- Bump version ----------------
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version in pyproject.toml
+        id: bump
+        env:
+          BUMP_KIND: ${{ inputs.version_bump }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          import pathlib
+          import sys
+
+          bump_kind = os.environ["BUMP_KIND"]
+          pyproject_path = pathlib.Path("pyproject.toml")
+          text = pyproject_path.read_text(encoding="utf-8")
+
+          # Match the FIRST `version = "..."` under [project].
+          # We deliberately keep this simple: scan line by line within the
+          # [project] section until we hit the next [section] header.
+          lines = text.splitlines()
+          in_project = False
+          new_lines = []
+          current_version = None
+          new_version = None
+
+          version_re = re.compile(r'^version\s*=\s*"([^"]+)"\s*$')
+
+          def bump(version: str, kind: str) -> str:
+              # Strip pre-release / build metadata for the bump; we always
+              # release a clean X.Y.Z from this workflow.
+              core = re.split(r'[-+a]', version, maxsplit=1)[0]
+              parts = core.split(".")
+              if len(parts) != 3 or not all(p.isdigit() for p in parts):
+                  print(f"ERROR: unsupported version format: {version!r}", file=sys.stderr)
+                  sys.exit(1)
+              major, minor, patch = (int(p) for p in parts)
+              if kind == "major":
+                  major, minor, patch = major + 1, 0, 0
+              elif kind == "minor":
+                  minor, patch = minor + 1, 0
+              elif kind == "patch":
+                  patch = patch + 1
+              else:
+                  print(f"ERROR: unknown bump kind: {kind!r}", file=sys.stderr)
+                  sys.exit(1)
+              return f"{major}.{minor}.{patch}"
+
+          for line in lines:
+              stripped = line.strip()
+              if stripped.startswith("[") and stripped.endswith("]"):
+                  in_project = (stripped == "[project]")
+                  new_lines.append(line)
+                  continue
+              if in_project and current_version is None:
+                  m = version_re.match(line)
+                  if m:
+                      current_version = m.group(1)
+                      new_version = bump(current_version, bump_kind)
+                      new_lines.append(f'version = "{new_version}"')
+                      continue
+              new_lines.append(line)
+
+          if current_version is None or new_version is None:
+              print("ERROR: could not find version under [project]", file=sys.stderr)
+              sys.exit(1)
+
+          pyproject_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+          gh_out = os.environ.get("GITHUB_OUTPUT")
+          if gh_out:
+              with open(gh_out, "a", encoding="utf-8") as fh:
+                  fh.write(f"old_version={current_version}\n")
+                  fh.write(f"new_version={new_version}\n")
+                  fh.write(f"tag=v{new_version}\n")
+          print(f"Bumped {current_version} -> {new_version}")
+          PY
+
+      - name: Commit and tag the release
+        run: |
+          git add pyproject.toml
+          git commit -m "chore: release ${{ steps.bump.outputs.tag }}"
+          git tag -a "${{ steps.bump.outputs.tag }}" -m "ctxr-fsm ${{ steps.bump.outputs.tag }}"
+
+      # ---------------- Build distributions ----------------
+      - name: Build sdist + wheel
+        run: |
+          rm -rf dist
+          uv build
+
+      - name: Show built artifacts
+        run: ls -la dist/
+
+      # ---------------- Publish ----------------
+      - name: Publish to TestPyPI (dry run)
+        if: ${{ inputs.dry_run == true }}
+        run: uv publish --repository testpypi dist/*
+
+      - name: Publish to PyPI (Trusted Publishing via OIDC)
+        if: ${{ inputs.dry_run != true }}
+        run: uv publish dist/*
+
+      # ---------------- Push tag + commit ----------------
+      # We push the bump + tag for BOTH real and dry-run flows so that the
+      # repo history reflects the version that was actually built. If you
+      # want to keep dry-run truly side-effect-free, gate this step on
+      # `if: ${{ inputs.dry_run != true }}` instead.
+      - name: Push commit and tag to origin
+        run: git push origin HEAD --follow-tags

--- a/.github/workflows/python-tag-on-main.yml
+++ b/.github/workflows/python-tag-on-main.yml
@@ -1,0 +1,56 @@
+# Tag-on-main workflow for the Python @ctxr/fsm package.
+#
+# IMPORTANT: This workflow ONLY creates a git tag when pyproject.toml's
+# version changes on main. It DOES NOT publish to PyPI.
+#
+# Per Principle 2 (Manual publish + sibling linking), PyPI publishing is
+# always manual (workflow_dispatch only) and lives in a separate workflow.
+# CI may build, test, and tag — CI MUST NOT publish.
+
+name: Python — Tag on main
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Extract version
+        id: extract
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "CTXR_FSM_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Current version: $VERSION"
+
+      - name: Check if version changed
+        id: changed
+        run: |
+          PREV_VERSION=$(git show HEAD~1:pyproject.toml | python -c "import tomllib,sys; print(tomllib.load(sys.stdin.buffer)['project']['version'])")
+          echo "Previous version: $PREV_VERSION"
+          echo "Current version:  $CTXR_FSM_VERSION"
+          if [ "$PREV_VERSION" = "$CTXR_FSM_VERSION" ]; then
+            echo "Version unchanged; skipping tag."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version changed; will tag."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$CTXR_FSM_VERSION" -m "Release v$CTXR_FSM_VERSION"
+          git push origin "v$CTXR_FSM_VERSION"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,99 @@ A bare LLM loop is a probability cloud over tool calls; an FSM is a contract. Ea
 
 The pre-rewrite Node.js package `@ctxr/fsm` lives at [`legacy-js/`](legacy-js/) and still publishes to npm from there via its own workflow. It cohabits this repository so existing JS consumers (notably `skill-code-review`) keep working unchanged while the Python rewrite stabilises; migrating JS consumers onto `ctxr-fsm` is tracked separately and is not a precondition for using either side.
 
+## Development
+
+### One-time setup
+
+```bash
+git clone https://github.com/ctxr-dev/fsm.git
+cd fsm
+
+# Python side
+uv sync --all-extras --dev
+
+# UI side
+cd ui && npm ci && cd ..
+```
+
+Requires Python 3.12+, Node 22+, and uv (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+
+### Run the test suites
+
+```bash
+# Python: unit + integration + CLI + MCP + API + lifecycle + enforcement + examples
+uv run pytest tests/
+
+# Python static analysis
+uv run ruff check ctxr/ tests/ examples/
+uv run mypy ctxr/fsm/
+
+# Frontend
+cd ui && npm test && npm run build && cd ..
+```
+
+Expected: `456 passed` (Python) + `17 passed` (UI) on a clean checkout.
+
+### Run an example
+
+```bash
+uv run python examples/plan_implement_qa_fix.py
+uv run python examples/code_review_pipeline.py
+uv run python examples/research_with_retries.py
+```
+
+Each example uses a tmpdir for the run database, drives the FSM through simulated worker outputs, and prints the resulting state tree + event log. See docs/examples-tour.md for what each one teaches.
+
+### Boot the dev supervisor
+
+```bash
+# In one terminal:
+uv run ctxr-fsm init                  # creates .ctxr-fsm/fsm.db + applies migrations + patches CLAUDE.md/AGENTS.md
+uv run ctxr-fsm serve --mode dev      # supervisor boots MCP (HTTP-SSE) + FastAPI + Vite UI
+
+# In another terminal:
+uv run ctxr-fsm doctor                # diagnostic report
+uv run ctxr-fsm runs ls               # empty until you start a run
+uv run ctxr-fsm spec register examples.plan_implement_qa_fix:spec
+```
+
+The supervisor:
+- assigns ports automatically (and remembers them in `.ctxr-fsm/ports.json`)
+- writes PID files under `.ctxr-fsm/pids/`
+- watches `ctxr/fsm/` for file changes and gracefully drains + respawns MCP + API
+- never spawns a second copy if you re-invoke from the same project root
+
+Browse the UI at `http://localhost:5173`, the FastAPI docs at `http://localhost:<api_port>/docs` (port from `ctxr-fsm doctor`), and connect an MCP client to `http://localhost:<mcp_port>/sse`.
+
+### Run the MCP server standalone (for Claude Code stdio integration)
+
+```bash
+uv run ctxr-fsm mcp --db ./.ctxr-fsm/fsm.db
+```
+
+This blocks on stdio; pair it with a Claude Code (or other MCP client) session configured to launch the binary on demand. See docs/mcp-tools.md.
+
+### Contribution loop
+
+1. Branch off the latest unmerged tip (workstream chain). Use a `<scope>/<short-name>` style branch name.
+2. Make changes inside one of `ctxr/fsm/{core,sqlite,cli,mcp,api,memory}`, `ui/`, `examples/`, or `docs/`. Don't cross layer boundaries (see docs/architecture.md for the dependency rule).
+3. Run the full verify gauntlet locally (pytest + ruff + mypy + ui).
+4. Commit + push + open a PR against the previous workstream branch (or main if it's a follow-on).
+5. CI runs `python-ci.yml` on the PR (lint + test matrix on Python 3.12 + 3.13 + UI build).
+6. After review + green CI, the human gate is: merge.
+7. Publishes to PyPI are MANUAL via `python-publish.yml` workflow_dispatch (see docs/operating.md).
+
+### Useful one-liners
+
+| What | How |
+|---|---|
+| Watch tests rerun on file change | `uv run pytest tests/ -q --looponfail` (needs pytest-xdist) |
+| UI dev mode (HMR) | `cd ui && npm run dev` |
+| Show all CLI commands | `uv run ctxr-fsm --help` |
+| Inspect a run | `uv run ctxr-fsm run show <run-id>` |
+| Find drift signals | `uv run ctxr-fsm doctor` then `curl http://localhost:<api>/api/v1/admin/drift_signals` |
+| Clean local state | `rm -rf .ctxr-fsm/ .venv/ ui/node_modules/ ui/dist/` |
+
 ## Documentation
 
 - [docs/architecture.md](docs/architecture.md) — layered design, dependency rule, service topology
@@ -83,7 +176,6 @@ The pre-rewrite Node.js package `@ctxr/fsm` lives at [`legacy-js/`](legacy-js/) 
 
 - PyPI: [`ctxr-fsm`](https://pypi.org/project/ctxr-fsm/) (publishes from this repo — manual `workflow_dispatch` only)
 - GitHub: [ctxr-dev/fsm](https://github.com/ctxr-dev/fsm) — issues, PRs, CI
-- Plan: `/Users/developer/.claude/plans/how-it-fits-toasty-gray.md` — single source of truth for workstreams (W0–W12), locked decisions, verification gates
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,6 @@
 
 `ctxr-fsm` is a workstation-scale finite-state-machine runtime for agent orchestration. It is a Python 3.12+ library plus a small set of long-running services (MCP server, FastAPI server, UI dev server, supervisor) that share one SQLite database per project. Every higher layer depends only on the layers below it; nothing in the core imports SQLite, HTTP, MCP, or the UI.
 
-The full workstream plan, including locked decisions and verification gates, lives at `/Users/developer/.claude/plans/how-it-fits-toasty-gray.md`.
-
 ## Layered overview
 
 ```

--- a/docs/integration-skills.md
+++ b/docs/integration-skills.md
@@ -1,0 +1,454 @@
+# Integrating ctxr-fsm into a skill or agent
+
+This is the worked-example blueprint for any **skill, agent, or service**
+that wants to use `ctxr-fsm` as its FSM substrate — either by migrating an
+existing pipeline or by being authored against the FSM from day one.
+
+> **Scope note.** The canonical case study throughout this guide is
+> `skill-code-review` (the lens-specialist pipeline that today ships as a
+> Node CLI under `legacy-js/`). Its **migration to the Python `ctxr-fsm`
+> substrate is explicitly OUT OF SCOPE for the current `fsm/` repo plan**
+> — `legacy-js/` is preserved untouched. Use this guide either as the
+> blueprint for that future migration **or** as the green-field recipe
+> for a brand-new skill that targets `ctxr-fsm` from the start.
+
+Cross-references:
+- [`docs/mcp-tools.md`](./mcp-tools.md) — the 17 `fsm.*` MCP tool surface
+- [`docs/api.md`](./api.md) and [`docs/http-api.md`](./http-api.md) — Python facade + REST/SSE
+- [`docs/enforcement.md`](./enforcement.md) — capability, integrity, adversarial, observational gates
+- [`examples/code_review_pipeline.py`](../examples/code_review_pipeline.py) — the runnable end-to-end template
+- [`ctxr/fsm/memory/principles.md`](../ctxr/fsm/memory/principles.md) — the agent-facing discipline
+
+---
+
+## TL;DR table
+
+| Step | What you do | Where |
+|---|---|---|
+| 1. Declare requirement | `SKILL.md` frontmatter: `requires.fsm.{mcp_server, min_version, server_must_be_reachable}` | Skill manifest |
+| 2. Pre-check at startup | Call `fsm.healthcheck`; return `MissingRequirement` on failure | Skill preamble |
+| 3. Define the FSM spec | Pydantic `FsmSpec` in a Python module | `<skill>/specs/<role>.py` |
+| 4. Register the spec | `ctxr-fsm spec register <module>:<attr>` (one-time, or at install) | `ctxr-fsm` CLI |
+| 5. Start a run | `fsm.start_run(spec_id, args)` | MCP or API |
+| 6. Brief → dispatch → commit loop | `fsm.get_brief` → dispatch worker → `fsm.commit_outputs` (+ `fsm.confirm_commit`) | MCP, API, or Python |
+| 7. Honour `allowed_tools` | Read `brief.allowed_tools`; restrict tool surface during the state | Hook + skill prompt |
+| 8. Sign every commit | `CommitSignature.compute(brief_id, inputs, outputs, session_id)` | Skill code |
+| 9. Observe non-`fsm` tool calls | `fsm.observe_tool_call` for every `Bash`/`Read`/`WebFetch`/sub-agent call | Skill code or harness |
+| 10. Handle faults via `fsm.resume_run` / `fsm.recover_journal` | DON'T improvise recovery | Operator step |
+
+The 10 steps map 1:1 onto the lifecycle quick reference in
+[`principles.md`](../ctxr/fsm/memory/principles.md): `healthcheck → list_specs
+→ start_run → (get_brief → dispatch → commit_outputs [→ confirm_commit])* →
+terminal`.
+
+---
+
+## The three integration shapes
+
+Pick **one**. They share the same FSM spec, the same DB, and the same
+enforcement model — only the transport changes.
+
+### A. Python in-process
+
+The skill runs in the same Python process as the FSM and calls the
+`Project` facade directly. Minimum latency, no MCP, no HTTP. Best for
+service skills that already live in a Python codebase.
+
+```python
+# my_skill/runner.py
+from pathlib import Path
+import uuid
+from ctxr.fsm.core import RunCtx, advance, build_brief
+from ctxr.fsm.core.models import CommitSignature
+from ctxr.fsm.sqlite import Project
+from my_skill.specs.lens_specialist import spec
+from my_skill.workers import dispatch_lens_worker  # your code
+
+def review(target: str, db_path: Path, session_id: str) -> dict:
+    with Project.open(db_path) as project:
+        registered = project.register_spec(spec, project_slug="skill-code-review")
+        run = project.start_run(spec_id=registered.spec.id, args={"target": target})
+
+        env: dict = dict(run.args or {})
+        state_id, iteration_n = spec.entry, None
+        while True:
+            state = spec.get_state(state_id)
+            brief = build_brief(spec, state, env=env, run_id=uuid.UUID(run.id),
+                                iteration_n=iteration_n)
+            if state.worker is None and state.loop is None:
+                outputs = {}                                # terminal
+            else:
+                outputs = dispatch_lens_worker(brief)       # YOUR code
+                _ = CommitSignature.compute(                # see step 8
+                    brief.brief_id, brief.inputs, outputs, session_id,
+                )
+
+            ctx = RunCtx(run_id=uuid.UUID(run.id), fsm_id=spec.id,
+                         current_state=state_id, iteration_n=iteration_n, env=env)
+            result = advance(spec, ctx, outputs)
+            if result.kind == "fault":
+                raise RuntimeError(f"FSM fault: {result.reason}")
+            if result.kind == "loop_continue":
+                iteration_n = result.iteration_n
+                continue
+            env = {**env, **outputs}
+            if result.kind == "terminal":
+                return {"verdict": env.get("verdict"), "run_id": run.id}
+            state_id = result.next_state or ""
+            iteration_n = 1 if spec.get_state(state_id).loop else None
+```
+
+The canonical version of this loop — with full persistence, aggregator
+hints, post-validation, and event emission — lives in
+[`examples/code_review_pipeline.py`](../examples/code_review_pipeline.py).
+
+### B. MCP-driven
+
+The skill is an LLM agent (Claude Code, Codex CLI, Cursor) that calls
+`fsm.*` tools over MCP stdio. The skill never imports `ctxr.fsm`; the
+skill's "runtime" is the MCP client. This is the default shape for
+prompt-defined skills.
+
+```text
+# .claude/skills/skill-code-review/SKILL.md   (preamble excerpt)
+1. Call fsm.healthcheck(). If it fails, return MissingRequirement with
+   install command "pip install ctxr-fsm" and STOP.
+2. spec_id = (fsm.list_specs() | first where slug == "code-review-lens-specialist").id
+3. run = fsm.start_run(spec_id=spec_id, args={"target": <user input>})
+4. Loop:
+     brief = fsm.get_brief(run_id=run.id)
+     if brief.terminal: return brief.outputs
+     outs = dispatch_worker(brief.worker.prompt_template, brief.inputs,
+                            schema=brief.worker.response_schema,
+                            tools=brief.allowed_tools)   # honour the surface
+     sig = CommitSignature.compute(brief.brief_id, brief.inputs,
+                                    outs, session_id)
+     ack = fsm.commit_outputs(run_id=run.id, outputs=outs, signature=sig)
+     if ack.commit_token:
+         fsm.confirm_commit(token=ack.commit_token,
+                            expected_next_state=ack.next_state)
+```
+
+The Claude Code pre-tool-use hook (see [`enforcement.md`](./enforcement.md))
+enforces `brief.allowed_tools` server-side, so a wandering LLM cannot
+silently call `Bash` from a state that only declared `Read`.
+
+### C. HTTP-driven
+
+The skill drives the FSM via the FastAPI REST + SSE endpoints. Useful
+for browser-side tools (the `fsm-ui` SPA), CI pipelines that already speak
+HTTP, dashboards, or third-party orchestrators that do not embed MCP.
+
+```bash
+# Boot the server (one-shot)
+ctxr-fsm api --host 127.0.0.1 --port 8000 --db ./.ctxr-fsm/fsm.db
+
+# In the skill (any language)
+curl -fsS http://127.0.0.1:8000/healthz                                 # step 2
+SPEC_ID=$(curl -fsS -H "Authorization: Bearer $T" \
+    http://127.0.0.1:8000/api/v1/specs | jq -r \
+    '.[] | select(.slug=="code-review-lens-specialist") | .id')
+RUN_ID=$(curl -fsS -H "Authorization: Bearer $T" -X POST \
+    http://127.0.0.1:8000/api/v1/runs \
+    -d "{\"spec_id\":\"$SPEC_ID\",\"args\":{\"target\":\"PR #42\"}}" | jq -r .id)
+
+# Live event stream while the loop runs (SSE)
+curl -N -H "Authorization: Bearer $T" \
+    "http://127.0.0.1:8000/api/v1/runs/$RUN_ID/events"
+```
+
+Brief / commit / confirm endpoints mirror the MCP surface 1:1 — see
+[`docs/http-api.md`](./http-api.md) for the route catalog and auth model.
+
+---
+
+## Worked example: `skill-code-review` (the lens-specialist pipeline)
+
+The skill today dispatches **6 lens specialists** — gap, blind-spot,
+edge-case, infeasibility, divergence, missed-step — and synthesizes a
+**GO / CONDITIONAL / NO-GO** verdict. Below is what that same pipeline
+looks like once expressed against `ctxr-fsm`.
+
+### A. The FSM spec — `skill_code_review/specs/lens_specialist.py`
+
+```python
+from ctxr.fsm.core import (
+    FsmSpec, State, Worker, Loop, Predicate, Transition,
+    ResponseSchema, VerifierSpec,
+)
+
+LENSES = ["gap", "blind-spot", "edge-case",
+          "infeasibility", "divergence", "missed-step"]
+
+# Schemas elided for brevity — each Worker carries a ResponseSchema
+# whose JSON Schema enforces the worker's output shape.
+_lens_iter_schema = ResponseSchema(schema={
+    "type": "object",
+    "required": ["lens", "findings", "done"],
+    "properties": {
+        "lens": {"type": "string", "enum": LENSES},
+        "findings": {"type": "array", "items": {"type": "object"}},
+        "done": {"type": "boolean"},
+    },
+})
+
+spec = FsmSpec(
+    id="code-review-lens-specialist", version=1, entry="scan_diff",
+    states=[
+        State(id="scan_diff",
+              worker=Worker(role="diff-scanner",
+                            prompt_template="Scan the diff for {target}",
+                            inputs=["target"],
+                            response_schema=ResponseSchema(schema={...})),
+              allowed_tools=["Read", "Bash"],
+              outputs=["files_changed"],
+              transitions=[Transition(to="dispatch_lenses", when="always")]),
+        State(id="dispatch_lenses",
+              loop=Loop(worker=Worker(role="lens-specialist",
+                                      prompt_template="Lens: {lens_name}",
+                                      inputs=["files_changed"],
+                                      response_schema=_lens_iter_schema),
+                        max_iterations=6, done_field="done"),
+              allowed_tools=["Read", "Grep"],
+              outputs=["lens", "findings", "done"],
+              transitions=[Transition(to="collect_findings", when="always")]),
+        State(id="collect_findings",
+              worker=Worker(role="findings-collector",
+                            prompt_template="Merge per-lens findings.",
+                            inputs=["aggregated_findings"],
+                            response_schema=ResponseSchema(schema={...})),
+              outputs=["unified_findings"],
+              transitions=[Transition(to="synthesize_verdict", when="always")]),
+        State(id="synthesize_verdict",
+              worker=Worker(role="verdict-synthesiser",
+                            prompt_template="Apply GO/CONDITIONAL/NO-GO.",
+                            inputs=["unified_findings"],
+                            response_schema=ResponseSchema(schema={...})),
+              verifier=VerifierSpec(
+                  role="verdict-auditor",
+                  prompt_template="Does the verdict follow the rule?",
+                  response_schema=ResponseSchema(schema={...}),
+                  parallel_count=3, majority_threshold=2),
+              allowed_tools=["Read"],
+              post_validations=[Predicate(
+                  "verdict == 'GO' OR verdict == 'CONDITIONAL' OR verdict == 'NO-GO'")],
+              outputs=["verdict", "explanation"],
+              transitions=[Transition(to="done", when="always")]),
+        State(id="done", transitions=[]),
+    ],
+)
+```
+
+Notes:
+
+- The `Loop` covers all 6 lenses with `done_field="done"`. The runner
+  injects the current lens name into env between iterations.
+- Each state declares its **`allowed_tools`** — the synthesizer only
+  needs `Read`; the scanner gets `Bash` for `git diff`.
+- The verdict state attaches a **3-of-3 verifier panel** with a 2-majority
+  threshold. The verifier sees `unified_findings` plus the proposed
+  `verdict` and answers boolean — the FSM rejects the commit on `False`.
+- A `post_validation` predicate re-asserts the verdict-shape invariant
+  inside the engine, catching a buggy worker before the run is marked
+  terminal.
+
+### B. The `SKILL.md` frontmatter
+
+```yaml
+---
+name: skill-code-review
+description: Review the current diff via the lens-specialist FSM.
+requires:
+  fsm:
+    mcp_server: ctxr-fsm
+    min_version: "0.1.0"
+    server_must_be_reachable: true
+---
+```
+
+The `requires.fsm` block is the **machine-readable pre-check** for
+Principle 1 (requirement pre-check, ask-to-satisfy). A host that does
+not see a reachable `ctxr-fsm` MCP server stops before any LLM tokens
+are spent.
+
+### C. The skill preamble
+
+Installed by `ctxr-fsm install-memory` (the FSM-discipline section) plus
+the skill's own dispatch instructions:
+
+> Before doing anything, call `fsm.healthcheck()`. If it fails, return
+> `MissingRequirement` with the install command `pip install ctxr-fsm`
+> and STOP. Once healthy, `fsm.list_specs` to find the
+> `code-review-lens-specialist` spec; `fsm.start_run` with
+> `args = {target: <user-supplied diff or PR url>}`; loop:
+> `fsm.get_brief` → dispatch the lens specialist as a sub-agent with
+> `brief.prompt_template` + `brief.inputs` → sub-agent returns JSON
+> matching `brief.worker.response_schema` →
+> `fsm.commit_outputs(run_id, outputs, signature=CommitSignature.compute(...))`
+> → `fsm.confirm_commit` if the result carries a token → repeat until
+> terminal. The verdict + explanation are the run's terminal outputs.
+
+### D. The install hook (registers the spec on first install)
+
+```python
+# skill_code_review/install_spec.py
+from ctxr.fsm.cli._common import resolve_db_path
+from ctxr.fsm.sqlite import Project
+from skill_code_review.specs.lens_specialist import spec
+
+def install() -> None:
+    db_path = resolve_db_path(None)            # honours .fsmrc.json + env
+    with Project.open(db_path) as project:
+        result = project.register_spec(spec, project_slug="skill-code-review")
+        print(f"registered {result.spec.slug}@v{result.spec.version} "
+              f"(created={result.created})")
+
+if __name__ == "__main__":
+    install()
+```
+
+Wire this into the package's post-install hook, or document it as a
+one-liner the operator runs after `pip install`:
+
+```bash
+pip install skill-code-review
+python -m skill_code_review.install_spec   # → registered code-review-lens-specialist@v1
+```
+
+`register_spec` is **idempotent** — re-running it on an unchanged spec
+returns `created=False` and does not bump the version. Edit the spec,
+re-run, and a new version row is minted automatically (see
+[`docs/data-model.md`](./data-model.md)).
+
+### E. Migration checklist for the existing JS-based skill
+
+When the time comes (this is the out-of-scope work flagged at the top
+of this guide), the migration from `legacy-js/` to the Python substrate
+is:
+
+- [ ] Port `.fsm.yaml` (or the hand-rolled JS FSM in
+      `scripts/run-review.mjs`) into a Pydantic `FsmSpec` exactly as
+      shown in section A.
+- [ ] Replace the Node runner's shell loop with the MCP tool dispatch
+      loop in section B of "The three integration shapes".
+- [ ] Replace `SKILL.md`'s `requires.fsm.npm` block (if any) with the
+      `requires.fsm.mcp_server` block from section B above.
+- [ ] Add `install_spec.py` (section D) and call it from the package's
+      post-install hook.
+- [ ] Update CI to test the Python-driven flow end-to-end via
+      `tests/integration/test_pipeline.py` (mirror
+      `tests/integration/examples/test_code_review_pipeline.py`).
+- [ ] **Leave `legacy-js/` in place** until the new flow has shipped at
+      least one production review. The old runner is the rollback path.
+
+---
+
+## Honouring the enforcement layers
+
+Every consumer is responsible for cooperating with the four enforcement
+groups documented in [`docs/enforcement.md`](./enforcement.md). The skill
+authoring rules:
+
+### `allowed_tools` (Layer 2 + Layer 4)
+
+- Read `brief.allowed_tools` at every state entry. Your effective surface
+  is **`fsm.* + allowed_tools`** — nothing else.
+- If your worker would call a tool not in that set, **refuse locally
+  first**. The Claude Code pre-tool-use hook (Layer 4) is a defence-in-
+  depth backstop, not the primary gate.
+- Empty `allowed_tools` means the worker may call **only** `fsm.*` for
+  that state. This is normal for a `synthesize_*` style state.
+
+### Cosignature (Layer 5)
+
+**Always sign your commits.** The skill computes:
+
+```python
+sig = CommitSignature.compute(
+    brief_id   = brief.brief_id,
+    inputs     = brief.inputs,
+    outputs    = my_outputs,
+    session_id = session_id,        # stable per FSM-driving session
+).signature
+ack = fsm.commit_outputs(run_id=run.id, outputs=my_outputs, signature=sig)
+```
+
+The server recomputes `sha256(brief_id || canonical_json(inputs) ||
+canonical_json(outputs) || session_id)` and rejects mismatches with
+`error: signature_mismatch`. Skipping the signature on a state whose
+`allowed_tools` is non-empty triggers an automatic `signature_required`
+reject — the FSM treats an unsigned commit as a layer-5 bypass attempt.
+
+### Verifier panel (Layer 3)
+
+If the state declares a `verifier`, the FSM runs `parallel_count`
+verifier dispatches in parallel and accepts the commit only when at
+least `majority_threshold` return `verdict_supported: true`. **Your
+skill code does not see the verifier** — it just gets `verifier_passed`
+or `verifier_rejected` in the `CommitResult` envelope. On
+`verifier_rejected`, re-do the work; do not argue with the panel
+(Principle 7).
+
+### Drift detector (Layer 8)
+
+- **Do** call `fsm.observe_tool_call` for every non-`fsm.*` tool you
+  invoke during a run (Principle 9). Skipping is itself a drift signal.
+- **Don't** call tools outside `allowed_tools`. The drift detector will
+  see and pause the run (`drift_paused`); the operator then has to
+  resume.
+
+### Two-phase commit (Layer 12)
+
+When `fsm.commit_outputs` returns a `commit_token`, the brief had
+`requires_confirm: true`. Follow up immediately with
+`fsm.confirm_commit(token, expected_next_state)`. The token TTL is 60
+seconds — sit on it longer and you'll get `commit_token_expired` and
+have to redo the state.
+
+---
+
+## Distribution
+
+A consumer project that wants to use your skill:
+
+```bash
+# 1. One-time bootstrap (writes .fsmrc.json + .ctxr-fsm/fsm.db
+#    + installs FSM principles into the AI client's memory).
+ctxr-fsm init
+
+# 2. Install the skill itself.
+pip install skill-code-review            # or: uv add skill-code-review
+
+# 3. Register the skill's FsmSpec into the project DB (idempotent).
+python -m skill_code_review.install_spec
+
+# 4. The AI client (Claude Code, Codex, Cursor) reads the skill's
+#    SKILL.md, sees the requires.fsm block, calls fsm.healthcheck,
+#    then fsm.list_specs → fsm.start_run → loop. No further setup.
+```
+
+Three contracts make this work without bespoke per-host plumbing:
+
+1. **`requires.fsm` in `SKILL.md`** — declares the dependency in a
+   machine-readable shape every modern AI client can parse.
+2. **`ctxr-fsm install-memory`** — writes the host-specific principles
+   adapter (Claude / Codex / Cursor) so the LLM knows the protocol
+   without the skill author re-explaining it.
+3. **Idempotent `register_spec`** — re-running the install hook on a
+   stale checkout is safe. Spec hashing in
+   [`docs/data-model.md`](./data-model.md) guarantees version bumps only
+   when the spec actually changes.
+
+---
+
+## Where to go next
+
+| You want to… | Read |
+|---|---|
+| See the full Python control loop with persistence + aggregators | [`examples/code_review_pipeline.py`](../examples/code_review_pipeline.py) |
+| Look up an `fsm.*` tool signature | [`docs/mcp-tools.md`](./mcp-tools.md) |
+| Hit the FSM from HTTP / a browser | [`docs/http-api.md`](./http-api.md) |
+| Understand the gate that just rejected your commit | [`docs/enforcement.md`](./enforcement.md) |
+| Recover a faulted run | [`docs/recovery.md`](./recovery.md) |
+| Internalise the agent-side discipline | [`ctxr/fsm/memory/principles.md`](../ctxr/fsm/memory/principles.md) |
+| Compare more end-to-end pipelines | [`docs/examples-tour.md`](./examples-tour.md) |


### PR DESCRIPTION
## Summary

Final workstream of the SQLite-backed Python FSM plan. Three GitHub Actions workflows for the Python side. **Principle 2 honoured: publish workflow is workflow_dispatch ONLY with zero auto-triggers.**

> **Base branch is \`w9/docs\` (PR #35).**

## Workflows

| File | LOC | Purpose |
|---|---|---|
| \`.github/workflows/python-ci.yml\` | 140 | Lint + test (matrix 3.12 + 3.13) + ui-build on every push to main, PR, or workflow_dispatch. Concurrency cancellation. |
| \`.github/workflows/python-publish.yml\` | 182 | **Manual only.** workflow_dispatch with version_bump + dry_run inputs. Trusted Publishing OIDC (no API token). dry_run pushes to TestPyPI. |
| \`.github/workflows/python-tag-on-main.yml\` | 56 | ONLY tags, never publishes. Path-filtered on pyproject.toml; skips when version didn't actually change. |

## Verify

- [x] \`uv run pytest tests/\` — **456 passed** (no regression).
- [x] \`uv run ruff check ctxr/ tests/ examples/\` — clean.
- [x] \`uv run mypy ctxr/fsm/\` — **60 source files clean**.
- [x] \`cd ui && npm test\` — **17 passed**.
- [x] All 3 yaml files validated via PyYAML.
- [x] \`python-publish.yml\` has zero \`push\`/\`tag\`/\`schedule\`/\`pull_request\` triggers.

## End of the plan

W10 closes the SQLite-backed Python FSM substrate. Full sequence shipped:

| # | Workstream | PR |
|---|---|---|
| W0 | Cohabitation | #24 |
| W1 | ctxr.fsm.core | #25 |
| W2 | ctxr.fsm.sqlite | #26 |
| W3 | ctxr-fsm CLI | #27 |
| W4 | ctxr.fsm.mcp | #28 |
| W5 | ctxr.fsm.api | #29 |
| W6 | fsm-ui | #30 |
| W7 | service lifecycle | #31 |
| W11 | principles + install-memory | #32 |
| W8 | examples | #33 |
| W12 | enforcement primitives | #34 |
| W9 | docs | #35 |
| W10 | CI/CD | **this** |

## Plan reference

\`/Users/developer/.claude/plans/how-it-fits-toasty-gray.md\`.