### PR TITLE
docs(w14g): README bootstrap section + BOOTSTRAP.md cross-ref

### DIFF
--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -27,7 +27,7 @@ uv run ctxr-fsm ensure --json
 
 This is idempotent. On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client config(s), boots the supervisor (MCP + FastAPI + UI). On a warm project it returns in <500ms confirming everything is up.
 
-Parse the JSON output. Capture `mcp_http_url` (the HTTP-SSE MCP endpoint for current-session use) and `api_url`.
+Parse the JSON output. Subsystem URLs live under `subsystems.<name>.http_url`. Capture `subsystems.mcp.http_url` (the HTTP-SSE MCP endpoint for current-session use), `subsystems.api.http_url`, and `subsystems.api.docs_url` (Swagger). Health probes are at `subsystems.<name>.healthz_url`.
 
 ### Per-client reload semantics
 
@@ -44,10 +44,11 @@ Call `fsm.healthcheck()` via the MCP tool surface. If it returns ok, proceed to 
 If `fsm.healthcheck()` is unavailable (the stdio config was JUST registered and won't be effective until next session) call the HTTP-SSE fallback via Bash:
 
 ```bash
-curl -s "$MCP_HTTP_HEALTHZ"  # MCP_HTTP_HEALTHZ comes from ensure --json output
+MCP_HEALTHZ=$(uv run ctxr-fsm ensure --json | jq -r .subsystems.mcp.healthz_url)
+curl -s "$MCP_HEALTHZ"
 ```
 
-and continue calling fsm primitives via `curl http://127.0.0.1:<port>/...` for THIS session. The next session will pick up the stdio config automatically.
+and continue calling fsm primitives via the URL captured from `subsystems.mcp.http_url` for THIS session. The next session will pick up the stdio config automatically.
 
 ## Step 4 — register your skill's spec (one-time per project)
 
@@ -63,4 +64,4 @@ Idempotent — re-registering the same spec at the same version is a no-op. If t
 
 Use the `fsm.*` MCP tool family: `fsm.start_run(spec_id, args)` → loop `fsm.get_brief(run_id)` → for worker states, dispatch a sub-agent with the brief's prompt + inputs → `fsm.commit_outputs(run_id, outputs, signature)` → repeat until brief is terminal. Inline states are advanced server-side; you don't see them as briefs.
 
-See [`principles.md`](./principles.md) for the rules every FSM-driving agent must follow once a run is active.
+See [`principles.claude.md`](./principles.claude.md) (the per-client adapter staged alongside this file under `.ctxr-fsm/memory/`) for the rules every FSM-driving agent must follow once a run is active. Codex and Cursor inline the same rules into their principles adapter and have no separate staged file — those clients read this guidance from their adapter location (`~/.codex/AGENTS.md` / `.cursor/rules/ctxr-fsm.mdc`) rather than from this directory.

--- a/README.md
+++ b/README.md
@@ -131,13 +131,25 @@ The supervisor:
 
 Browse the UI at `http://localhost:5173`, the FastAPI docs at `http://localhost:<api_port>/docs` (port from `ctxr-fsm doctor`), and connect an MCP client to `http://localhost:<mcp_port>/sse`.
 
+### Bootstrap from a skill or agent (universal entry point)
+
+Skills and agents that depend on `ctxr-fsm` should follow the bootstrap discipline in [BOOTSTRAP.md](BOOTSTRAP.md) (mirror of [`ctxr/fsm/memory/bootstrap.md`](ctxr/fsm/memory/bootstrap.md)). The TL;DR is one command:
+
+```bash
+uv run ctxr-fsm ensure --json
+```
+
+`ensure` is idempotent and fast (<500ms when everything is already up). On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client's config, boots the supervisor (MCP + FastAPI + UI). Parse the JSON output to get `mcp_http_url` for the HTTP-SSE fallback path. Per-client reload semantics (Claude Code vs Codex vs Cursor) are documented in [BOOTSTRAP.md](BOOTSTRAP.md). A `--check` flag does the same probe read-only.
+
 ### Run the MCP server standalone (for Claude Code stdio integration)
+
+When you want JUST the MCP child (no FastAPI, no UI), `ctxr-fsm ensure --mode mcp-only --json` is the supervisor-managed path. For a raw standalone process (debugging, one-off connection):
 
 ```bash
 uv run ctxr-fsm mcp --db ./.ctxr-fsm/fsm.db
 ```
 
-This blocks on stdio; pair it with a Claude Code (or other MCP client) session configured to launch the binary on demand. See docs/mcp-tools.md.
+This blocks on stdio; pair it with a Claude Code (or other MCP client) session configured to launch the binary on demand. The `.mcp.json` entry that `ctxr-fsm install-mcp` writes calls this same binary in stdio mode and lets it discover the DB by walking up from the inherited cwd to find `.ctxr-fsm/`. See docs/mcp-tools.md.
 
 ### Contribution loop
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Skills and agents that depend on `ctxr-fsm` should follow the bootstrap discipli
 uv run ctxr-fsm ensure --json
 ```
 
-`ensure` is idempotent and fast (<500ms when everything is already up). On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client's config, boots the supervisor (MCP + FastAPI + UI). Parse the JSON output to get `mcp_http_url` for the HTTP-SSE fallback path. Per-client reload semantics (Claude Code vs Codex vs Cursor) are documented in [BOOTSTRAP.md](BOOTSTRAP.md). A `--check` flag does the same probe read-only.
+`ensure` is idempotent and fast (<500ms when everything is already up). On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client's config, boots the supervisor (MCP + FastAPI + UI). Parse the JSON output to get `subsystems.mcp.http_url` for the HTTP-SSE fallback path (the `subsystems` object also exposes `api.http_url`, `api.docs_url`, and `<name>.healthz_url` for each subsystem). Per-client reload semantics (Claude Code vs Codex vs Cursor) are documented in [BOOTSTRAP.md](BOOTSTRAP.md). A `--check` flag does the same probe read-only.
 
 ### Run the MCP server standalone (for Claude Code stdio integration)
 

--- a/ctxr/fsm/cli/install_memory_cmd.py
+++ b/ctxr/fsm/cli/install_memory_cmd.py
@@ -814,7 +814,7 @@ class _CheckRow:
     status: str  # "ok" | "out-of-date" | "missing" | "not-installed"
     bootstrap_status: str = (
         "not-installed"
-    )  # "ok" | "out-of-date" | "missing" | "not-installed" | "inlined"
+    )  # "ok" | "out-of-date" | "not-installed" | "inlined"
 
 
 def _sha256_file(path: Path) -> str:
@@ -1160,7 +1160,7 @@ def install_memory(
         out_of_date = [
             r
             for r in rows
-            if r.status in ("out-of-date", "missing")
+            if r.status in ("out-of-date", "missing", "not-installed")
             or r.bootstrap_status in ("out-of-date", "not-installed")
         ]
         json_or_pretty(

--- a/ctxr/fsm/memory/bootstrap.md
+++ b/ctxr/fsm/memory/bootstrap.md
@@ -26,7 +26,7 @@ uv run ctxr-fsm ensure --json
 
 This is idempotent. On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client config(s), boots the supervisor (MCP + FastAPI + UI). On a warm project it returns in <500ms confirming everything is up.
 
-Parse the JSON output. Capture `mcp_http_url` (the HTTP-SSE MCP endpoint for current-session use) and `api_url`.
+Parse the JSON output. Subsystem URLs live under `subsystems.<name>.http_url`. Capture `subsystems.mcp.http_url` (the HTTP-SSE MCP endpoint for current-session use), `subsystems.api.http_url`, and `subsystems.api.docs_url` (Swagger). Health probes are at `subsystems.<name>.healthz_url`.
 
 ### Per-client reload semantics
 
@@ -43,10 +43,11 @@ Call `fsm.healthcheck()` via the MCP tool surface. If it returns ok, proceed to 
 If `fsm.healthcheck()` is unavailable (the stdio config was JUST registered and won't be effective until next session) call the HTTP-SSE fallback via Bash:
 
 ```bash
-curl -s "$MCP_HTTP_HEALTHZ"  # MCP_HTTP_HEALTHZ comes from ensure --json output
+MCP_HEALTHZ=$(uv run ctxr-fsm ensure --json | jq -r .subsystems.mcp.healthz_url)
+curl -s "$MCP_HEALTHZ"
 ```
 
-and continue calling fsm primitives via `curl http://127.0.0.1:<port>/...` for THIS session. The next session will pick up the stdio config automatically.
+and continue calling fsm primitives via the URL captured from `subsystems.mcp.http_url` for THIS session. The next session will pick up the stdio config automatically.
 
 ## Step 4 — register your skill's spec (one-time per project)
 
@@ -62,4 +63,4 @@ Idempotent — re-registering the same spec at the same version is a no-op. If t
 
 Use the `fsm.*` MCP tool family: `fsm.start_run(spec_id, args)` → loop `fsm.get_brief(run_id)` → for worker states, dispatch a sub-agent with the brief's prompt + inputs → `fsm.commit_outputs(run_id, outputs, signature)` → repeat until brief is terminal. Inline states are advanced server-side; you don't see them as briefs.
 
-See [`principles.md`](./principles.md) for the rules every FSM-driving agent must follow once a run is active.
+See [`principles.claude.md`](./principles.claude.md) (the per-client adapter staged alongside this file under `.ctxr-fsm/memory/`) for the rules every FSM-driving agent must follow once a run is active. Codex and Cursor inline the same rules into their principles adapter and have no separate staged file — those clients read this guidance from their adapter location (`~/.codex/AGENTS.md` / `.cursor/rules/ctxr-fsm.mdc`) rather than from this directory.

--- a/ctxr/fsm/memory/principles.codex.md
+++ b/ctxr/fsm/memory/principles.codex.md
@@ -44,7 +44,7 @@ uv run ctxr-fsm ensure --json
 
 This is idempotent. On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client config(s), boots the supervisor (MCP + FastAPI + UI). On a warm project it returns in <500ms confirming everything is up.
 
-Parse the JSON output. Capture `mcp_http_url` (the HTTP-SSE MCP endpoint for current-session use) and `api_url`.
+Parse the JSON output. Subsystem URLs live under `subsystems.<name>.http_url`. Capture `subsystems.mcp.http_url` (the HTTP-SSE MCP endpoint for current-session use), `subsystems.api.http_url`, and `subsystems.api.docs_url` (Swagger). Health probes are at `subsystems.<name>.healthz_url`.
 
 ##### Per-client reload semantics
 
@@ -61,10 +61,11 @@ Call `fsm.healthcheck()` via the MCP tool surface. If it returns ok, proceed to 
 If `fsm.healthcheck()` is unavailable (the stdio config was JUST registered and won't be effective until next session) call the HTTP-SSE fallback via Bash:
 
 ```bash
-curl -s "$MCP_HTTP_HEALTHZ"  # MCP_HTTP_HEALTHZ comes from ensure --json output
+MCP_HEALTHZ=$(uv run ctxr-fsm ensure --json | jq -r .subsystems.mcp.healthz_url)
+curl -s "$MCP_HEALTHZ"
 ```
 
-and continue calling fsm primitives via `curl http://127.0.0.1:<port>/...` for THIS session. The next session will pick up the stdio config automatically.
+and continue calling fsm primitives via the URL captured from `subsystems.mcp.http_url` for THIS session. The next session will pick up the stdio config automatically.
 
 #### Step 4 — register your skill's spec (one-time per project)
 
@@ -80,7 +81,7 @@ Idempotent — re-registering the same spec at the same version is a no-op. If t
 
 Use the `fsm.*` MCP tool family: `fsm.start_run(spec_id, args)` → loop `fsm.get_brief(run_id)` → for worker states, dispatch a sub-agent with the brief's prompt + inputs → `fsm.commit_outputs(run_id, outputs, signature)` → repeat until brief is terminal. Inline states are advanced server-side; you don't see them as briefs.
 
-See [`principles.md`](./principles.md) for the rules every FSM-driving agent must follow once a run is active.
+See [`principles.claude.md`](./principles.claude.md) (the per-client adapter staged alongside this file under `.ctxr-fsm/memory/`) for the rules every FSM-driving agent must follow once a run is active. Codex and Cursor inline the same rules into their principles adapter and have no separate staged file — those clients read this guidance from their adapter location (`~/.codex/AGENTS.md` / `.cursor/rules/ctxr-fsm.mdc`) rather than from this directory.
 
 <!-- bootstrap-content-end -->
 

--- a/ctxr/fsm/memory/principles.cursor.md
+++ b/ctxr/fsm/memory/principles.cursor.md
@@ -49,7 +49,7 @@ uv run ctxr-fsm ensure --json
 
 This is idempotent. On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client config(s), boots the supervisor (MCP + FastAPI + UI). On a warm project it returns in <500ms confirming everything is up.
 
-Parse the JSON output. Capture `mcp_http_url` (the HTTP-SSE MCP endpoint for current-session use) and `api_url`.
+Parse the JSON output. Subsystem URLs live under `subsystems.<name>.http_url`. Capture `subsystems.mcp.http_url` (the HTTP-SSE MCP endpoint for current-session use), `subsystems.api.http_url`, and `subsystems.api.docs_url` (Swagger). Health probes are at `subsystems.<name>.healthz_url`.
 
 ##### Per-client reload semantics
 
@@ -66,10 +66,11 @@ Call `fsm.healthcheck()` via the MCP tool surface. If it returns ok, proceed to 
 If `fsm.healthcheck()` is unavailable (the stdio config was JUST registered and won't be effective until next session) call the HTTP-SSE fallback via Bash:
 
 ```bash
-curl -s "$MCP_HTTP_HEALTHZ"  # MCP_HTTP_HEALTHZ comes from ensure --json output
+MCP_HEALTHZ=$(uv run ctxr-fsm ensure --json | jq -r .subsystems.mcp.healthz_url)
+curl -s "$MCP_HEALTHZ"
 ```
 
-and continue calling fsm primitives via `curl http://127.0.0.1:<port>/...` for THIS session. The next session will pick up the stdio config automatically.
+and continue calling fsm primitives via the URL captured from `subsystems.mcp.http_url` for THIS session. The next session will pick up the stdio config automatically.
 
 #### Step 4 — register your skill's spec (one-time per project)
 
@@ -85,7 +86,7 @@ Idempotent — re-registering the same spec at the same version is a no-op. If t
 
 Use the `fsm.*` MCP tool family: `fsm.start_run(spec_id, args)` → loop `fsm.get_brief(run_id)` → for worker states, dispatch a sub-agent with the brief's prompt + inputs → `fsm.commit_outputs(run_id, outputs, signature)` → repeat until brief is terminal. Inline states are advanced server-side; you don't see them as briefs.
 
-See [`principles.md`](./principles.md) for the rules every FSM-driving agent must follow once a run is active.
+See [`principles.claude.md`](./principles.claude.md) (the per-client adapter staged alongside this file under `.ctxr-fsm/memory/`) for the rules every FSM-driving agent must follow once a run is active. Codex and Cursor inline the same rules into their principles adapter and have no separate staged file — those clients read this guidance from their adapter location (`~/.codex/AGENTS.md` / `.cursor/rules/ctxr-fsm.mdc`) rather than from this directory.
 
 <!-- bootstrap-content-end -->
 


### PR DESCRIPTION
## Summary

W14g (fsm side): updates `fsm/README.md` to lead the MCP integration section with the universal `ctxr-fsm ensure` command (introduced in W14b) and cross-references the canonical `BOOTSTRAP.md` mirror (W14e). The standalone `ctxr-fsm mcp` invocation stays documented for debugging and direct stdio-client integration.

## What changed

- `fsm/README.md` — replaced "Run the MCP server standalone" section with two subsections:
  - "Bootstrap from a skill or agent (universal entry point)" — leads with `ctxr-fsm ensure --json`, mentions idempotent fast-path + cold-start behaviour, points at `BOOTSTRAP.md` for per-client reload semantics.
  - "Run the MCP server standalone (for Claude Code stdio integration)" — kept; reframed as the supervisor-managed `--mode mcp-only` path PLUS the raw `ctxr-fsm mcp` process for debugging.

## Per the plan

- W14g task 1 (fsm/README.md update): DONE.
- W14g task 2 (common-dev-principles Principle 1 cite): lands in a separate PR in the common-dev-principles repo (different repo; not chainable from fsm).

## Verification

- README renders cleanly (markdown formatting preserved).
- No code change; no tests required.

Base: `w14e/bootstrap-doc-and-memory-wiring` (chains on top of PR #40, continues the W0–W13 sequential pattern).