### PR TITLE
feat(w14b+c+d): ctxr-fsm ensure + active-mcp.json discovery + install-mcp client-config merger

### DIFF
--- a/ctxr/fsm/cli/__init__.py
+++ b/ctxr/fsm/cli/__init__.py
@@ -47,9 +47,11 @@ import typer
 from ctxr.fsm.cli import (
     api_cmd,
     doctor_cmd,
+    ensure_cmd,
     export_cmd,
     import_cmd,
     init_cmd,
+    install_mcp_cmd,
     install_memory_cmd,
     mcp_cmd,
     migrate_cmd,
@@ -98,6 +100,25 @@ app.command(
     name="install-memory",
     help="Install (or check) FSM-usage principles into AI-client memory.",
 )(install_memory_cmd.install_memory)
+# ``install-mcp`` (W14d) registers ctxr-fsm as a stdio MCP server in
+# each detected client's config file: .mcp.json / .claude/settings.json
+# (Claude Code project-local), ~/.codex/config.toml (Codex user-level,
+# preferring the ``codex mcp add`` CLI when available), and
+# ~/.cursor/mcp.json (Cursor user-level). Idempotent: only the
+# ``ctxr-fsm`` entry is owned; every other entry passes through.
+app.command(
+    name="install-mcp",
+    help="Register (or check) ctxr-fsm as a stdio MCP server in client configs.",
+)(install_mcp_cmd.install_mcp)
+# ``ensure`` (W14b) is the single bootstrap entry point every skill
+# invokes from its SKILL.md preamble. Idempotent, fast on the warm
+# path (<500ms), self-heals init + memory + mcp-config + supervisor.
+# Emits a JSON document on stdout (default when piped; --no-json for
+# interactive pretty output).
+app.command(
+    name="ensure",
+    help="Ensure the project is bootstrapped and the supervisor is up.",
+)(ensure_cmd.ensure)
 
 # The ``spec`` group bundles spec validate / register / list under one
 # namespace so the top-level help screen stays short. Adding it via

--- a/ctxr/fsm/cli/_common.py
+++ b/ctxr/fsm/cli/_common.py
@@ -70,6 +70,21 @@ _DEFAULT_DB_RELATIVE: Path = Path(".ctxr-fsm") / "fsm.db"
 _ENV_VAR_NAME: str = "CTXR_FSM_DB"
 
 
+def _walk_up_for_state_dir(start: Path) -> Path | None:
+    """Return the nearest ancestor of ``start`` containing ``.ctxr-fsm``.
+
+    Walk-up tier of :func:`resolve_db_path` — see that function's
+    docstring for the rationale. Returns ``None`` if no ancestor has a
+    ``.ctxr-fsm`` directory so the caller can fall back to the cwd
+    default.
+    """
+    current = start.resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".ctxr-fsm").is_dir():
+            return candidate
+    return None
+
+
 def resolve_db_path(db_opt: Path | None) -> Path:
     """Apply the CLI's layered precedence to produce a concrete DB path.
 
@@ -78,8 +93,18 @@ def resolve_db_path(db_opt: Path | None) -> Path:
     1. ``--db`` / ``-d`` (the ``db_opt`` argument).
     2. ``$CTXR_FSM_DB`` (read live from ``os.environ`` so the lookup
        reflects any test ``monkeypatch.setenv`` call).
-    3. ``$(pwd) / .ctxr-fsm / fsm.db`` — the canonical project-local
+    3. Walk up from the current working directory looking for an
+       ancestor that contains ``.ctxr-fsm/``; return that ancestor's
+       ``.ctxr-fsm/fsm.db``.
+    4. ``$(pwd) / .ctxr-fsm / fsm.db`` — the canonical project-local
        location, matching the directory that ``ctxr-fsm init`` creates.
+
+    The walk-up tier (step 3) was added in W14d so the stdio MCP entry
+    written by ``ctxr-fsm install-mcp`` stays portable across
+    projects: a client (Claude Code, Cursor, Codex) spawns
+    ``ctxr-fsm mcp`` with the user's CURRENT cwd inherited; the
+    walk-up finds the right project root even when the user is
+    several directories deep.
 
     The returned path is always absolute (resolved against the current
     working directory) so downstream code can compare and log paths
@@ -90,6 +115,9 @@ def resolve_db_path(db_opt: Path | None) -> Path:
     env_value = os.environ.get(_ENV_VAR_NAME)
     if env_value:
         return Path(env_value).expanduser().resolve()
+    found_root = _walk_up_for_state_dir(Path.cwd())
+    if found_root is not None:
+        return (found_root / _DEFAULT_DB_RELATIVE).resolve()
     return (Path.cwd() / _DEFAULT_DB_RELATIVE).resolve()
 
 

--- a/ctxr/fsm/cli/doctor_cmd.py
+++ b/ctxr/fsm/cli/doctor_cmd.py
@@ -67,6 +67,7 @@ from ctxr.fsm.cli._common import (
 from ctxr.fsm.cli.lifecycle.primitives import (
     _probe_healthz,
     pid_is_alive,
+    read_active_mcp_file,
     read_pid_file,
     recall_port,
 )
@@ -230,16 +231,25 @@ def _supervisor_subsystem_report(
 def _supervisor_report(project_root: Path) -> dict[str, Any]:
     """Aggregate per-subsystem reports into one stable map.
 
-    Returns ``{"subsystems": {name: report, ...}}`` so the JSON output
-    can grow additional supervisor-level keys (e.g. an ``active_run``
-    section once W12 lands) without breaking the existing
+    Returns ``{"subsystems": {name: report, ...},
+    "active_mcp": <discovery-doc> | None}`` so the JSON output can grow
+    additional supervisor-level keys (e.g. an ``active_run`` section
+    once W12 lands) without breaking the existing
     ``payload["supervisor"]["subsystems"]["mcp"]`` access path.
+
+    The ``active_mcp`` block is the W14c discovery document — verbatim
+    if present, ``None`` when no supervisor has booted yet (or the
+    last one shut down cleanly). Operators reach for this when a
+    skill complains about the HTTP-SSE MCP URL — the doctor's surface
+    is the canonical "what URL would the bootstrap fall back to right
+    now" answer.
     """
     return {
         "subsystems": {
             name: _supervisor_subsystem_report(name, project_root=project_root)
             for name in _SUPERVISOR_SUBSYSTEMS
-        }
+        },
+        "active_mcp": read_active_mcp_file(project_root),
     }
 
 

--- a/ctxr/fsm/cli/ensure_cmd.py
+++ b/ctxr/fsm/cli/ensure_cmd.py
@@ -1,0 +1,647 @@
+"""``ctxr-fsm ensure`` — single bootstrap entry point skills call (W14b).
+
+This command is the **one** thing every ctxr-fsm-driven skill invokes
+from its SKILL.md preamble. It is idempotent + fast (<500ms on the
+warm path) and self-heals every dimension that could be cold:
+
+1. **init** — ``./.ctxr-fsm/`` + ``fsm.db`` + alembic head.
+2. **memory** — FSM-usage principles wired into CLAUDE.md /
+   AGENTS.md / .cursor/rules/ (W11's install-memory).
+3. **mcp-config** — stdio MCP entry merged into the detected client
+   configs (W14d's install-mcp).
+4. **supervisor** — MCP (+ API + UI in ``full`` mode) spawned as a
+   detached background process, with healthz probed for up to
+   ``--timeout`` seconds.
+
+The command's stdout is a single JSON document the skill parses to
+discover URLs + verify status. Pretty output is available behind
+``--no-json`` for human invocation.
+
+Algorithm summary (per W14b brief)
+----------------------------------
+
+1. Resolve project root (cwd walk-up for ``.ctxr-fsm/``; ``--project-root``
+   overrides; falls back to cwd).
+2. ``init`` step: if DB missing OR alembic head not current → call
+   ``run_init``. Idempotent.
+3. ``memory`` step: ``run_install_memory(target=project_root,
+   client=client)`` unless ``--no-memory``.
+4. ``mcp_config`` step: ``run_install_mcp(target_dir=project_root,
+   client=client)`` unless ``--no-mcp-config``.
+5. ``supervisor`` step: for each of ``{mcp, api, ui}`` (or just
+   ``{mcp}`` in mcp-only mode), call ``acquire_singleton``. NOT-up
+   subsystems → spawn one ``ctxr-fsm serve`` detached process that
+   boots whatever is missing; poll healthz for up to ``--timeout``.
+6. Read ``active-mcp.json`` for the final URL set.
+7. Emit JSON.
+
+``--check`` bypasses steps 2-3 mutation + the spawn in step 5 (probes
+only), returning a per-step ``current``/``missing``/``unchanged``
+status.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+import typer
+
+from ctxr.fsm.cli._common import json_or_pretty
+from ctxr.fsm.cli.init_cmd import run_init
+from ctxr.fsm.cli.install_mcp_cmd import run_install_mcp
+from ctxr.fsm.cli.install_memory_cmd import run_install_memory
+from ctxr.fsm.cli.lifecycle.primitives import (
+    pid_is_alive,
+    read_active_mcp_file,
+    read_pid_file,
+)
+
+__all__ = ["ensure", "run_ensure"]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CLIENT_CHOICES: tuple[str, ...] = ("auto", "claude", "codex", "cursor", "none")
+_MODE_CHOICES: tuple[str, ...] = ("full", "mcp-only")
+
+# How often (seconds) we poll between healthz attempts while waiting
+# for a freshly-spawned supervisor to come up. 100ms is short enough
+# to make the warm-path fast (the discovery file lands inside one or
+# two polls) and long enough that we don't spin the CPU.
+_POLL_INTERVAL_S: float = 0.1
+
+
+# ---------------------------------------------------------------------------
+# Project-root resolution (walk-up from cwd)
+# ---------------------------------------------------------------------------
+
+
+def _walk_up_for_state_dir(start: Path) -> Path | None:
+    """Return the nearest ancestor of ``start`` containing ``.ctxr-fsm/``.
+
+    Mirror of the helper in ``cli/_common.py`` and ``mcp/server.py``;
+    re-declared here so the ensure command does not pull either of
+    those into a hot-path import chain. The three implementations are
+    one-screen and trivially kept in sync.
+    """
+    current = start.resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".ctxr-fsm").is_dir():
+            return candidate
+    return None
+
+
+def _resolve_project_root(explicit: Path | None) -> Path:
+    """Resolve the project root the ensure command will operate on."""
+    if explicit is not None:
+        return explicit.expanduser().resolve()
+    found = _walk_up_for_state_dir(Path.cwd())
+    if found is not None:
+        return found
+    return Path.cwd().resolve()
+
+
+# ---------------------------------------------------------------------------
+# Subsystem probing (read-only)
+# ---------------------------------------------------------------------------
+
+
+def _probe_subsystem_alive(name: str, project_root: Path) -> tuple[bool, int | None, str | None]:
+    """Return ``(alive, pid, probe_url)`` for ``name``'s singleton state.
+
+    "alive" here means BOTH:
+
+    * The pid recorded in ``.ctxr-fsm/pids/<name>.pid`` is alive
+      (per :func:`pid_is_alive`).
+    * Its recorded ``probe_url`` answers ``/healthz`` with 200
+      (when the subsystem advertises a probe URL — UI omits one
+      because Vite has no /healthz route, in which case a live pid
+      alone is enough).
+
+    Returning a tuple (not a bool) lets the caller surface diagnostic
+    detail in the final JSON without re-reading the file.
+    """
+    # Construct the pid path manually rather than calling
+    # ``pid_file_for`` — that helper has a side effect (creating
+    # ``.ctxr-fsm/pids/``). ``run_ensure(check=True)`` MUST never
+    # mutate the project tree, so we use the bare path here.
+    pid_path = project_root / ".ctxr-fsm" / "pids" / f"{name}.pid"
+    record = read_pid_file(pid_path)
+    if record is None:
+        return False, None, None
+    raw_pid = record.get("pid")
+    pid = int(raw_pid) if isinstance(raw_pid, int) else None
+    probe_url_raw = record.get("probe_url")
+    probe_url = probe_url_raw if isinstance(probe_url_raw, str) and probe_url_raw else None
+
+    if pid is None or not pid_is_alive(pid):
+        return False, pid, probe_url
+
+    if probe_url is None:
+        # Live pid but no probe — match the supervisor's own
+        # singleton primitive: a live pid alone is enough for
+        # non-HTTP subsystems.
+        return True, pid, None
+
+    healthz_url = probe_url.rstrip("/") + "/healthz"
+    try:
+        resp = httpx.get(healthz_url, timeout=1.0)
+    except (httpx.HTTPError, OSError):
+        return False, pid, probe_url
+    if resp.status_code != 200:
+        return False, pid, probe_url
+    return True, pid, probe_url
+
+
+def _alembic_at_head(db_path: Path) -> bool:
+    """Return True iff ``alembic_version`` table exists and has a row.
+
+    A missing DB collapses to False (caller will run init). When
+    ``alembic_version`` exists with a non-null version, we treat the
+    DB as "current" — a strict head-comparison would require loading
+    the Alembic script directory and is much heavier than the
+    bootstrap path needs to pay on every ensure call. ``run_init``'s
+    own ``run_migrations`` is itself idempotent, so a stale revision
+    that slips through here will be upgraded on the next genuine
+    init call; the ensure fast-path stays cheap.
+    """
+    if not db_path.exists():
+        return False
+    import sqlite3
+
+    try:
+        con = sqlite3.connect(str(db_path))
+    except sqlite3.Error:
+        return False
+    try:
+        try:
+            row = con.execute(
+                "SELECT version_num FROM alembic_version"
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return False
+    finally:
+        con.close()
+    return row is not None and row[0] is not None
+
+
+# ---------------------------------------------------------------------------
+# Detached supervisor spawn
+# ---------------------------------------------------------------------------
+
+
+def _spawn_supervisor_detached(
+    *, project_root: Path, db_path: Path, mcp_only: bool
+) -> int:
+    """Spawn ``ctxr-fsm serve`` as a detached background process.
+
+    The supervisor runs in a new session (``start_new_session=True``)
+    so a SIGINT in the ensuring shell doesn't take it down. stdout +
+    stderr are redirected to a per-day log file under
+    ``<project_root>/.ctxr-fsm/logs/`` so a later operator can
+    inspect what happened during the cold start.
+
+    Returns the spawned pid (for the ensure summary; ownership is
+    transferred to the OS — the parent process is free to exit).
+    """
+    logs_dir = project_root / ".ctxr-fsm" / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_path = logs_dir / f"supervisor-{time.strftime('%Y%m%d')}.log"
+    log_fp = open(log_path, "ab", buffering=0)  # noqa: SIM115
+    cmd = [
+        sys.executable or "python3",
+        "-m",
+        "ctxr.fsm.cli",
+        "serve",
+        "--mode",
+        "dev",
+        "--db",
+        str(db_path),
+    ]
+    if mcp_only:
+        cmd.append("--mcp-only")
+
+    # ``sys.executable -m ctxr.fsm.cli`` is brittle if the package
+    # entry point isn't a module — fall back to the ``ctxr-fsm``
+    # console script when sys.executable isn't a usable Python.
+    if not sys.executable:
+        cmd = ["ctxr-fsm", "serve", "--mode", "dev", "--db", str(db_path)]
+        if mcp_only:
+            cmd.append("--mcp-only")
+
+    # Some environments don't expose the ``-m ctxr.fsm.cli`` module
+    # entry (the project ships only the ``ctxr-fsm`` console script).
+    # Probe ``ctxr-fsm`` on PATH first; if found, prefer it.
+    import shutil
+
+    binary = shutil.which("ctxr-fsm")
+    if binary is not None:
+        cmd = [binary, "serve", "--mode", "dev", "--db", str(db_path)]
+        if mcp_only:
+            cmd.append("--mcp-only")
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(project_root),
+        stdin=subprocess.DEVNULL,
+        stdout=log_fp,
+        stderr=log_fp,
+        start_new_session=True,
+        close_fds=True,
+    )
+    return proc.pid
+
+
+# ---------------------------------------------------------------------------
+# Pure ensure body (used by Typer command + tests + ensure --check)
+# ---------------------------------------------------------------------------
+
+
+def _subsystem_list(mode: str) -> tuple[str, ...]:
+    return ("mcp",) if mode == "mcp-only" else ("mcp", "api", "ui")
+
+
+def _wait_for_active_mcp(
+    project_root: Path, *, subsystems: tuple[str, ...], timeout: float
+) -> dict[str, Any] | None:
+    """Poll for ``active-mcp.json`` to include every required subsystem.
+
+    The supervisor writes the file once MCP's /healthz succeeds. We
+    additionally wait for each required subsystem's healthz to pass
+    so the returned URLs are guaranteed live (not "supervisor is
+    up but API hasn't finished migrating yet").
+
+    Returns the parsed document on success, ``None`` on timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        doc = read_active_mcp_file(project_root)
+        if doc is not None:
+            doc_subs = doc.get("subsystems", {})
+            if isinstance(doc_subs, dict) and all(s in doc_subs for s in subsystems):
+                # Probe each one's healthz where applicable.
+                all_ready = True
+                for sub in subsystems:
+                    block = doc_subs.get(sub, {})
+                    healthz = block.get("healthz_url") if isinstance(block, dict) else None
+                    if healthz is None:
+                        # UI has no healthz; pid liveness is the
+                        # signal. We already trust the supervisor's
+                        # write of the block.
+                        continue
+                    try:
+                        resp = httpx.get(healthz, timeout=1.0)
+                        if resp.status_code != 200:
+                            all_ready = False
+                            break
+                    except (httpx.HTTPError, OSError):
+                        all_ready = False
+                        break
+                if all_ready:
+                    return doc
+        time.sleep(_POLL_INTERVAL_S)
+    return None
+
+
+def run_ensure(
+    *,
+    project_root: Path | None = None,
+    client: Literal["auto", "claude", "codex", "cursor", "none"] = "auto",
+    mode: Literal["full", "mcp-only"] = "full",
+    no_memory: bool = False,
+    no_mcp_config: bool = False,
+    check: bool = False,
+    timeout: float = 15.0,
+) -> dict[str, Any]:
+    """Run the ensure pipeline and return the JSON-shaped summary.
+
+    Pure (non-printing) entry point so tests and ``ctxr-fsm ensure``
+    share one body. See the module docstring for the full algorithm.
+
+    The returned dict matches the schema documented in the W14b brief:
+    ``status / project_root / duration_ms / actions / subsystems``
+    + ``mcp_stdio_registered`` (list of client labels).
+    """
+    started_at = time.monotonic()
+    root = _resolve_project_root(project_root)
+    db_path = root / ".ctxr-fsm" / "fsm.db"
+    required = _subsystem_list(mode)
+
+    actions: dict[str, str] = {
+        "init": "skipped",
+        "memory": "skipped",
+        "mcp_config": "skipped",
+        "supervisor": "skipped",
+    }
+    mcp_stdio_registered: list[str] = []
+    spawn_pid: int | None = None
+    failure_detail: str | None = None
+
+    # ---- Step 1: init ----------------------------------------------
+    init_needed = not db_path.exists() or not _alembic_at_head(db_path)
+    if init_needed:
+        if check:
+            actions["init"] = "missing"
+        else:
+            run_init(db_path=db_path, no_memory=True, cwd=root)
+            actions["init"] = "applied"
+    else:
+        actions["init"] = "current"
+
+    # ---- Step 2: memory --------------------------------------------
+    if no_memory:
+        actions["memory"] = "skipped"
+    elif check:
+        actions["memory"] = (
+            "current" if not init_needed else "missing"
+        )
+    else:
+        try:
+            mem_result = run_install_memory(target=root, client=client)
+            # If every per-client result was a "noop", that counts as
+            # current rather than applied.
+            results = mem_result.get("results", [])
+            if results and all(r.get("action") == "noop" for r in results):
+                actions["memory"] = "current"
+            else:
+                actions["memory"] = "applied"
+        except Exception as exc:
+            actions["memory"] = "failed"
+            failure_detail = f"memory installer: {type(exc).__name__}: {exc}"
+
+    # ---- Step 3: mcp_config ----------------------------------------
+    if no_mcp_config or client == "none":
+        actions["mcp_config"] = "skipped"
+    elif check:
+        probe = run_install_mcp(target_dir=root, client=client, check=True)
+        statuses = [
+            r.get("status")
+            for r in probe.get("results", [])
+            if "status" in r
+        ]
+        if not statuses or all(s == "installed" for s in statuses):
+            actions["mcp_config"] = "current"
+        else:
+            actions["mcp_config"] = "missing"
+        mcp_stdio_registered = [
+            r["client"] for r in probe.get("results", [])
+            if r.get("status") == "installed"
+        ]
+    else:
+        try:
+            mcp_result = run_install_mcp(target_dir=root, client=client)
+            results = mcp_result.get("results", [])
+            applied_any = any(
+                r.get("action") in ("applied", "would-apply") for r in results
+            )
+            unchanged_all = bool(results) and all(
+                r.get("action") == "unchanged" for r in results
+            )
+            if applied_any:
+                actions["mcp_config"] = "applied"
+            elif unchanged_all:
+                actions["mcp_config"] = "unchanged"
+            elif not results:
+                actions["mcp_config"] = "skipped"
+            else:
+                actions["mcp_config"] = "applied"
+            # Every successful or unchanged result counts as registered.
+            mcp_stdio_registered = [
+                r["client"]
+                for r in results
+                if r.get("action") in ("applied", "unchanged")
+            ]
+        except Exception as exc:
+            actions["mcp_config"] = "failed"
+            failure_detail = f"mcp install: {type(exc).__name__}: {exc}"
+
+    # ---- Step 4: supervisor ----------------------------------------
+    # Probe what's up.
+    pre_state: dict[str, tuple[bool, int | None, str | None]] = {
+        sub: _probe_subsystem_alive(sub, root) for sub in required
+    }
+    all_up = all(alive for alive, _, _ in pre_state.values())
+
+    if all_up:
+        actions["supervisor"] = "reused"
+    elif check:
+        actions["supervisor"] = "missing"
+    else:
+        # Spawn a single supervisor that boots whatever is missing.
+        spawn_pid = _spawn_supervisor_detached(
+            project_root=root, db_path=db_path, mcp_only=(mode == "mcp-only")
+        )
+        # Wait for the discovery file + healthz of every required
+        # subsystem.
+        doc = _wait_for_active_mcp(root, subsystems=required, timeout=timeout)
+        if doc is None:
+            actions["supervisor"] = "failed"
+            failure_detail = (
+                f"supervisor did not produce a healthy active-mcp.json "
+                f"within {timeout:.1f}s (pid={spawn_pid})"
+            )
+        else:
+            actions["supervisor"] = "spawned"
+
+    # ---- Step 5: read discovery file -------------------------------
+    doc = read_active_mcp_file(root)
+    subsystems_payload: dict[str, Any] = {}
+    if doc is not None:
+        doc_subs = doc.get("subsystems", {})
+        if isinstance(doc_subs, dict):
+            for sub in required:
+                block = doc_subs.get(sub)
+                if isinstance(block, dict):
+                    sub_status: str
+                    if not check:
+                        # Spawned this run? Otherwise reused.
+                        if actions["supervisor"] == "spawned":
+                            sub_status = "spawned"
+                        elif actions["supervisor"] == "reused":
+                            sub_status = "reused"
+                        elif actions["supervisor"] == "failed":
+                            sub_status = "failed"
+                        else:
+                            sub_status = "ready"
+                    else:
+                        sub_status = "ready" if pre_state[sub][0] else "missing"
+                    subsystems_payload[sub] = {
+                        "http_url": block.get("http_url"),
+                        "healthz_url": block.get("healthz_url"),
+                        "pid": block.get("pid"),
+                        "status": sub_status,
+                    }
+                    if "docs_url" in block:
+                        subsystems_payload[sub]["docs_url"] = block["docs_url"]
+
+    # ---- Final status -----------------------------------------------
+    status: str
+    if failure_detail is not None:
+        status = "failed"
+    elif check:
+        missing_pieces: list[str] = []
+        if actions["init"] == "missing":
+            missing_pieces.append("init")
+        if actions["memory"] == "missing":
+            missing_pieces.append("memory")
+        if actions["mcp_config"] == "missing":
+            missing_pieces.append("mcp-config")
+        if actions["supervisor"] == "missing":
+            missing_pieces.append("supervisor")
+        status = (
+            "missing:" + ",".join(missing_pieces) if missing_pieces else "ready"
+        )
+    else:
+        # Did all required subsystems report ready/spawned/reused?
+        ok = all(
+            subsystems_payload.get(s, {}).get("status")
+            in ("ready", "spawned", "reused")
+            for s in required
+        )
+        status = "ready" if ok else "degraded"
+
+    duration_ms = int((time.monotonic() - started_at) * 1000)
+
+    summary: dict[str, Any] = {
+        "status": status,
+        "project_root": str(root),
+        "duration_ms": duration_ms,
+        "actions": actions,
+        "mcp_stdio_registered": mcp_stdio_registered,
+        "subsystems": subsystems_payload,
+    }
+    if spawn_pid is not None:
+        summary["spawned_supervisor_pid"] = spawn_pid
+    if failure_detail is not None:
+        summary["failure_detail"] = failure_detail
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Typer entry point
+# ---------------------------------------------------------------------------
+
+
+def _json_default() -> bool:
+    """Default the --json flag to True when stdout is not a TTY.
+
+    Skills consume the ensure output programmatically; defaulting to
+    JSON on a pipe avoids forcing every caller to remember
+    ``--json``. Interactive terminals get the pretty-printed default.
+    """
+    try:
+        return not sys.stdout.isatty()
+    except Exception:
+        return True
+
+
+def ensure(
+    project_root: Path | None = typer.Option(  # noqa: B008 — typer sentinel
+        None,
+        "--project-root",
+        help=(
+            "Project root to ensure. Defaults to walk-up from the "
+            "current directory looking for .ctxr-fsm/; falls back to "
+            "cwd when no ancestor matches."
+        ),
+        resolve_path=True,
+    ),
+    client: str = typer.Option(
+        "auto",
+        "--client",
+        help=(
+            "MCP client config(s) to register against: 'auto' (detect "
+            "every matching client config in the project + user), "
+            "'claude', 'codex', 'cursor', or 'none' (skip)."
+        ),
+    ),
+    mode: str = typer.Option(
+        "full",
+        "--mode",
+        help=(
+            "Bootstrap scope: 'full' (MCP + API + UI; default) or "
+            "'mcp-only' (just the MCP server; useful for headless CI)."
+        ),
+    ),
+    no_memory: bool = typer.Option(
+        False,
+        "--no-memory",
+        help="Skip the install-memory step (CLAUDE.md / AGENTS.md patches).",
+    ),
+    no_mcp_config: bool = typer.Option(
+        False,
+        "--no-mcp-config",
+        help=(
+            "Skip the install-mcp step (mostly for tests; rarely "
+            "user-facing)."
+        ),
+    ),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help=(
+            "Read-only probe: report per-step status without taking "
+            "action; never spawns processes; never mutates files."
+        ),
+    ),
+    timeout: float = typer.Option(
+        15.0,
+        "--timeout",
+        help=(
+            "Wall-clock seconds the ensure command waits for the "
+            "supervisor's healthz before returning status='failed'. "
+            "Default 15s covers a cold uv-run + FastMCP import graph."
+        ),
+        min=1.0,
+        max=300.0,
+    ),
+    json_mode: bool | None = typer.Option(
+        None,
+        "--json/--no-json",
+        help=(
+            "Force JSON or pretty-printed output. Default: JSON when "
+            "stdout is not a TTY, pretty otherwise."
+        ),
+    ),
+) -> None:
+    """Ensure the project is fully bootstrapped + the supervisor is up.
+
+    One-shot, idempotent, fast on the warm path (<500ms). See the
+    module docstring for the full algorithm.
+    """
+    if client not in _CLIENT_CHOICES:
+        raise typer.BadParameter(
+            f"--client must be one of {_CLIENT_CHOICES!r} (got {client!r})"
+        )
+    if mode not in _MODE_CHOICES:
+        raise typer.BadParameter(
+            f"--mode must be one of {_MODE_CHOICES!r} (got {mode!r})"
+        )
+
+    effective_json = _json_default() if json_mode is None else json_mode
+    summary = run_ensure(
+        project_root=project_root,
+        client=client,  # type: ignore[arg-type]
+        mode=mode,  # type: ignore[arg-type]
+        no_memory=no_memory,
+        no_mcp_config=no_mcp_config,
+        check=check,
+        timeout=timeout,
+    )
+    json_or_pretty(summary, effective_json)
+
+    # Exit non-zero on a failed run so wrapping scripts can react.
+    status = summary.get("status", "")
+    if isinstance(status, str) and (status == "failed" or status == "degraded"):
+        raise typer.Exit(1)
+    if check and isinstance(status, str) and status.startswith("missing:"):
+        raise typer.Exit(1)
+
+

--- a/ctxr/fsm/cli/ensure_cmd.py
+++ b/ctxr/fsm/cli/ensure_cmd.py
@@ -54,7 +54,10 @@ import typer
 from ctxr.fsm.cli._common import json_or_pretty
 from ctxr.fsm.cli.init_cmd import run_init
 from ctxr.fsm.cli.install_mcp_cmd import run_install_mcp
-from ctxr.fsm.cli.install_memory_cmd import run_install_memory
+from ctxr.fsm.cli.install_memory_cmd import (
+    run_install_memory,
+    run_install_memory_check,
+)
 from ctxr.fsm.cli.lifecycle.primitives import (
     pid_is_alive,
     read_active_mcp_file,
@@ -211,41 +214,31 @@ def _spawn_supervisor_detached(
     Returns the spawned pid (for the ensure summary; ownership is
     transferred to the OS — the parent process is free to exit).
     """
+    import shutil
+
     logs_dir = project_root / ".ctxr-fsm" / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     log_path = logs_dir / f"supervisor-{time.strftime('%Y%m%d')}.log"
     log_fp = open(log_path, "ab", buffering=0)  # noqa: SIM115
-    cmd = [
-        sys.executable or "python3",
-        "-m",
-        "ctxr.fsm.cli",
-        "serve",
-        "--mode",
-        "dev",
-        "--db",
-        str(db_path),
-    ]
+
+    # Single resolution path: rely on the ``ctxr-fsm`` console script
+    # the project's pyproject.toml ships. The previous code had a
+    # ``[sys.executable, "-m", "ctxr.fsm.cli", ...]`` construction as
+    # a "fallback" but the package has no ``__main__.py`` under
+    # ``ctxr.fsm.cli`` — the module form would fail with "No module
+    # named ctxr.fsm.cli.__main__", confusing operators in the rare
+    # case that the console script is genuinely missing. We surface
+    # that case as a clear MissingRequirement-style error instead.
+    binary = shutil.which("ctxr-fsm")
+    if binary is None:
+        raise RuntimeError(
+            "ctxr-fsm console script not found on PATH; install the "
+            "package with `uv add ctxr-fsm` / `pipx install ctxr-fsm` / "
+            "`pip install --user ctxr-fsm` and re-run."
+        )
+    cmd = [binary, "serve", "--mode", "dev", "--db", str(db_path)]
     if mcp_only:
         cmd.append("--mcp-only")
-
-    # ``sys.executable -m ctxr.fsm.cli`` is brittle if the package
-    # entry point isn't a module — fall back to the ``ctxr-fsm``
-    # console script when sys.executable isn't a usable Python.
-    if not sys.executable:
-        cmd = ["ctxr-fsm", "serve", "--mode", "dev", "--db", str(db_path)]
-        if mcp_only:
-            cmd.append("--mcp-only")
-
-    # Some environments don't expose the ``-m ctxr.fsm.cli`` module
-    # entry (the project ships only the ``ctxr-fsm`` console script).
-    # Probe ``ctxr-fsm`` on PATH first; if found, prefer it.
-    import shutil
-
-    binary = shutil.which("ctxr-fsm")
-    if binary is not None:
-        cmd = [binary, "serve", "--mode", "dev", "--db", str(db_path)]
-        if mcp_only:
-            cmd.append("--mcp-only")
 
     proc = subprocess.Popen(
         cmd,
@@ -356,18 +349,44 @@ def run_ensure(
         actions["init"] = "current"
 
     # ---- Step 2: memory --------------------------------------------
-    if no_memory:
+    # ``client == "none"`` short-circuits memory too (mirrors the
+    # mcp_config branch). install_memory's _CLIENT_CHOICES does NOT
+    # accept ``"none"`` (it has no equivalent of --no-mcp-config), so
+    # calling it would raise typer.BadParameter and the catch-all
+    # below would flip the whole ensure status to ``failed`` for what
+    # is actually a "the user asked to skip" path.
+    if no_memory or client == "none":
         actions["memory"] = "skipped"
     elif check:
-        actions["memory"] = (
-            "current" if not init_needed else "missing"
-        )
+        # Delegate to install_memory's pure --check probe so we report
+        # the actual on-disk memory state rather than the
+        # ``init_needed`` heuristic. Previously a project where init
+        # had run but the AI-client memory files had been deleted
+        # would silently report ``current``; now the per-client probe
+        # surfaces the drift via the rows' ``status`` field.
+        try:
+            mem_probe = run_install_memory_check(target=root, client=client)
+        except Exception as exc:
+            actions["memory"] = "failed"
+            failure_detail = f"memory check: {type(exc).__name__}: {exc}"
+        else:
+            mem_results = mem_probe.get("results", [])
+            statuses = [r.get("status") for r in mem_results if "status" in r]
+            if not statuses:
+                # No client detected at all — neither current nor
+                # missing applies; report skipped so the top-level
+                # status surfaces the upstream missing_init / etc.
+                actions["memory"] = "skipped"
+            elif all(s == "ok" for s in statuses):
+                actions["memory"] = "current"
+            else:
+                actions["memory"] = "missing"
     else:
         try:
             mem_result = run_install_memory(target=root, client=client)
             # If every per-client result was a "noop", that counts as
             # current rather than applied.
-            results = mem_result.get("results", [])
+            results = mem_result.get("results", []) if isinstance(mem_result, dict) else []
             if results and all(r.get("action") == "noop" for r in results):
                 actions["memory"] = "current"
             else:

--- a/ctxr/fsm/cli/init_cmd.py
+++ b/ctxr/fsm/cli/init_cmd.py
@@ -42,7 +42,7 @@ from ctxr.fsm.cli._common import (
 )
 from ctxr.fsm.sqlite.project import run_migrations
 
-__all__ = ["init"]
+__all__ = ["init", "run_init"]
 
 
 _GITIGNORE_ENTRY: str = ".ctxr-fsm/"
@@ -110,6 +110,73 @@ def _read_alembic_revision(db_path: Path) -> str | None:
     return str(row[0])
 
 
+def run_init(
+    *,
+    db_path: Path,
+    no_memory: bool = False,
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    """Pure (non-printing) core of ``ctxr-fsm init``.
+
+    Used both by the Typer command :func:`init` and by
+    ``ctxr-fsm ensure`` (W14b), which calls this directly so the
+    bootstrap pipeline can compose init + install-memory +
+    install-mcp + supervisor into a single per-call summary.
+
+    Parameters
+    ----------
+    db_path:
+        Concrete SQLite DB path. The caller resolved it via
+        :func:`resolve_db_path` (no env-var or precedence work
+        happens here).
+    no_memory:
+        When ``True``, skip the W11 memory installer call (matches
+        the CLI ``--no-memory`` flag).
+    cwd:
+        Directory used for the ``.gitignore`` check + memory
+        installer target. Defaults to :func:`Path.cwd`. The ensure
+        command passes the resolved project root explicitly so a
+        deeper invocation cwd doesn't end up patching the wrong tree.
+    """
+    project_dir = db_path.parent
+    project_dir.mkdir(parents=True, exist_ok=True)
+    pids_dir = project_dir / "pids"
+    pids_dir.mkdir(parents=True, exist_ok=True)
+
+    run_migrations(db_path)
+
+    effective_cwd = cwd if cwd is not None else Path.cwd()
+    gitignore_updated = False
+    if (effective_cwd / ".git").is_dir():
+        gitignore_updated = _ensure_gitignore_entry(effective_cwd)
+
+    revision = _read_alembic_revision(db_path)
+
+    memory_installer: dict[str, Any] | str
+    if no_memory:
+        memory_installer = "skipped (--no-memory)"
+    else:
+        try:
+            from ctxr.fsm.cli.install_memory_cmd import run_install_memory
+
+            memory_installer = run_install_memory(
+                target=effective_cwd, client="auto"
+            )
+        except Exception as exc:
+            memory_installer = f"failed: {type(exc).__name__}: {exc}"
+
+    return {
+        "db_path": str(db_path),
+        "project_dir": str(project_dir),
+        "pids_dir": str(pids_dir),
+        "alembic_revision": revision,
+        "gitignore_updated": gitignore_updated,
+        "ports_json": str(project_dir / "ports.json")
+        + " (placeholder — populated by the serve subcommand in W7)",
+        "memory_installer": memory_installer,
+    }
+
+
 def init(
     db: Path | None = DB_OPTION,
     json_mode: bool = JSON_OPTION,
@@ -134,65 +201,5 @@ def init(
     Finishes by printing a summary.
     """
     db_path = resolve_db_path(db)
-    project_dir = db_path.parent
-    project_dir.mkdir(parents=True, exist_ok=True)
-    pids_dir = project_dir / "pids"
-    pids_dir.mkdir(parents=True, exist_ok=True)
-
-    # Run migrations directly — never via subprocess. ``run_migrations``
-    # handles the env-var dance so the alembic env.py picks up the
-    # right URL.
-    run_migrations(db_path)
-
-    cwd = Path.cwd()
-    gitignore_updated = False
-    if (cwd / ".git").is_dir():
-        gitignore_updated = _ensure_gitignore_entry(cwd)
-
-    revision = _read_alembic_revision(db_path)
-
-    # ---- Memory installer (W11) ----------------------------------
-    #
-    # We invoke the in-process function (not the CLI command) so any
-    # side effects happen in the same Python process and we don't need
-    # to spawn a subprocess. Auto-detect mode is the right default —
-    # it patches CLAUDE.md / AGENTS.md / .cursor/rules/ only if those
-    # files exist, leaving a project with none of them untouched.
-    #
-    # We catch broad exceptions so a failed memory install never
-    # bricks ``ctxr-fsm init``; the summary surfaces the error so the
-    # operator can re-run ``ctxr-fsm install-memory`` directly to see
-    # the full traceback.
-    memory_installer: dict[str, Any] | str
-    if no_memory:
-        memory_installer = "skipped (--no-memory)"
-    else:
-        try:
-            # Local import to keep ``init`` startup cheap when
-            # ``--no-memory`` is passed — and to avoid a hard import
-            # cycle if the install-memory module ever wants to import
-            # init helpers.
-            from ctxr.fsm.cli.install_memory_cmd import run_install_memory
-
-            # ``run_install_memory`` is the non-printing core of
-            # ``install-memory``; we embed its summary as a sub-field
-            # so init's own JSON output remains a single valid
-            # document.
-            memory_installer = run_install_memory(target=cwd, client="auto")
-        except Exception as exc:
-            # Surface failures as a field rather than crashing init —
-            # the operator can re-run ``ctxr-fsm install-memory`` to
-            # get the full traceback.
-            memory_installer = f"failed: {type(exc).__name__}: {exc}"
-
-    summary: dict[str, Any] = {
-        "db_path": str(db_path),
-        "project_dir": str(project_dir),
-        "pids_dir": str(pids_dir),
-        "alembic_revision": revision,
-        "gitignore_updated": gitignore_updated,
-        "ports_json": str(project_dir / "ports.json")
-        + " (placeholder — populated by the serve subcommand in W7)",
-        "memory_installer": memory_installer,
-    }
+    summary = run_init(db_path=db_path, no_memory=no_memory, cwd=Path.cwd())
     json_or_pretty(summary, json_mode)

--- a/ctxr/fsm/cli/install_mcp_cmd.py
+++ b/ctxr/fsm/cli/install_mcp_cmd.py
@@ -1,0 +1,823 @@
+"""``ctxr-fsm install-mcp`` — register ctxr-fsm as an MCP server in client configs.
+
+This command wires the ctxr-fsm stdio MCP entry into whichever AI-client
+config files we can find:
+
+* **Claude Code project-local** — ``<target>/.mcp.json`` (the
+  workspace-scoped MCP server map) and/or
+  ``<target>/.claude/settings.json`` (the project-scoped settings
+  block with an ``mcpServers`` key). Both are JSON and we only OWN
+  the ``mcpServers.ctxr-fsm`` key — every other top-level key and
+  every other server in ``mcpServers`` passes through unmodified.
+* **Codex user-level** — ``~/.codex/config.toml`` ``[mcp_servers.ctxr-fsm]``
+  table. We prefer ``codex mcp add`` when the ``codex`` binary is on
+  PATH; otherwise we hand-edit the TOML directly. Our table is the
+  only one we touch.
+* **Cursor user-level** — ``~/.cursor/mcp.json`` ``mcpServers.ctxr-fsm``.
+
+The stdio entry written is the same in every shape:
+
+* JSON: ``{"command":"ctxr-fsm","args":["mcp","--transport","stdio"],"env":{}}``
+* TOML: ``command = "ctxr-fsm"\\nargs = ["mcp", "--transport", "stdio"]``
+
+The MCP server learns its DB path at startup by walking up from the
+inherited cwd looking for ``.ctxr-fsm/`` (see ``ctxr.fsm.cli.mcp_cmd``
+— that walk-up is what makes the stdio entry portable across
+projects).
+
+Modes
+-----
+
+* ``run_install_mcp(target_dir, client="auto")`` — apply patches.
+* ``run_install_mcp(target_dir, client=..., check=True)`` — read-only
+  probe; returns ``status: installed|missing|out-of-date`` per detected
+  client.
+* ``run_install_mcp(target_dir, client=..., dry_run=True)`` — describe
+  the patches that would be written; no filesystem mutation.
+
+Idempotency
+-----------
+
+* If the existing on-disk file already contains an entry deep-equal to
+  ours, we do not rewrite the file at all (``action="unchanged"``).
+* Otherwise the merge preserves every other key verbatim, writes via
+  tmp+rename, and indents output to match the file's existing style
+  (2-space / 4-space / tab; defaults to 2-space when undetermined or
+  empty).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import typer
+
+from ctxr.fsm.cli._common import json_or_pretty
+
+__all__ = ["install_mcp", "run_install_mcp"]
+
+
+# ---------------------------------------------------------------------------
+# Constants — entry shape + supported clients
+# ---------------------------------------------------------------------------
+
+# Allowed values for the ``--client`` flag. ``auto`` is a meta-value
+# that fans out to every detected client. ``none`` short-circuits to a
+# no-op — useful for ``ctxr-fsm ensure --no-mcp-config`` plumbing.
+_CLIENT_CHOICES: tuple[str, ...] = ("auto", "claude", "codex", "cursor", "none")
+
+# The MCP entry's logical name as it appears in every client config.
+# Kept as a constant so a rename only touches one place + every
+# matching test can grep for the same literal.
+_ENTRY_NAME: str = "ctxr-fsm"
+
+# The stdio entry payload (JSON-shape). Codex's TOML emit is derived
+# from this dict so the two surfaces stay in lockstep.
+_STDIO_ENTRY_JSON: dict[str, Any] = {
+    "command": "ctxr-fsm",
+    "args": ["mcp", "--transport", "stdio"],
+    "env": {},
+}
+
+
+# ---------------------------------------------------------------------------
+# Indent detection (JSON files)
+# ---------------------------------------------------------------------------
+
+
+def _detect_indent(text: str) -> str:
+    """Return the indent unit used by the file's first nested line.
+
+    The merge path preserves whatever style the user already had so
+    a re-write does not balloon a diff with whitespace-only noise. We
+    look at the first line that begins with whitespace and try to
+    classify it:
+
+    * Starts with a tab → ``"\\t"``.
+    * Starts with N spaces (1 ≤ N ≤ 8) → ``"  "`` or ``"    "`` etc.
+    * Anything else (empty file, single-line JSON, unknown form) →
+      default to 2 spaces.
+
+    We deliberately default to 2-space rather than ``json.dumps``'s
+    default of "no indent / single line" so a fresh file we create
+    is human-readable straight away.
+    """
+    for line in text.splitlines():
+        if not line:
+            continue
+        if line[0] == "\t":
+            return "\t"
+        if line[0] == " ":
+            count = 0
+            for ch in line:
+                if ch != " ":
+                    break
+                count += 1
+            if 1 <= count <= 8:
+                return " " * count
+            return "  "
+    return "  "
+
+
+# ---------------------------------------------------------------------------
+# JSON read / merge / write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Atomic write via tmp + rename, ensuring trailing newline.
+
+    Same idiom as :func:`ctxr.fsm.cli.lifecycle.primitives._atomic_write_text`;
+    duplicated here to avoid pulling the lifecycle module into the
+    install path. Both files are stable enough that the drift cost is
+    near zero.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text if text.endswith("\n") else text + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _load_json_or_empty(path: Path) -> tuple[dict[str, Any], str | None]:
+    """Return ``(dict, original_text)``; both empty when file is missing.
+
+    A bare list / number / string at the JSON root is treated as a
+    malformed file for our purposes (we own a key inside an object
+    layer) and raises so the caller can surface a friendly error
+    rather than silently overwriting.
+    """
+    if not path.exists():
+        return {}, None
+    text = path.read_text(encoding="utf-8")
+    stripped = text.strip()
+    if not stripped:
+        return {}, text
+    try:
+        loaded = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{path} exists but is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(loaded, dict):
+        raise ValueError(
+            f"{path} top-level must be a JSON object; got {type(loaded).__name__}"
+        )
+    return loaded, text
+
+
+def _ensure_mcp_servers_block(
+    doc: dict[str, Any], *, source_path: Path
+) -> dict[str, Any]:
+    """Return ``doc['mcpServers']``, creating it as an empty dict if absent.
+
+    Refuses to overwrite a non-object ``mcpServers`` value: that
+    indicates the file was written by a different tool with a
+    different contract, and silently clobbering it would be a much
+    worse failure mode than a loud error. The brief explicitly calls
+    out this guard.
+    """
+    block = doc.get("mcpServers")
+    if block is None:
+        new_block: dict[str, Any] = {}
+        doc["mcpServers"] = new_block
+        return new_block
+    if not isinstance(block, dict):
+        raise ValueError(
+            f"{source_path}: 'mcpServers' must be a JSON object; "
+            f"got {type(block).__name__}. Aborting to avoid clobbering "
+            "the existing config."
+        )
+    return block
+
+
+def _merge_json_entry(
+    *, path: Path, dry_run: bool, check: bool
+) -> dict[str, Any]:
+    """JSON merger shared by Claude .mcp.json / Cursor mcp.json.
+
+    Returns a per-client outcome dict with keys:
+
+    * ``path`` — the file we read/wrote.
+    * ``action`` — one of ``applied`` | ``unchanged`` | ``would-apply`` |
+      ``would-create`` | ``check:installed`` | ``check:missing`` |
+      ``check:out-of-date``.
+    * ``status`` (check mode only) — same as the suffix of ``action``.
+    * ``detail`` — short human-readable note for diagnostics.
+    """
+    existing, original_text = _load_json_or_empty(path)
+    indent = _detect_indent(original_text or "")
+
+    existing_servers = (
+        _ensure_mcp_servers_block(existing, source_path=path)
+        if path.exists()
+        else {}
+    )
+    current_entry = existing_servers.get(_ENTRY_NAME)
+    desired_entry = dict(_STDIO_ENTRY_JSON)
+    is_installed = current_entry == desired_entry
+
+    if check:
+        if current_entry is None:
+            status = "missing"
+        elif is_installed:
+            status = "installed"
+        else:
+            status = "out-of-date"
+        return {
+            "path": str(path),
+            "action": f"check:{status}",
+            "status": status,
+            "detail": (
+                "entry matches desired stdio shape"
+                if status == "installed"
+                else "entry absent" if status == "missing"
+                else "entry present but differs from desired shape"
+            ),
+        }
+
+    if is_installed:
+        return {
+            "path": str(path),
+            "action": "unchanged",
+            "detail": "ctxr-fsm entry already matches; no write needed",
+        }
+
+    # Build the patched document for both dry-run preview + write.
+    patched = existing if path.exists() else {}
+    servers = (
+        _ensure_mcp_servers_block(patched, source_path=path)
+        if path.exists()
+        else {}
+    )
+    if not path.exists():
+        # Fresh file: single block, single entry.
+        patched = {"mcpServers": {_ENTRY_NAME: desired_entry}}
+        servers = patched["mcpServers"]
+    else:
+        servers[_ENTRY_NAME] = desired_entry
+        patched["mcpServers"] = servers
+
+    new_text = json.dumps(patched, indent=indent, sort_keys=False) + "\n"
+
+    if dry_run:
+        return {
+            "path": str(path),
+            "action": ("would-create" if not path.exists() else "would-apply"),
+            "detail": (
+                f"would write {len(new_text)} bytes "
+                f"({'create' if not path.exists() else 'update'})"
+            ),
+            "preview": new_text,
+        }
+
+    _atomic_write(path, new_text)
+    return {
+        "path": str(path),
+        "action": "applied",
+        "detail": "ctxr-fsm entry merged into mcpServers",
+    }
+
+
+# ---------------------------------------------------------------------------
+# TOML read / merge / write (Codex)
+# ---------------------------------------------------------------------------
+
+
+def _emit_codex_toml_block() -> str:
+    """Return the canonical ``[mcp_servers.ctxr-fsm]`` block as text.
+
+    Hand-rolled (rather than via ``tomli-w``) because we only own a
+    single, fixed-shape table with two string-array values; the cost
+    of a third-party write-dependency for this one case is not worth
+    it. The format we emit is the TOML canonical form (``key = ...``,
+    arrays bracketed, strings double-quoted).
+    """
+    # ``json.dumps`` is the easiest way to emit a JSON-style string
+    # array that also happens to be valid TOML for an array of
+    # quoted strings.
+    args_arr = json.dumps(_STDIO_ENTRY_JSON["args"])
+    return (
+        "[mcp_servers.ctxr-fsm]\n"
+        f'command = "{_STDIO_ENTRY_JSON["command"]}"\n'
+        f"args = {args_arr}\n"
+    )
+
+
+def _read_codex_toml(path: Path) -> dict[str, Any] | None:
+    """Return the parsed TOML doc, or ``None`` if absent.
+
+    Malformed TOML raises (caller surfaces a friendly error) so we
+    never silently overwrite hand-edited content we can't parse.
+    """
+    if not path.exists():
+        return None
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _codex_current_entry(doc: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Extract ``mcp_servers.ctxr-fsm`` from a parsed Codex doc."""
+    if doc is None:
+        return None
+    block = doc.get("mcp_servers")
+    if not isinstance(block, dict):
+        return None
+    entry = block.get(_ENTRY_NAME)
+    if isinstance(entry, dict):
+        return entry
+    return None
+
+
+def _codex_entry_matches_desired(entry: dict[str, Any] | None) -> bool:
+    """Compare an existing Codex TOML entry to the desired stdio shape.
+
+    We compare only the keys we own (``command`` and ``args``). Codex
+    users sometimes add their own ``env`` / ``cwd`` keys; preserving
+    those (rather than wiping them) is the polite default.
+    """
+    if entry is None:
+        return False
+    matches: bool = (
+        entry.get("command") == _STDIO_ENTRY_JSON["command"]
+        and entry.get("args") == _STDIO_ENTRY_JSON["args"]
+    )
+    return matches
+
+
+def _splice_codex_toml_block(*, original: str, new_block: str) -> str:
+    """Replace ``[mcp_servers.ctxr-fsm]`` in ``original`` with ``new_block``.
+
+    A minimal hand-rolled splicer that only touches our own table.
+    Algorithm:
+
+    1. Scan the file line by line.
+    2. Locate the ``[mcp_servers.ctxr-fsm]`` header.
+    3. Drop every line from that header up to (but not including) the
+       NEXT line that begins with ``[`` (the next table header) — that
+       is the slice of the document our table owns.
+    4. Insert ``new_block`` at the header's start position.
+    5. If the header was not present, append ``new_block`` to the END
+       of the file (preceded by a blank line if the file is non-empty
+       and doesn't already end with one).
+
+    The result preserves every other table, comment, and blank line.
+    """
+    header = "[mcp_servers.ctxr-fsm]"
+    lines = original.splitlines(keepends=True)
+    start_idx: int | None = None
+    end_idx: int | None = None
+    for i, line in enumerate(lines):
+        if line.strip() == header:
+            start_idx = i
+            # Find the next table header (any ``[...]`` at column 0).
+            for j in range(i + 1, len(lines)):
+                stripped = lines[j].lstrip()
+                if stripped.startswith("[") and not stripped.startswith("[["):
+                    # New table header. Backtrack over any
+                    # immediately-preceding blank lines so we don't
+                    # leave a double-blank where the table used to be.
+                    end_idx = j
+                    while end_idx > start_idx + 1 and lines[end_idx - 1].strip() == "":
+                        end_idx -= 1
+                    break
+            else:
+                end_idx = len(lines)
+            break
+
+    if start_idx is None:
+        # Append at the end. Pad with blank lines so the new table is
+        # visually separated from whatever ended the file.
+        prefix = original
+        if prefix and not prefix.endswith("\n"):
+            prefix += "\n"
+        if prefix.strip():
+            prefix += "\n"
+        return prefix + new_block
+
+    # Splice: keep [0:start_idx) + new block + [end_idx:).
+    head = "".join(lines[:start_idx])
+    tail = "".join(lines[end_idx or start_idx + 1 :])
+    return head + new_block + tail
+
+
+def _can_use_codex_cli() -> bool:
+    """``True`` iff the ``codex`` binary is on PATH.
+
+    Probed via :func:`shutil.which` so we never spawn the binary just
+    to see whether it exists. The CLI path is preferred because it
+    keeps Codex's own validation in the loop (the CLI rejects bad
+    args / writes the canonical TOML form).
+    """
+    return shutil.which("codex") is not None
+
+
+def _invoke_codex_cli_add(*, dry_run: bool) -> dict[str, Any]:
+    """Run ``codex mcp add ctxr-fsm -- ctxr-fsm mcp --transport stdio``.
+
+    Returns the same outcome dict shape JSON merger returns so callers
+    can treat both paths uniformly. ``dry_run`` short-circuits to a
+    "would-invoke" record without spawning Codex.
+    """
+    cmd = [
+        "codex",
+        "mcp",
+        "add",
+        _ENTRY_NAME,
+        "--",
+        "ctxr-fsm",
+        "mcp",
+        "--transport",
+        "stdio",
+    ]
+    if dry_run:
+        return {
+            "path": "~/.codex/config.toml",
+            "action": "would-apply",
+            "detail": f"would invoke: {' '.join(cmd)}",
+        }
+    res = subprocess.run(
+        cmd, capture_output=True, text=True, check=False
+    )
+    if res.returncode != 0:
+        return {
+            "path": "~/.codex/config.toml",
+            "action": "failed",
+            "detail": (
+                f"codex mcp add exited {res.returncode}: "
+                f"stdout={res.stdout!r} stderr={res.stderr!r}"
+            ),
+        }
+    return {
+        "path": "~/.codex/config.toml",
+        "action": "applied",
+        "detail": "codex mcp add succeeded",
+    }
+
+
+def _merge_codex_toml_direct(
+    *, path: Path, dry_run: bool, check: bool
+) -> dict[str, Any]:
+    """TOML merger fallback when the ``codex`` binary is absent."""
+    try:
+        existing_doc = _read_codex_toml(path)
+    except tomllib.TOMLDecodeError as exc:
+        return {
+            "path": str(path),
+            "action": "failed",
+            "detail": f"{path} exists but is not valid TOML: {exc}",
+        }
+
+    current_entry = _codex_current_entry(existing_doc)
+    matches = _codex_entry_matches_desired(current_entry)
+
+    if check:
+        if current_entry is None:
+            status = "missing"
+        elif matches:
+            status = "installed"
+        else:
+            status = "out-of-date"
+        return {
+            "path": str(path),
+            "action": f"check:{status}",
+            "status": status,
+            "detail": (
+                "entry matches desired stdio shape"
+                if status == "installed"
+                else "entry absent" if status == "missing"
+                else "entry present but differs from desired shape"
+            ),
+        }
+
+    if matches:
+        return {
+            "path": str(path),
+            "action": "unchanged",
+            "detail": "ctxr-fsm table already matches; no write needed",
+        }
+
+    original_text = path.read_text(encoding="utf-8") if path.exists() else ""
+    patched_text = _splice_codex_toml_block(
+        original=original_text, new_block=_emit_codex_toml_block()
+    )
+
+    if dry_run:
+        return {
+            "path": str(path),
+            "action": "would-create" if not path.exists() else "would-apply",
+            "detail": f"would write {len(patched_text)} bytes",
+            "preview": patched_text,
+        }
+
+    _atomic_write(path, patched_text)
+    return {
+        "path": str(path),
+        "action": "applied",
+        "detail": "ctxr-fsm TOML table spliced",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Client detection + dispatch
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ClientTask:
+    """One concrete (client, target_path) pair the dispatcher will act on."""
+
+    client: Literal["claude", "codex", "cursor"]
+    path: Path
+    # For Claude only: the workspace .mcp.json AND the settings.json
+    # block can BOTH be present; the dispatcher emits one task per
+    # path so the per-task report is still a single outcome dict.
+    label: str = ""
+
+    # Keep mypy happy with field()
+    _: tuple[()] = field(default=())
+
+
+def _claude_targets(target_dir: Path) -> list[Path]:
+    """Return the Claude config paths to act on.
+
+    Per the brief:
+
+    * ``<target_dir>/.mcp.json`` is preferred when it already exists OR
+      when ``target_dir`` looks like a workspace root (has ``.git/`` or
+      a ``CLAUDE.md``).
+    * ``<target_dir>/.claude/settings.json`` is also probed; if its
+      ``mcpServers`` block exists we also touch it.
+
+    Both are appended so a project that uses both surfaces stays in
+    sync. If neither exists and the dir doesn't look like a workspace,
+    we still default to ``.mcp.json`` (fresh-create) when the explicit
+    client is ``claude`` — the brief is explicit about this contract
+    for the "auto" path (workspace-root heuristic) and the "claude"
+    explicit path (always emit).
+    """
+    out: list[Path] = []
+    workspace_marker = (
+        (target_dir / ".git").exists() or (target_dir / "CLAUDE.md").exists()
+    )
+    mcp_json = target_dir / ".mcp.json"
+    if mcp_json.exists() or workspace_marker:
+        out.append(mcp_json)
+    settings_json = target_dir / ".claude" / "settings.json"
+    if settings_json.exists():
+        out.append(settings_json)
+    if not out:
+        # Caller asked us about Claude explicitly but neither file
+        # exists and the dir isn't obviously a workspace; fall back to
+        # the .mcp.json convention so a fresh-create still happens.
+        out.append(mcp_json)
+    return out
+
+
+def _cursor_target() -> Path:
+    """Return ``~/.cursor/mcp.json``.
+
+    Cursor's MCP config lives in the user home, not per-project.
+    """
+    return Path.home() / ".cursor" / "mcp.json"
+
+
+def _codex_target() -> Path:
+    """Return ``~/.codex/config.toml`` (Codex user-level config)."""
+    return Path.home() / ".codex" / "config.toml"
+
+
+def _resolve_tasks(target_dir: Path, client: str) -> list[_ClientTask]:
+    """Resolve the ``--client`` value into concrete (client, path) tasks.
+
+    ``auto`` probes each client and includes those whose config file
+    exists OR (for Claude) whose target dir is a workspace root.
+    Explicit names always emit a task even when the file is absent
+    (the merger will create it).
+    """
+    tasks: list[_ClientTask] = []
+
+    if client in ("auto", "claude"):
+        # Auto includes Claude only when SOMETHING points at it
+        # (existing file or workspace marker); explicit always emits.
+        if client == "claude":
+            for path in _claude_targets(target_dir):
+                tasks.append(_ClientTask(client="claude", path=path))
+        else:
+            workspace = (
+                (target_dir / ".git").exists()
+                or (target_dir / "CLAUDE.md").exists()
+            )
+            mcp_json = target_dir / ".mcp.json"
+            settings_json = target_dir / ".claude" / "settings.json"
+            if mcp_json.exists() or workspace:
+                tasks.append(_ClientTask(client="claude", path=mcp_json))
+            if settings_json.exists():
+                tasks.append(_ClientTask(client="claude", path=settings_json))
+
+    if client in ("auto", "codex"):
+        codex_path = _codex_target()
+        if client == "codex" or codex_path.exists():
+            tasks.append(_ClientTask(client="codex", path=codex_path))
+
+    if client in ("auto", "cursor"):
+        cursor_path = _cursor_target()
+        if client == "cursor" or cursor_path.exists():
+            tasks.append(_ClientTask(client="cursor", path=cursor_path))
+
+    return tasks
+
+
+def _dispatch_one(
+    task: _ClientTask, *, dry_run: bool, check: bool
+) -> dict[str, Any]:
+    """Run one task and return its outcome dict.
+
+    Dispatches by client kind: Claude + Cursor share the JSON merger;
+    Codex uses the CLI path when available and the TOML splicer
+    otherwise.
+    """
+    if task.client in ("claude", "cursor"):
+        try:
+            outcome = _merge_json_entry(
+                path=task.path, dry_run=dry_run, check=check
+            )
+        except ValueError as exc:
+            outcome = {
+                "path": str(task.path),
+                "action": "failed",
+                "detail": str(exc),
+            }
+        outcome["client"] = task.client
+        return outcome
+
+    # Codex.
+    if not check and not dry_run and _can_use_codex_cli():
+        outcome = _invoke_codex_cli_add(dry_run=False)
+        outcome["client"] = "codex"
+        return outcome
+    if dry_run and _can_use_codex_cli():
+        outcome = _invoke_codex_cli_add(dry_run=True)
+        outcome["client"] = "codex"
+        return outcome
+    outcome = _merge_codex_toml_direct(
+        path=task.path, dry_run=dry_run, check=check
+    )
+    outcome["client"] = "codex"
+    return outcome
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — used by both Typer command and ``ctxr-fsm ensure``
+# ---------------------------------------------------------------------------
+
+
+def run_install_mcp(
+    target_dir: Path,
+    client: Literal["auto", "claude", "codex", "cursor", "none"] = "auto",
+    dry_run: bool = False,
+    check: bool = False,
+) -> dict[str, Any]:
+    """Apply (or probe) the ctxr-fsm stdio MCP entry across detected clients.
+
+    Pure function: never prints, never raises typer.Exit — callers
+    layer that on top. Returns a JSON-serialisable summary dict::
+
+        {
+          "target": "/abs/path",
+          "client": "auto",
+          "dry_run": False,
+          "check": False,
+          "results": [
+            {"client": "claude", "path": "...", "action": "applied", ...},
+            ...
+          ],
+        }
+    """
+    if client not in _CLIENT_CHOICES:
+        raise ValueError(
+            f"client must be one of {_CLIENT_CHOICES!r}; got {client!r}"
+        )
+
+    target_dir = target_dir.expanduser().resolve()
+
+    summary: dict[str, Any] = {
+        "target": str(target_dir),
+        "client": client,
+        "dry_run": dry_run,
+        "check": check,
+        "results": [],
+    }
+
+    if client == "none":
+        summary["results"] = []
+        return summary
+
+    tasks = _resolve_tasks(target_dir, client)
+    if not tasks:
+        summary["results"] = []
+        summary["detail"] = (
+            "no client config files detected (looked for .mcp.json, "
+            ".claude/settings.json, ~/.codex/config.toml, ~/.cursor/mcp.json)"
+        )
+        return summary
+
+    results: list[dict[str, Any]] = []
+    for task in tasks:
+        results.append(_dispatch_one(task, dry_run=dry_run, check=check))
+    summary["results"] = results
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Typer entry point
+# ---------------------------------------------------------------------------
+
+
+def install_mcp(
+    target: Path | None = typer.Option(  # noqa: B008 — typer sentinel
+        None,
+        "--target",
+        help=(
+            "Directory containing project-local MCP client config "
+            "(.mcp.json, .claude/settings.json). Defaults to the "
+            "current working directory."
+        ),
+        resolve_path=True,
+    ),
+    client: str = typer.Option(
+        "auto",
+        "--client",
+        help=(
+            "Which MCP client config to patch: 'auto' (detect), 'claude', "
+            "'codex', 'cursor', or 'none' (no-op)."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Print the patches that would be written without touching "
+            "the filesystem."
+        ),
+    ),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help=(
+            "Read-only probe: report status per client without applying. "
+            "Exits non-zero if any client is missing or out-of-date."
+        ),
+    ),
+    json_mode: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of pretty-printed output.",
+    ),
+) -> None:
+    """Register ctxr-fsm as a stdio MCP server in detected client configs.
+
+    See the module docstring for the full per-client behaviour and
+    idempotency guarantees.
+    """
+    if client not in _CLIENT_CHOICES:
+        raise typer.BadParameter(
+            f"--client must be one of {', '.join(_CLIENT_CHOICES)}, "
+            f"got {client!r}"
+        )
+
+    resolved_target = (target if target is not None else Path.cwd()).resolve()
+
+    try:
+        # Typer narrows ``client`` at the str level; cast to the literal
+        # union the pure function expects without re-validating here.
+        summary = run_install_mcp(
+            target_dir=resolved_target,
+            client=client,  # type: ignore[arg-type]
+            dry_run=dry_run,
+            check=check,
+        )
+    except ValueError as exc:
+        # _resolve_tasks doesn't raise ValueError but the JSON parser
+        # underneath does on a malformed existing file. Surface that
+        # as a non-zero exit with a friendly stderr message.
+        sys.stderr.write(f"error: {exc}\n")
+        raise typer.Exit(1) from exc
+
+    json_or_pretty(summary, json_mode)
+
+    # In --check mode: exit non-zero if any client is missing /
+    # out-of-date so CI scripts can detect drift.
+    if check:
+        bad = [
+            r for r in summary.get("results", [])
+            if r.get("status") in ("missing", "out-of-date")
+        ]
+        if bad:
+            raise typer.Exit(1)

--- a/ctxr/fsm/cli/install_memory_cmd.py
+++ b/ctxr/fsm/cli/install_memory_cmd.py
@@ -78,7 +78,7 @@ import typer
 from ctxr.fsm.cli._common import json_or_pretty
 from ctxr.fsm.memory import get_principles_path
 
-__all__ = ["install_memory", "run_install_memory"]
+__all__ = ["install_memory", "run_install_memory", "run_install_memory_check"]
 
 
 # ---------------------------------------------------------------------------
@@ -719,6 +719,71 @@ def _diff_preview(old: str, new: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def run_install_memory_check(
+    *,
+    target: Path,
+    client: str = "auto",
+) -> dict[str, Any]:
+    """Programmatic ``install-memory --check`` probe.
+
+    Pure function returning a JSON-serialisable summary; intentionally
+    does NOT print, raise on drift, or call ``typer.Exit``. Callers
+    (notably ``ctxr-fsm ensure --check``) decide how to surface drift
+    by looking at each row's ``status`` field
+    (``"ok"`` / ``"out-of-date"`` / ``"missing"`` / ``"not-installed"``).
+    The Typer command :func:`install_memory` wraps this then prints
+    and exits non-zero when any row is out-of-date.
+
+    Returns ``{"target", "package_version", "results": [...]}``;
+    each result row has ``client``, ``host_file``, ``package_version``,
+    ``installed_version``, ``status``. When no clients are detected the
+    summary uses the same ``{"detected": [], "message": ...}`` shape
+    as :func:`run_install_memory`.
+
+    Raises :class:`typer.BadParameter` for an unknown client name (same
+    behaviour as the CLI surface).
+    """
+    if client not in _CLIENT_CHOICES:
+        raise typer.BadParameter(
+            f"--client must be one of {', '.join(_CLIENT_CHOICES)}, got {client!r}"
+        )
+
+    target = target.resolve()
+    detections = _detect_clients(target, client)
+
+    if not detections:
+        return {
+            "target": str(target),
+            "client": client,
+            "detected": [],
+            "message": (
+                "no AI-client memory files found "
+                "(looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md, "
+                ".cursor/rules/)"
+            ),
+        }
+
+    canonical_package_file = get_principles_path("canonical")
+    package_version = _parse_version(
+        canonical_package_file.read_text(encoding="utf-8")
+    )
+    rows = [_check_one(d, package_version) for d in detections]
+    return {
+        "target": str(target),
+        "package_version": package_version,
+        "results": [
+            {
+                "client": r.client,
+                "host_file": str(r.host_file) if r.host_file else None,
+                "package_version": r.package_version,
+                "installed_version": r.installed_version,
+                "status": r.status,
+            }
+            for r in rows
+        ],
+    }
+
+
 def run_install_memory(
     *,
     target: Path,
@@ -888,49 +953,15 @@ def install_memory(
     resolved_target: Path = (target if target is not None else Path.cwd()).resolve()
 
     if check:
-        # --check has its own report shape (per-client status rows) and
-        # an explicit non-zero exit when anything is out of date — keep
-        # its logic local rather than threading another mode through
-        # ``run_install_memory``.
-        detections = _detect_clients(resolved_target, client)
-        if not detections:
-            json_or_pretty(
-                {
-                    "target": str(resolved_target),
-                    "client": client,
-                    "detected": [],
-                    "message": (
-                        "no AI-client memory files found "
-                        "(looked for CLAUDE.md, .claude/CLAUDE.md, AGENTS.md, "
-                        ".cursor/rules/)"
-                    ),
-                },
-                json_mode,
-            )
-            return
-        canonical_package_file = get_principles_path("canonical")
-        package_version = _parse_version(
-            canonical_package_file.read_text(encoding="utf-8")
-        )
-        rows = [_check_one(d, package_version) for d in detections]
-        out_of_date = [r for r in rows if r.status in ("out-of-date", "missing")]
-        json_or_pretty(
-            {
-                "target": str(resolved_target),
-                "package_version": package_version,
-                "results": [
-                    {
-                        "client": r.client,
-                        "host_file": str(r.host_file) if r.host_file else None,
-                        "package_version": r.package_version,
-                        "installed_version": r.installed_version,
-                        "status": r.status,
-                    }
-                    for r in rows
-                ],
-            },
-            json_mode,
-        )
+        # Delegate to the programmatic probe so ``ctxr-fsm ensure --check``
+        # can call the same code path without going through Typer.
+        summary = run_install_memory_check(target=resolved_target, client=client)
+        json_or_pretty(summary, json_mode)
+        results = summary.get("results", [])
+        out_of_date = [
+            r for r in results
+            if r.get("status") in ("out-of-date", "missing")
+        ]
         if out_of_date:
             raise typer.Exit(1)
         return

--- a/ctxr/fsm/cli/lifecycle/primitives.py
+++ b/ctxr/fsm/cli/lifecycle/primitives.py
@@ -52,13 +52,18 @@ __all__ = [
     "PidLock",
     "ReusedSubsystem",
     "acquire_singleton",
+    "active_mcp_file_path",
+    "now_iso_ms",
     "pick_port",
     "pid_file_for",
     "pid_is_alive",
+    "read_active_mcp_file",
     "read_pid_file",
     "recall_port",
     "release_singleton",
+    "remember_active_mcp_file",
     "remember_port",
+    "remove_active_mcp_file",
     "write_active_run_marker",
     "write_pid_file",
 ]
@@ -81,6 +86,12 @@ _STATE_DIR_NAME: str = ".ctxr-fsm"
 _PORTS_FILE_NAME: str = "ports.json"
 _PIDS_DIR_NAME: str = "pids"
 _ACTIVE_RUN_FILE_NAME: str = "active-run.json"
+# W14c: discovery file the supervisor writes once its MCP child is
+# answering /healthz. Skills + ``ctxr-fsm ensure`` read it to find the
+# HTTP-SSE MCP URL when the stdio entry is not registered with the
+# active client yet. Removed on graceful supervisor shutdown so a stale
+# document never points a skill at a dead port.
+_ACTIVE_MCP_FILE_NAME: str = "active-mcp.json"
 
 
 def _state_dir(project_root: Path) -> Path:
@@ -137,6 +148,26 @@ def _now_iso() -> str:
     diff-friendly when a human inspects them.
     """
     return datetime.now(UTC).isoformat()
+
+
+def now_iso_ms() -> str:
+    """Return the current UTC time as ISO-8601 with millisecond precision.
+
+    Project convention (per the plan): every timestamp the FSM
+    substrate persists is ISO-8601 in UTC with millisecond precision so
+    cross-row sort is total and the printed form fits in a fixed
+    column. Python's :meth:`datetime.isoformat` defaults to microsecond
+    precision when a microsecond component is non-zero, so we truncate
+    explicitly to keep the surface stable.
+
+    Returned shape: ``"2026-05-29T12:34:56.789+00:00"``.
+    """
+    now = datetime.now(UTC)
+    # Truncate microseconds → milliseconds (Python's stdlib has no
+    # nicer hook). We multiply-then-int to round-down rather than risk
+    # banker's rounding on the boundary.
+    truncated_us = (now.microsecond // 1000) * 1000
+    return now.replace(microsecond=truncated_us).isoformat(timespec="milliseconds")
 
 
 # ---------------------------------------------------------------------------
@@ -484,6 +515,89 @@ def release_singleton(lock: PidLock, *, project_root: Path) -> None:
 # ---------------------------------------------------------------------------
 # Active-run marker
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Active-MCP discovery file (W14c)
+# ---------------------------------------------------------------------------
+
+
+def active_mcp_file_path(project_root: Path) -> Path:
+    """Return ``<project_root>/.ctxr-fsm/active-mcp.json`` (no I/O).
+
+    Pure path helper exposed so callers that want to ``stat()`` the
+    file or remove it manually (tests, ``ensure --check``) reach the
+    same location the writer uses without duplicating the constant.
+    We deliberately do NOT go through :func:`_state_dir` — that
+    helper has a side effect (``mkdir(exist_ok=True)``) which would
+    violate the "read-only probe" contract :func:`ensure --check`
+    relies on. The bare ``project_root / .ctxr-fsm / ...`` join is
+    semantically identical for reads.
+    """
+    return project_root / _STATE_DIR_NAME / _ACTIVE_MCP_FILE_NAME
+
+
+def remember_active_mcp_file(
+    payload: dict[str, Any], *, project_root: Path
+) -> None:
+    """Atomically write the supervisor's active-MCP discovery document.
+
+    Sole writer is the W7 supervisor, once its MCP child's ``/healthz``
+    is answering. The skill bootstrap discipline (W14e) tells agents to
+    parse this file when the stdio MCP entry is not registered with
+    the active client yet, so the contents MUST match the
+    documented schema:
+
+    ``{started_at, supervisor_pid, version, subsystems: {<name>:
+    {http_url, healthz_url, pid, docs_url?}}}``.
+
+    The write goes through :func:`_atomic_write_text` (tmp + rename)
+    so a concurrent reader either sees the previous document or the
+    new one in full — never a half-written file that JSON would
+    reject. ``_state_dir`` is called explicitly here (rather than via
+    :func:`active_mcp_file_path`) so the ``.ctxr-fsm/`` directory is
+    created on the write path even though the read-only path-helper
+    is now side-effect-free.
+    """
+    path = _state_dir(project_root) / _ACTIVE_MCP_FILE_NAME
+    _atomic_write_text(path, json.dumps(payload, sort_keys=True, indent=2))
+
+
+def read_active_mcp_file(project_root: Path) -> dict[str, Any] | None:
+    """Return the parsed active-MCP document, or ``None`` if absent / bad.
+
+    Mirror of :func:`read_pid_file`: missing file and malformed file
+    collapse to the same return value because every caller's natural
+    reaction in both cases is the same — "treat the supervisor as not
+    ready, fall through to a spawn-or-wait branch".
+    """
+    path = active_mcp_file_path(project_root)
+    if not path.exists():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    return loaded
+
+
+def remove_active_mcp_file(project_root: Path) -> None:
+    """Best-effort removal of the active-MCP discovery document.
+
+    Called by the supervisor's graceful shutdown path so a stopped
+    project never leaves a stale document pointing at a now-dead
+    port. ``FileNotFoundError`` is the post-condition we want
+    (file gone) so we swallow it; any other OSError surfaces as a
+    log line elsewhere — the supervisor is already shutting down
+    and a noisy crash would just confuse the operator.
+    """
+    path = active_mcp_file_path(project_root)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
 
 
 def write_active_run_marker(

--- a/ctxr/fsm/cli/lifecycle/supervisor.py
+++ b/ctxr/fsm/cli/lifecycle/supervisor.py
@@ -689,7 +689,6 @@ def _subsystem_payload(
     *,
     project_root: Path,
     port: int | None,
-    fallback_healthz: bool,
 ) -> dict[str, Any] | None:
     """Build the per-subsystem block for ``active-mcp.json`` or None.
 
@@ -722,9 +721,12 @@ def _subsystem_payload(
     base_url = f"http://127.0.0.1:{port}"
     payload: dict[str, Any] = {
         "http_url": base_url + ("/sse" if name == "mcp" else ""),
-        "healthz_url": (
-            f"{base_url}/healthz" if (fallback_healthz or name != "ui") else None
-        ),
+        # UI has no /healthz route (Vite does not expose one); MCP and
+        # API both mount one. Encoded directly here rather than via a
+        # parameter — every caller previously passed the same value
+        # and the parameter name suggested optionality that did not
+        # exist.
+        "healthz_url": f"{base_url}/healthz" if name != "ui" else None,
         "pid": pid,
     }
     if name == "api":
@@ -771,18 +773,18 @@ def _publish_active_mcp_file(
 
     subsystems: dict[str, Any] = {}
     mcp_block = _subsystem_payload(
-        "mcp", project_root=project_root, port=ports.get("mcp"), fallback_healthz=False
+        "mcp", project_root=project_root, port=ports.get("mcp")
     )
     if mcp_block is not None:
         subsystems["mcp"] = mcp_block
     api_block = _subsystem_payload(
-        "api", project_root=project_root, port=ports.get("api"), fallback_healthz=False
+        "api", project_root=project_root, port=ports.get("api")
     )
     if api_block is not None:
         subsystems["api"] = api_block
     if include_ui:
         ui_block = _subsystem_payload(
-            "ui", project_root=project_root, port=ports.get("ui"), fallback_healthz=False
+            "ui", project_root=project_root, port=ports.get("ui")
         )
         if ui_block is not None:
             subsystems["ui"] = ui_block

--- a/ctxr/fsm/cli/lifecycle/supervisor.py
+++ b/ctxr/fsm/cli/lifecycle/supervisor.py
@@ -73,7 +73,7 @@ import sys
 from contextlib import suppress
 from dataclasses import asdict
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import anyio
 import httpx
@@ -83,11 +83,15 @@ from ctxr.fsm.cli.lifecycle.primitives import (
     PidLock,
     ReusedSubsystem,
     acquire_singleton,
+    now_iso_ms,
     pick_port,
     pid_file_for,
+    read_pid_file,
     recall_port,
     release_singleton,
+    remember_active_mcp_file,
     remember_port,
+    remove_active_mcp_file,
     write_pid_file,
 )
 from ctxr.fsm.sqlite.drift import (
@@ -415,16 +419,23 @@ async def _boot_subsystem(
     db_path: Path | None,
     task_group: anyio.abc.TaskGroup,
     is_ui: bool = False,
-) -> tuple[PidLock | None, int | None, anyio.abc.Process | None]:
+) -> tuple[PidLock | None, int | None, anyio.abc.Process | None, bool]:
     """Acquire the singleton for ``name`` and (maybe) spawn the child.
 
-    Returns ``(lock, port, proc)`` where any element may be ``None``:
+    Returns ``(lock, port, proc, healthz_ok)`` where any element except
+    ``healthz_ok`` may be ``None``:
 
     * ``lock is None`` when :func:`acquire_singleton` returned a
       :class:`ReusedSubsystem` — we skipped spawning entirely.
     * ``proc is None`` likewise indicates "reuse" (no child of ours).
     * ``port`` is the bound port whether we spawned or reused; the
       banner needs both cases.
+    * ``healthz_ok`` is ``True`` on the reuse path (the singleton
+      probe just succeeded) or whenever our own ``/healthz`` poll
+      returned 200. ``False`` for spawn paths where the probe ran out
+      its budget. UI children skip the probe entirely (Vite has no
+      ``/healthz``) and the value collapses to ``True`` so callers can
+      treat "no probe expected" as a non-failure.
 
     On the spawn path we:
 
@@ -447,12 +458,15 @@ async def _boot_subsystem(
         )
         # Even on reuse the operator wants the URL in the banner, so
         # we return the existing port (parsed back from the probe URL
-        # to avoid divergence with the live singleton).
+        # to avoid divergence with the live singleton). Reuse implies
+        # the singleton's own /healthz probe just succeeded, so the
+        # ``healthz_ok`` channel collapses to True without needing
+        # a second poll here.
         try:
             reused_port = int(acq.probe_url.rsplit(":", 1)[-1].rstrip("/"))
         except (ValueError, AttributeError):
             reused_port = port
-        return None, reused_port, None
+        return None, reused_port, None, True
 
     # Build the right command for this subsystem.
     if name == "mcp":
@@ -504,9 +518,10 @@ async def _boot_subsystem(
 
     # Health probe (best-effort). We only run it for HTTP children;
     # the UI's "ready" signal is Vite's banner, not a /healthz route.
+    healthz_ok = True
     if not is_ui:
-        ok = await _poll_healthz(probe_url)
-        if not ok:
+        healthz_ok = await _poll_healthz(probe_url)
+        if not healthz_ok:
             _log(
                 f"[ctxr-fsm supervisor] {name} did not answer /healthz within "
                 f"{_HEALTH_PROBE_BUDGET_SECONDS:.0f}s — continuing anyway."
@@ -516,7 +531,7 @@ async def _boot_subsystem(
     # the next restart prefers it.
     remember_port(name, port, project_root=project_root)
 
-    return acq, port, proc
+    return acq, port, proc, healthz_ok
 
 
 # ---------------------------------------------------------------------------
@@ -582,7 +597,7 @@ async def _reload_loop(
         # get the same health-probe + port-memory treatment as the
         # initial boot.
         for name in ("mcp", "api"):
-            new_lock, _new_port, new_proc = await _boot_subsystem(
+            new_lock, _new_port, new_proc, _ok = await _boot_subsystem(
                 name,
                 project_root=project_root,
                 db_path=db_path,
@@ -592,6 +607,14 @@ async def _reload_loop(
             locks[name] = new_lock
 
         _log("[ctxr-fsm supervisor] respawned mcp + api")
+
+        # After respawn the MCP child has a new pid + (possibly) port;
+        # rewrite the discovery file so any skill that just spawned a
+        # reader between drain and respawn does not latch onto the now-
+        # dead pid. We re-read the supervisor's pid files for the truth
+        # of which pid currently owns each subsystem (the reload above
+        # rewrote them via ``_record_child_pid``).
+        _publish_active_mcp_file_from_disk(project_root=project_root)
 
 
 # ---------------------------------------------------------------------------
@@ -657,6 +680,153 @@ async def _signal_scope(cancel_scope: anyio.CancelScope) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Active-MCP discovery file (W14c)
+# ---------------------------------------------------------------------------
+
+
+def _subsystem_payload(
+    name: str,
+    *,
+    project_root: Path,
+    port: int | None,
+    fallback_healthz: bool,
+) -> dict[str, Any] | None:
+    """Build the per-subsystem block for ``active-mcp.json`` or None.
+
+    Returns ``None`` when ``port`` is ``None`` (the subsystem was not
+    booted in this mode) so the caller can simply drop unset slots.
+
+    Healthz URL convention:
+
+    * MCP: ``http://127.0.0.1:<port>/healthz`` (FastMCP exposes one).
+    * API: ``http://127.0.0.1:<port>/healthz`` (FastAPI mount).
+    * UI: no /healthz — Vite has none. Field set to ``None`` so a
+      consumer that wants to probe falls through to its own waiter
+      (the UI's "ready" signal is the dev banner, not a route).
+
+    ``pid`` is read straight from the singleton pid file the supervisor
+    just rewrote with the child's pid (see ``_record_child_pid``).
+    Missing or malformed pid file leaves the field as ``None``;
+    consumers should treat that as "supervisor still booting".
+    """
+    if port is None:
+        return None
+    pid_path = pid_file_for(name, project_root=project_root)
+    pid_record = read_pid_file(pid_path)
+    pid: int | None = None
+    if pid_record is not None:
+        raw = pid_record.get("pid")
+        if isinstance(raw, int):
+            pid = raw
+
+    base_url = f"http://127.0.0.1:{port}"
+    payload: dict[str, Any] = {
+        "http_url": base_url + ("/sse" if name == "mcp" else ""),
+        "healthz_url": (
+            f"{base_url}/healthz" if (fallback_healthz or name != "ui") else None
+        ),
+        "pid": pid,
+    }
+    if name == "api":
+        # The API child mounts OpenAPI docs at ``/docs``; surfaced here
+        # so a browser-first consumer doesn't have to know the FastAPI
+        # default off by heart.
+        payload["docs_url"] = f"{base_url}/docs"
+    return payload
+
+
+def _publish_active_mcp_file(
+    *,
+    project_root: Path,
+    ports: dict[str, int | None],
+    include_ui: bool,
+) -> None:
+    """Write the W14c discovery document for the supervisor's current state.
+
+    Schema (per the plan):
+
+    .. code-block:: json
+
+        {
+          "started_at": "ISO-8601 UTC ms",
+          "supervisor_pid": 1234,
+          "version": "0.2.0",
+          "subsystems": {
+            "mcp": {"http_url": ..., "healthz_url": ..., "pid": 1},
+            "api": {"http_url": ..., "healthz_url": ..., "pid": 2,
+                     "docs_url": ...},
+            "ui":  {"http_url": ..., "healthz_url": null, "pid": 3}
+          }
+        }
+
+    Subsystems whose port is ``None`` are omitted (``--mcp-only`` runs
+    omit api + ui; prod mode omits ui). The MCP entry is always
+    present at call time because the publish call is gated on a
+    successful MCP healthz; this helper does not re-check.
+    """
+    # Lazy import to avoid pulling ``ctxr.fsm`` (which transitively
+    # imports the entire engine surface) at supervisor module-import
+    # time. ``ctxr-fsm --help`` should stay cheap.
+    from ctxr.fsm import __version__ as _pkg_version
+
+    subsystems: dict[str, Any] = {}
+    mcp_block = _subsystem_payload(
+        "mcp", project_root=project_root, port=ports.get("mcp"), fallback_healthz=False
+    )
+    if mcp_block is not None:
+        subsystems["mcp"] = mcp_block
+    api_block = _subsystem_payload(
+        "api", project_root=project_root, port=ports.get("api"), fallback_healthz=False
+    )
+    if api_block is not None:
+        subsystems["api"] = api_block
+    if include_ui:
+        ui_block = _subsystem_payload(
+            "ui", project_root=project_root, port=ports.get("ui"), fallback_healthz=False
+        )
+        if ui_block is not None:
+            subsystems["ui"] = ui_block
+
+    payload: dict[str, Any] = {
+        "started_at": now_iso_ms(),
+        "supervisor_pid": os.getpid(),
+        "version": _pkg_version,
+        "subsystems": subsystems,
+    }
+    remember_active_mcp_file(payload, project_root=project_root)
+
+
+def _publish_active_mcp_file_from_disk(*, project_root: Path) -> None:
+    """Re-publish ``active-mcp.json`` after a reload, reading ports from disk.
+
+    The reload loop's contract is "drain + respawn MCP + API, leave UI
+    alone". The fresh pids land in the singleton pid files via
+    ``_record_child_pid``, and the per-subsystem ports stay the same
+    (we ``remember_port`` after every spawn and the new spawn prefers
+    the remembered port). So a faithful "what's running right now"
+    document just needs to ask :func:`recall_port` for each subsystem
+    and let :func:`_subsystem_payload` walk the pid files.
+
+    If the MCP port can't be recalled (something pathological happened
+    during the reload), we skip the publish rather than write a
+    document with a missing critical key — better to keep the previous
+    document live than to lie about the state.
+    """
+    ports: dict[str, int | None] = {
+        "mcp": recall_port("mcp", project_root=project_root),
+        "api": recall_port("api", project_root=project_root),
+        "ui": recall_port("ui", project_root=project_root),
+    }
+    if ports["mcp"] is None:
+        return
+    _publish_active_mcp_file(
+        project_root=project_root,
+        ports=ports,
+        include_ui=ports["ui"] is not None,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Public entry points
 # ---------------------------------------------------------------------------
 
@@ -665,6 +835,7 @@ async def run_supervisor(
     mode: Literal["dev", "prod"] = "dev",
     db_path: Path | None = None,
     project_root: Path | None = None,
+    mcp_only: bool = False,
 ) -> None:
     """Boot the unified ``ctxr-fsm serve`` supervisor.
 
@@ -699,9 +870,13 @@ async def run_supervisor(
 
             # Boot order: API first so the UI child can see the API
             # port the moment Vite starts. MCP last because it has
-            # the slowest cold-start (FastMCP import graph).
-            for name in ("api", "mcp"):
-                lock, port, proc = await _boot_subsystem(
+            # the slowest cold-start (FastMCP import graph). When
+            # ``mcp_only`` is set we skip the API entirely (W14b's
+            # headless-CI path), leaving only MCP in the subsystem set.
+            mcp_healthz_ok = False
+            boot_order = ("mcp",) if mcp_only else ("api", "mcp")
+            for name in boot_order:
+                lock, port, proc, healthz_ok = await _boot_subsystem(
                     name,
                     project_root=project_root,
                     db_path=db_path,
@@ -710,9 +885,11 @@ async def run_supervisor(
                 children[name] = proc
                 locks[name] = lock
                 ports[name] = port
+                if name == "mcp":
+                    mcp_healthz_ok = healthz_ok
 
-            if mode == "dev":
-                lock, port, proc = await _boot_subsystem(
+            if mode == "dev" and not mcp_only:
+                lock, port, proc, _ok = await _boot_subsystem(
                     "ui",
                     project_root=project_root,
                     db_path=db_path,
@@ -722,6 +899,19 @@ async def run_supervisor(
                 children["ui"] = proc
                 locks["ui"] = lock
                 ports["ui"] = port
+
+            # W14c: publish ``.ctxr-fsm/active-mcp.json`` once the MCP
+            # child has answered /healthz. Skips the write when MCP
+            # never came up — pointing skills at a dead URL would just
+            # make their fallback path noisier. Includes whatever
+            # subsystems we actually booted (UI omitted in prod mode
+            # or mcp_only; API omitted in mcp_only).
+            if mcp_healthz_ok and ports["mcp"] is not None:
+                _publish_active_mcp_file(
+                    project_root=project_root,
+                    ports=ports,
+                    include_ui=(mode == "dev" and not mcp_only),
+                )
 
             # Banner. We render even-when-skipped URLs because the
             # operator's mental model is "here are the three things
@@ -790,16 +980,26 @@ async def run_supervisor(
             for _name, lock in locks.items():
                 if lock is not None:
                     release_singleton(lock, project_root=project_root)
+            # W14c: drop the discovery file so a later ``ensure`` /
+            # skill bootstrap doesn't try to talk to a stopped
+            # supervisor. Best-effort: a stray file is annoying, not
+            # broken (the healthz probes will fail anyway).
+            remove_active_mcp_file(project_root=project_root)
         _log("[ctxr-fsm supervisor] stopped.")
 
 
-def main(mode: str = "dev", db_path: Path | None = None) -> None:
+def main(
+    mode: str = "dev",
+    db_path: Path | None = None,
+    mcp_only: bool = False,
+) -> None:
     """Synchronous entry point for the Typer CLI.
 
     Validates ``mode`` against the documented set so we never pass an
     unknown literal into the async body (where the :class:`Literal`
     annotation would be silently lost at runtime). Any other parameter
-    is forwarded verbatim.
+    is forwarded verbatim. ``mcp_only=True`` makes the supervisor boot
+    ONLY the MCP child (W14b's headless-CI / ensure-mcp-only path).
     """
     if mode not in ("dev", "prod"):
         raise ValueError(f"mode must be 'dev' or 'prod' (got {mode!r})")
@@ -809,4 +1009,6 @@ def main(mode: str = "dev", db_path: Path | None = None) -> None:
     # call site stays type-safe without sprinkling ``cast`` at the
     # entry point.
     runner: Literal["dev", "prod"] = "prod" if mode == "prod" else "dev"
-    anyio.run(functools.partial(run_supervisor, runner, db_path, None))
+    anyio.run(
+        functools.partial(run_supervisor, runner, db_path, None, mcp_only)
+    )

--- a/ctxr/fsm/cli/serve_cmd.py
+++ b/ctxr/fsm/cli/serve_cmd.py
@@ -61,6 +61,16 @@ def serve(
             "operator's job (systemd, nohup, container PID 1)."
         ),
     ),
+    mcp_only: bool = typer.Option(
+        False,
+        "--mcp-only",
+        help=(
+            "Boot ONLY the MCP child; skip the API and UI subsystems. "
+            "Useful for headless CI and for ``ctxr-fsm ensure --mode "
+            "mcp-only``. The active-mcp.json discovery file still lands "
+            "with only the mcp block populated."
+        ),
+    ),
 ) -> None:
     """Run the unified ``ctxr-fsm serve`` supervisor.
 
@@ -86,4 +96,4 @@ def serve(
     # wraps :func:`anyio.run` around the async ``run_supervisor`` body
     # and handles the SIGINT/SIGTERM translation internally, so this
     # call only returns once every child has been drained.
-    main(mode=mode, db_path=db)
+    main(mode=mode, db_path=db, mcp_only=mcp_only)

--- a/ctxr/fsm/mcp/__init__.py
+++ b/ctxr/fsm/mcp/__init__.py
@@ -107,6 +107,42 @@ mcp: FastMCP = FastMCP(
 )
 
 
+# ----------------------------------------------------------------------
+# Health probe (W14c)
+# ----------------------------------------------------------------------
+#
+# FastMCP's HTTP-SSE transport runs under a Starlette app; we mount a
+# trivial ``/healthz`` route there so the W7 supervisor (and ``ctxr-fsm
+# ensure``) can probe the same liveness URL we expose on every other
+# subsystem. Without this the supervisor would never publish the
+# discovery file (``active-mcp.json`` only lands once MCP healthz hits
+# 200) and ensure would time out.
+#
+# Stdio transport has no HTTP surface; the route is harmless there
+# (FastMCP simply ignores custom_route registrations when the
+# transport is stdio).
+
+
+@mcp.custom_route("/healthz", methods=["GET"])  # type: ignore[untyped-decorator]
+async def _healthz(_request: object) -> object:  # pragma: no cover - trivial
+    """Return 200 OK; the W7 supervisor probes this to gate readiness.
+
+    Body is the same one-word ``"ok"`` the FastAPI side returns so a
+    grep across log lines doesn't have to special-case the MCP
+    subsystem. Starlette's PlainTextResponse is the lightest carrier;
+    we import lazily so a CLI invocation that never boots the HTTP
+    transport doesn't pay the import cost.
+
+    ``type: ignore[untyped-decorator]`` on the decorator: FastMCP's
+    ``custom_route`` is typed loosely (it accepts Any callable) and
+    mypy flags it as an untyped decorator. The body itself is fully
+    typed; the ignore is purely about FastMCP's decorator signature.
+    """
+    from starlette.responses import PlainTextResponse
+
+    return PlainTextResponse("ok", status_code=200)
+
+
 # Import the tools module for its decorator side effects. This must
 # happen AFTER ``mcp`` is constructed because the decorators reach for
 # the live instance. Local import to avoid the top-of-file cycle that

--- a/ctxr/fsm/mcp/server.py
+++ b/ctxr/fsm/mcp/server.py
@@ -84,6 +84,24 @@ _DEFAULT_DB_RELATIVE: Path = Path(".ctxr-fsm") / "fsm.db"
 _DB_ENV_VAR: str = "CTXR_FSM_DB"
 
 
+def _walk_up_for_state_dir(start: Path) -> Path | None:
+    """Return the nearest ancestor of ``start`` that contains ``.ctxr-fsm``.
+
+    Walk-up makes the stdio MCP entry portable across projects: the
+    client (Claude Code / Cursor / Codex) spawns ``ctxr-fsm mcp`` with
+    the user's CURRENT cwd, and we walk up to find the project root
+    even when the user is several directories deep. Returns ``None``
+    when no ancestor contains the marker, so the caller can fall back
+    to the cwd default (and surface a helpful "did you run init?"
+    error if the file is missing too).
+    """
+    current = start.resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".ctxr-fsm").is_dir():
+            return candidate
+    return None
+
+
 def resolve_db_path(db_opt: Path | None) -> Path:
     """Apply the project's layered precedence to produce a concrete DB path.
 
@@ -91,17 +109,32 @@ def resolve_db_path(db_opt: Path | None) -> Path:
 
     1. The explicit ``db_opt`` argument (e.g. ``--db``).
     2. ``$CTXR_FSM_DB`` from the process environment.
-    3. ``./.ctxr-fsm/fsm.db`` relative to the current working directory.
+    3. Walk up from the current working directory looking for an
+       ancestor that contains ``.ctxr-fsm/``; return that ancestor's
+       ``.ctxr-fsm/fsm.db``.
+    4. Fall back to ``./.ctxr-fsm/fsm.db`` relative to the current
+       working directory. This may not exist yet; the caller surfaces
+       a helpful "did you run ``ctxr-fsm init``?" error.
 
-    Identical contract to :func:`ctxr.fsm.cli._common.resolve_db_path`;
-    kept independent so the MCP package does not transitively depend on
-    the Typer-based CLI module.
+    The walk-up tier (step 3) is what makes the stdio MCP entry
+    portable across projects (W14d). A client (Claude Code, Cursor,
+    Codex) launches ``ctxr-fsm mcp`` with the user's CURRENT cwd
+    inherited; the walk-up finds the right project root even when the
+    user is several directories deep.
+
+    Identical contract to :func:`ctxr.fsm.cli._common.resolve_db_path`
+    (which also gained the walk-up tier); kept independent so the MCP
+    package does not transitively depend on the Typer-based CLI
+    module.
     """
     if db_opt is not None:
         return db_opt.expanduser().resolve()
     env_value = os.environ.get(_DB_ENV_VAR)
     if env_value:
         return Path(env_value).expanduser().resolve()
+    found_root = _walk_up_for_state_dir(Path.cwd())
+    if found_root is not None:
+        return (found_root / _DEFAULT_DB_RELATIVE).resolve()
     return (Path.cwd() / _DEFAULT_DB_RELATIVE).resolve()
 
 

--- a/tests/integration/bootstrap/test_ensure_check_mode.py
+++ b/tests/integration/bootstrap/test_ensure_check_mode.py
@@ -1,0 +1,75 @@
+"""``ctxr-fsm ensure --check`` is read-only (W14b).
+
+The check mode is the cheapest probe a skill can run: it must never
+spawn the supervisor, never mutate any file, and return per-step
+status in a single JSON document.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ctxr.fsm.cli.ensure_cmd import run_ensure
+
+
+def test_check_on_fresh_dir_reports_missing(tmp_path: Path) -> None:
+    """A fresh tmpdir with no .ctxr-fsm yet returns ``status: missing:...``.
+
+    Asserts:
+
+    * No ``.ctxr-fsm`` dir is created.
+    * No supervisor process is spawned (pids dir is empty).
+    * The summary lists ``init`` and ``supervisor`` as missing.
+    """
+    summary = run_ensure(
+        project_root=tmp_path,
+        client="none",
+        mode="full",
+        no_memory=True,
+        no_mcp_config=True,
+        check=True,
+        timeout=2.0,
+    )
+    assert summary["status"].startswith("missing:")
+    assert "init" in summary["status"]
+    assert "supervisor" in summary["status"]
+    assert summary["actions"]["init"] == "missing"
+    # mcp-config skipped because client=none.
+    assert summary["actions"]["mcp_config"] == "skipped"
+    # No filesystem mutation.
+    assert not (tmp_path / ".ctxr-fsm").exists()
+
+
+def test_check_is_fast(tmp_path: Path) -> None:
+    """Even on cold check the run completes in well under the user-facing budget.
+
+    1000ms is a generous CI threshold; the smoke run earlier showed
+    1ms locally. A check that exceeds this is almost certainly
+    accidentally spawning something.
+    """
+    summary = run_ensure(
+        project_root=tmp_path,
+        client="none",
+        mode="full",
+        no_memory=True,
+        no_mcp_config=True,
+        check=True,
+        timeout=2.0,
+    )
+    assert summary["duration_ms"] < 1000, summary
+
+
+def test_check_does_not_touch_pid_files(tmp_path: Path) -> None:
+    """Verify no pid files are created by --check."""
+    (tmp_path / ".ctxr-fsm" / "pids").mkdir(parents=True)
+    run_ensure(
+        project_root=tmp_path,
+        client="none",
+        mode="full",
+        no_memory=True,
+        no_mcp_config=True,
+        check=True,
+        timeout=2.0,
+    )
+    pids_dir = tmp_path / ".ctxr-fsm" / "pids"
+    assert list(pids_dir.iterdir()) == [], list(pids_dir.iterdir())

--- a/tests/integration/bootstrap/test_ensure_cli_surface.py
+++ b/tests/integration/bootstrap/test_ensure_cli_surface.py
@@ -1,0 +1,103 @@
+"""CLI-surface tests for ``ctxr-fsm ensure`` (W14b).
+
+Invokes the Typer command via ``uv run`` (subprocess) so the
+JSON-on-pipe default + the typer exit-code contract are observed
+end-to-end. The actual ensure pipeline is exercised in --check mode
+with all sub-steps skipped so the test stays fast (no supervisor
+spawn, no real init).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def _run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["uv", "run", "ctxr-fsm", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_json_is_default_when_stdout_is_a_pipe() -> None:
+    """Stdout-not-a-TTY (subprocess.PIPE) → emit JSON without explicit ``--json``.
+
+    Skills consuming ensure parse stdout as JSON; defaulting to JSON
+    on a pipe is what makes "ensure --check" → ``json.loads(...)``
+    a one-line idiom.
+    """
+    with tempfile.TemporaryDirectory(prefix="ensure-cli-") as tmpdir:
+        proj = Path(tmpdir)
+        result = _run_cli(
+            [
+                "ensure",
+                "--check",
+                "--no-memory",
+                "--no-mcp-config",
+                "--client",
+                "none",
+                "--project-root",
+                str(proj),
+            ],
+            cwd=proj,
+        )
+        # --check on a fresh dir exits non-zero (status: missing:...).
+        # That's fine; the test cares about stdout being parseable JSON.
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise AssertionError(
+                f"ensure stdout was not JSON despite being on a pipe.\n"
+                f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+            ) from exc
+        assert "status" in payload
+        assert "project_root" in payload
+
+
+def test_check_mode_exits_nonzero_when_missing() -> None:
+    """`--check` exits non-zero on a fresh tmpdir (status: missing:...).
+
+    Scripts can use the exit code as a quick "is everything wired up?"
+    gate without parsing the JSON body.
+    """
+    with tempfile.TemporaryDirectory(prefix="ensure-cli-") as tmpdir:
+        proj = Path(tmpdir)
+        result = _run_cli(
+            [
+                "ensure",
+                "--check",
+                "--no-memory",
+                "--no-mcp-config",
+                "--client",
+                "none",
+                "--project-root",
+                str(proj),
+            ],
+            cwd=proj,
+        )
+        assert result.returncode != 0
+        payload = json.loads(result.stdout)
+        assert payload["status"].startswith("missing:")
+
+
+def test_help_renders() -> None:
+    """``ctxr-fsm ensure --help`` exits 0 and prints flag descriptions."""
+    result = subprocess.run(
+        ["uv", "run", "ctxr-fsm", "ensure", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--client" in result.stdout
+    assert "--mode" in result.stdout
+    assert "--check" in result.stdout
+    assert "--timeout" in result.stdout

--- a/tests/integration/bootstrap/test_ensure_cold_start.py
+++ b/tests/integration/bootstrap/test_ensure_cold_start.py
@@ -1,0 +1,194 @@
+"""Cold-start integration: ``ctxr-fsm ensure`` drives the full pipeline (W14b).
+
+The single end-to-end test in this module verifies the happy-path
+contract:
+
+1. Tmpdir project with no ``.ctxr-fsm/``, no client config.
+2. Run ``ensure --mode mcp-only --no-memory --no-mcp-config --client none``
+   (mcp-only narrows the spawn to JUST the MCP child; the API + UI
+   children take much longer to boot under ``uv run`` and the test
+   doesn't need them to verify the happy path).
+3. Expect status="ready", actions show the init / supervisor steps
+   applied, ``active-mcp.json`` lands on disk with the mcp block.
+4. Cleanup: SIGTERM the spawned supervisor so the test process exits
+   cleanly.
+
+Why mcp-only here
+-----------------
+
+The full ``ensure`` spec demands the full trio when ``--mode full``.
+Booting all three under ``uv run`` from a cold cache takes 60-90s on
+fresh CI runners, which is acceptable for a single end-to-end test
+but compounds badly when a future change adds a second integration
+case. The mcp-only path exercises every part of the pipeline (init,
+supervisor spawn, active-mcp.json publication, ensure summary
+assembly) and the warm-path test elsewhere in this suite covers the
+``mode=full`` reuse semantics.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+_ENSURE_TIMEOUT_S: float = 120.0
+_SHUTDOWN_TIMEOUT_S: float = 30.0
+
+
+def _kill_pid(pid: int) -> None:
+    """Send SIGTERM then SIGKILL; absorb the standard race errors.
+
+    The supervisor's own SIGTERM handler triggers a drain of its
+    children, which we want; SIGKILL is the last resort.
+    """
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        return
+    # Wait for graceful exit.
+    deadline = time.monotonic() + _SHUTDOWN_TIMEOUT_S
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.1)
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.kill(pid, signal.SIGKILL)
+
+
+def test_ensure_cold_start_mcp_only(tmp_path: Path) -> None:
+    """End-to-end cold start: ensure boots the MCP supervisor and reports ready.
+
+    Asserts the headline contract pieces:
+
+    * ``status: "ready"`` in the JSON summary.
+    * ``actions.init = "applied"`` and ``actions.supervisor = "spawned"``.
+    * ``.ctxr-fsm/active-mcp.json`` lands on disk with an mcp block.
+    * ``subsystems.mcp`` is in the summary with status spawned/ready.
+    """
+    spawned_pid: int | None = None
+    try:
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "ctxr-fsm",
+                "ensure",
+                "--mode",
+                "mcp-only",
+                "--no-memory",
+                "--no-mcp-config",
+                "--client",
+                "none",
+                "--project-root",
+                str(tmp_path),
+                "--json",
+                "--timeout",
+                "90",
+            ],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            timeout=_ENSURE_TIMEOUT_S,
+            check=False,
+        )
+
+        # Parse stdout. We tolerate a non-zero exit only when the
+        # status is genuinely failed; the happy path should be 0.
+        if not result.stdout.strip():
+            raise AssertionError(
+                f"ensure produced no stdout. stderr:\n{result.stderr}"
+            )
+        summary = json.loads(result.stdout)
+        spawned_pid = summary.get("spawned_supervisor_pid")
+
+        assert summary["status"] == "ready", (
+            f"expected status=ready; got {summary}\nstderr: {result.stderr}"
+        )
+        assert result.returncode == 0, (
+            f"ensure exit {result.returncode}\nstdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+        # Per-action assertions.
+        assert summary["actions"]["init"] == "applied", summary
+        assert summary["actions"]["supervisor"] == "spawned", summary
+
+        # Discovery file landed.
+        amcp_path = tmp_path / ".ctxr-fsm" / "active-mcp.json"
+        assert amcp_path.exists(), (
+            f"active-mcp.json missing.\nstderr: {result.stderr}"
+        )
+        doc = json.loads(amcp_path.read_text(encoding="utf-8"))
+        assert "mcp" in doc["subsystems"]
+
+        # Summary has the mcp block.
+        assert "mcp" in summary["subsystems"]
+        mcp_block = summary["subsystems"]["mcp"]
+        assert mcp_block["status"] in ("spawned", "ready")
+        assert mcp_block["http_url"].endswith("/sse")
+        assert isinstance(mcp_block["pid"], int) and mcp_block["pid"] > 0
+
+    finally:
+        # Reap the supervisor we spawned. Walk the pid file too in
+        # case the JSON output was malformed.
+        if spawned_pid is None:
+            pid_file = tmp_path / ".ctxr-fsm" / "pids" / "mcp.pid"
+            if pid_file.exists():
+                try:
+                    pid_payload = json.loads(pid_file.read_text())
+                    if isinstance(pid_payload.get("pid"), int):
+                        spawned_pid = pid_payload["pid"]
+                except json.JSONDecodeError:
+                    spawned_pid = None
+        if spawned_pid is not None:
+            _kill_pid(spawned_pid)
+
+
+def test_ensure_timeout_failed_when_supervisor_wont_come_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the supervisor never reports healthy, ensure returns status=failed.
+
+    We force this by monkeypatching the in-process ensure body
+    (``_spawn_supervisor_detached``) to return immediately without
+    starting any subprocess; the discovery file never lands, so the
+    wait loop exhausts its budget and ensure reports the failure.
+    """
+    from ctxr.fsm.cli import ensure_cmd
+    from ctxr.fsm.cli.ensure_cmd import run_ensure
+    from ctxr.fsm.cli.init_cmd import run_init
+
+    # Pre-init so the init step is "current" (not the failure point).
+    run_init(
+        db_path=tmp_path / ".ctxr-fsm" / "fsm.db",
+        no_memory=True,
+        cwd=tmp_path,
+    )
+
+    # Spawn = no-op: returns a sentinel pid but starts nothing.
+    monkeypatch.setattr(
+        ensure_cmd, "_spawn_supervisor_detached",
+        lambda **kwargs: 999999,
+    )
+
+    summary = run_ensure(
+        project_root=tmp_path,
+        client="none",
+        mode="mcp-only",
+        no_memory=True,
+        no_mcp_config=True,
+        check=False,
+        timeout=1.0,  # tight budget so the test stays fast
+    )
+    assert summary["status"] == "failed", summary
+    assert summary["actions"]["supervisor"] == "failed"
+    assert "failure_detail" in summary

--- a/tests/integration/bootstrap/test_ensure_parallel_invocations.py
+++ b/tests/integration/bootstrap/test_ensure_parallel_invocations.py
@@ -1,0 +1,146 @@
+"""Parallel ``ctxr-fsm ensure`` calls converge on one supervisor (W14b).
+
+The W7 singleton primitive promises that two concurrent supervisor
+spawns observe each other and at most one of them survives. The
+ensure command sits ABOVE that primitive, but its idempotency
+contract demands the same outcome from the caller's perspective:
+running ensure twice in close succession produces ONE supervisor
+process (one pid in ``.ctxr-fsm/pids/mcp.pid``) and one
+``active-mcp.json`` file.
+
+Implementation note
+-------------------
+
+We run two ensures sequentially (not in true parallel) because:
+
+1. ``subprocess.Popen`` + ``uv run`` are slow to boot; a true
+   parallel test would have flaky timing and obscure the contract
+   we're actually testing.
+2. The singleton primitive's race window is observable even on the
+   sequential path: ensure #1 spawns a supervisor + waits for healthz;
+   ensure #2 starts AFTER healthz lands, so it MUST see the
+   singleton and report ``actions.supervisor = reused``.
+
+A future change could add a true-parallel variant using two threads
+spawning at the same time; the singleton primitive's own test suite
+under ``tests/unit/lifecycle/test_acquire_singleton.py`` already
+covers the file-on-disk race directly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+_TIMEOUT_S: float = 120.0
+
+
+def _kill_pid(pid: int) -> None:
+    """Reap a spawned supervisor (best-effort)."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        return
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.1)
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.kill(pid, signal.SIGKILL)
+
+
+def _run_ensure_mcp_only(project_root: Path, timeout_s: int) -> dict[str, object]:
+    """Run one ``ctxr-fsm ensure`` invocation and return the parsed summary."""
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "ctxr-fsm",
+            "ensure",
+            "--mode",
+            "mcp-only",
+            "--no-memory",
+            "--no-mcp-config",
+            "--client",
+            "none",
+            "--project-root",
+            str(project_root),
+            "--json",
+            "--timeout",
+            str(timeout_s),
+        ],
+        cwd=str(project_root),
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_S,
+        check=False,
+    )
+    if not result.stdout.strip():
+        raise AssertionError(
+            f"ensure produced no stdout (rc={result.returncode}).\n"
+            f"stderr: {result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+def test_second_ensure_reuses_singleton_from_first(tmp_path: Path) -> None:
+    """Run ensure twice; the second sees the first's supervisor.
+
+    Asserts:
+
+    * First call: ``actions.supervisor = "spawned"``.
+    * Second call: ``actions.supervisor = "reused"``.
+    * The active-mcp.json's supervisor_pid (or mcp.pid) is unchanged
+      between calls — i.e. no second process exists.
+    * Second-call ``duration_ms`` is meaningfully shorter than the
+      first (the warm path skips the spawn + healthz wait).
+    """
+    spawned_pid: int | None = None
+    try:
+        first = _run_ensure_mcp_only(tmp_path, timeout_s=90)
+        assert first["status"] == "ready", first
+        assert first["actions"]["supervisor"] == "spawned"
+        spawned_pid = first.get("spawned_supervisor_pid")
+
+        # Sanity: discovery file lists one mcp pid.
+        amcp_path = tmp_path / ".ctxr-fsm" / "active-mcp.json"
+        first_doc = json.loads(amcp_path.read_text(encoding="utf-8"))
+        first_mcp_pid = first_doc["subsystems"]["mcp"]["pid"]
+        assert isinstance(first_mcp_pid, int) and first_mcp_pid > 0
+
+        # Second invocation.
+        second = _run_ensure_mcp_only(tmp_path, timeout_s=30)
+        assert second["status"] == "ready", second
+        assert second["actions"]["supervisor"] == "reused", second
+        # No second supervisor spawned.
+        assert "spawned_supervisor_pid" not in second
+
+        # The mcp pid in the discovery file is unchanged.
+        second_doc = json.loads(amcp_path.read_text(encoding="utf-8"))
+        second_mcp_pid = second_doc["subsystems"]["mcp"]["pid"]
+        assert second_mcp_pid == first_mcp_pid, (
+            "active-mcp.json mcp pid changed across ensure calls — "
+            "the singleton was not reused."
+        )
+    finally:
+        # Reap whichever pid lands in mcp.pid (could be the supervisor
+        # pid OR the mcp child pid after _record_child_pid).
+        pid_file = tmp_path / ".ctxr-fsm" / "pids" / "mcp.pid"
+        if pid_file.exists():
+            try:
+                payload = json.loads(pid_file.read_text())
+                pid_val = payload.get("pid")
+                if isinstance(pid_val, int):
+                    _kill_pid(pid_val)
+            except json.JSONDecodeError:
+                pass
+        if spawned_pid is not None:
+            _kill_pid(spawned_pid)

--- a/tests/integration/bootstrap/test_ensure_resolution.py
+++ b/tests/integration/bootstrap/test_ensure_resolution.py
@@ -1,0 +1,71 @@
+"""Project-root resolution + sub-action wiring tests for ``run_ensure`` (W14b).
+
+Fast in-process tests (no supervisor spawn) that nail down the
+pipeline's no-side-effect branches: walk-up to the project root,
+explicit ``--project-root`` override, and the per-action ``skipped``
+defaults when every step is turned off.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ctxr.fsm.cli.ensure_cmd import _resolve_project_root, run_ensure
+
+
+def test_resolves_explicit_project_root(tmp_path: Path) -> None:
+    """``--project-root`` overrides the walk-up."""
+    p = tmp_path / "x" / "y"
+    p.mkdir(parents=True)
+    assert _resolve_project_root(p) == p.resolve()
+
+
+def test_walks_up_to_state_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Walk-up finds the nearest ancestor with ``.ctxr-fsm/``."""
+    root = tmp_path / "proj"
+    (root / ".ctxr-fsm").mkdir(parents=True)
+    deep = root / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    monkeypatch.chdir(deep)
+    assert _resolve_project_root(None) == root.resolve()
+
+
+def test_falls_back_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ``.ctxr-fsm/`` in chain → cwd is the answer."""
+    monkeypatch.chdir(tmp_path)
+    assert _resolve_project_root(None) == tmp_path.resolve()
+
+
+def test_ensure_with_all_steps_skipped_is_trivially_missing(
+    tmp_path: Path,
+) -> None:
+    """Running --check with every step disabled produces a clean summary.
+
+    Useful as the harness for testing the report shape itself.
+    """
+    summary = run_ensure(
+        project_root=tmp_path,
+        client="none",
+        mode="full",
+        no_memory=True,
+        no_mcp_config=True,
+        check=True,
+        timeout=2.0,
+    )
+    # Steps disabled / not applicable should land as either
+    # ``missing`` (init, supervisor) or ``skipped`` (memory,
+    # mcp-config).
+    assert summary["actions"]["memory"] == "skipped"
+    assert summary["actions"]["mcp_config"] == "skipped"
+    assert "project_root" in summary
+    assert os.path.isabs(summary["project_root"])
+    assert isinstance(summary["duration_ms"], int)
+    assert summary["mcp_stdio_registered"] == []
+    assert summary["subsystems"] == {}

--- a/tests/integration/bootstrap/test_ensure_warm_fast_path.py
+++ b/tests/integration/bootstrap/test_ensure_warm_fast_path.py
@@ -1,0 +1,211 @@
+"""Warm-path coverage for ``ctxr-fsm ensure`` (W14b).
+
+Simulates a warm project by:
+
+1. Running ``ctxr-fsm init`` to land the DB.
+2. Synthesising live ``pids/<name>.pid`` records + an
+   ``active-mcp.json`` document that point at this very test process
+   (so the pid liveness check passes) and a fake but answerable
+   healthz endpoint (``httpx`` is mocked via monkeypatch).
+
+We assert that ``ensure`` in this state returns ``status: ready`` with
+``actions.supervisor = reused`` in well under the 2000ms budget
+(brief threshold) and never spawns a subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from ctxr.fsm.cli import ensure_cmd
+from ctxr.fsm.cli.ensure_cmd import run_ensure
+from ctxr.fsm.cli.init_cmd import run_init
+from ctxr.fsm.cli.lifecycle.primitives import remember_active_mcp_file
+
+
+def _stage_pids(project_root: Path, names: list[str]) -> None:
+    """Write a singleton pid file per name pointing at this process.
+
+    A live pid + matching probe URL is what ``_probe_subsystem_alive``
+    treats as "subsystem is up"; pointing at ``os.getpid()`` makes
+    the liveness probe trivially succeed.
+    """
+    pids_dir = project_root / ".ctxr-fsm" / "pids"
+    pids_dir.mkdir(parents=True, exist_ok=True)
+    self_pid = os.getpid()
+    for name in names:
+        (pids_dir / f"{name}.pid").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "pid": self_pid,
+                    "probe_url": "http://127.0.0.1:65000",
+                    "acquired_at": "2026-05-29T00:00:00.000+00:00",
+                },
+                sort_keys=True,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+
+def _stage_active_mcp_doc(project_root: Path, *, subsystems: list[str]) -> None:
+    """Write a fake but well-formed discovery doc.
+
+    The URLs need to point at an endpoint our mocked httpx will
+    answer — but we mock httpx wholesale so the value just needs to
+    be a string.
+    """
+    sub_payload: dict[str, Any] = {}
+    for name in subsystems:
+        block = {
+            "http_url": f"http://127.0.0.1:65000{'/sse' if name == 'mcp' else ''}",
+            "healthz_url": (
+                "http://127.0.0.1:65000/healthz" if name != "ui" else None
+            ),
+            "pid": os.getpid(),
+        }
+        if name == "api":
+            block["docs_url"] = "http://127.0.0.1:65000/docs"
+        sub_payload[name] = block
+    remember_active_mcp_file(
+        {
+            "started_at": "2026-05-29T00:00:00.000+00:00",
+            "supervisor_pid": os.getpid(),
+            "version": "0.0.0-test",
+            "subsystems": sub_payload,
+        },
+        project_root=project_root,
+    )
+
+
+def _mock_httpx_get_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force ``httpx.get`` to always return a 200 response.
+
+    The warm-path test mustn't make real network calls — both the
+    pid-probe healthz and the wait-loop healthz get patched.
+    """
+
+    class _Resp:
+        status_code = 200
+        text = "ok"
+
+    def _fake_get(url: str, *args: Any, **kwargs: Any) -> _Resp:
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+
+
+def test_warm_path_is_under_2000ms(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-baked warm project exits ensure in < 2000ms with reused.
+
+    The brief says <500ms is the goal but CI flakiness justifies the
+    looser 2000ms ceiling for the assertion.
+    """
+    # 1. Real init so the DB + alembic head land.
+    run_init(
+        db_path=tmp_path / ".ctxr-fsm" / "fsm.db",
+        no_memory=True,
+        cwd=tmp_path,
+    )
+    # 2. Stage live pids + discovery doc.
+    _stage_pids(tmp_path, names=["mcp", "api", "ui"])
+    _stage_active_mcp_doc(tmp_path, subsystems=["mcp", "api", "ui"])
+    # 3. Mock httpx so the healthz probes succeed without a real
+    #    listener on the port.
+    _mock_httpx_get_ok(monkeypatch)
+    # 4. Avoid touching any client-config files: skip both memory and
+    #    mcp-config.
+    summary = run_ensure(
+        project_root=tmp_path,
+        client="none",
+        mode="full",
+        no_memory=True,
+        no_mcp_config=True,
+        check=False,
+        timeout=5.0,
+    )
+    assert summary["status"] == "ready", summary
+    assert summary["actions"]["supervisor"] == "reused"
+    assert summary["actions"]["init"] == "current"
+    assert summary["actions"]["memory"] == "skipped"
+    assert summary["actions"]["mcp_config"] == "skipped"
+    # Hard duration assertion: < 2s warm path on CI.
+    assert summary["duration_ms"] < 2000, summary
+
+    # Belt-and-braces: no subprocess was spawned (no ``spawned_supervisor_pid``).
+    assert "spawned_supervisor_pid" not in summary
+
+
+def test_warm_path_does_not_spawn_when_already_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replace ``_spawn_supervisor_detached`` with a sentinel and confirm it is never called."""
+    run_init(
+        db_path=tmp_path / ".ctxr-fsm" / "fsm.db",
+        no_memory=True,
+        cwd=tmp_path,
+    )
+    _stage_pids(tmp_path, names=["mcp", "api", "ui"])
+    _stage_active_mcp_doc(tmp_path, subsystems=["mcp", "api", "ui"])
+    _mock_httpx_get_ok(monkeypatch)
+
+    spawn_calls: list[bool] = []
+
+    def _fail_spawn(**_kwargs: Any) -> int:
+        spawn_calls.append(True)
+        raise RuntimeError("ensure must not spawn when warm")
+
+    monkeypatch.setattr(
+        ensure_cmd, "_spawn_supervisor_detached", _fail_spawn
+    )
+
+    summary = run_ensure(
+        project_root=tmp_path,
+        client="none",
+        mode="full",
+        no_memory=True,
+        no_mcp_config=True,
+        check=False,
+        timeout=5.0,
+    )
+    assert spawn_calls == []
+    assert summary["actions"]["supervisor"] == "reused"
+
+
+def test_mcp_only_warm_only_probes_mcp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In ``mcp-only`` mode the absence of api+ui pids is OK if mcp is up."""
+    run_init(
+        db_path=tmp_path / ".ctxr-fsm" / "fsm.db",
+        no_memory=True,
+        cwd=tmp_path,
+    )
+    _stage_pids(tmp_path, names=["mcp"])
+    _stage_active_mcp_doc(tmp_path, subsystems=["mcp"])
+    _mock_httpx_get_ok(monkeypatch)
+
+    summary = run_ensure(
+        project_root=tmp_path,
+        client="none",
+        mode="mcp-only",
+        no_memory=True,
+        no_mcp_config=True,
+        check=False,
+        timeout=5.0,
+    )
+    assert summary["status"] == "ready", summary
+    assert summary["actions"]["supervisor"] == "reused"
+    # Only mcp listed in the subsystems block.
+    assert set(summary["subsystems"].keys()) == {"mcp"}

--- a/tests/integration/install_mcp/test_install_mcp_claude.py
+++ b/tests/integration/install_mcp/test_install_mcp_claude.py
@@ -1,0 +1,172 @@
+"""Coverage for the Claude side of ``ctxr-fsm install-mcp`` (W14d).
+
+Three scenarios:
+
+1. **Preserves unrelated entries.** A pre-existing ``.mcp.json`` that
+   already lists three other MCP servers in ``mcpServers`` must come
+   out the other side of an ``install-mcp`` with all three unchanged
+   and a fresh ``ctxr-fsm`` entry merged alongside.
+2. **Creates from scratch.** Running ``install-mcp`` against a project
+   where no ``.mcp.json`` exists creates the file with just the
+   ``mcpServers.ctxr-fsm`` block.
+3. **Aborts on bad shape.** If the file's ``mcpServers`` value is a
+   list (not an object), the merger errors out rather than clobbering
+   user data.
+
+We exercise the pure ``run_install_mcp`` function (not the Typer
+command) so the tests stay in-process and fast.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ctxr.fsm.cli.install_mcp_cmd import run_install_mcp
+
+EXPECTED_ENTRY = {
+    "command": "ctxr-fsm",
+    "args": ["mcp", "--transport", "stdio"],
+    "env": {},
+}
+
+
+def _seed_workspace_marker(tmp_path: Path) -> None:
+    """Make ``tmp_path`` look like a Claude Code workspace root.
+
+    The detector treats either ``.git/`` or ``CLAUDE.md`` as the
+    workspace marker — we plant the cheaper one (a single file) so
+    the .mcp.json path is the canonical target.
+    """
+    (tmp_path / "CLAUDE.md").write_text("# project memory\n", encoding="utf-8")
+
+
+def test_preserves_unrelated_mcp_servers_when_merging(tmp_path: Path) -> None:
+    """Existing entries in mcpServers and other top-level keys pass through.
+
+    The brief is explicit: only ``mcpServers.ctxr-fsm`` is OWNED;
+    every other key (top-level OR inside mcpServers) is sacred.
+    """
+    _seed_workspace_marker(tmp_path)
+    mcp_json = tmp_path / ".mcp.json"
+    original = {
+        "$schema": "https://example.com/mcp-schema.json",
+        "mcpServers": {
+            "github": {
+                "command": "uvx",
+                "args": ["mcp-github"],
+                "env": {"GITHUB_TOKEN": "***"},
+            },
+            "notion": {
+                "command": "npx",
+                "args": ["@notionhq/mcp-server"],
+                "env": {},
+            },
+        },
+        "comment": "hand-edited by the user",
+    }
+    mcp_json.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+    result = run_install_mcp(tmp_path, client="claude")
+    assert {r["client"] for r in result["results"]} == {"claude"}, result
+    claude_row = result["results"][0]
+    assert claude_row["action"] == "applied", claude_row
+
+    patched = json.loads(mcp_json.read_text(encoding="utf-8"))
+    # Top-level keys preserved.
+    assert patched["$schema"] == original["$schema"]
+    assert patched["comment"] == original["comment"]
+    # Existing mcpServers entries preserved.
+    assert patched["mcpServers"]["github"] == original["mcpServers"]["github"]
+    assert patched["mcpServers"]["notion"] == original["mcpServers"]["notion"]
+    # New entry merged with the exact desired shape.
+    assert patched["mcpServers"]["ctxr-fsm"] == EXPECTED_ENTRY
+
+
+def test_creates_mcp_json_when_absent(tmp_path: Path) -> None:
+    """A workspace without ``.mcp.json`` gets one created on install."""
+    _seed_workspace_marker(tmp_path)
+    mcp_json = tmp_path / ".mcp.json"
+    assert not mcp_json.exists()
+
+    result = run_install_mcp(tmp_path, client="claude")
+    claude_row = result["results"][0]
+    assert claude_row["action"] == "applied", claude_row
+
+    assert mcp_json.exists()
+    loaded = json.loads(mcp_json.read_text(encoding="utf-8"))
+    assert loaded == {"mcpServers": {"ctxr-fsm": EXPECTED_ENTRY}}
+
+
+def test_aborts_when_mcp_servers_is_wrong_type(tmp_path: Path) -> None:
+    """A list-valued ``mcpServers`` is treated as malformed and reported.
+
+    Silently coercing the value would lose the user's data; the
+    merger surfaces the error as a per-result outcome instead.
+    """
+    _seed_workspace_marker(tmp_path)
+    mcp_json = tmp_path / ".mcp.json"
+    mcp_json.write_text(
+        json.dumps({"mcpServers": ["broken"]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    result = run_install_mcp(tmp_path, client="claude")
+    claude_row = result["results"][0]
+    assert claude_row["action"] == "failed", claude_row
+    assert "mcpServers" in claude_row["detail"]
+    # File untouched on failure.
+    after = json.loads(mcp_json.read_text(encoding="utf-8"))
+    assert after == {"mcpServers": ["broken"]}
+
+
+def test_reapply_is_unchanged(tmp_path: Path) -> None:
+    """A second install on a project where the entry already matches is a no-op.
+
+    Idempotency contract: when the existing entry deep-equals the
+    desired one, we return ``action: unchanged`` and do not rewrite
+    the file. We assert this by comparing mtime + bytes across runs.
+    """
+    _seed_workspace_marker(tmp_path)
+    mcp_json = tmp_path / ".mcp.json"
+
+    run_install_mcp(tmp_path, client="claude")
+    first_bytes = mcp_json.read_bytes()
+    first_mtime_ns = mcp_json.stat().st_mtime_ns
+
+    result = run_install_mcp(tmp_path, client="claude")
+    claude_row = result["results"][0]
+    assert claude_row["action"] == "unchanged", claude_row
+
+    # Byte-identical; mtime untouched (we deliberately skipped the
+    # rewrite).
+    assert mcp_json.read_bytes() == first_bytes
+    assert mcp_json.stat().st_mtime_ns == first_mtime_ns
+
+
+def test_preserves_existing_indent_style(tmp_path: Path) -> None:
+    """If the file uses 4-space indent, the rewrite stays 4-space.
+
+    Keeps reviewer diffs focused on the actual config change rather
+    than whitespace churn.
+    """
+    _seed_workspace_marker(tmp_path)
+    mcp_json = tmp_path / ".mcp.json"
+    original = (
+        '{\n'
+        '    "mcpServers": {\n'
+        '        "github": {\n'
+        '            "command": "uvx"\n'
+        '        }\n'
+        '    }\n'
+        '}\n'
+    )
+    mcp_json.write_text(original, encoding="utf-8")
+
+    run_install_mcp(tmp_path, client="claude")
+    text = mcp_json.read_text(encoding="utf-8")
+    # The first nested key line should still be indented by 4 spaces.
+    nested_line = next(
+        ln for ln in text.splitlines() if ln.startswith(" ") and ln.lstrip()
+    )
+    leading = len(nested_line) - len(nested_line.lstrip(" "))
+    assert leading == 4, f"expected 4-space indent preserved; got {leading}: {nested_line!r}"

--- a/tests/integration/install_mcp/test_install_mcp_codex.py
+++ b/tests/integration/install_mcp/test_install_mcp_codex.py
@@ -1,0 +1,138 @@
+"""Codex side of ``ctxr-fsm install-mcp`` (W14d).
+
+Two paths to cover:
+
+* **CLI preferred when present.** When the ``codex`` binary is on
+  PATH, the installer invokes ``codex mcp add ...`` and does not
+  touch the TOML directly. We monkeypatch the ``_can_use_codex_cli``
+  probe + ``_invoke_codex_cli_add`` to assert dispatch.
+* **TOML fallback when CLI absent.** When the probe returns False,
+  the installer falls back to a direct TOML splice that preserves
+  every other table.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ctxr.fsm.cli import install_mcp_cmd
+from ctxr.fsm.cli.install_mcp_cmd import run_install_mcp
+
+
+def _redirect_codex_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Point ``_codex_target`` at a tmpdir-rooted path.
+
+    We monkeypatch the module's ``_codex_target`` helper rather than
+    HOME so we don't accidentally pick up the host's real Codex
+    config when ``_can_use_codex_cli`` returns True on the test
+    machine.
+    """
+    target = tmp_path / "codex_home" / ".codex" / "config.toml"
+    monkeypatch.setattr(install_mcp_cmd, "_codex_target", lambda: target)
+    return target
+
+
+def test_codex_cli_path_is_invoked_when_codex_binary_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``codex`` is on PATH, the installer dispatches to ``codex mcp add``.
+
+    Asserts via a stub: the real subprocess would mutate the host's
+    user-level config, which is unacceptable for a test. The stub
+    records its invocation count + returns a synthetic "applied"
+    outcome.
+    """
+    _redirect_codex_path(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mcp_cmd, "_can_use_codex_cli", lambda: True)
+
+    invocations: list[dict[str, bool]] = []
+
+    def _stub_invoke(*, dry_run: bool) -> dict[str, str]:
+        invocations.append({"dry_run": dry_run})
+        return {
+            "path": "~/.codex/config.toml",
+            "action": "applied",
+            "detail": "stubbed codex mcp add",
+        }
+
+    monkeypatch.setattr(install_mcp_cmd, "_invoke_codex_cli_add", _stub_invoke)
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    result = run_install_mcp(proj, client="codex")
+    assert len(invocations) == 1
+    assert invocations[0]["dry_run"] is False
+    codex_row = next(r for r in result["results"] if r["client"] == "codex")
+    assert codex_row["action"] == "applied"
+
+
+def test_codex_direct_toml_when_codex_binary_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without ``codex`` on PATH, the installer hand-edits the TOML.
+
+    Preserves every unrelated table verbatim; only adds (or replaces)
+    the ``[mcp_servers.ctxr-fsm]`` block.
+    """
+    codex_path = _redirect_codex_path(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mcp_cmd, "_can_use_codex_cli", lambda: False)
+
+    # Seed an existing config with unrelated tables.
+    codex_path.parent.mkdir(parents=True, exist_ok=True)
+    original = (
+        "[user]\n"
+        'name = "test"\n'
+        "\n"
+        "[mcp_servers.linear]\n"
+        'command = "uvx"\n'
+        'args = ["mcp-linear"]\n'
+        "\n"
+        "[settings]\n"
+        "auto_save = true\n"
+    )
+    codex_path.write_text(original, encoding="utf-8")
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    result = run_install_mcp(proj, client="codex")
+    codex_row = next(r for r in result["results"] if r["client"] == "codex")
+    assert codex_row["action"] == "applied", codex_row
+
+    patched = codex_path.read_text(encoding="utf-8")
+    # Other tables preserved (substring matches because we keep the
+    # original whitespace + value lines).
+    assert "[user]" in patched
+    assert 'name = "test"' in patched
+    assert "[mcp_servers.linear]" in patched
+    assert "[settings]" in patched
+    assert "auto_save = true" in patched
+    # Our table is present.
+    assert "[mcp_servers.ctxr-fsm]" in patched
+    assert 'command = "ctxr-fsm"' in patched
+    assert '["mcp", "--transport", "stdio"]' in patched
+
+
+def test_codex_toml_unchanged_on_reapply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second TOML install when the block matches returns 'unchanged'.
+
+    Mirrors the JSON merger's idempotency contract.
+    """
+    codex_path = _redirect_codex_path(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mcp_cmd, "_can_use_codex_cli", lambda: False)
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+
+    first = run_install_mcp(proj, client="codex")
+    assert first["results"][0]["action"] == "applied"
+    bytes_first = codex_path.read_bytes()
+
+    second = run_install_mcp(proj, client="codex")
+    assert second["results"][0]["action"] == "unchanged", second
+    assert codex_path.read_bytes() == bytes_first

--- a/tests/integration/install_mcp/test_install_mcp_cursor.py
+++ b/tests/integration/install_mcp/test_install_mcp_cursor.py
@@ -1,0 +1,74 @@
+"""Cursor side of ``ctxr-fsm install-mcp`` (W14d).
+
+Cursor's MCP config lives at ``~/.cursor/mcp.json`` (user-level, not
+per-project), so the test redirects ``HOME`` into a tmpdir via
+``monkeypatch`` before invoking the merger.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ctxr.fsm.cli.install_mcp_cmd import run_install_mcp
+
+EXPECTED_ENTRY = {
+    "command": "ctxr-fsm",
+    "args": ["mcp", "--transport", "stdio"],
+    "env": {},
+}
+
+
+def test_cursor_creates_user_config_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without any prior Cursor config, install writes ``~/.cursor/mcp.json``."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    # ``Path.home()`` uses HOME on POSIX; on macOS some Pythons also
+    # respect ``USERPROFILE`` via expanduser. Set both for safety.
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+    target = tmp_path / "proj"
+    target.mkdir()
+    result = run_install_mcp(target, client="cursor")
+    row = result["results"][0]
+    assert row["client"] == "cursor"
+    assert row["action"] == "applied", row
+
+    cursor_path = fake_home / ".cursor" / "mcp.json"
+    assert cursor_path.exists()
+    payload = json.loads(cursor_path.read_text(encoding="utf-8"))
+    assert payload == {"mcpServers": {"ctxr-fsm": EXPECTED_ENTRY}}
+
+
+def test_cursor_preserves_other_servers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-existing Cursor config keeps its other servers intact."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+    cursor_path = fake_home / ".cursor" / "mcp.json"
+    cursor_path.parent.mkdir(parents=True, exist_ok=True)
+    original = {
+        "mcpServers": {
+            "linear": {"command": "uvx", "args": ["mcp-linear"], "env": {}},
+        }
+    }
+    cursor_path.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+    target = tmp_path / "proj"
+    target.mkdir()
+    result = run_install_mcp(target, client="cursor")
+    assert result["results"][0]["action"] == "applied"
+
+    patched = json.loads(cursor_path.read_text(encoding="utf-8"))
+    assert patched["mcpServers"]["linear"] == original["mcpServers"]["linear"]
+    assert patched["mcpServers"]["ctxr-fsm"] == EXPECTED_ENTRY

--- a/tests/integration/install_mcp/test_install_mcp_modes.py
+++ b/tests/integration/install_mcp/test_install_mcp_modes.py
@@ -1,0 +1,121 @@
+"""--dry-run, --check, and reapply modes for ``ctxr-fsm install-mcp`` (W14d).
+
+These cross-cutting tests target the contract every per-client merger
+honours:
+
+* ``--dry-run`` never writes to the filesystem.
+* ``--check`` reports per-client status without applying.
+* A second invocation after a fresh install is a no-op (no rewrite,
+  ``action=unchanged``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ctxr.fsm.cli.install_mcp_cmd import run_install_mcp
+
+
+def _seed_workspace(tmp_path: Path) -> Path:
+    """Make a tmp dir look like a Claude workspace root for auto detection."""
+    (tmp_path / "CLAUDE.md").write_text("# project memory\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_dry_run_does_not_mutate_filesystem(tmp_path: Path) -> None:
+    """``dry_run=True`` returns a preview but never writes any file.
+
+    Verified by:
+
+    * The would-be ``.mcp.json`` does not exist after the call.
+    * The result includes a ``preview`` field with the patch content.
+    """
+    proj = _seed_workspace(tmp_path)
+    mcp_json = proj / ".mcp.json"
+
+    result = run_install_mcp(proj, client="claude", dry_run=True)
+    claude_row = result["results"][0]
+    assert claude_row["action"] in {"would-create", "would-apply"}, claude_row
+    assert "preview" in claude_row
+    # File was never created.
+    assert not mcp_json.exists()
+
+
+def test_check_reports_missing_for_fresh_project(tmp_path: Path) -> None:
+    """``check=True`` on an uninitialised project returns 'missing'.
+
+    No filesystem mutation; the file should still not exist after
+    the probe.
+    """
+    proj = _seed_workspace(tmp_path)
+    mcp_json = proj / ".mcp.json"
+
+    result = run_install_mcp(proj, client="claude", check=True)
+    claude_row = result["results"][0]
+    assert claude_row["action"] == "check:missing"
+    assert claude_row["status"] == "missing"
+    assert not mcp_json.exists()
+
+
+def test_check_reports_installed_after_apply(tmp_path: Path) -> None:
+    """Run apply, then check, then expect ``installed``."""
+    proj = _seed_workspace(tmp_path)
+    run_install_mcp(proj, client="claude")
+    result = run_install_mcp(proj, client="claude", check=True)
+    claude_row = result["results"][0]
+    assert claude_row["action"] == "check:installed", claude_row
+    assert claude_row["status"] == "installed"
+
+
+def test_check_reports_out_of_date_when_entry_differs(
+    tmp_path: Path,
+) -> None:
+    """A pre-existing ctxr-fsm entry with stale args reports out-of-date.
+
+    Models the case where a future release changes the stdio invocation
+    shape; the current installer's contract is to detect it via
+    check mode without rewriting.
+    """
+    proj = _seed_workspace(tmp_path)
+    mcp_json = proj / ".mcp.json"
+    mcp_json.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "ctxr-fsm": {
+                        "command": "ctxr-fsm",
+                        "args": ["mcp"],  # missing --transport stdio
+                        "env": {},
+                    }
+                }
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_install_mcp(proj, client="claude", check=True)
+    claude_row = result["results"][0]
+    assert claude_row["action"] == "check:out-of-date"
+    assert claude_row["status"] == "out-of-date"
+
+
+def test_client_none_is_noop(tmp_path: Path) -> None:
+    """``client='none'`` short-circuits before any detection or writes.
+
+    Useful for ``ctxr-fsm ensure --no-mcp-config`` so the ensure
+    machinery can call through a single helper without branching.
+    """
+    proj = _seed_workspace(tmp_path)
+    result = run_install_mcp(proj, client="none")
+    assert result["results"] == []
+
+
+def test_rejects_unknown_client(tmp_path: Path) -> None:
+    """An unknown ``client`` value raises a clear ValueError."""
+    proj = _seed_workspace(tmp_path)
+    with pytest.raises(ValueError, match="client must be one of"):
+        run_install_mcp(proj, client="garbage")  # type: ignore[arg-type]

--- a/tests/integration/install_mcp/test_mcp_cwd_walkup.py
+++ b/tests/integration/install_mcp/test_mcp_cwd_walkup.py
@@ -1,0 +1,123 @@
+"""Coverage for the cwd walk-up resolution in W14d.
+
+``ctxr-fsm install-mcp`` writes a stdio MCP entry that runs
+``ctxr-fsm mcp --transport stdio`` with no ``--db`` flag. The MCP
+server must therefore discover its project DB by walking up from the
+spawning client's cwd looking for ``.ctxr-fsm/``. Both
+:func:`ctxr.fsm.mcp.server.resolve_db_path` and
+:func:`ctxr.fsm.cli._common.resolve_db_path` implement that walk-up
+in lock-step so the stdio entry stays portable across projects.
+
+We exercise the pure resolver against a constructed tmpdir tree
+(``project_root/.ctxr-fsm/`` + a deep subdir as the cwd) so the test
+is fast and never spawns a subprocess.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ctxr.fsm.cli._common import resolve_db_path as cli_resolve
+from ctxr.fsm.mcp.server import resolve_db_path as mcp_resolve
+
+
+def _stage_project(tmp_path: Path) -> tuple[Path, Path]:
+    """Create ``<root>/.ctxr-fsm`` and a deep nested subdir.
+
+    Returns ``(project_root, deep_subdir)`` so the caller can chdir
+    into ``deep_subdir`` and assert the walk-up finds ``project_root``.
+    """
+    project_root = tmp_path / "myproj"
+    (project_root / ".ctxr-fsm").mkdir(parents=True)
+    deep = project_root / "src" / "feature" / "module"
+    deep.mkdir(parents=True)
+    return project_root, deep
+
+
+def test_cli_resolver_walks_up_to_state_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI resolver finds the nearest ancestor ``.ctxr-fsm/`` from cwd."""
+    project_root, deep = _stage_project(tmp_path)
+    monkeypatch.chdir(deep)
+    monkeypatch.delenv("CTXR_FSM_DB", raising=False)
+
+    resolved = cli_resolve(None)
+    expected = (project_root / ".ctxr-fsm" / "fsm.db").resolve()
+    assert resolved == expected
+
+
+def test_mcp_resolver_walks_up_to_state_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MCP server resolver matches the CLI resolver exactly."""
+    project_root, deep = _stage_project(tmp_path)
+    monkeypatch.chdir(deep)
+    monkeypatch.delenv("CTXR_FSM_DB", raising=False)
+
+    resolved = mcp_resolve(None)
+    expected = (project_root / ".ctxr-fsm" / "fsm.db").resolve()
+    assert resolved == expected
+
+
+def test_resolvers_agree_when_no_state_dir_in_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When no ancestor has ``.ctxr-fsm/``, fall back to cwd's default.
+
+    The error case ("init has not been run") surfaces downstream when
+    the caller tries to open the missing DB file; the resolver itself
+    just hands back the canonical path.
+    """
+    isolated = tmp_path / "no_state_anywhere" / "deep"
+    isolated.mkdir(parents=True)
+    monkeypatch.chdir(isolated)
+    monkeypatch.delenv("CTXR_FSM_DB", raising=False)
+
+    expected = (isolated / ".ctxr-fsm" / "fsm.db").resolve()
+    assert cli_resolve(None) == expected
+    assert mcp_resolve(None) == expected
+
+
+def test_explicit_db_flag_short_circuits_walkup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit ``--db`` argument takes precedence over the walk-up."""
+    _project_root, deep = _stage_project(tmp_path)
+    monkeypatch.chdir(deep)
+    explicit = tmp_path / "elsewhere" / "custom.db"
+    explicit.parent.mkdir(parents=True, exist_ok=True)
+
+    assert cli_resolve(explicit) == explicit.resolve()
+    assert mcp_resolve(explicit) == explicit.resolve()
+
+
+def test_env_var_takes_precedence_over_walkup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``$CTXR_FSM_DB`` wins over the walk-up tier."""
+    _project_root, deep = _stage_project(tmp_path)
+    monkeypatch.chdir(deep)
+    env_target = tmp_path / "via-env" / "fsm.db"
+    env_target.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CTXR_FSM_DB", str(env_target))
+
+    expected = env_target.resolve()
+    assert cli_resolve(None) == expected
+    assert mcp_resolve(None) == expected
+
+
+def test_immediate_cwd_with_state_dir_is_picked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When cwd itself has ``.ctxr-fsm``, no actual walking is needed."""
+    project_root = tmp_path / "topproj"
+    (project_root / ".ctxr-fsm").mkdir(parents=True)
+    monkeypatch.chdir(project_root)
+    monkeypatch.delenv("CTXR_FSM_DB", raising=False)
+
+    expected = (project_root / ".ctxr-fsm" / "fsm.db").resolve()
+    assert cli_resolve(None) == expected
+    assert mcp_resolve(None) == expected

--- a/tests/integration/lifecycle/test_active_mcp_json.py
+++ b/tests/integration/lifecycle/test_active_mcp_json.py
@@ -1,0 +1,377 @@
+"""End-to-end lifecycle coverage for ``.ctxr-fsm/active-mcp.json`` (W14c).
+
+The discovery file is the only thing standing between the W14e skill
+bootstrap discipline and "agent stares at a blank prompt because the
+stdio MCP entry was registered too recently to be effective". So this
+test exercises the full contract:
+
+1. ``ctxr-fsm serve`` boots → ``.ctxr-fsm/active-mcp.json`` exists,
+   parses as JSON, declares MCP+API+UI subsystems with the right
+   shape (http_url / healthz_url / pid; docs_url for API; ui's
+   healthz_url is null because Vite has no /healthz route).
+2. The file is atomically written (no half-written document
+   observable mid-rename — covered by reading the file repeatedly
+   while the supervisor is up).
+3. A graceful SIGTERM shutdown removes the file so a later ``ensure``
+   call doesn't talk to a dead port.
+4. ``ctxr-fsm doctor`` surfaces the file under
+   ``supervisor.active_mcp`` while the supervisor is up.
+
+Why a real subprocess
+---------------------
+
+We piggy-back on the same fixture pattern as
+``test_serve_reuse.py``: spawning the actual ``uv run ctxr-fsm
+serve`` because the discovery contract spans the supervisor module +
+the on-disk filesystem, and an in-process facsimile would short-circuit
+the very atomic-write + signal-handler interactions we want to cover.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Tunables (mirror test_serve_reuse — kept in sync deliberately)
+# ---------------------------------------------------------------------------
+
+_BOOT_TIMEOUT_S: float = 90.0
+_SHUTDOWN_TIMEOUT_S: float = 30.0
+_BOOT_BANNER_PREFIX: str = "[ctxr-fsm supervisor] booted:"
+_ACTIVE_MCP_FILE_REL: Path = Path(".ctxr-fsm") / "active-mcp.json"
+
+
+# ---------------------------------------------------------------------------
+# Stub project layout (reuses the test_serve_reuse contract)
+# ---------------------------------------------------------------------------
+
+_STUB_UI_PACKAGE_JSON: str = json.dumps(
+    {
+        "name": "ctxr-fsm-test-stub-ui",
+        "private": True,
+        "version": "0.0.0",
+        "scripts": {
+            "dev": "python3 -c \"import sys, time; sys.stdout.flush(); time.sleep(3600)\"",
+        },
+    },
+    indent=2,
+)
+
+
+def _stage_project_root(tmpdir: Path) -> Path:
+    """Build the minimal tree the supervisor's boot path walks.
+
+    Mirror of the test_serve_reuse helper. Pre-creates ``.ctxr-fsm/pids``
+    so the test can stat the discovery file beside it without having
+    to wait for the first write to create the directory.
+    """
+    (tmpdir / ".ctxr-fsm" / "pids").mkdir(parents=True, exist_ok=True)
+    (tmpdir / "ctxr" / "fsm").mkdir(parents=True, exist_ok=True)
+    (tmpdir / "ui").mkdir(parents=True, exist_ok=True)
+    (tmpdir / "ui" / "package.json").write_text(
+        _STUB_UI_PACKAGE_JSON, encoding="utf-8"
+    )
+    return tmpdir
+
+
+# ---------------------------------------------------------------------------
+# Stderr drainer (slimmed clone of the one in test_serve_reuse)
+# ---------------------------------------------------------------------------
+
+
+class _StderrDrain:
+    """Background pump that copies a subprocess's stderr into a buffer.
+
+    See ``test_serve_reuse._StderrDrain`` for the full rationale. We
+    duplicate it here (rather than reach across test modules) so each
+    integration file stays self-contained and a regression in the
+    drainer surfaces as one focused failure rather than rippling
+    through every integration test that needs to wait on a log line.
+    """
+
+    def __init__(self, stream: object, label: str) -> None:
+        self._stream = stream
+        self._label = label
+        self._lock = threading.Lock()
+        self._buffer: list[str] = []
+        self._event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._pump, daemon=True, name=f"drain[{label}]"
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _pump(self) -> None:
+        stream = self._stream
+        if stream is None:
+            return
+        try:
+            for raw in iter(stream.readline, b""):
+                try:
+                    line = raw.decode("utf-8", errors="replace")
+                except Exception:  # pragma: no cover - decode defensive
+                    line = repr(raw)
+                with self._lock:
+                    self._buffer.append(line)
+                self._event.set()
+        except (ValueError, OSError):
+            return
+
+    def wait_for(self, substring: str, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        while True:
+            with self._lock:
+                joined = "".join(self._buffer)
+            if substring in joined:
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            self._event.clear()
+            self._event.wait(timeout=min(remaining, 0.5))
+
+    def snapshot(self) -> str:
+        with self._lock:
+            return "".join(self._buffer)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+
+
+def _supervisor_argv(db_path: Path, *, mode: str = "dev") -> list[str]:
+    """``uv run ctxr-fsm serve --mode <mode> --db <db>``."""
+    return [
+        "uv",
+        "run",
+        "ctxr-fsm",
+        "serve",
+        "--mode",
+        mode,
+        "--db",
+        str(db_path),
+    ]
+
+
+@contextmanager
+def _spawn_supervisor(
+    *, project_root: Path, db_path: Path, label: str, mode: str = "dev"
+) -> Iterator[tuple[subprocess.Popen[bytes], _StderrDrain]]:
+    """Yield a ``(Popen, drainer)`` pair scoped to a single supervisor.
+
+    Wraps spawn + drain + shutdown so a botched test never strands a
+    supervisor holding a port. SIGTERM lets the supervisor run its own
+    drain (releasing pid files + removing ``active-mcp.json``); the
+    drain budget mirrors the supervisor's own (5s per child + 5s
+    grace) plus generous slack for slow CI.
+    """
+    env = os.environ.copy()
+    proc = subprocess.Popen(
+        _supervisor_argv(db_path, mode=mode),
+        cwd=str(project_root),
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    drain = _StderrDrain(proc.stderr, label=f"{label}.stderr")
+    drain.start()
+    stdout_drain = _StderrDrain(proc.stdout, label=f"{label}.stdout")
+    stdout_drain.start()
+    try:
+        yield proc, drain
+    finally:
+        if proc.poll() is None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            with contextlib.suppress(subprocess.TimeoutExpired):  # pragma: no cover
+                proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_file(path: Path, *, timeout: float) -> bool:
+    """Poll ``path`` until it exists or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def test_active_mcp_json_written_on_boot_and_removed_on_shutdown() -> None:
+    """The supervisor writes the discovery file on boot and removes it on shutdown.
+
+    Walks the full lifecycle in one test so the write and remove
+    contracts share a fixture (a separate "boot only" test would
+    leave a supervisor running, and a separate "shutdown only" test
+    couldn't observe the post-boot file without re-implementing the
+    boot wait).
+    """
+    with tempfile.TemporaryDirectory(prefix="ctxr-fsm-amcp-") as tmpdir:
+        project_root = _stage_project_root(Path(tmpdir))
+        db_path = project_root / "fsm.db"
+        active_mcp = project_root / _ACTIVE_MCP_FILE_REL
+
+        # Sanity: no discovery file before the supervisor runs.
+        assert not active_mcp.exists()
+
+        with _spawn_supervisor(
+            project_root=project_root, db_path=db_path, label="serve"
+        ) as (proc, drain):
+            booted = drain.wait_for(_BOOT_BANNER_PREFIX, timeout=_BOOT_TIMEOUT_S)
+            assert booted, (
+                f"supervisor never emitted {_BOOT_BANNER_PREFIX!r} within "
+                f"{_BOOT_TIMEOUT_S:.0f}s.\n--- stderr ---\n{drain.snapshot()}"
+            )
+            assert proc.poll() is None, (
+                f"supervisor died after boot (rc={proc.returncode}).\n"
+                f"--- stderr ---\n{drain.snapshot()}"
+            )
+
+            # The supervisor publishes the discovery file only after
+            # MCP's /healthz responds; on a cold ``uv run`` boot that
+            # write can land a few hundred ms after the banner. Give it
+            # a generous waiting window (still well under the boot
+            # budget so a real failure doesn't hide behind an
+            # over-generous timeout).
+            assert _wait_for_file(active_mcp, timeout=10.0), (
+                f"active-mcp.json was not written within 10s of boot.\n"
+                f"--- stderr ---\n{drain.snapshot()}"
+            )
+
+            payload = json.loads(active_mcp.read_text(encoding="utf-8"))
+
+            # Top-level schema.
+            assert set(payload.keys()) >= {
+                "started_at",
+                "supervisor_pid",
+                "version",
+                "subsystems",
+            }, payload
+            assert isinstance(payload["started_at"], str) and payload[
+                "started_at"
+            ].endswith("+00:00")
+            assert isinstance(payload["supervisor_pid"], int)
+            assert payload["supervisor_pid"] > 0
+            assert isinstance(payload["version"], str)
+            assert isinstance(payload["subsystems"], dict)
+
+            # All three subsystems present in dev mode.
+            sub = payload["subsystems"]
+            assert set(sub.keys()) == {"mcp", "api", "ui"}, sub.keys()
+
+            # MCP block shape.
+            mcp_block = sub["mcp"]
+            assert mcp_block["http_url"].startswith("http://127.0.0.1:")
+            assert mcp_block["http_url"].endswith("/sse")
+            assert mcp_block["healthz_url"].startswith("http://127.0.0.1:")
+            assert mcp_block["healthz_url"].endswith("/healthz")
+            assert isinstance(mcp_block["pid"], int) and mcp_block["pid"] > 0
+
+            # API block shape.
+            api_block = sub["api"]
+            assert api_block["http_url"].startswith("http://127.0.0.1:")
+            assert api_block["healthz_url"].endswith("/healthz")
+            assert api_block["docs_url"].endswith("/docs")
+            assert isinstance(api_block["pid"], int) and api_block["pid"] > 0
+
+            # UI block shape: ``healthz_url`` deliberately None (Vite).
+            ui_block = sub["ui"]
+            assert ui_block["http_url"].startswith("http://127.0.0.1:")
+            assert ui_block["healthz_url"] is None
+            assert isinstance(ui_block["pid"], int) and ui_block["pid"] > 0
+
+        # Context manager SIGTERMed the supervisor; the discovery file
+        # MUST be gone (graceful-shutdown contract).
+        # Allow a brief moment for the shutdown's ``finally`` to land.
+        deadline = time.monotonic() + 10.0
+        while active_mcp.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert not active_mcp.exists(), (
+            "active-mcp.json was not removed on graceful shutdown.\n"
+            f"--- stderr ---\n{drain.snapshot()}"
+        )
+
+
+def test_doctor_reports_active_mcp_contents() -> None:
+    """``ctxr-fsm doctor --json`` surfaces the discovery doc verbatim.
+
+    Operators reach for ``doctor`` when a skill says "MCP unreachable";
+    the discovery doc is what the skill bootstrap would have parsed,
+    so doctor showing the same bytes is the diagnostic shortcut.
+    """
+    with tempfile.TemporaryDirectory(prefix="ctxr-fsm-amcp-doc-") as tmpdir:
+        project_root = _stage_project_root(Path(tmpdir))
+        db_path = project_root / "fsm.db"
+        active_mcp = project_root / _ACTIVE_MCP_FILE_REL
+
+        with _spawn_supervisor(
+            project_root=project_root, db_path=db_path, label="serve"
+        ) as (_proc, drain):
+            booted = drain.wait_for(_BOOT_BANNER_PREFIX, timeout=_BOOT_TIMEOUT_S)
+            assert booted, drain.snapshot()
+            assert _wait_for_file(active_mcp, timeout=10.0)
+
+            # Doctor against the same project root.
+            res = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "ctxr-fsm",
+                    "doctor",
+                    "--json",
+                    "--db",
+                    str(db_path),
+                ],
+                cwd=str(project_root),
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+            assert res.returncode == 0, (
+                f"doctor exited {res.returncode}\nstdout: {res.stdout}\n"
+                f"stderr: {res.stderr}"
+            )
+            report = json.loads(res.stdout)
+            assert "supervisor" in report
+            sup = report["supervisor"]
+            assert "active_mcp" in sup
+            doc = sup["active_mcp"]
+            assert doc is not None, (
+                f"doctor returned None for active_mcp; expected the "
+                f"discovery doc.\nreport: {report}"
+            )
+            assert "subsystems" in doc
+            # The doctor reads the file at call time, so its view of
+            # the subsystem set must match the on-disk file.
+            disk_payload = json.loads(active_mcp.read_text(encoding="utf-8"))
+            assert doc["subsystems"].keys() == disk_payload["subsystems"].keys()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual debug path
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/lifecycle/test_active_mcp_primitives.py
+++ b/tests/unit/lifecycle/test_active_mcp_primitives.py
@@ -1,0 +1,163 @@
+"""Unit tests for the ``active-mcp.json`` primitives (W14c).
+
+Covers the read / write / remove + path helpers in isolation:
+
+* Atomic write goes through tmp + rename (we observe the
+  ``.tmp`` sibling is gone after the call).
+* Re-reads round-trip the payload exactly.
+* Missing file collapses to ``None`` (no exception).
+* Malformed JSON collapses to ``None``.
+* ``remove`` is idempotent when the file is already gone.
+* ``now_iso_ms`` returns a string with millisecond precision and the
+  ``+00:00`` UTC offset (project convention).
+
+The supervisor end-to-end behaviour (file written on boot, removed on
+shutdown) lives in ``tests/integration/lifecycle/test_active_mcp_json.py``
+because it needs a real ``ctxr-fsm serve`` subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ctxr.fsm.cli.lifecycle.primitives import (
+    active_mcp_file_path,
+    now_iso_ms,
+    read_active_mcp_file,
+    remember_active_mcp_file,
+    remove_active_mcp_file,
+)
+
+
+def test_active_mcp_file_path_under_state_dir(tmp_path: Path) -> None:
+    """Path helper resolves under ``<project_root>/.ctxr-fsm/`` exactly.
+
+    The skill bootstrap discipline (W14e) tells agents to look for the
+    file at this exact location; an accidental relocation (e.g. into
+    ``pids/``) would silently break every skill that depends on the
+    fallback path.
+    """
+    path = active_mcp_file_path(tmp_path)
+    assert path == tmp_path / ".ctxr-fsm" / "active-mcp.json"
+
+
+def test_remember_round_trips(tmp_path: Path) -> None:
+    """Write + read returns the same document byte-for-equivalent.
+
+    ``json.dumps(sort_keys=True)`` makes the on-disk bytes
+    deterministic, and ``json.loads`` mirrors it back into the same
+    dict.
+    """
+    payload = {
+        "started_at": now_iso_ms(),
+        "supervisor_pid": 1234,
+        "version": "0.2.0",
+        "subsystems": {
+            "mcp": {
+                "http_url": "http://127.0.0.1:8770/sse",
+                "healthz_url": "http://127.0.0.1:8770/healthz",
+                "pid": 5,
+            },
+        },
+    }
+    remember_active_mcp_file(payload, project_root=tmp_path)
+    loaded = read_active_mcp_file(tmp_path)
+    assert loaded == payload
+
+
+def test_remember_is_atomic_no_tmp_left_behind(tmp_path: Path) -> None:
+    """The tmp-then-rename idiom does not leave a ``.tmp`` sibling."""
+    remember_active_mcp_file(
+        {"started_at": now_iso_ms(), "supervisor_pid": 0,
+         "version": "0.0.0", "subsystems": {}},
+        project_root=tmp_path,
+    )
+    state_dir = tmp_path / ".ctxr-fsm"
+    siblings = sorted(p.name for p in state_dir.iterdir())
+    assert "active-mcp.json" in siblings
+    # Strictly: NO ``.tmp`` artefact.
+    assert not any(name.endswith(".tmp") for name in siblings), siblings
+
+
+def test_read_returns_none_when_missing(tmp_path: Path) -> None:
+    """Missing file collapses to ``None`` — caller treats supervisor as down."""
+    assert read_active_mcp_file(tmp_path) is None
+
+
+def test_read_returns_none_on_malformed_json(tmp_path: Path) -> None:
+    """A hand-edit that breaks JSON does not crash the reader.
+
+    Real-world failure: an operator opens the file in an editor and
+    saves a half-edit. The skill bootstrap retries via fall-through;
+    a crash here would block the retry on a non-bug.
+    """
+    (tmp_path / ".ctxr-fsm").mkdir(parents=True, exist_ok=True)
+    active_mcp_file_path(tmp_path).write_text("{not valid json", encoding="utf-8")
+    assert read_active_mcp_file(tmp_path) is None
+
+
+def test_remove_is_idempotent(tmp_path: Path) -> None:
+    """Removing a non-existent file is a no-op, not an exception.
+
+    Shutdown paths fire ``remove_active_mcp_file`` unconditionally; a
+    second supervisor crash that never wrote the file in the first
+    place would otherwise crash the cleanup.
+    """
+    # First call: file is absent → no-op.
+    remove_active_mcp_file(project_root=tmp_path)
+    # Now create and remove.
+    remember_active_mcp_file(
+        {"started_at": now_iso_ms(), "supervisor_pid": 0,
+         "version": "0.0.0", "subsystems": {}},
+        project_root=tmp_path,
+    )
+    assert active_mcp_file_path(tmp_path).exists()
+    remove_active_mcp_file(project_root=tmp_path)
+    assert not active_mcp_file_path(tmp_path).exists()
+    # Third call after removal: still a no-op.
+    remove_active_mcp_file(project_root=tmp_path)
+
+
+def test_now_iso_ms_has_millisecond_precision() -> None:
+    """``now_iso_ms`` truncates to milliseconds and includes a UTC offset.
+
+    Project convention (per the plan): every timestamp the FSM
+    substrate persists is ISO-8601 in UTC with millisecond precision.
+    Microsecond precision would make CLI output noisier than humans
+    need and microsecond-vs-millisecond drift breaks the row-comparison
+    contracts in the dummy-fsm-test (W14h).
+    """
+    s = now_iso_ms()
+    # ``2026-05-29T12:34:56.789+00:00`` — 29 chars exactly.
+    assert s.endswith("+00:00"), s
+    # The dot must precede a 3-digit ms run + the offset.
+    assert "." in s
+    ms_part = s.split(".", 1)[1].split("+", 1)[0]
+    assert ms_part.isdigit() and len(ms_part) == 3, s
+
+
+def test_remember_overwrites_existing_document(tmp_path: Path) -> None:
+    """A second write replaces the first verbatim (no append, no merge).
+
+    The supervisor calls ``remember_active_mcp_file`` on every reload;
+    this contract means a previous document's stale subsystem block
+    cannot leak into a fresh one.
+    """
+    first = {
+        "started_at": now_iso_ms(),
+        "supervisor_pid": 1,
+        "version": "0.0.1",
+        "subsystems": {"mcp": {"http_url": "http://127.0.0.1:1/sse"}},
+    }
+    second = {
+        "started_at": now_iso_ms(),
+        "supervisor_pid": 2,
+        "version": "0.0.2",
+        "subsystems": {"mcp": {"http_url": "http://127.0.0.1:2/sse"}},
+    }
+    remember_active_mcp_file(first, project_root=tmp_path)
+    remember_active_mcp_file(second, project_root=tmp_path)
+    bytes_on_disk = active_mcp_file_path(tmp_path).read_text(encoding="utf-8")
+    loaded = json.loads(bytes_on_disk)
+    assert loaded == second


### PR DESCRIPTION
## Summary

Bundled landing of W14b (ensure CLI), W14c (active-mcp.json discovery), and W14d (install-mcp client-config merger). These three pieces form one cohesive bootstrap surface — W14b depends on W14c (the discovery file the supervisor writes) and W14d (the install-mcp logic ensure delegates to), so shipping them separately would mean W14b's tests couldn't run end-to-end.

Chains on top of #38 (W14a InlineHandler engine extension); base is \`w14a/inline-handler-engine\` per the established W14-stack pattern.

### W14c — \`.ctxr-fsm/active-mcp.json\` discovery file
- \`lifecycle/primitives.py\`: \`active_mcp_file_path\` / \`remember_active_mcp_file\` / \`read_active_mcp_file\` / \`remove_active_mcp_file\` + \`now_iso_ms\` helper.
- \`lifecycle/supervisor.py\`: \`_publish_active_mcp_file\` (gated on MCP healthz=200) + reload-time \`_publish_active_mcp_file_from_disk\`; removed on graceful shutdown.
- Schema per plan: \`started_at\` / \`supervisor_pid\` / \`version\` / \`subsystems\` (\`mcp\` / \`api\` / \`ui\` with \`http_url\` / \`healthz_url\` / \`pid\`; \`api\` also gets \`docs_url\`; \`ui.healthz_url\` is \`null\` because Vite has none).
- \`doctor_cmd.py\`: \`doctor --json\` surfaces the discovery doc verbatim under \`supervisor.active_mcp\`.
- \`mcp/__init__.py\`: trivial \`/healthz\` route on the FastMCP HTTP-SSE transport so the supervisor can probe MCP the same way it probes API.

### W14d — \`install-mcp\` CLI + cwd walk-up
- \`cli/install_mcp_cmd.py\`: \`run_install_mcp(target_dir, client)\` + \`install-mcp\` Typer command.
  - Claude: \`.mcp.json\` / \`.claude/settings.json\` (workspace heuristic: \`.git\` or \`CLAUDE.md\`).
  - Cursor: \`~/.cursor/mcp.json\` user-level.
  - Codex: \`~/.codex/config.toml\` (prefers \`codex mcp add\` CLI when on PATH, falls back to a hand-rolled TOML splicer otherwise).
- Only the \`ctxr-fsm\` entry / table is owned; every other entry passes through verbatim.
- Atomic tmp+rename writes; preserves existing indent style (2/4/tab); detects out-of-date entries; deep-equal short-circuits to \`action=unchanged\` on no-op reapply.
- \`mcp/server.py\` + \`cli/_common.py\`: \`resolve_db_path\` gains a cwd walk-up tier so the stdio MCP entry stays portable across projects.

### W14b — \`ensure\` CLI
- \`cli/ensure_cmd.py\`: \`run_ensure(project_root, client, mode, ...)\` + Typer command. Single bootstrap entry point every skill calls from its SKILL.md preamble.
- Algorithm: walk-up project root → init (idempotent) → install-memory (unless \`--no-memory\`) → install-mcp (unless \`--no-mcp-config\` or \`client=none\`) → spawn detached supervisor if not already up → wait for \`active-mcp.json\` + per-subsystem healthz within \`--timeout\` → emit structured JSON.
- \`--check\` is read-only (no spawns, no mutation, per-step \`current\`/\`missing\` status).
- \`--mode mcp-only\` narrows boot to MCP only for headless CI.
- JSON default when stdout is not a TTY.
- \`cli/init_cmd.py\`: extracted \`run_init()\` pure core so ensure can call it without going through Typer.
- \`cli/serve_cmd.py\` + supervisor: \`--mcp-only\` flag.

## Acceptance criteria

- [x] Cold-start ensure spawns the supervisor and produces \`status: ready\` JSON with \`active-mcp.json\` on disk.
- [x] Warm-path ensure exits in < 2000ms with \`actions.supervisor = reused\` and no subprocess spawn.
- [x] \`--check\` is read-only (no \`.ctxr-fsm/\` mutation, no pid files written, no processes spawned).
- [x] Parallel ensure invocations converge on one supervisor (W7 singleton).
- [x] \`--mode mcp-only\` boots only the MCP subsystem.
- [x] JSON is the default output when stdin/stdout is not a TTY.
- [x] Timeout failure returns \`status: failed\` with structured detail.
- [x] \`install-mcp\` preserves unrelated entries in \`.mcp.json\` / Cursor / Codex configs.
- [x] \`install-mcp --check\` reports per-client \`installed\` / \`missing\` / \`out-of-date\`.
- [x] \`install-mcp --dry-run\` does not mutate any file.
- [x] Reapply is a true no-op (\`action=unchanged\`, byte-identical, mtime preserved).
- [x] MCP \`cwd\` walk-up resolves the right DB across all four precedence tiers.
- [x] \`active-mcp.json\` is written on supervisor boot (after MCP healthz=200) and removed on graceful shutdown.
- [x] \`doctor --json\` surfaces the discovery doc under \`supervisor.active_mcp\`.

## Test counts

- 68 new tests added across:
  - \`tests/unit/lifecycle/test_active_mcp_primitives.py\` (8)
  - \`tests/integration/lifecycle/test_active_mcp_json.py\` (2)
  - \`tests/integration/install_mcp/\` (22)
  - \`tests/integration/bootstrap/\` (36)
- Total: **564 passed** (full suite).
- \`uv run ruff check ctxr/fsm/ tests/\` → all checks passed.
- \`uv run mypy ctxr/fsm/\` → no issues found in 63 source files.

## Verification output

\`\`\`
uv run pytest --no-header
...
564 passed, 4 warnings in 82.85s

uv run ruff check ctxr/fsm/ tests/
All checks passed!

uv run mypy ctxr/fsm/
Success: no issues found in 63 source files
\`\`\`

## Deviations from the plan

1. The cold-start integration test runs in \`--mode mcp-only\` rather than \`--mode full\` because booting the full trio under \`uv run\` from a cold cache compounds CI time badly. The warm-path test exercises full mode (via fake pids + httpx mock) so both surfaces are covered.
2. The reload-time \`_publish_active_mcp_file_from_disk\` helper rebuilds the document from \`recall_port\` + pid files rather than threading port state through the reload loop — simpler and matches what the supervisor itself would see on a cold start.

## Test plan

- [x] \`uv run pytest\` green
- [x] \`uv run ruff check ctxr/fsm/ tests/\` clean
- [x] \`uv run mypy ctxr/fsm/\` clean
- [x] \`uv run ctxr-fsm ensure --help\` renders correctly
- [x] \`uv run ctxr-fsm install-mcp --help\` renders correctly
- [x] Smoke test of \`ctxr-fsm ensure --check\` in a fresh tmpdir returns \`status: missing:init,supervisor\` in ~1ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)