### PR TITLE
feat(w14a): InlineHandler engine extension

### DIFF
--- a/ctxr/fsm/core/__init__.py
+++ b/ctxr/fsm/core/__init__.py
@@ -57,9 +57,20 @@ from ctxr.fsm.core.engine import (
     EngineAdvanceResult,
     advance,
     build_brief,
+    execute_inline,
     resolve_transition,
     run_post_validations,
     validate_output,
+)
+
+# ---------------------------------------------------------------------------
+# Inline handler registry (W14a) — server-side deterministic state handlers
+# ---------------------------------------------------------------------------
+from ctxr.fsm.core.inline_registry import (
+    InlineContext,
+    InlineHandler,
+    InlineHandlerRegistry,
+    get_default_registry,
 )
 
 # ---------------------------------------------------------------------------
@@ -82,6 +93,8 @@ from ctxr.fsm.core.models import (
     DeliveryStatus,
     EventKind,
     FsmSpec,
+    InlineExecutionResult,
+    InlineSpec,
     Loop,
     LoopDecision,
     PostValidationResult,
@@ -168,6 +181,12 @@ __all__ = [
     "FsmSpec",
     # ── spec validation & hashing ─────────────────────────────────────
     "FsmValidationResult",
+    # ── inline handler registry (W14a) ────────────────────────────────
+    "InlineContext",
+    "InlineExecutionResult",
+    "InlineHandler",
+    "InlineHandlerRegistry",
+    "InlineSpec",
     "JournalProtocol",
     "Lock",
     "Loop",
@@ -207,7 +226,9 @@ __all__ = [
     "attach_methods",
     "build_brief",
     "evaluate_expression",
+    "execute_inline",
     "fsm_spec_hash",
+    "get_default_registry",
     "get_verifier_handler",
     "loop_decide",
     "outputs_path_for",

--- a/ctxr/fsm/core/engine.py
+++ b/ctxr/fsm/core/engine.py
@@ -36,11 +36,17 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ctxr.fsm.core.inline_registry import (
+    InlineContext,
+    InlineHandlerRegistry,
+    get_default_registry,
+)
 from ctxr.fsm.core.loop import decide as loop_decide
 from ctxr.fsm.core.loop import outputs_path_for
 from ctxr.fsm.core.models import (
     Brief,
     FsmSpec,
+    InlineExecutionResult,
     Loop,
     LoopDecision,
     PostValidationResult,
@@ -66,6 +72,7 @@ __all__ = [
     "EngineAdvanceResult",
     "advance",
     "build_brief",
+    "execute_inline",
     "resolve_transition",
     "run_post_validations",
     "validate_output",
@@ -648,4 +655,221 @@ def advance(
         next_state=next_state.id,
         brief=next_brief,
         evaluations=evaluations,
+    )
+
+
+# ---------------------------------------------------------------------------
+# execute_inline — server-side deterministic state handler
+# ---------------------------------------------------------------------------
+
+
+def execute_inline(
+    state: State,
+    ctx: RunCtx,
+    args: dict[str, Any],
+    inputs: dict[str, Any],
+    registry: InlineHandlerRegistry | None = None,
+) -> InlineExecutionResult:
+    """Run an inline state's registered handler and report the outcome.
+
+    This function is the pure entry point the W2 SQLite repository
+    layer will call inside its ``@atomic`` transaction to advance
+    through inline states without an LLM round-trip. It is intentionally
+    side-effect-free: it does NOT mutate any persistence, does NOT
+    emit events, and does NOT call back into :func:`advance`. The
+    caller wraps the result in a transaction, persists the inline
+    state's outputs + emits ``inline_executed`` / ``inline_failed``
+    events, then calls :func:`advance` with the handler's outputs to
+    resolve the outgoing transition.
+
+    Parameters
+    ----------
+    state:
+        The inline state being executed. Must have ``state.inline``
+        non-None; otherwise the function raises ``TypeError`` because
+        the call site is a programming error.
+    ctx:
+        The current :class:`RunCtx`. ``ctx.iteration_n`` is passed
+        through to the handler via :class:`InlineContext` so handlers
+        embedded in loop bodies (a future capability) can see their
+        iteration index. ``ctx.env`` is not threaded into the inline
+        context — the handler's input surface is ``args`` + ``inputs``,
+        mirroring the worker brief's input shape.
+    args:
+        The owning run's startup ``args`` dict. Passed through verbatim
+        on the :class:`InlineContext`.
+    inputs:
+        The inputs dict resolved by the caller from prior-state outputs,
+        in the same shape :class:`~ctxr.fsm.core.models.Brief.inputs`
+        carries.
+    registry:
+        Optional :class:`InlineHandlerRegistry` to look up the handler
+        in. When ``None``, the module-level default returned by
+        :func:`get_default_registry` is used.
+
+    Returns
+    -------
+    InlineExecutionResult
+        ``ok=True`` and ``outputs`` populated on success. ``ok=False``
+        with a kebab-case ``fault_reason`` on every failure mode:
+
+        * ``inline_handler_unregistered`` — no handler registered for
+          ``(ctx.fsm_id, state.inline.handler_id)``.
+        * ``inline_handler_raised`` — handler raised an exception.
+          The ``fault_reason`` includes the exception type name and
+          its ``str()`` representation; the full traceback is NOT
+          captured here (callers that want one log it from the
+          calling try/except at the SQLite-layer boundary).
+        * ``inline_handler_bad_return_type`` — handler returned
+          something other than ``dict[str, Any]``.
+        * ``inline_handler_validation_failed`` — handler returned a
+          dict but it did not validate against
+          ``state.inline.response_schema``.
+        * ``inline_handler_post_validation_failed`` — handler returned
+          a schema-valid dict but at least one
+          :attr:`~ctxr.fsm.core.models.InlineSpec.post_validations`
+          predicate evaluated to ``False``.
+    """
+    if state.inline is None:
+        raise TypeError(
+            f"execute_inline called on state {state.id!r} which is not an inline state"
+        )
+
+    inline_spec = state.inline
+    handler_id = inline_spec.handler_id
+    chosen_registry = registry if registry is not None else get_default_registry()
+
+    handler = chosen_registry.lookup(ctx.fsm_id, handler_id)
+    if handler is None:
+        return InlineExecutionResult(
+            handler_id=handler_id,
+            ok=False,
+            outputs={},
+            validation=ValidationResult(valid=True, errors=[]),
+            post_validations=None,
+            fault_reason=(
+                f"inline_handler_unregistered: {ctx.fsm_id}/{handler_id}"
+            ),
+        )
+
+    # Build the handler's read-only context envelope.
+    inline_ctx = InlineContext(
+        run_id=ctx.run_id,
+        fsm_id=ctx.fsm_id,
+        state_id=state.id,
+        iteration_n=ctx.iteration_n,
+        args=dict(args),
+        inputs=dict(inputs),
+    )
+
+    # Invoke the handler; capture any raise as a structured fault.
+    try:
+        raw_output = handler(inline_ctx)
+    except Exception as exc:
+        return InlineExecutionResult(
+            handler_id=handler_id,
+            ok=False,
+            outputs={},
+            validation=ValidationResult(valid=True, errors=[]),
+            post_validations=None,
+            fault_reason=(
+                f"inline_handler_raised: {type(exc).__name__}: {exc}"
+            ),
+        )
+
+    # The handler MUST return a dict; anything else is a contract bug.
+    if not isinstance(raw_output, dict):
+        return InlineExecutionResult(
+            handler_id=handler_id,
+            ok=False,
+            outputs={},
+            validation=ValidationResult(valid=True, errors=[]),
+            post_validations=None,
+            fault_reason=(
+                "inline_handler_bad_return_type: expected dict, "
+                f"got {type(raw_output).__name__}"
+            ),
+        )
+
+    # Validate against the optional response schema. A schema-less
+    # inline state is treated as always-valid (same convention the
+    # worker path uses in ``validate_output``).
+    if inline_spec.response_schema is None:
+        validation = ValidationResult(valid=True, errors=[])
+    else:
+        valid, errors = inline_spec.response_schema.model_validate_json_payload(
+            raw_output
+        )
+        validation = ValidationResult(valid=valid, errors=errors)
+        if not valid:
+            return InlineExecutionResult(
+                handler_id=handler_id,
+                ok=False,
+                outputs={},
+                validation=validation,
+                post_validations=None,
+                fault_reason="inline_handler_validation_failed",
+            )
+
+    # Run the inline-state's post-validation predicates (if any). The
+    # shape mirrors ``run_post_validations`` on workers but evaluates
+    # against ``raw_output`` directly — same convention.
+    post_result: PostValidationResult | None = None
+    if inline_spec.post_validations:
+        entries: list[PostValidationResultEntry] = []
+        all_valid = True
+        for predicate in inline_spec.post_validations:
+            if not validate_expression(predicate.expression):
+                entries.append(
+                    PostValidationResultEntry(
+                        check="inline_post_validation",
+                        expression=predicate.expression,
+                        result=False,
+                        error="malformed predicate expression",
+                    )
+                )
+                all_valid = False
+                continue
+            try:
+                result = evaluate_expression(predicate.expression, raw_output)
+            except (PredicateParseError, PredicateEvalError) as exc:
+                entries.append(
+                    PostValidationResultEntry(
+                        check="inline_post_validation",
+                        expression=predicate.expression,
+                        result=False,
+                        error=str(exc),
+                    )
+                )
+                all_valid = False
+                continue
+            entries.append(
+                PostValidationResultEntry(
+                    check="inline_post_validation",
+                    expression=predicate.expression,
+                    result=bool(result),
+                )
+            )
+            if not result:
+                all_valid = False
+        post_result = PostValidationResult(valid=all_valid, results=entries)
+        if not all_valid:
+            return InlineExecutionResult(
+                handler_id=handler_id,
+                ok=False,
+                outputs={},
+                validation=validation,
+                post_validations=post_result,
+                fault_reason="inline_handler_post_validation_failed",
+            )
+
+    # All-clear: handler returned a dict, the schema accepts it, and
+    # every post-validation passed.
+    return InlineExecutionResult(
+        handler_id=handler_id,
+        ok=True,
+        outputs=dict(raw_output),
+        validation=validation,
+        post_validations=post_result,
+        fault_reason=None,
     )

--- a/ctxr/fsm/core/inline_registry.py
+++ b/ctxr/fsm/core/inline_registry.py
@@ -1,0 +1,229 @@
+"""Process-local registry for inline state handlers.
+
+An inline state is a fourth FSM state kind (alongside ``worker``,
+``loop``, and ``terminal``) declared via
+:class:`~ctxr.fsm.core.models.InlineSpec`. Unlike worker states, an
+inline state's outputs are produced by a deterministic Python callable
+that runs in-process during :func:`~ctxr.fsm.core.engine.execute_inline`
+inside the same atomic transaction as the surrounding state
+transition.  This module owns the lookup table from
+``(spec_id, handler_id)`` to that callable.
+
+The registry is deliberately tiny and dependency-free:
+
+* **Process-local.** A single dict on a single object instance. No
+  global mutable state beyond the module-level default registry
+  exposed via :func:`get_default_registry`, and no per-process
+  locks (the engine layer is single-writer per-run via the W2 SQLite
+  locks; concurrent reads of a fully-populated registry are safe by
+  CPython's GIL-backed dict read semantics).
+* **No I/O.** Registration is a pure mapping update; lookup is a pure
+  mapping read.  The consumer's lifecycle (typically: register all
+  handlers at module-import time, then run engine work that calls
+  ``lookup``) is the same shape pickle-safe registries use.
+* **Per-spec scoping.** The registry keys on the pair
+  ``(spec_id, handler_id)``, so two different specs can reuse the
+  same ``handler_id`` slug without collision.
+
+The shape mirrors the W12 verifier handler pattern in
+:mod:`ctxr.fsm.core.verifier` but with one knob more: per-spec
+scoping. Where the verifier has at most one registered handler per
+process, an inline registry can hold arbitrarily many keyed pairs so
+multiple FSM specs can be active in the same Python process (the
+common case in a long-running supervisor / MCP server).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "InlineContext",
+    "InlineHandler",
+    "InlineHandlerRegistry",
+    "get_default_registry",
+]
+
+
+# ---------------------------------------------------------------------------
+# InlineContext — read-only handler input envelope
+# ---------------------------------------------------------------------------
+
+
+class InlineContext(BaseModel):
+    """Read-only context handed to an inline handler at advance time.
+
+    The shape mirrors the data already available inside the engine
+    when it resolves a state's body: the owning run, the state being
+    executed, the loop iteration counter (for inline states embedded
+    in loop bodies, if/when that becomes a thing), the run's startup
+    ``args``, and the resolved ``inputs`` dict (per the surrounding
+    :class:`~ctxr.fsm.core.models.State.outputs` declaration, materialised
+    from prior-state outputs by the engine).
+
+    Fields are immutable so a handler cannot accidentally mutate the
+    context and influence subsequent handler calls in the same
+    process. ``arbitrary_types_allowed=True`` is set because
+    :class:`uuid.UUID` is not a Pydantic-native type but Pydantic v2
+    serialises it cleanly when explicitly allowed.
+    """
+
+    model_config = ConfigDict(
+        strict=True,
+        frozen=True,
+        extra="forbid",
+        arbitrary_types_allowed=True,
+    )
+
+    run_id: uuid.UUID
+    fsm_id: str
+    state_id: str
+    iteration_n: int | None = None
+    args: dict[str, Any] = Field(default_factory=dict)
+    inputs: dict[str, Any] = Field(default_factory=dict)
+
+
+InlineHandler = Callable[[InlineContext], dict[str, Any]]
+"""Signature of a registered inline state handler.
+
+The handler receives a fully-populated :class:`InlineContext` and MUST
+return a plain ``dict[str, Any]`` carrying the state's outputs. The
+returned dict is validated by the engine against the inline state's
+:attr:`~ctxr.fsm.core.models.InlineSpec.response_schema` (when one is
+declared) and any
+:attr:`~ctxr.fsm.core.models.InlineSpec.post_validations` predicates
+before the engine advances. Handlers MUST be deterministic and free
+of I/O — they run inside the engine's atomic transaction; raising or
+hanging here pauses the whole transition.
+"""
+
+
+# ---------------------------------------------------------------------------
+# InlineHandlerRegistry — process-local lookup table
+# ---------------------------------------------------------------------------
+
+
+class InlineHandlerRegistry:
+    """A per-process registry of inline handlers keyed by ``(spec_id, handler_id)``.
+
+    The registry is a thin wrapper around a single dict; the wrapper
+    exists for ergonomic methods and a stable type to import. No
+    locking is performed: the typical pattern is "register at import,
+    look up during runs" and CPython's GIL makes individual dict reads
+    and writes atomic. Concurrent ``register`` and ``lookup`` from
+    multiple threads is therefore safe, though a handler observed via
+    ``lookup`` immediately before a concurrent ``unregister`` may be
+    invoked anyway — the engine is single-writer per-run so the
+    interleaving cannot happen in normal use.
+    """
+
+    __slots__ = ("_handlers",)
+
+    def __init__(self) -> None:
+        self._handlers: dict[tuple[str, str], InlineHandler] = {}
+
+    def register(
+        self,
+        spec_id: str,
+        handler_id: str,
+        handler: InlineHandler,
+    ) -> None:
+        """Register ``handler`` against ``(spec_id, handler_id)``.
+
+        Re-registering the same key overwrites the previous handler.
+        Empty / non-string keys raise ``ValueError`` immediately so a
+        bad call site fails loudly rather than poisoning a downstream
+        lookup.
+        """
+        if not isinstance(spec_id, str) or not spec_id:
+            raise ValueError("spec_id must be a non-empty string")
+        if not isinstance(handler_id, str) or not handler_id:
+            raise ValueError("handler_id must be a non-empty string")
+        if not callable(handler):
+            raise ValueError("handler must be callable")
+        self._handlers[(spec_id, handler_id)] = handler
+
+    def register_many(
+        self,
+        spec_id: str,
+        handlers: dict[str, InlineHandler],
+    ) -> None:
+        """Bulk-register every ``handler_id -> callable`` entry under ``spec_id``.
+
+        Convenience for the common skill bootstrap pattern of declaring
+        an ``INLINE_HANDLERS`` module-level dict and registering the
+        whole batch at startup. Each pair is delegated to
+        :meth:`register`, so the same validation applies.
+        """
+        for handler_id, handler in handlers.items():
+            self.register(spec_id, handler_id, handler)
+
+    def lookup(
+        self,
+        spec_id: str,
+        handler_id: str,
+    ) -> InlineHandler | None:
+        """Return the registered handler for ``(spec_id, handler_id)``, or ``None``.
+
+        Returning ``None`` for an unknown key is intentional — the
+        engine layer wraps the missing handler in a structured
+        :class:`~ctxr.fsm.core.models.InlineExecutionResult` so the
+        fault is reported, not raised. This keeps the engine's failure
+        handling uniform across "handler missing" and "handler raised"
+        cases.
+        """
+        return self._handlers.get((spec_id, handler_id))
+
+    def unregister(
+        self,
+        spec_id: str,
+        handler_id: str | None = None,
+    ) -> None:
+        """Remove registrations for ``spec_id``.
+
+        When ``handler_id`` is ``None``, drop every handler registered
+        under ``spec_id``. Otherwise drop only the single
+        ``(spec_id, handler_id)`` entry. Missing entries are a no-op
+        so the operation is idempotent.
+        """
+        if handler_id is None:
+            self._handlers = {
+                key: value
+                for key, value in self._handlers.items()
+                if key[0] != spec_id
+            }
+            return
+        self._handlers.pop((spec_id, handler_id), None)
+
+    def clear(self) -> None:
+        """Remove all registrations.
+
+        Useful in test setUp/tearDown to keep registries hermetic
+        between tests. The default module-singleton registry retains
+        its identity across calls; only its contents are wiped.
+        """
+        self._handlers.clear()
+
+
+# ---------------------------------------------------------------------------
+# Module-level default registry
+# ---------------------------------------------------------------------------
+
+
+_default_registry: InlineHandlerRegistry = InlineHandlerRegistry()
+
+
+def get_default_registry() -> InlineHandlerRegistry:
+    """Return the process-wide default :class:`InlineHandlerRegistry`.
+
+    Higher-level callers (the engine, the SQLite repository layer that
+    drives ``engine.execute_inline``) accept an optional ``registry``
+    argument so tests can pass a hermetic instance; production code
+    falls back to this singleton. The singleton is created at import
+    time so importing this module is enough to make it available.
+    """
+    return _default_registry

--- a/ctxr/fsm/core/models.py
+++ b/ctxr/fsm/core/models.py
@@ -59,6 +59,7 @@ def _sha256_hex(payload: bytes) -> str:
 
 
 _STATE_ID_RE = re_compile(r"^[a-z][a-z0-9_]*$")
+_HANDLER_ID_RE = re_compile(r"^[a-z][a-z0-9_]*$")
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +125,8 @@ class EventKind(StrEnum):
     commit_token_issued = "commit_token_issued"
     commit_token_consumed = "commit_token_consumed"
     commit_token_expired = "commit_token_expired"
+    inline_executed = "inline_executed"
+    inline_failed = "inline_failed"
 
 
 class DeliveryStatus(StrEnum):
@@ -316,6 +319,55 @@ class Predicate(BaseModel):
         return value
 
 
+class InlineSpec(BaseModel):
+    """A deterministic, server-side state handler specification.
+
+    An inline state is the fourth state kind alongside ``worker``,
+    ``loop``, and ``terminal``. Where a worker state pauses the engine
+    so an out-of-process LLM (or any other dispatcher) can produce the
+    state's outputs, an inline state runs a registered Python callable
+    in-process during ``engine.advance()`` — in the SAME atomic
+    transaction as the surrounding state transition, with no LLM round
+    trip.
+
+    Fields
+    ------
+    handler_id:
+        Snake-case slug identifying which registered callable to invoke
+        for this state. The engine looks this id up in the inline
+        handler registry at advance time; registration is the consumer's
+        responsibility and is NOT validated at spec-load time.
+    response_schema:
+        Optional JSON Schema (wrapped in :class:`ResponseSchema`) the
+        handler's return dict is validated against. When the inline
+        state has outgoing transitions, a schema is required so the
+        transition guards have a defined output shape to read.
+    post_validations:
+        Optional :class:`Predicate` list evaluated against the handler's
+        output. Same semantics as :attr:`State.post_validations`, except
+        these are scoped to the inline handler's return value.
+    purpose:
+        Human-readable description shown in briefs/dashboards alongside
+        the surrounding state's :attr:`State.purpose`.
+    """
+
+    model_config = _DOMAIN_CFG
+
+    handler_id: str
+    response_schema: ResponseSchema | None = None
+    post_validations: list[Predicate] = Field(default_factory=list)
+    purpose: str = ""
+
+    @field_validator("handler_id")
+    @classmethod
+    def _handler_id_shape(cls, value: str) -> str:
+        if not _HANDLER_ID_RE.match(value):
+            raise ValueError(
+                "InlineSpec.handler_id must match ^[a-z][a-z0-9_]*$"
+            )
+        return value
+
+
 class Transition(BaseModel):
     """A single transition out of a state, with a guard."""
 
@@ -425,6 +477,7 @@ class State(BaseModel):
     preconditions: list[str] = Field(default_factory=list)
     worker: Worker | None = None
     loop: Loop | None = None
+    inline: InlineSpec | None = None
     outputs: list[str] = Field(default_factory=list)
     post_validations: list[Predicate] = Field(default_factory=list)
     transitions: list[Transition] = Field(default_factory=list)
@@ -438,11 +491,49 @@ class State(BaseModel):
             raise ValueError("state id must match ^[a-z][a-z0-9_]*$")
         return value
 
+    @property
+    def kind(self) -> Literal["loop", "inline", "worker", "terminal"]:
+        """Return the derived kind of this state.
+
+        The kind is derived from which body fields are set, not stored:
+
+        * ``"loop"``   — :attr:`loop` is non-None.
+        * ``"inline"`` — :attr:`inline` is non-None (and :attr:`loop` is None).
+        * ``"worker"`` — :attr:`worker` is non-None (and :attr:`loop` /
+          :attr:`inline` are None).
+        * ``"terminal"`` — all three body fields are None AND
+          :attr:`transitions` is empty.
+
+        A state with no body fields but a non-empty :attr:`transitions`
+        list is structurally invalid (a "pass-through" worker would
+        need somebody to produce its outputs) and raises ``ValueError``.
+        """
+        if self.loop is not None:
+            return "loop"
+        if self.inline is not None:
+            return "inline"
+        if self.worker is not None:
+            return "worker"
+        if not self.transitions:
+            return "terminal"
+        raise ValueError(
+            f"state {self.id!r}: terminal-by-content but has transitions; "
+            "set a worker / loop / inline body or remove the transitions"
+        )
+
     @model_validator(mode="after")
     def _consistency(self) -> State:
         if self.worker is not None and self.loop is not None:
             raise ValueError(
                 f"state {self.id!r}: cannot have both `worker` and `loop` set"
+            )
+        if self.inline is not None and self.worker is not None:
+            raise ValueError(
+                f"state {self.id!r}: cannot have both `inline` and `worker` set"
+            )
+        if self.inline is not None and self.loop is not None:
+            raise ValueError(
+                f"state {self.id!r}: cannot have both `inline` and `loop` set"
             )
         if self.loop is not None:
             schema = (
@@ -456,6 +547,16 @@ class State(BaseModel):
                     f"state {self.id!r}: loop.done_field {self.loop.done_field!r} "
                     "must be declared in loop.worker.response_schema.properties"
                 )
+        if (
+            self.inline is not None
+            and self.transitions
+            and self.inline.response_schema is None
+        ):
+            raise ValueError(
+                f"state {self.id!r}: inline state with transitions must declare "
+                "inline.response_schema so transition guards have a defined "
+                "output shape to read"
+            )
         return self
 
 
@@ -661,6 +762,41 @@ class PostValidationResult(BaseModel):
     results: list[PostValidationResultEntry]
 
 
+class InlineExecutionResult(BaseModel):
+    """The outcome of executing an inline state handler.
+
+    Returned by :func:`ctxr.fsm.core.engine.execute_inline`. The shape
+    is a single envelope (not a discriminated union) so callers can
+    branch on the ``ok`` flag and consume ``fault_reason`` / ``outputs``
+    accordingly:
+
+    * ``ok=True``  — the handler ran, returned a dict, validated
+      against any declared response schema and post-validations. The
+      handler's return value is in ``outputs``.
+    * ``ok=False`` — the handler did not produce usable outputs.
+      ``fault_reason`` carries a short slug naming the failure mode
+      (``inline_handler_unregistered``, ``inline_handler_raised``,
+      ``inline_handler_bad_return_type``,
+      ``inline_handler_validation_failed``,
+      ``inline_handler_post_validation_failed``). ``validation`` always
+      carries the schema-validation report (vacuously valid when no
+      schema is declared); ``post_validations`` is populated only when
+      the inline spec declared post-validations.
+
+    The model is strict + frozen + extra-forbid like the surrounding
+    domain envelopes; mis-typed kwargs surface immediately.
+    """
+
+    model_config = _DOMAIN_CFG
+
+    handler_id: str
+    ok: bool
+    outputs: dict[str, Any] = Field(default_factory=dict)
+    validation: ValidationResult
+    post_validations: PostValidationResult | None = None
+    fault_reason: str | None = None
+
+
 class TransitionEvaluation(BaseModel):
     """The outcome of evaluating one transition guard at exit time."""
 
@@ -707,6 +843,8 @@ __all__ = [
     "DeliveryStatus",
     "EventKind",
     "FsmSpec",
+    "InlineExecutionResult",
+    "InlineSpec",
     "Loop",
     "LoopDecision",
     "PostValidationResult",

--- a/ctxr/fsm/core/spec.py
+++ b/ctxr/fsm/core/spec.py
@@ -216,6 +216,38 @@ def _check_loop_semantics(state: State) -> list[str]:
     return errors
 
 
+def _check_inline_semantics(state: State) -> list[str]:
+    """Return error strings for any inline-shape violations on ``state``.
+
+    Pydantic's :class:`State` validator already raises on construction
+    when an inline state with outgoing transitions has no
+    ``inline.response_schema`` (transition guards need a defined output
+    shape to read), so a well-constructed :class:`FsmSpec` cannot
+    reach this function with a violation. The check is repeated here
+    as a *defensive* invariant: it documents the rule, runs cheaply,
+    and survives any future relaxation of the constructor-time
+    validator.
+
+    Inline handler REGISTRATION is intentionally NOT validated here:
+    handlers register at runtime via
+    :class:`~ctxr.fsm.core.inline_registry.InlineHandlerRegistry` and
+    a missing handler surfaces at engine advance time as a structured
+    :class:`~ctxr.fsm.core.models.InlineExecutionResult` fault — not
+    as a spec-load error. The contract is documented on
+    :func:`validate_fsm_spec`.
+    """
+    errors: list[str] = []
+    if state.inline is None:
+        return errors
+    if state.transitions and state.inline.response_schema is None:
+        errors.append(
+            f"state {state.id!r}: inline state with transitions must declare "
+            "inline.response_schema so transition guards have a defined output "
+            "shape to read"
+        )
+    return errors
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -233,11 +265,29 @@ def validate_fsm_spec(spec: FsmSpec) -> FsmValidationResult:
     3. **Loop semantics.** For each state with a :attr:`State.loop`,
        :attr:`Loop.done_field` must appear in the loop worker's
        response schema properties.
-    4. **Predicate parsability.** Every Predicate expression embedded
+    4. **Inline semantics.** For each state with a
+       :attr:`State.inline`, declaring outgoing transitions requires
+       :attr:`~ctxr.fsm.core.models.InlineSpec.response_schema` to be
+       set (so transition guards have a defined output shape to read).
+       Inline states with no transitions are valid terminals.
+    5. **Predicate parsability.** Every Predicate expression embedded
        in a transition guard or a post-validation must parse via
        :func:`ctxr.fsm.core.predicates.validate_expression`. If the
        predicates module is not importable in the current environment
        (e.g. early bootstrap), this check is skipped silently.
+
+    What is **not** validated here:
+
+    * Inline handler **registration** is intentionally out of scope.
+      Inline handlers register at runtime against
+      :class:`~ctxr.fsm.core.inline_registry.InlineHandlerRegistry`;
+      a missing registration surfaces at engine advance time as a
+      structured :class:`~ctxr.fsm.core.models.InlineExecutionResult`
+      fault with ``fault_reason="inline_handler_unregistered: ..."``.
+      Validating the registry at spec-load time would couple this
+      module to runtime state and break the
+      ``Project.register_spec`` → ``Project.register_inline_handlers``
+      ordering that consumers are free to interleave.
 
     Returns a :class:`FsmValidationResult` whose ``valid`` field is
     ``True`` iff no errors were collected.
@@ -274,7 +324,11 @@ def validate_fsm_spec(spec: FsmSpec) -> FsmValidationResult:
     for state in spec.states:
         errors.extend(_check_loop_semantics(state))
 
-    # --- (4) Predicate parsability ------------------------------------------
+    # --- (4) Inline semantics -----------------------------------------------
+    for state in spec.states:
+        errors.extend(_check_inline_semantics(state))
+
+    # --- (5) Predicate parsability ------------------------------------------
     validator = _resolve_predicate_validator()
     if validator is not None:
         for location, expression in _iter_predicate_expressions(spec):

--- a/tests/unit/core/test_engine_inline_execution.py
+++ b/tests/unit/core/test_engine_inline_execution.py
@@ -1,0 +1,459 @@
+"""Tests for :func:`ctxr.fsm.core.engine.execute_inline` (W14a).
+
+Covers:
+
+* Happy path: a registered handler returns a schema-valid dict and the
+  engine reports ``ok=True`` with the outputs.
+* Unregistered handler reports ``ok=False`` with
+  ``fault_reason="inline_handler_unregistered: ..."``.
+* Handler that raises is caught and reported as
+  ``fault_reason="inline_handler_raised: ..."``; the engine does not
+  re-raise.
+* Handler that returns a non-dict reports ``fault_reason="inline_handler_bad_return_type: ..."``.
+* Handler returns a dict that fails the inline state's response schema
+  → ``fault_reason="inline_handler_validation_failed"`` and the
+  validation errors are surfaced.
+* Handler returns a schema-valid dict but a post-validation predicate
+  evaluates ``False`` → ``fault_reason="inline_handler_post_validation_failed"``.
+* Multiple-handler registry: looking up a handler under one spec does
+  not collide with the same handler_id under another spec.
+* Schema-less inline state: the engine accepts ANY dict and reports
+  ``ok=True``.
+* Inline state without an InlineSpec (defensive): ``execute_inline``
+  raises ``TypeError`` because the call site is a programming error.
+* ``execute_inline`` defaults to the module-level registry when none
+  is passed explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from ctxr.fsm.core.engine import execute_inline
+from ctxr.fsm.core.inline_registry import (
+    InlineContext,
+    InlineHandlerRegistry,
+    get_default_registry,
+)
+from ctxr.fsm.core.models import (
+    InlineSpec,
+    Predicate,
+    ResponseSchema,
+    RunCtx,
+    State,
+    Transition,
+    Worker,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _verdict_schema() -> ResponseSchema:
+    """Build a tiny schema declaring a required ``verdict`` boolean."""
+    return ResponseSchema(
+        schema={
+            "type": "object",
+            "properties": {
+                "verdict": {"type": "boolean"},
+                "note": {"type": "string"},
+            },
+            "required": ["verdict"],
+        }
+    )
+
+
+def _ctx(fsm_id: str = "spec-a", current_state: str = "s1") -> RunCtx:
+    return RunCtx(
+        run_id=uuid4(),
+        fsm_id=fsm_id,
+        current_state=current_state,
+    )
+
+
+def _inline_state(
+    state_id: str = "s1",
+    handler_id: str = "h1",
+    response_schema: ResponseSchema | None = None,
+    post_validations: list[Predicate] | None = None,
+    transitions: list[Transition] | None = None,
+) -> State:
+    spec = InlineSpec(
+        handler_id=handler_id,
+        response_schema=response_schema,
+        post_validations=list(post_validations or []),
+    )
+    return State(
+        id=state_id,
+        inline=spec,
+        transitions=list(transitions or []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_happy_path_runs_handler_and_validates() -> None:
+    registry = InlineHandlerRegistry()
+
+    def handler(ctx: InlineContext) -> dict[str, Any]:
+        # Echo the args back into the outputs as a smoke check.
+        return {"verdict": True, "note": "ok", "args_seen": ctx.args}
+
+    registry.register("spec-a", "h1", handler)
+    state = _inline_state(handler_id="h1", response_schema=_verdict_schema())
+    ctx = _ctx(fsm_id="spec-a")
+
+    result = execute_inline(
+        state=state,
+        ctx=ctx,
+        args={"goal": "do it"},
+        inputs={"x": 1},
+        registry=registry,
+    )
+
+    assert result.ok is True
+    assert result.handler_id == "h1"
+    assert result.outputs["verdict"] is True
+    assert result.outputs["args_seen"] == {"goal": "do it"}
+    assert result.validation.valid is True
+    assert result.validation.errors == []
+    assert result.post_validations is None
+    assert result.fault_reason is None
+
+
+def test_execute_inline_passes_inputs_into_handler() -> None:
+    registry = InlineHandlerRegistry()
+    seen: dict[str, Any] = {}
+
+    def handler(ctx: InlineContext) -> dict[str, Any]:
+        seen["inputs"] = dict(ctx.inputs)
+        seen["state_id"] = ctx.state_id
+        seen["fsm_id"] = ctx.fsm_id
+        seen["iteration_n"] = ctx.iteration_n
+        return {"verdict": True}
+
+    registry.register("spec-a", "h1", handler)
+    state = _inline_state(handler_id="h1", response_schema=_verdict_schema())
+    ctx = _ctx(fsm_id="spec-a", current_state="s1")
+
+    execute_inline(
+        state=state,
+        ctx=ctx,
+        args={},
+        inputs={"a": "alpha", "b": 99},
+        registry=registry,
+    )
+
+    assert seen["inputs"] == {"a": "alpha", "b": 99}
+    assert seen["state_id"] == "s1"
+    assert seen["fsm_id"] == "spec-a"
+    assert seen["iteration_n"] is None
+
+
+# ---------------------------------------------------------------------------
+# Unregistered handler
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_unregistered_handler_returns_structured_fault() -> None:
+    registry = InlineHandlerRegistry()
+    state = _inline_state(handler_id="missing_one", response_schema=_verdict_schema())
+    ctx = _ctx(fsm_id="spec-x")
+
+    result = execute_inline(
+        state=state,
+        ctx=ctx,
+        args={},
+        inputs={},
+        registry=registry,
+    )
+
+    assert result.ok is False
+    assert result.fault_reason is not None
+    assert result.fault_reason.startswith("inline_handler_unregistered:")
+    assert "spec-x" in result.fault_reason
+    assert "missing_one" in result.fault_reason
+    assert result.outputs == {}
+
+
+# ---------------------------------------------------------------------------
+# Handler raises
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_raising_handler_is_caught_and_reported() -> None:
+    registry = InlineHandlerRegistry()
+
+    def handler(ctx: InlineContext) -> dict[str, Any]:
+        raise RuntimeError("boom")
+
+    registry.register("spec-a", "h1", handler)
+    state = _inline_state(handler_id="h1", response_schema=_verdict_schema())
+    ctx = _ctx(fsm_id="spec-a")
+
+    result = execute_inline(
+        state=state,
+        ctx=ctx,
+        args={},
+        inputs={},
+        registry=registry,
+    )
+
+    assert result.ok is False
+    assert result.fault_reason is not None
+    assert result.fault_reason.startswith("inline_handler_raised:")
+    assert "RuntimeError" in result.fault_reason
+    assert "boom" in result.fault_reason
+    # Outputs are empty; the engine does not silently swallow partial data.
+    assert result.outputs == {}
+
+
+# ---------------------------------------------------------------------------
+# Handler returns non-dict
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_bad_return_type_is_reported() -> None:
+    registry = InlineHandlerRegistry()
+
+    def handler(ctx: InlineContext) -> dict[str, Any]:
+        return ["not", "a", "dict"]  # type: ignore[return-value]
+
+    registry.register("spec-a", "h1", handler)
+    state = _inline_state(handler_id="h1", response_schema=_verdict_schema())
+    ctx = _ctx(fsm_id="spec-a")
+
+    result = execute_inline(
+        state=state,
+        ctx=ctx,
+        args={},
+        inputs={},
+        registry=registry,
+    )
+
+    assert result.ok is False
+    assert result.fault_reason is not None
+    assert result.fault_reason.startswith("inline_handler_bad_return_type:")
+    assert "list" in result.fault_reason
+    assert result.outputs == {}
+
+
+# ---------------------------------------------------------------------------
+# Schema validation failure
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_schema_mismatch_is_reported() -> None:
+    registry = InlineHandlerRegistry()
+
+    def handler(ctx: InlineContext) -> dict[str, Any]:
+        # ``verdict`` is required + must be boolean; this returns int.
+        return {"verdict": 7}
+
+    registry.register("spec-a", "h1", handler)
+    state = _inline_state(handler_id="h1", response_schema=_verdict_schema())
+    ctx = _ctx(fsm_id="spec-a")
+
+    result = execute_inline(
+        state=state,
+        ctx=ctx,
+        args={},
+        inputs={},
+        registry=registry,
+    )
+
+    assert result.ok is False
+    assert result.fault_reason == "inline_handler_validation_failed"
+    assert result.validation.valid is False
+    assert result.validation.errors  # at least one error message present
+    assert result.outputs == {}
+
+
+# ---------------------------------------------------------------------------
+# Post-validation failure
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_post_validation_failure_is_reported() -> None:
+    registry = InlineHandlerRegistry()
+
+    def handler(ctx: InlineContext) -> dict[str, Any]:
+        return {"verdict": False, "note": "bad"}
+
+    registry.register("spec-a", "h1", handler)
+    # Post-validation asserts ``verdict == True``; the handler returns False.
+    state = _inline_state(
+        handler_id="h1",
+        response_schema=_verdict_schema(),
+        post_validations=[Predicate("verdict == true")],
+    )
+    ctx = _ctx(fsm_id="spec-a")
+
+    result = execute_inline(
+        state=state,
+        ctx=ctx,
+        args={},
+        inputs={},
+        registry=registry,
+    )
+
+    assert result.ok is False
+    assert result.fault_reason == "inline_handler_post_validation_failed"
+    assert result.validation.valid is True  # the schema part was fine
+    assert result.post_validations is not None
+    assert result.post_validations.valid is False
+    assert len(result.post_validations.results) == 1
+    assert result.post_validations.results[0].result is False
+
+
+def test_execute_inline_post_validation_success_clears_fault_reason() -> None:
+    registry = InlineHandlerRegistry()
+
+    def handler(ctx: InlineContext) -> dict[str, Any]:
+        return {"verdict": True, "note": "ok"}
+
+    registry.register("spec-a", "h1", handler)
+    state = _inline_state(
+        handler_id="h1",
+        response_schema=_verdict_schema(),
+        post_validations=[Predicate("verdict == true")],
+    )
+    ctx = _ctx(fsm_id="spec-a")
+
+    result = execute_inline(
+        state=state,
+        ctx=ctx,
+        args={},
+        inputs={},
+        registry=registry,
+    )
+
+    assert result.ok is True
+    assert result.fault_reason is None
+    assert result.post_validations is not None
+    assert result.post_validations.valid is True
+
+
+# ---------------------------------------------------------------------------
+# Per-spec scoping at execute_inline level
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_per_spec_scoping_resolves_correct_handler() -> None:
+    """Two specs can register the same handler_id without execute_inline collision."""
+    registry = InlineHandlerRegistry()
+
+    def handler_a(ctx: InlineContext) -> dict[str, Any]:
+        return {"verdict": True, "note": "from-a"}
+
+    def handler_b(ctx: InlineContext) -> dict[str, Any]:
+        return {"verdict": True, "note": "from-b"}
+
+    registry.register("spec-a", "common", handler_a)
+    registry.register("spec-b", "common", handler_b)
+
+    state = _inline_state(handler_id="common", response_schema=_verdict_schema())
+
+    result_a = execute_inline(
+        state=state,
+        ctx=_ctx(fsm_id="spec-a"),
+        args={},
+        inputs={},
+        registry=registry,
+    )
+    result_b = execute_inline(
+        state=state,
+        ctx=_ctx(fsm_id="spec-b"),
+        args={},
+        inputs={},
+        registry=registry,
+    )
+
+    assert result_a.ok and result_a.outputs["note"] == "from-a"
+    assert result_b.ok and result_b.outputs["note"] == "from-b"
+
+
+# ---------------------------------------------------------------------------
+# Schema-less inline state
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_schemaless_state_accepts_any_dict_output() -> None:
+    """A terminal inline state without response_schema is always-valid."""
+    registry = InlineHandlerRegistry()
+
+    def handler(ctx: InlineContext) -> dict[str, Any]:
+        return {"anything": "goes", "n": 42}
+
+    registry.register("spec-a", "h1", handler)
+    state = _inline_state(handler_id="h1", response_schema=None)
+    ctx = _ctx(fsm_id="spec-a")
+
+    result = execute_inline(
+        state=state,
+        ctx=ctx,
+        args={},
+        inputs={},
+        registry=registry,
+    )
+
+    assert result.ok is True
+    assert result.validation.valid is True
+    assert result.outputs == {"anything": "goes", "n": 42}
+
+
+# ---------------------------------------------------------------------------
+# Defensive: execute_inline on a non-inline state
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_raises_on_non_inline_state() -> None:
+    """Calling execute_inline on a worker state is a programming error."""
+    state = State(id="worker_state", worker=Worker(role="w", prompt_template="t"))
+    with pytest.raises(TypeError, match="not an inline state"):
+        execute_inline(
+            state=state,
+            ctx=_ctx(),
+            args={},
+            inputs={},
+            registry=InlineHandlerRegistry(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Default registry fallback
+# ---------------------------------------------------------------------------
+
+
+def test_execute_inline_defaults_to_module_level_registry_when_none_supplied() -> None:
+    """Passing ``registry=None`` falls back to ``get_default_registry()``."""
+    default = get_default_registry()
+    spec_id = "spec-default-fallback-test"
+    try:
+
+        def handler(ctx: InlineContext) -> dict[str, Any]:
+            return {"verdict": True}
+
+        default.register(spec_id, "h1", handler)
+        state = _inline_state(handler_id="h1", response_schema=_verdict_schema())
+        ctx = _ctx(fsm_id=spec_id)
+
+        result = execute_inline(
+            state=state,
+            ctx=ctx,
+            args={},
+            inputs={},
+        )
+
+        assert result.ok is True
+        assert result.outputs == {"verdict": True}
+    finally:
+        # Keep the global registry hermetic between tests.
+        default.unregister(spec_id)

--- a/tests/unit/core/test_inline_registry.py
+++ b/tests/unit/core/test_inline_registry.py
@@ -1,0 +1,231 @@
+"""Tests for :mod:`ctxr.fsm.core.inline_registry` (W14a).
+
+Covers:
+
+* :meth:`InlineHandlerRegistry.register` happy path and per-spec scoping.
+* :meth:`InlineHandlerRegistry.lookup` for known + unknown keys.
+* :meth:`InlineHandlerRegistry.register_many` bulk-registration.
+* :meth:`InlineHandlerRegistry.unregister` for one entry + entire spec.
+* :meth:`InlineHandlerRegistry.clear` wipes everything.
+* :func:`get_default_registry` returns a single process-wide singleton.
+* :meth:`InlineHandlerRegistry.register` argument validation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from ctxr.fsm.core.inline_registry import (
+    InlineContext,
+    InlineHandlerRegistry,
+    get_default_registry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(value: str) -> Any:
+    """Build a handler that returns a payload dict tagged with ``value``."""
+
+    def _handler(ctx: InlineContext) -> dict[str, Any]:
+        return {"tag": value, "run_id": str(ctx.run_id)}
+
+    return _handler
+
+
+def _ctx(fsm_id: str = "spec-a", state_id: str = "s1") -> InlineContext:
+    return InlineContext(
+        run_id=uuid4(),
+        fsm_id=fsm_id,
+        state_id=state_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# register / lookup
+# ---------------------------------------------------------------------------
+
+
+def test_register_then_lookup_returns_same_callable() -> None:
+    registry = InlineHandlerRegistry()
+    handler = _make_handler("h1")
+    registry.register("spec-a", "h1", handler)
+
+    found = registry.lookup("spec-a", "h1")
+    assert found is handler
+
+
+def test_lookup_unknown_key_returns_none() -> None:
+    registry = InlineHandlerRegistry()
+    assert registry.lookup("spec-x", "missing") is None
+
+
+def test_register_overwrites_existing_key() -> None:
+    registry = InlineHandlerRegistry()
+    first = _make_handler("first")
+    second = _make_handler("second")
+    registry.register("spec-a", "h1", first)
+    registry.register("spec-a", "h1", second)
+
+    found = registry.lookup("spec-a", "h1")
+    assert found is second
+    # The first handler is gone.
+    out = found(_ctx())  # type: ignore[misc]
+    assert out["tag"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# per-spec scoping
+# ---------------------------------------------------------------------------
+
+
+def test_same_handler_id_under_different_specs_does_not_collide() -> None:
+    """Two specs can register the same handler_id without overlap."""
+    registry = InlineHandlerRegistry()
+    handler_a = _make_handler("from-a")
+    handler_b = _make_handler("from-b")
+    registry.register("spec-a", "collect_findings", handler_a)
+    registry.register("spec-b", "collect_findings", handler_b)
+
+    found_a = registry.lookup("spec-a", "collect_findings")
+    found_b = registry.lookup("spec-b", "collect_findings")
+    assert found_a is handler_a
+    assert found_b is handler_b
+    assert found_a is not found_b
+
+
+# ---------------------------------------------------------------------------
+# register_many
+# ---------------------------------------------------------------------------
+
+
+def test_register_many_registers_every_pair() -> None:
+    registry = InlineHandlerRegistry()
+    handlers = {
+        "alpha": _make_handler("a"),
+        "beta": _make_handler("b"),
+        "gamma": _make_handler("g"),
+    }
+    registry.register_many("spec-a", handlers)
+
+    assert registry.lookup("spec-a", "alpha") is handlers["alpha"]
+    assert registry.lookup("spec-a", "beta") is handlers["beta"]
+    assert registry.lookup("spec-a", "gamma") is handlers["gamma"]
+
+
+def test_register_many_empty_dict_is_noop() -> None:
+    registry = InlineHandlerRegistry()
+    registry.register_many("spec-a", {})
+    # No registrations created.
+    assert registry.lookup("spec-a", "any") is None
+
+
+# ---------------------------------------------------------------------------
+# unregister
+# ---------------------------------------------------------------------------
+
+
+def test_unregister_single_entry_leaves_other_entries_intact() -> None:
+    registry = InlineHandlerRegistry()
+    registry.register("spec-a", "h1", _make_handler("h1"))
+    registry.register("spec-a", "h2", _make_handler("h2"))
+    registry.register("spec-b", "h1", _make_handler("h1-b"))
+
+    registry.unregister("spec-a", "h1")
+
+    assert registry.lookup("spec-a", "h1") is None
+    assert registry.lookup("spec-a", "h2") is not None
+    assert registry.lookup("spec-b", "h1") is not None
+
+
+def test_unregister_entire_spec_removes_all_its_handlers() -> None:
+    registry = InlineHandlerRegistry()
+    registry.register("spec-a", "h1", _make_handler("h1"))
+    registry.register("spec-a", "h2", _make_handler("h2"))
+    registry.register("spec-b", "h1", _make_handler("h1-b"))
+
+    registry.unregister("spec-a")
+
+    assert registry.lookup("spec-a", "h1") is None
+    assert registry.lookup("spec-a", "h2") is None
+    assert registry.lookup("spec-b", "h1") is not None
+
+
+def test_unregister_missing_entry_is_idempotent_noop() -> None:
+    registry = InlineHandlerRegistry()
+    registry.register("spec-a", "h1", _make_handler("h1"))
+    # Should not raise; should leave existing registrations untouched.
+    registry.unregister("spec-a", "does_not_exist")
+    registry.unregister("nope_spec")
+    assert registry.lookup("spec-a", "h1") is not None
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+
+def test_clear_removes_all_registrations() -> None:
+    registry = InlineHandlerRegistry()
+    registry.register("spec-a", "h1", _make_handler("a1"))
+    registry.register("spec-b", "h1", _make_handler("b1"))
+    registry.clear()
+
+    assert registry.lookup("spec-a", "h1") is None
+    assert registry.lookup("spec-b", "h1") is None
+
+
+# ---------------------------------------------------------------------------
+# default registry singleton identity
+# ---------------------------------------------------------------------------
+
+
+def test_get_default_registry_returns_singleton() -> None:
+    a = get_default_registry()
+    b = get_default_registry()
+    assert a is b
+
+
+def test_default_registry_is_an_inline_handler_registry() -> None:
+    r = get_default_registry()
+    assert isinstance(r, InlineHandlerRegistry)
+
+
+def test_default_registry_state_is_preserved_across_calls() -> None:
+    r = get_default_registry()
+    try:
+        r.register("test-spec-default-singleton", "h1", _make_handler("x"))
+        # Re-fetch and ensure the same registrations persist.
+        again = get_default_registry()
+        assert again.lookup("test-spec-default-singleton", "h1") is not None
+    finally:
+        # Keep tests hermetic for any later default-registry tests.
+        r.unregister("test-spec-default-singleton")
+
+
+# ---------------------------------------------------------------------------
+# argument validation on register
+# ---------------------------------------------------------------------------
+
+
+def test_register_rejects_empty_spec_id() -> None:
+    registry = InlineHandlerRegistry()
+    with pytest.raises(ValueError):
+        registry.register("", "h1", _make_handler("x"))
+
+
+def test_register_rejects_empty_handler_id() -> None:
+    registry = InlineHandlerRegistry()
+    with pytest.raises(ValueError):
+        registry.register("spec-a", "", _make_handler("x"))
+
+
+def test_register_rejects_non_callable_handler() -> None:
+    registry = InlineHandlerRegistry()
+    with pytest.raises(ValueError):
+        registry.register("spec-a", "h1", "not_callable")  # type: ignore[arg-type]

--- a/tests/unit/core/test_models_inline_spec.py
+++ b/tests/unit/core/test_models_inline_spec.py
@@ -1,0 +1,240 @@
+"""Tests for :class:`InlineSpec` and the ``State.kind`` derived property (W14a).
+
+Covers:
+
+* :class:`InlineSpec` field validation (``handler_id`` shape).
+* :attr:`State.kind` property correctness across the four state kinds
+  (worker / loop / inline / terminal).
+* :attr:`State.kind` raising on a structurally-impossible terminal-by-
+  content state that still declares transitions.
+* State construction rejecting incompatible body combinations:
+  ``inline`` + ``worker``, ``inline`` + ``loop``.
+* State construction rejecting an inline state with transitions but no
+  ``inline.response_schema`` (transition guards have no shape to read).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ctxr.fsm.core.models import (
+    InlineSpec,
+    Loop,
+    ResponseSchema,
+    State,
+    Transition,
+    Worker,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers (inline; same convention as test_models.py)
+# ---------------------------------------------------------------------------
+
+
+def _bool_schema(field: str = "done") -> ResponseSchema:
+    """Build a tiny ResponseSchema declaring ``field`` as boolean."""
+    return ResponseSchema(
+        schema={
+            "type": "object",
+            "properties": {field: {"type": "boolean"}},
+            "required": [field],
+        }
+    )
+
+
+def _simple_worker(role: str = "worker") -> Worker:
+    """Minimal worker with a non-empty role + prompt."""
+    return Worker(role=role, prompt_template="do the thing")
+
+
+# ---------------------------------------------------------------------------
+# InlineSpec field validation
+# ---------------------------------------------------------------------------
+
+
+def test_inline_spec_accepts_minimal_handler_id() -> None:
+    spec = InlineSpec(handler_id="risk_tier_triage")
+    assert spec.handler_id == "risk_tier_triage"
+    assert spec.response_schema is None
+    assert spec.post_validations == []
+    assert spec.purpose == ""
+
+
+def test_inline_spec_accepts_full_population() -> None:
+    spec = InlineSpec(
+        handler_id="compute_risk",
+        response_schema=_bool_schema("verdict_ok"),
+        post_validations=[],
+        purpose="compute risk tier from changed files",
+    )
+    assert spec.handler_id == "compute_risk"
+    assert spec.response_schema is not None
+    assert spec.purpose == "compute risk tier from changed files"
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "BadHandler",
+        "1starts_with_digit",
+        "has-dash",
+        "has.dot",
+        "",
+        "UPPER",
+        "has space",
+    ],
+)
+def test_inline_spec_rejects_bad_handler_id_shape(bad_id: str) -> None:
+    with pytest.raises(ValidationError):
+        InlineSpec(handler_id=bad_id)
+
+
+@pytest.mark.parametrize(
+    "good_id",
+    ["a", "h1", "risk_tier_triage", "collect_findings", "x_y_z_123"],
+)
+def test_inline_spec_accepts_snake_case_handler_id(good_id: str) -> None:
+    spec = InlineSpec(handler_id=good_id)
+    assert spec.handler_id == good_id
+
+
+# ---------------------------------------------------------------------------
+# State.kind derived property — four-way correctness
+# ---------------------------------------------------------------------------
+
+
+def test_state_kind_returns_worker_for_worker_state() -> None:
+    state = State(id="plan", worker=_simple_worker())
+    assert state.kind == "worker"
+
+
+def test_state_kind_returns_loop_for_loop_state() -> None:
+    worker = Worker(
+        role="iter",
+        prompt_template="iterate",
+        response_schema=_bool_schema("done"),
+    )
+    state = State(id="iterating", loop=Loop(worker=worker, done_field="done"))
+    assert state.kind == "loop"
+
+
+def test_state_kind_returns_inline_for_inline_state() -> None:
+    state = State(id="triage", inline=InlineSpec(handler_id="risk_tier_triage"))
+    assert state.kind == "inline"
+
+
+def test_state_kind_returns_terminal_for_bare_state() -> None:
+    state = State(id="done")
+    assert state.kind == "terminal"
+
+
+def test_state_kind_loop_wins_over_other_for_unambiguous_states() -> None:
+    """A loop state's kind reports as 'loop' regardless of transitions."""
+    worker = Worker(
+        role="iter",
+        prompt_template="iterate",
+        response_schema=_bool_schema("done"),
+    )
+    state = State(
+        id="iterating",
+        loop=Loop(worker=worker, done_field="done"),
+        transitions=[Transition(to="next_state", when="always")],
+    )
+    assert state.kind == "loop"
+
+
+# ---------------------------------------------------------------------------
+# State.kind raises on the structurally-impossible terminal-with-transitions
+# ---------------------------------------------------------------------------
+
+
+def test_state_kind_raises_when_terminal_by_content_has_transitions() -> None:
+    """A state with no body and transitions is structurally invalid.
+
+    Pydantic does not reject this at construction (a terminal "passes
+    through" might be desirable in some hypothetical future), but
+    ``State.kind`` is the read-time gate: a caller trying to dispatch
+    on kind hits a clear error rather than silently treating the state
+    as terminal.
+    """
+    state = State(
+        id="passthrough",
+        transitions=[Transition(to="elsewhere", when="always")],
+    )
+    with pytest.raises(ValueError, match="terminal-by-content"):
+        _ = state.kind
+
+
+# ---------------------------------------------------------------------------
+# State construction: body-combination rejections
+# ---------------------------------------------------------------------------
+
+
+def test_state_rejects_both_inline_and_worker() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        State(
+            id="mixed",
+            inline=InlineSpec(handler_id="some_handler"),
+            worker=_simple_worker(),
+        )
+    msg = str(excinfo.value)
+    assert "inline" in msg and "worker" in msg
+
+
+def test_state_rejects_both_inline_and_loop() -> None:
+    worker = Worker(
+        role="iter",
+        prompt_template="iterate",
+        response_schema=_bool_schema("done"),
+    )
+    loop = Loop(worker=worker, done_field="done")
+    with pytest.raises(ValidationError) as excinfo:
+        State(
+            id="mixed",
+            inline=InlineSpec(handler_id="some_handler"),
+            loop=loop,
+        )
+    msg = str(excinfo.value)
+    assert "inline" in msg and "loop" in msg
+
+
+# ---------------------------------------------------------------------------
+# State construction: inline+transitions requires response_schema
+# ---------------------------------------------------------------------------
+
+
+def test_state_rejects_inline_with_transitions_but_no_schema() -> None:
+    """Inline state with transitions must declare inline.response_schema."""
+    with pytest.raises(ValidationError) as excinfo:
+        State(
+            id="needs_schema",
+            inline=InlineSpec(handler_id="some_handler"),
+            transitions=[Transition(to="next_state", when="always")],
+        )
+    msg = str(excinfo.value)
+    assert "inline.response_schema" in msg or "inline" in msg
+
+
+def test_state_accepts_inline_with_transitions_when_schema_set() -> None:
+    state = State(
+        id="ok_inline",
+        inline=InlineSpec(
+            handler_id="some_handler",
+            response_schema=_bool_schema("verdict_ok"),
+        ),
+        transitions=[Transition(to="next_state", when="always")],
+    )
+    assert state.kind == "inline"
+    assert state.inline is not None
+    assert state.inline.response_schema is not None
+
+
+def test_state_accepts_inline_terminal_without_schema() -> None:
+    """An inline state with NO transitions is a valid terminal."""
+    state = State(
+        id="terminal_inline",
+        inline=InlineSpec(handler_id="cleanup"),
+    )
+    assert state.kind == "inline"
+    assert state.transitions == []

--- a/tests/unit/core/test_spec_validate_inline.py
+++ b/tests/unit/core/test_spec_validate_inline.py
@@ -1,0 +1,225 @@
+"""Tests for :func:`ctxr.fsm.core.spec.validate_fsm_spec` over inline states (W14a).
+
+Covers:
+
+* ``validate_fsm_spec`` accepts an :class:`FsmSpec` containing inline
+  states (worker → inline → terminal pattern).
+* ``validate_fsm_spec`` accepts a spec with an inline state used as a
+  terminal (no transitions, no response_schema needed).
+* The construction-time check for "inline+transitions requires
+  response_schema" prevents an invalid spec from even reaching the
+  validator; we exercise that interaction at the spec-building boundary.
+* Reachability over inline states is honoured (inline states are
+  traversed by the BFS walk just like worker states).
+* Inline handler **registration** is NOT validated at spec-load time:
+  a spec referencing a handler_id with NO registered handler still
+  validates cleanly. (The fault surfaces at advance time instead.)
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ctxr.fsm.core.models import (
+    FsmSpec,
+    InlineSpec,
+    ResponseSchema,
+    State,
+    Transition,
+    Worker,
+)
+from ctxr.fsm.core.spec import validate_fsm_spec
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _verdict_schema() -> ResponseSchema:
+    return ResponseSchema(
+        schema={
+            "type": "object",
+            "properties": {
+                "verdict": {"type": "boolean"},
+            },
+            "required": ["verdict"],
+        }
+    )
+
+
+def _simple_worker(role: str = "w") -> Worker:
+    return Worker(role=role, prompt_template="do work")
+
+
+# ---------------------------------------------------------------------------
+# validate_fsm_spec accepts inline-bearing specs
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_worker_inline_terminal_spec() -> None:
+    """Realistic worker → inline → terminal shape validates cleanly."""
+    start = State(
+        id="plan",
+        worker=_simple_worker(role="planner"),
+        transitions=[Transition(to="triage", when="always")],
+    )
+    triage = State(
+        id="triage",
+        inline=InlineSpec(
+            handler_id="risk_tier_triage",
+            response_schema=_verdict_schema(),
+        ),
+        transitions=[Transition(to="done", when="always")],
+    )
+    done = State(id="done")
+
+    spec = FsmSpec(
+        id="port-test",
+        version=1,
+        entry="plan",
+        states=[start, triage, done],
+    )
+
+    result = validate_fsm_spec(spec)
+
+    assert result.valid is True
+    assert result.errors == []
+    assert result.unreachable_states == []
+    assert result.dangling_transitions == []
+    assert result.invalid_predicates == []
+
+
+def test_validate_accepts_terminal_inline_state_without_schema() -> None:
+    """An inline state with no transitions and no schema is a valid terminal."""
+    start = State(
+        id="plan",
+        worker=_simple_worker(role="planner"),
+        transitions=[Transition(to="cleanup", when="always")],
+    )
+    cleanup = State(
+        id="cleanup",
+        inline=InlineSpec(handler_id="terminal_cleanup"),
+    )
+
+    spec = FsmSpec(
+        id="terminal-inline",
+        version=1,
+        entry="plan",
+        states=[start, cleanup],
+    )
+
+    result = validate_fsm_spec(spec)
+    assert result.valid is True
+    assert result.errors == []
+
+
+def test_validate_accepts_inline_only_spec_one_state() -> None:
+    """A spec whose entry is an inline terminal state validates cleanly."""
+    only = State(
+        id="just_inline",
+        inline=InlineSpec(handler_id="solo"),
+    )
+    spec = FsmSpec(id="solo-spec", version=1, entry="just_inline", states=[only])
+
+    result = validate_fsm_spec(spec)
+    assert result.valid is True
+
+
+# ---------------------------------------------------------------------------
+# Construction-time check for inline+transitions+no-schema
+# ---------------------------------------------------------------------------
+
+
+def test_build_spec_with_inline_transitions_no_schema_fails_at_state_construction() -> None:
+    """The State validator rejects the invalid combo before FsmSpec sees it.
+
+    This documents the layering: ``validate_fsm_spec`` would also catch
+    the violation (see ``_check_inline_semantics``), but the
+    construction-time validator on :class:`State` fires first and is
+    the canonical gate.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        State(
+            id="bad",
+            inline=InlineSpec(handler_id="x"),
+            transitions=[Transition(to="elsewhere", when="always")],
+        )
+    assert "inline" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Reachability over inline states
+# ---------------------------------------------------------------------------
+
+
+def test_validate_reachability_traverses_inline_states() -> None:
+    """An inline state on the spine is reachable from entry."""
+    a = State(
+        id="a",
+        worker=_simple_worker(role="a"),
+        transitions=[Transition(to="b", when="always")],
+    )
+    b = State(
+        id="b",
+        inline=InlineSpec(
+            handler_id="middle_inline",
+            response_schema=_verdict_schema(),
+        ),
+        transitions=[Transition(to="c", when="always")],
+    )
+    c = State(id="c")
+
+    spec = FsmSpec(id="spec-reach", version=1, entry="a", states=[a, b, c])
+    result = validate_fsm_spec(spec)
+    assert result.valid is True
+    assert result.unreachable_states == []
+
+
+def test_validate_reports_unreachable_inline_state() -> None:
+    """An inline state nobody points to is reported as unreachable."""
+    a = State(
+        id="a",
+        worker=_simple_worker(role="a"),
+        # Note: no transition to ``orphan`` anywhere.
+        transitions=[Transition(to="terminal", when="always")],
+    )
+    orphan = State(id="orphan", inline=InlineSpec(handler_id="never_run"))
+    terminal = State(id="terminal")
+
+    spec = FsmSpec(
+        id="orphan-spec",
+        version=1,
+        entry="a",
+        states=[a, orphan, terminal],
+    )
+    result = validate_fsm_spec(spec)
+    assert result.valid is False
+    assert "orphan" in result.unreachable_states
+
+
+# ---------------------------------------------------------------------------
+# Handler registration is NOT checked at spec-load time
+# ---------------------------------------------------------------------------
+
+
+def test_validate_does_not_require_handler_registration() -> None:
+    """A spec with an inline state whose handler is NOT registered validates fine.
+
+    The fault surfaces only at engine advance time
+    (``inline_handler_unregistered``). This separation lets consumers
+    register the spec and the inline handlers independently — e.g.
+    ``Project.register_spec`` before ``Project.register_inline_handlers``
+    is allowed, and reverse order works too.
+    """
+    a = State(
+        id="a",
+        inline=InlineSpec(handler_id="not_yet_registered_handler"),
+    )
+    spec = FsmSpec(id="unreg-spec", version=1, entry="a", states=[a])
+
+    result = validate_fsm_spec(spec)
+    # No reference to any runtime registry was made; only structural
+    # validation ran.
+    assert result.valid is True
+    assert result.errors == []


### PR DESCRIPTION
## Summary

Extends `ctxr.fsm.core` with a fourth FSM state kind, `inline`: a deterministic Python callable that runs server-side during `engine.advance()`, in the same atomic transaction as the surrounding state transition, with no LLM/worker involvement.

This is the engine surface skill-code-review (W14f) and other future skills will ship their deterministic state handlers against, replacing today's Node shell-loop runner with registered Python callables driven by the engine.

* **Models.** New `InlineSpec`, `InlineExecutionResult`; new `State.inline` field; new `State.kind` derived property (returns `"loop"` / `"inline"` / `"worker"` / `"terminal"`); new `EventKind.inline_executed` / `inline_failed`; `State._consistency` rejects `inline` + `worker` / `inline` + `loop` combinations, and an inline state with transitions must declare `inline.response_schema`.
* **Registry.** New module `ctxr/fsm/core/inline_registry.py`: process-local `InlineHandlerRegistry` keyed `(spec_id, handler_id)`, pickle-safe, dependency-free, exposed via a module-singleton + `get_default_registry()`. Per-spec scoping lets two specs share a `handler_id` slug without collision.
* **Engine.** New pure function `engine.execute_inline(state, ctx, args, inputs, registry?)`. Looks up the handler, invokes it with a read-only `InlineContext`, validates the return against the optional response schema, runs any post-validation predicates, and returns a structured `InlineExecutionResult` (with five `fault_reason` slugs covering missing handler, raised handler, bad return type, schema violation, post-validation failure). Pure: no persistence, no events; the W2 SQLite repo wires this into its `@atomic` transaction as W14b/c follow-up work.
* **Spec.** `validate_fsm_spec` gains a defensive inline semantics check and documents explicitly that handler **registration** is NOT validated at spec-load time — faults surface at engine advance time so consumers can interleave `Project.register_spec` and `Project.register_inline_handlers` freely.
* **Public re-exports** added to `ctxr.fsm.core.__init__`: `InlineSpec`, `InlineExecutionResult`, `InlineContext`, `InlineHandler`, `InlineHandlerRegistry`, `get_default_registry`, `execute_inline`.

Plan reference: `how-it-fits-toasty-gray.md` -> W14a (lines 616-633).

## Tests

60 new tests across four files; all green. Baseline 197 core tests untouched; full suite still at 100%.

| File | Tests | Covers |
|---|---|---|
| `test_models_inline_spec.py` | 25 | InlineSpec validation, State.kind correctness across the four kinds, inline+worker / inline+loop rejection, inline+transitions-needs-schema rule |
| `test_inline_registry.py` | 16 | registry CRUD, per-spec scoping, default-registry singleton, register argument validation |
| `test_engine_inline_execution.py` | 12 | happy path; unregistered / raising / non-dict / schema-mismatched / post-validation-failing handlers; per-spec scoping; schema-less inline; defensive TypeError on non-inline state; default-registry fallback |
| `test_spec_validate_inline.py` | 7 | validator accepts inline-bearing specs; reachability over inline; handler registration not required at spec-load time |

## Verification

```
uv run pytest tests/unit/core/ -q       -> 257 passed (197 baseline + 60 new)
uv run pytest                           -> 516 passed (456 baseline + 60 new)
uv run ruff check ctxr/fsm/core/ tests/unit/core/  -> All checks passed
uv run mypy ctxr/fsm/core/              -> Success: no issues found in 10 source files
```

Per the W14a scope: NO changes to `ctxr/fsm/sqlite`, `ctxr/fsm/mcp`, `ctxr/fsm/api`, or `ctxr/fsm/cli`. The W2 SQLite repository wires `execute_inline` into its `@atomic` transaction as W14b/c follow-up.

## Test plan

- [ ] CI: `uv run pytest`, `uv run ruff check ctxr/fsm/core/ tests/unit/core/`, `uv run mypy ctxr/fsm/core/` all green on the PR branch.
- [ ] Review the discriminated-result shape of `InlineExecutionResult` and confirm the five `fault_reason` slugs cover every contractual failure mode.
- [ ] Confirm the per-spec scoping decision (`(spec_id, handler_id)` key) matches the W14a plan note: "two different specs can reuse the same handler_id slug without collision."

## Stacking

Base branch is `w13/cleanup-integration-devloop` (PR #37, still open in review). W14a chains on top, matching the established PR #24-#37 pattern.

Stops at the human merge gate (no merge, no dev-issue move-to-Done).