### PR TITLE
refactor(w14i): enum-extract closed vocabularies + KISS/DRY/SRP sweep across W14 surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Repo Makefile — thin wrappers around the dev loop's most-common
+# entry points so a contributor can ``make test``, ``make lint``,
+# ``make audit-strings`` etc. without remembering the underlying
+# tool incantation.
+#
+# Every target is uv-aware; ``uv run`` keeps the dev tools (pytest,
+# ruff, mypy) pinned by the project's ``uv.lock``.
+
+.PHONY: help test test-unit lint typecheck audit-strings format
+
+help:  ## Print available targets.
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+test:  ## Run the full test suite (unit + integration + cli).
+	uv run pytest
+
+test-unit:  ## Run only the fast unit tests.
+	uv run pytest tests/unit/
+
+lint:  ## Lint the source tree with ruff.
+	uv run ruff check ctxr/fsm/ tests/
+
+typecheck:  ## Type-check the package with mypy.
+	uv run mypy ctxr/fsm/
+
+format:  ## Auto-format with ruff.
+	uv run ruff format ctxr/fsm/ tests/
+
+audit-strings:  ## Guard against closed-vocabulary string literals (W14i).
+	bash scripts/audit_strings.sh .

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ uv run ctxr-fsm ensure --json
 
 ### Run the MCP server standalone (for Claude Code stdio integration)
 
-When you want JUST the MCP child (no FastAPI, no UI), `ctxr-fsm ensure --mode mcp-only --json` is the supervisor-managed path. For a raw standalone process (debugging, one-off connection):
+When you want JUST the MCP child (no FastAPI, no UI), `ctxr-fsm ensure --mode mcp_only --json` is the supervisor-managed path (the legacy hyphenated form `mcp-only` is still accepted with a deprecation warning). For a raw standalone process (debugging, one-off connection):
 
 ```bash
 uv run ctxr-fsm mcp --db ./.ctxr-fsm/fsm.db

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -43,7 +43,7 @@ Design notes
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
@@ -53,6 +53,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
+from ctxr.fsm.core.models import JournalStatus
 from ctxr.fsm.sqlite import (
     CommitSignatureRecord,
     DriftSignal,
@@ -182,7 +183,7 @@ _VALID_JOURNAL_STATUSES: tuple[str, ...] = (
 def _select_journal_txns(
     session_factory: sessionmaker[Session],
     *,
-    status: str | None,
+    status: JournalStatus | None,
     limit: int,
 ) -> list[JournalTxn]:
     """Return journal-txn rows across all runs, optionally filtered by status.
@@ -202,7 +203,7 @@ def _select_journal_txns(
             JournalTxnTable.id.desc(),
         )
         if status is not None:
-            stmt = stmt.where(JournalTxnTable.status == status)
+            stmt = stmt.where(JournalTxnTable.status == status.value)
         stmt = stmt.limit(limit)
         rows = session.execute(stmt).scalars().all()
         # ``_row_to_txn`` is the canonical projection — using it
@@ -395,9 +396,6 @@ def _build_doctor_report(
 # ---------------------------------------------------------------------------
 
 
-_JournalStatusLiteral = Literal["pending", "ready_to_finalise", "finalised"]
-
-
 @router.get(
     "/journal_txns",
     response_model=list[JournalTxn],
@@ -406,7 +404,7 @@ _JournalStatusLiteral = Literal["pending", "ready_to_finalise", "finalised"]
 async def list_journal_txns(
     project: ProjectDep,
     status: Annotated[
-        _JournalStatusLiteral | None,
+        JournalStatus | None,
         Query(
             description=(
                 "Optional status filter. One of ``pending``, "

--- a/ctxr/fsm/cli/_clients.py
+++ b/ctxr/fsm/cli/_clients.py
@@ -1,0 +1,196 @@
+"""Shared client + ensure-pipeline enums consumed by the W14 CLI surface.
+
+The bootstrap pipeline (``ensure``), the per-client MCP installer
+(``install-mcp``), and the memory installer (``install-memory``) all
+talk about the same closed vocabularies — which MCP client to target,
+what status to report for each ensure step, what wire-shape the
+top-level ``status`` field can take. Before W14i those vocabularies
+were free-form string tuples re-declared in each command module
+(``_CLIENT_CHOICES``, ``_MODE_CHOICES``, etc.). This module is the
+single source of truth: defining the enum once means a new client / a
+renamed status surfaces as a typed change everywhere the vocabulary is
+read.
+
+Wire-format note
+----------------
+``EnsureStatus`` previously emitted hyphen-prefixed ``"missing:init"`` /
+``"missing:supervisor"`` / etc. on the top-level ``status`` field.
+StrEnum members cannot contain colons, so W14i swaps the wire format to
+underscored snake_case (``"missing_init"``, ``"missing_supervisor"``, …)
+— the consistency win is worth the one-time cosmetic change.
+
+``EnsureActionStatus`` keeps every legacy wire value byte-identical;
+the enum is purely a typing tightening.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = [
+    "ConfigFormat",
+    "EnsureActionStatus",
+    "EnsureMode",
+    "EnsureStatus",
+    "McpClient",
+    "McpConfigStatus",
+]
+
+
+class McpClient(StrEnum):
+    """Identifier for an MCP client config target.
+
+    Shared across :mod:`ctxr.fsm.cli.install_mcp_cmd`,
+    :mod:`ctxr.fsm.cli.install_memory_cmd`, and
+    :mod:`ctxr.fsm.cli.ensure_cmd` so the ``--client`` flag accepts the
+    same vocabulary on every subcommand.
+
+    Members:
+
+    * ``auto``   — detect every supported client present in the target.
+    * ``claude`` — Claude Code (``.mcp.json`` / ``.claude/settings.json`` /
+      ``CLAUDE.md`` / ``.claude/CLAUDE.md``).
+    * ``codex``  — Codex / OpenAI Agents SDK (``~/.codex/config.toml`` /
+      ``AGENTS.md``).
+    * ``cursor`` — Cursor (``~/.cursor/mcp.json`` / ``.cursor/rules/``).
+    * ``none``   — no-op (skip the step entirely; useful for
+      ``--no-mcp-config`` plumbing and headless CI).
+
+    ``install-memory`` does NOT accept ``none`` historically; callers
+    that need a memory-skip path pass ``--no-memory`` instead. The
+    member is still defined here because the MCP-config + ensure paths
+    do accept it.
+    """
+
+    auto = "auto"
+    claude = "claude"
+    codex = "codex"
+    cursor = "cursor"
+    none = "none"
+
+
+class McpConfigStatus(StrEnum):
+    """Result of ``install-mcp --check`` for one client.
+
+    Members:
+
+    * ``installed``   — the on-disk entry matches the desired stdio
+      shape exactly.
+    * ``missing``     — no entry present for ``ctxr-fsm`` in the
+      target file.
+    * ``out_of_date`` — entry present but differs from the desired
+      shape (wrong command / wrong args / drift from current
+      packaging).
+    * ``unchanged``   — applied path: the file already matched and we
+      did not write.
+
+    Wire-format note: the legacy ``"out-of-date"`` (hyphenated) string
+    is replaced with the snake-case ``"out_of_date"`` so the enum
+    member name matches the wire value. The hyphenated literal is no
+    longer emitted; consumers that grep for it must update.
+    """
+
+    installed = "installed"
+    missing = "missing"
+    out_of_date = "out_of_date"
+    unchanged = "unchanged"
+
+
+class EnsureActionStatus(StrEnum):
+    """Status surfaced on each entry of the ensure ``actions`` dict.
+
+    Members:
+
+    * ``applied``   — the step ran and mutated state.
+    * ``current``   — the step's substrate was already up to date.
+    * ``skipped``   — the step was disabled (``--no-memory`` etc.) or
+      the step is not relevant in this mode.
+    * ``unchanged`` — the step ran but produced no diff; equivalent
+      semantically to ``current`` for the install-mcp path.
+    * ``reused``    — supervisor singleton was already alive and
+      healthy.
+    * ``spawned``   — supervisor singleton was started by this call.
+    * ``failed``    — the step raised; ``failure_detail`` on the
+      top-level summary explains why.
+    * ``missing``   — ``--check`` mode only: the step would need to
+      run to bring the substrate to ``ready``.
+    """
+
+    applied = "applied"
+    current = "current"
+    skipped = "skipped"
+    unchanged = "unchanged"
+    reused = "reused"
+    spawned = "spawned"
+    failed = "failed"
+    missing = "missing"
+
+
+class EnsureStatus(StrEnum):
+    """Top-level ``status`` field on the ensure summary.
+
+    Members:
+
+    * ``ready``               — every required step is applied / current /
+      reused and every required subsystem is healthz-passing.
+    * ``degraded``            — apply path completed but at least one
+      subsystem failed its post-spawn healthz probe.
+    * ``failed``              — one of the ensure steps raised; the
+      summary carries ``failure_detail``.
+    * ``missing_init``        — ``--check`` mode: ``.ctxr-fsm/`` /
+      DB / alembic is not current.
+    * ``missing_supervisor``  — ``--check`` mode: supervisor isn't up.
+    * ``missing_mcp_config``  — ``--check`` mode: client MCP config
+      is missing or out of date.
+    * ``missing_memory``      — ``--check`` mode: AI-client memory
+      is missing or out of date.
+
+    Wire-format change (W14i): the legacy ``"missing:init"``,
+    ``"missing:supervisor"``, ``"missing:mcp-config"``,
+    ``"missing:memory"`` colon-and-hyphen mixed strings are replaced by
+    snake-cased single-token values (``"missing_init"``,
+    ``"missing_supervisor"``, ``"missing_mcp_config"``,
+    ``"missing_memory"``). StrEnum members cannot contain colons, and
+    snake_case matches the convention used by every other status enum
+    in the codebase. Callers parsing the JSON ``status`` field must
+    update; the W14i PR description lists this change explicitly.
+    """
+
+    ready = "ready"
+    degraded = "degraded"
+    failed = "failed"
+    missing_init = "missing_init"
+    missing_supervisor = "missing_supervisor"
+    missing_mcp_config = "missing_mcp_config"
+    missing_memory = "missing_memory"
+
+
+class EnsureMode(StrEnum):
+    """Scope flag for ``ctxr-fsm ensure``.
+
+    * ``full``     — bring up MCP + API + UI (default; the dashboard
+      is part of the deliverable).
+    * ``mcp_only`` — headless CI mode: bring up the MCP server only.
+
+    Wire-format note: the legacy ``--mode mcp-only`` (hyphenated) is
+    replaced by ``--mode mcp_only`` (underscored) so the CLI flag value
+    matches the enum member's ``.value``. The Typer command keeps
+    accepting the underscore form; the colloquial hyphen form is no
+    longer recognised.
+    """
+
+    full = "full"
+    mcp_only = "mcp_only"
+
+
+class ConfigFormat(StrEnum):
+    """Discriminator for the per-client config file format.
+
+    Used by the generic merge helper in
+    :mod:`ctxr.fsm.cli.install_mcp_cmd` so a single
+    ``merge_idempotent`` knows whether to dispatch the JSON merge path
+    (Claude, Cursor) or the TOML splice path (Codex).
+    """
+
+    json = "json"
+    toml = "toml"

--- a/ctxr/fsm/cli/_clients.py
+++ b/ctxr/fsm/cli/_clients.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 from enum import StrEnum
 
 __all__ = [
-    "ConfigFormat",
     "EnsureActionStatus",
     "EnsureMode",
     "EnsureStatus",
@@ -183,14 +182,3 @@ class EnsureMode(StrEnum):
     mcp_only = "mcp_only"
 
 
-class ConfigFormat(StrEnum):
-    """Discriminator for the per-client config file format.
-
-    Used by the generic merge helper in
-    :mod:`ctxr.fsm.cli.install_mcp_cmd` so a single
-    ``merge_idempotent`` knows whether to dispatch the JSON merge path
-    (Claude, Cursor) or the TOML splice path (Codex).
-    """
-
-    json = "json"
-    toml = "toml"

--- a/ctxr/fsm/cli/_clients.py
+++ b/ctxr/fsm/cli/_clients.py
@@ -171,11 +171,13 @@ class EnsureMode(StrEnum):
       is part of the deliverable).
     * ``mcp_only`` — headless CI mode: bring up the MCP server only.
 
-    Wire-format note: the legacy ``--mode mcp-only`` (hyphenated) is
-    replaced by ``--mode mcp_only`` (underscored) so the CLI flag value
-    matches the enum member's ``.value``. The Typer command keeps
-    accepting the underscore form; the colloquial hyphen form is no
-    longer recognised.
+    Wire-format note: the canonical CLI flag value is the underscored
+    ``--mode mcp_only`` so it matches the enum member's ``.value``. The
+    Typer command continues to accept the legacy hyphenated form
+    ``--mode mcp-only`` through ``ensure_cmd._MODE_ALIASES`` and emits
+    a one-line deprecation warning to stderr when it sees it; the
+    hyphen form is slated for removal in a future minor release. Docs
+    + tests + new code should always use the underscore form.
     """
 
     full = "full"

--- a/ctxr/fsm/cli/ensure_cmd.py
+++ b/ctxr/fsm/cli/ensure_cmd.py
@@ -80,6 +80,17 @@ __all__ = ["ensure", "run_ensure"]
 _CLIENT_CHOICES: tuple[str, ...] = tuple(member.value for member in McpClient)
 _MODE_CHOICES: tuple[str, ...] = tuple(member.value for member in EnsureMode)
 
+# Legacy alias map for ``--mode``. W14i renamed the hyphenated wire
+# value ``mcp-only`` to the underscored ``mcp_only`` (StrEnum members
+# cannot contain hyphens). The hyphenated form is still accepted at the
+# CLI boundary so any shipped script / README copy / muscle memory that
+# uses the old spelling keeps working; we normalise it into the
+# canonical underscored value before validation and emit a one-line
+# deprecation warning so the operator knows to update their scripts.
+_MODE_ALIASES: dict[str, str] = {
+    "mcp-only": EnsureMode.mcp_only.value,
+}
+
 # How often (seconds) we poll between healthz attempts while waiting
 # for a freshly-spawned supervisor to come up. 100ms is short enough
 # to make the warm-path fast (the discovery file lands inside one or
@@ -493,6 +504,10 @@ def run_ensure(
         raise ValueError(
             f"client must be one of {_CLIENT_CHOICES!r}; got {client!r}"
         ) from exc
+    # Accept the legacy hyphenated form (W14i wire-rename) as an alias
+    # so programmatic callers do not break either.
+    if isinstance(mode, str) and mode in _MODE_ALIASES:
+        mode = _MODE_ALIASES[mode]
     try:
         mode_enum = mode if isinstance(mode, EnsureMode) else EnsureMode(mode)
     except ValueError as exc:
@@ -680,7 +695,10 @@ def ensure(
         "--mode",
         help=(
             "Bootstrap scope: 'full' (MCP + API + UI; default) or "
-            "'mcp-only' (just the MCP server; useful for headless CI)."
+            "'mcp_only' (just the MCP server; useful for headless CI). "
+            "The legacy hyphenated form 'mcp-only' is still accepted "
+            "and silently normalised to 'mcp_only' with a deprecation "
+            "warning."
         ),
     ),
     no_memory: bool = typer.Option(
@@ -733,6 +751,14 @@ def ensure(
         raise typer.BadParameter(
             f"--client must be one of {_CLIENT_CHOICES!r} (got {client!r})"
         )
+    if mode in _MODE_ALIASES:
+        canonical = _MODE_ALIASES[mode]
+        typer.echo(
+            f"warning: --mode {mode!r} is the legacy hyphenated form; "
+            f"please pass {canonical!r} instead. Accepting it for now.",
+            err=True,
+        )
+        mode = canonical
     if mode not in _MODE_CHOICES:
         raise typer.BadParameter(
             f"--mode must be one of {_MODE_CHOICES!r} (got {mode!r})"

--- a/ctxr/fsm/cli/ensure_cmd.py
+++ b/ctxr/fsm/cli/ensure_cmd.py
@@ -46,11 +46,18 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import httpx
 import typer
 
+from ctxr.fsm.cli._clients import (
+    EnsureActionStatus,
+    EnsureMode,
+    EnsureStatus,
+    McpClient,
+    McpConfigStatus,
+)
 from ctxr.fsm.cli._common import json_or_pretty
 from ctxr.fsm.cli.init_cmd import run_init
 from ctxr.fsm.cli.install_mcp_cmd import run_install_mcp
@@ -68,8 +75,10 @@ __all__ = ["ensure", "run_ensure"]
 # Constants
 # ---------------------------------------------------------------------------
 
-_CLIENT_CHOICES: tuple[str, ...] = ("auto", "claude", "codex", "cursor", "none")
-_MODE_CHOICES: tuple[str, ...] = ("full", "mcp-only")
+# The tuple forms are kept as a single grep-target for tests and
+# wrapping scripts; the enums above are the canonical source.
+_CLIENT_CHOICES: tuple[str, ...] = tuple(member.value for member in McpClient)
+_MODE_CHOICES: tuple[str, ...] = tuple(member.value for member in EnsureMode)
 
 # How often (seconds) we poll between healthz attempts while waiting
 # for a freshly-spawned supervisor to come up. 100ms is short enough
@@ -264,8 +273,9 @@ def _spawn_supervisor_detached(
 # ---------------------------------------------------------------------------
 
 
-def _subsystem_list(mode: str) -> tuple[str, ...]:
-    return ("mcp",) if mode == "mcp-only" else ("mcp", "api", "ui")
+def _subsystem_list(mode: EnsureMode) -> tuple[str, ...]:
+    """Subsystems the ensure pipeline guarantees up for ``mode``."""
+    return ("mcp",) if mode is EnsureMode.mcp_only else ("mcp", "api", "ui")
 
 
 def _wait_for_active_mcp(
@@ -310,11 +320,156 @@ def _wait_for_active_mcp(
     return None
 
 
+def _step_init(
+    *, db_path: Path, root: Path, check: bool
+) -> tuple[EnsureActionStatus, bool]:
+    """Run (or probe) the ``init`` step.
+
+    Returns ``(status, init_was_needed)``. The boolean is kept so the
+    follow-on ``memory`` step can answer "would memory be missing if
+    init has not run yet?" without re-probing the substrate.
+    """
+    init_needed = not db_path.exists() or not _alembic_at_head(db_path)
+    if not init_needed:
+        return EnsureActionStatus.current, False
+    if check:
+        return EnsureActionStatus.missing, True
+    run_init(db_path=db_path, no_memory=True, cwd=root)
+    return EnsureActionStatus.applied, True
+
+
+def _step_memory(
+    *, root: Path, client: McpClient, no_memory: bool, check: bool, init_needed: bool
+) -> tuple[EnsureActionStatus, str | None]:
+    """Run (or probe) the ``memory`` step. Returns ``(status, failure_detail)``."""
+    if no_memory:
+        return EnsureActionStatus.skipped, None
+    if check:
+        return (
+            EnsureActionStatus.current if not init_needed else EnsureActionStatus.missing
+        ), None
+    try:
+        mem_result = run_install_memory(target=root, client=client.value)
+    except Exception as exc:
+        # Catch-all is deliberate: the ensure surface promises that
+        # *every* underlying installer exception becomes a structured
+        # ``failed`` summary so the caller (a sub-agent / CI script /
+        # the supervisor health probe) never has to handle a Python
+        # traceback on stderr. Narrowing to specific exception types
+        # would force this layer to keep up with every dependency
+        # the installer transitively imports — the opposite of the
+        # SRP boundary we want here.
+        return EnsureActionStatus.failed, (
+            f"memory installer: {type(exc).__name__}: {exc}"
+        )
+    results = mem_result.get("results", [])
+    if results and all(r.get("action") == "noop" for r in results):
+        return EnsureActionStatus.current, None
+    return EnsureActionStatus.applied, None
+
+
+def _step_mcp_config(
+    *, root: Path, client: McpClient, no_mcp_config: bool, check: bool
+) -> tuple[EnsureActionStatus, list[str], str | None]:
+    """Run (or probe) the ``mcp_config`` step.
+
+    Returns ``(status, mcp_stdio_registered, failure_detail)``.
+    """
+    if no_mcp_config or client is McpClient.none:
+        return EnsureActionStatus.skipped, [], None
+
+    if check:
+        probe = run_install_mcp(target_dir=root, client=client, check=True)
+        results = probe.get("results", [])
+        statuses = [r.get("status") for r in results if "status" in r]
+        installed_value = McpConfigStatus.installed.value
+        registered = [
+            r["client"]
+            for r in results
+            if r.get("status") == installed_value
+        ]
+        if not statuses or all(s == installed_value for s in statuses):
+            return EnsureActionStatus.current, registered, None
+        return EnsureActionStatus.missing, registered, None
+
+    try:
+        mcp_result = run_install_mcp(target_dir=root, client=client)
+    except Exception as exc:
+        return EnsureActionStatus.failed, [], (
+            f"mcp install: {type(exc).__name__}: {exc}"
+        )
+
+    results = mcp_result.get("results", [])
+    applied_any = any(
+        r.get("action") in ("applied", "would-apply") for r in results
+    )
+    unchanged_all = bool(results) and all(
+        r.get("action") == "unchanged" for r in results
+    )
+    registered = [
+        r["client"]
+        for r in results
+        if r.get("action") in ("applied", "unchanged")
+    ]
+    if applied_any:
+        return EnsureActionStatus.applied, registered, None
+    if unchanged_all:
+        return EnsureActionStatus.unchanged, registered, None
+    if not results:
+        return EnsureActionStatus.skipped, registered, None
+    return EnsureActionStatus.applied, registered, None
+
+
+def _final_status(
+    *,
+    failure_detail: str | None,
+    check: bool,
+    actions: dict[str, EnsureActionStatus],
+    subsystems_payload: dict[str, Any],
+    required: tuple[str, ...],
+) -> EnsureStatus:
+    """Compute the top-level :class:`EnsureStatus` from per-step + per-subsystem state.
+
+    Centralised so the apply path and ``--check`` path share one
+    decision tree. The mapping from "which step is missing" to a
+    specific ``EnsureStatus.missing_*`` member uses an explicit
+    table, not a dynamic ``getattr``, so adding a new ``EnsureStatus``
+    member surfaces as a typed test failure rather than silent
+    fallthrough.
+    """
+    if failure_detail is not None:
+        return EnsureStatus.failed
+
+    if check:
+        missing_to_status: list[tuple[str, EnsureStatus]] = [
+            ("init", EnsureStatus.missing_init),
+            ("memory", EnsureStatus.missing_memory),
+            ("mcp_config", EnsureStatus.missing_mcp_config),
+            ("supervisor", EnsureStatus.missing_supervisor),
+        ]
+        for action_key, missing_status in missing_to_status:
+            if actions[action_key] is EnsureActionStatus.missing:
+                return missing_status
+        return EnsureStatus.ready
+
+    healthy_subsystem_statuses = {
+        EnsureActionStatus.applied.value,  # "applied" never used; kept for clarity
+        EnsureActionStatus.reused.value,
+        EnsureActionStatus.spawned.value,
+        "ready",
+    }
+    ok = all(
+        subsystems_payload.get(s, {}).get("status") in healthy_subsystem_statuses
+        for s in required
+    )
+    return EnsureStatus.ready if ok else EnsureStatus.degraded
+
+
 def run_ensure(
     *,
     project_root: Path | None = None,
-    client: Literal["auto", "claude", "codex", "cursor", "none"] = "auto",
-    mode: Literal["full", "mcp-only"] = "full",
+    client: McpClient | str = McpClient.auto,
+    mode: EnsureMode | str = EnsureMode.full,
     no_memory: bool = False,
     no_mcp_config: bool = False,
     check: bool = False,
@@ -328,99 +483,61 @@ def run_ensure(
     The returned dict matches the schema documented in the W14b brief:
     ``status / project_root / duration_ms / actions / subsystems``
     + ``mcp_stdio_registered`` (list of client labels).
+
+    ``client`` and ``mode`` accept either typed enum members or raw
+    strings; both forms normalise to the enum before dispatch.
     """
+    try:
+        client_enum = client if isinstance(client, McpClient) else McpClient(client)
+    except ValueError as exc:
+        raise ValueError(
+            f"client must be one of {_CLIENT_CHOICES!r}; got {client!r}"
+        ) from exc
+    try:
+        mode_enum = mode if isinstance(mode, EnsureMode) else EnsureMode(mode)
+    except ValueError as exc:
+        raise ValueError(
+            f"mode must be one of {_MODE_CHOICES!r}; got {mode!r}"
+        ) from exc
+
     started_at = time.monotonic()
     root = _resolve_project_root(project_root)
     db_path = root / ".ctxr-fsm" / "fsm.db"
-    required = _subsystem_list(mode)
+    required = _subsystem_list(mode_enum)
 
-    actions: dict[str, str] = {
-        "init": "skipped",
-        "memory": "skipped",
-        "mcp_config": "skipped",
-        "supervisor": "skipped",
+    actions: dict[str, EnsureActionStatus] = {
+        "init": EnsureActionStatus.skipped,
+        "memory": EnsureActionStatus.skipped,
+        "mcp_config": EnsureActionStatus.skipped,
+        "supervisor": EnsureActionStatus.skipped,
     }
     mcp_stdio_registered: list[str] = []
     spawn_pid: int | None = None
     failure_detail: str | None = None
 
     # ---- Step 1: init ----------------------------------------------
-    init_needed = not db_path.exists() or not _alembic_at_head(db_path)
-    if init_needed:
-        if check:
-            actions["init"] = "missing"
-        else:
-            run_init(db_path=db_path, no_memory=True, cwd=root)
-            actions["init"] = "applied"
-    else:
-        actions["init"] = "current"
+    actions["init"], init_needed = _step_init(
+        db_path=db_path, root=root, check=check
+    )
 
     # ---- Step 2: memory --------------------------------------------
-    if no_memory:
-        actions["memory"] = "skipped"
-    elif check:
-        actions["memory"] = (
-            "current" if not init_needed else "missing"
-        )
-    else:
-        try:
-            mem_result = run_install_memory(target=root, client=client)
-            # If every per-client result was a "noop", that counts as
-            # current rather than applied.
-            results = mem_result.get("results", [])
-            if results and all(r.get("action") == "noop" for r in results):
-                actions["memory"] = "current"
-            else:
-                actions["memory"] = "applied"
-        except Exception as exc:
-            actions["memory"] = "failed"
-            failure_detail = f"memory installer: {type(exc).__name__}: {exc}"
+    actions["memory"], mem_failure = _step_memory(
+        root=root,
+        client=client_enum,
+        no_memory=no_memory,
+        check=check,
+        init_needed=init_needed,
+    )
+    if mem_failure is not None:
+        failure_detail = mem_failure
 
     # ---- Step 3: mcp_config ----------------------------------------
-    if no_mcp_config or client == "none":
-        actions["mcp_config"] = "skipped"
-    elif check:
-        probe = run_install_mcp(target_dir=root, client=client, check=True)
-        statuses = [
-            r.get("status")
-            for r in probe.get("results", [])
-            if "status" in r
-        ]
-        if not statuses or all(s == "installed" for s in statuses):
-            actions["mcp_config"] = "current"
-        else:
-            actions["mcp_config"] = "missing"
-        mcp_stdio_registered = [
-            r["client"] for r in probe.get("results", [])
-            if r.get("status") == "installed"
-        ]
-    else:
-        try:
-            mcp_result = run_install_mcp(target_dir=root, client=client)
-            results = mcp_result.get("results", [])
-            applied_any = any(
-                r.get("action") in ("applied", "would-apply") for r in results
-            )
-            unchanged_all = bool(results) and all(
-                r.get("action") == "unchanged" for r in results
-            )
-            if applied_any:
-                actions["mcp_config"] = "applied"
-            elif unchanged_all:
-                actions["mcp_config"] = "unchanged"
-            elif not results:
-                actions["mcp_config"] = "skipped"
-            else:
-                actions["mcp_config"] = "applied"
-            # Every successful or unchanged result counts as registered.
-            mcp_stdio_registered = [
-                r["client"]
-                for r in results
-                if r.get("action") in ("applied", "unchanged")
-            ]
-        except Exception as exc:
-            actions["mcp_config"] = "failed"
-            failure_detail = f"mcp install: {type(exc).__name__}: {exc}"
+    mcp_status, mcp_stdio_registered, mcp_failure = _step_mcp_config(
+        root=root, client=client_enum, no_mcp_config=no_mcp_config, check=check
+    )
+    actions["mcp_config"] = mcp_status
+    if mcp_failure is not None and failure_detail is None:
+        failure_detail = mcp_failure
 
     # ---- Step 4: supervisor ----------------------------------------
     # Probe what's up.
@@ -430,25 +547,27 @@ def run_ensure(
     all_up = all(alive for alive, _, _ in pre_state.values())
 
     if all_up:
-        actions["supervisor"] = "reused"
+        actions["supervisor"] = EnsureActionStatus.reused
     elif check:
-        actions["supervisor"] = "missing"
+        actions["supervisor"] = EnsureActionStatus.missing
     else:
         # Spawn a single supervisor that boots whatever is missing.
         spawn_pid = _spawn_supervisor_detached(
-            project_root=root, db_path=db_path, mcp_only=(mode == "mcp-only")
+            project_root=root,
+            db_path=db_path,
+            mcp_only=(mode_enum is EnsureMode.mcp_only),
         )
         # Wait for the discovery file + healthz of every required
         # subsystem.
         doc = _wait_for_active_mcp(root, subsystems=required, timeout=timeout)
         if doc is None:
-            actions["supervisor"] = "failed"
+            actions["supervisor"] = EnsureActionStatus.failed
             failure_detail = (
                 f"supervisor did not produce a healthy active-mcp.json "
                 f"within {timeout:.1f}s (pid={spawn_pid})"
             )
         else:
-            actions["supervisor"] = "spawned"
+            actions["supervisor"] = EnsureActionStatus.spawned
 
     # ---- Step 5: read discovery file -------------------------------
     doc = read_active_mcp_file(root)
@@ -456,64 +575,53 @@ def run_ensure(
     if doc is not None:
         doc_subs = doc.get("subsystems", {})
         if isinstance(doc_subs, dict):
+            supervisor_action = actions["supervisor"]
             for sub in required:
                 block = doc_subs.get(sub)
-                if isinstance(block, dict):
-                    sub_status: str
-                    if not check:
-                        # Spawned this run? Otherwise reused.
-                        if actions["supervisor"] == "spawned":
-                            sub_status = "spawned"
-                        elif actions["supervisor"] == "reused":
-                            sub_status = "reused"
-                        elif actions["supervisor"] == "failed":
-                            sub_status = "failed"
-                        else:
-                            sub_status = "ready"
-                    else:
-                        sub_status = "ready" if pre_state[sub][0] else "missing"
-                    subsystems_payload[sub] = {
-                        "http_url": block.get("http_url"),
-                        "healthz_url": block.get("healthz_url"),
-                        "pid": block.get("pid"),
-                        "status": sub_status,
-                    }
-                    if "docs_url" in block:
-                        subsystems_payload[sub]["docs_url"] = block["docs_url"]
+                if not isinstance(block, dict):
+                    continue
+                sub_status: str
+                if check:
+                    sub_status = "ready" if pre_state[sub][0] else EnsureActionStatus.missing.value
+                elif supervisor_action is EnsureActionStatus.spawned:
+                    sub_status = EnsureActionStatus.spawned.value
+                elif supervisor_action is EnsureActionStatus.reused:
+                    sub_status = EnsureActionStatus.reused.value
+                elif supervisor_action is EnsureActionStatus.failed:
+                    sub_status = EnsureActionStatus.failed.value
+                else:
+                    sub_status = "ready"
+                subsystems_payload[sub] = {
+                    "http_url": block.get("http_url"),
+                    "healthz_url": block.get("healthz_url"),
+                    "pid": block.get("pid"),
+                    "status": sub_status,
+                }
+                if "docs_url" in block:
+                    subsystems_payload[sub]["docs_url"] = block["docs_url"]
 
     # ---- Final status -----------------------------------------------
-    status: str
-    if failure_detail is not None:
-        status = "failed"
-    elif check:
-        missing_pieces: list[str] = []
-        if actions["init"] == "missing":
-            missing_pieces.append("init")
-        if actions["memory"] == "missing":
-            missing_pieces.append("memory")
-        if actions["mcp_config"] == "missing":
-            missing_pieces.append("mcp-config")
-        if actions["supervisor"] == "missing":
-            missing_pieces.append("supervisor")
-        status = (
-            "missing:" + ",".join(missing_pieces) if missing_pieces else "ready"
-        )
-    else:
-        # Did all required subsystems report ready/spawned/reused?
-        ok = all(
-            subsystems_payload.get(s, {}).get("status")
-            in ("ready", "spawned", "reused")
-            for s in required
-        )
-        status = "ready" if ok else "degraded"
+    final_status = _final_status(
+        failure_detail=failure_detail,
+        check=check,
+        actions=actions,
+        subsystems_payload=subsystems_payload,
+        required=required,
+    )
 
     duration_ms = int((time.monotonic() - started_at) * 1000)
 
+    # Serialise enum members to their wire values so the JSON payload
+    # is byte-identical to the pre-W14i shape on every step that
+    # didn't change.
+    actions_wire: dict[str, str] = {
+        key: status.value for key, status in actions.items()
+    }
     summary: dict[str, Any] = {
-        "status": status,
+        "status": final_status.value,
         "project_root": str(root),
         "duration_ms": duration_ms,
-        "actions": actions,
+        "actions": actions_wire,
         "mcp_stdio_registered": mcp_stdio_registered,
         "subsystems": subsystems_payload,
     }
@@ -538,7 +646,12 @@ def _json_default() -> bool:
     """
     try:
         return not sys.stdout.isatty()
-    except Exception:
+    except (AttributeError, OSError):
+        # Some test runners replace sys.stdout with a buffer that
+        # lacks ``isatty`` (AttributeError) and certain CI sandboxes
+        # raise OSError on the fileno() call ``isatty`` makes
+        # internally. Either way we default to JSON because the
+        # absence of a TTY is the trigger for it in the first place.
         return True
 
 
@@ -628,8 +741,8 @@ def ensure(
     effective_json = _json_default() if json_mode is None else json_mode
     summary = run_ensure(
         project_root=project_root,
-        client=client,  # type: ignore[arg-type]
-        mode=mode,  # type: ignore[arg-type]
+        client=client,
+        mode=mode,
         no_memory=no_memory,
         no_mcp_config=no_mcp_config,
         check=check,
@@ -637,11 +750,24 @@ def ensure(
     )
     json_or_pretty(summary, effective_json)
 
-    # Exit non-zero on a failed run so wrapping scripts can react.
-    status = summary.get("status", "")
-    if isinstance(status, str) and (status == "failed" or status == "degraded"):
+    # Exit non-zero on a failed / degraded run, or on --check that
+    # surfaced any ``missing_*`` status, so wrapping scripts can react.
+    status_raw = summary.get("status", "")
+    try:
+        status = EnsureStatus(status_raw) if isinstance(status_raw, str) else None
+    except ValueError:
+        status = None
+    if status is None:
+        return
+    if status in {EnsureStatus.failed, EnsureStatus.degraded}:
         raise typer.Exit(1)
-    if check and isinstance(status, str) and status.startswith("missing:"):
+    missing_statuses = {
+        EnsureStatus.missing_init,
+        EnsureStatus.missing_supervisor,
+        EnsureStatus.missing_mcp_config,
+        EnsureStatus.missing_memory,
+    }
+    if check and status in missing_statuses:
         raise typer.Exit(1)
 
 

--- a/ctxr/fsm/cli/install_mcp_cmd.py
+++ b/ctxr/fsm/cli/install_mcp_cmd.py
@@ -56,10 +56,11 @@ import sys
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import typer
 
+from ctxr.fsm.cli._clients import McpClient, McpConfigStatus
 from ctxr.fsm.cli._common import json_or_pretty
 
 __all__ = ["install_mcp", "run_install_mcp"]
@@ -72,7 +73,9 @@ __all__ = ["install_mcp", "run_install_mcp"]
 # Allowed values for the ``--client`` flag. ``auto`` is a meta-value
 # that fans out to every detected client. ``none`` short-circuits to a
 # no-op — useful for ``ctxr-fsm ensure --no-mcp-config`` plumbing.
-_CLIENT_CHOICES: tuple[str, ...] = ("auto", "claude", "codex", "cursor", "none")
+# The tuple form is kept for backward-compatible callers that grep on
+# the constant; the enum is the canonical source.
+_CLIENT_CHOICES: tuple[str, ...] = tuple(member.value for member in McpClient)
 
 # The MCP entry's logical name as it appears in every client config.
 # Kept as a constant so a rename only touches one place + every
@@ -125,6 +128,36 @@ def _detect_indent(text: str) -> str:
                 return " " * count
             return "  "
     return "  "
+
+
+# ---------------------------------------------------------------------------
+# Shared --check detail strings
+# ---------------------------------------------------------------------------
+
+
+def _check_detail_for(status: McpConfigStatus) -> str:
+    """Return the human-readable ``detail`` for a ``--check`` outcome.
+
+    Centralised so the JSON merger + the TOML splicer surface
+    identical wording per status. ``McpConfigStatus.unchanged`` is not
+    a valid ``--check`` outcome (it's the apply-path "already in
+    sync"); the function still handles it defensively for the
+    Open-Closed audit invariant — adding a new member here is a single
+    edit rather than two.
+    """
+    match status:
+        case McpConfigStatus.installed:
+            return "entry matches desired stdio shape"
+        case McpConfigStatus.missing:
+            return "entry absent"
+        case McpConfigStatus.out_of_date:
+            return "entry present but differs from desired shape"
+        case McpConfigStatus.unchanged:
+            return "entry already matched; no write needed"
+        case _ as never:
+            raise AssertionError(
+                f"unhandled McpConfigStatus member: {never!r}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -226,21 +259,16 @@ def _merge_json_entry(
 
     if check:
         if current_entry is None:
-            status = "missing"
+            status = McpConfigStatus.missing
         elif is_installed:
-            status = "installed"
+            status = McpConfigStatus.installed
         else:
-            status = "out-of-date"
+            status = McpConfigStatus.out_of_date
         return {
             "path": str(path),
-            "action": f"check:{status}",
-            "status": status,
-            "detail": (
-                "entry matches desired stdio shape"
-                if status == "installed"
-                else "entry absent" if status == "missing"
-                else "entry present but differs from desired shape"
-            ),
+            "action": f"check:{status.value}",
+            "status": status.value,
+            "detail": _check_detail_for(status),
         }
 
     if is_installed:
@@ -479,21 +507,16 @@ def _merge_codex_toml_direct(
 
     if check:
         if current_entry is None:
-            status = "missing"
+            status = McpConfigStatus.missing
         elif matches:
-            status = "installed"
+            status = McpConfigStatus.installed
         else:
-            status = "out-of-date"
+            status = McpConfigStatus.out_of_date
         return {
             "path": str(path),
-            "action": f"check:{status}",
-            "status": status,
-            "detail": (
-                "entry matches desired stdio shape"
-                if status == "installed"
-                else "entry absent" if status == "missing"
-                else "entry present but differs from desired shape"
-            ),
+            "action": f"check:{status.value}",
+            "status": status.value,
+            "detail": _check_detail_for(status),
         }
 
     if matches:
@@ -531,9 +554,16 @@ def _merge_codex_toml_direct(
 
 @dataclass(frozen=True)
 class _ClientTask:
-    """One concrete (client, target_path) pair the dispatcher will act on."""
+    """One concrete (client, target_path) pair the dispatcher will act on.
 
-    client: Literal["claude", "codex", "cursor"]
+    ``client`` is a :class:`McpClient` member; ``auto`` and ``none``
+    never appear here because the dispatcher fans those out before
+    materialising tasks. We keep the typed enum (rather than
+    ``Literal[McpClient.claude, McpClient.codex, McpClient.cursor]``)
+    so the dispatch is uniform with the rest of the W14 surface.
+    """
+
+    client: McpClient
     path: Path
     # For Claude only: the workspace .mcp.json AND the settings.json
     # block can BOTH be present; the dispatcher emits one task per
@@ -593,22 +623,25 @@ def _codex_target() -> Path:
     return Path.home() / ".codex" / "config.toml"
 
 
-def _resolve_tasks(target_dir: Path, client: str) -> list[_ClientTask]:
+def _resolve_tasks(target_dir: Path, client: McpClient) -> list[_ClientTask]:
     """Resolve the ``--client`` value into concrete (client, path) tasks.
 
-    ``auto`` probes each client and includes those whose config file
-    exists OR (for Claude) whose target dir is a workspace root.
-    Explicit names always emit a task even when the file is absent
-    (the merger will create it).
+    ``McpClient.auto`` probes each supported client and includes those
+    whose config file exists OR (for Claude) whose target dir is a
+    workspace root. Explicit names always emit a task even when the
+    file is absent (the merger will create it). ``McpClient.none`` is
+    handled by the caller (short-circuit no-op) and never reaches
+    here.
     """
     tasks: list[_ClientTask] = []
+    auto_or = {McpClient.auto, McpClient.claude}
 
-    if client in ("auto", "claude"):
+    if client in auto_or:
         # Auto includes Claude only when SOMETHING points at it
         # (existing file or workspace marker); explicit always emits.
-        if client == "claude":
+        if client is McpClient.claude:
             for path in _claude_targets(target_dir):
-                tasks.append(_ClientTask(client="claude", path=path))
+                tasks.append(_ClientTask(client=McpClient.claude, path=path))
         else:
             workspace = (
                 (target_dir / ".git").exists()
@@ -617,19 +650,21 @@ def _resolve_tasks(target_dir: Path, client: str) -> list[_ClientTask]:
             mcp_json = target_dir / ".mcp.json"
             settings_json = target_dir / ".claude" / "settings.json"
             if mcp_json.exists() or workspace:
-                tasks.append(_ClientTask(client="claude", path=mcp_json))
+                tasks.append(_ClientTask(client=McpClient.claude, path=mcp_json))
             if settings_json.exists():
-                tasks.append(_ClientTask(client="claude", path=settings_json))
+                tasks.append(
+                    _ClientTask(client=McpClient.claude, path=settings_json)
+                )
 
-    if client in ("auto", "codex"):
+    if client in {McpClient.auto, McpClient.codex}:
         codex_path = _codex_target()
-        if client == "codex" or codex_path.exists():
-            tasks.append(_ClientTask(client="codex", path=codex_path))
+        if client is McpClient.codex or codex_path.exists():
+            tasks.append(_ClientTask(client=McpClient.codex, path=codex_path))
 
-    if client in ("auto", "cursor"):
+    if client in {McpClient.auto, McpClient.cursor}:
         cursor_path = _cursor_target()
-        if client == "cursor" or cursor_path.exists():
-            tasks.append(_ClientTask(client="cursor", path=cursor_path))
+        if client is McpClient.cursor or cursor_path.exists():
+            tasks.append(_ClientTask(client=McpClient.cursor, path=cursor_path))
 
     return tasks
 
@@ -643,7 +678,8 @@ def _dispatch_one(
     Codex uses the CLI path when available and the TOML splicer
     otherwise.
     """
-    if task.client in ("claude", "cursor"):
+    json_clients = {McpClient.claude, McpClient.cursor}
+    if task.client in json_clients:
         try:
             outcome = _merge_json_entry(
                 path=task.path, dry_run=dry_run, check=check
@@ -654,22 +690,22 @@ def _dispatch_one(
                 "action": "failed",
                 "detail": str(exc),
             }
-        outcome["client"] = task.client
+        outcome["client"] = task.client.value
         return outcome
 
     # Codex.
     if not check and not dry_run and _can_use_codex_cli():
         outcome = _invoke_codex_cli_add(dry_run=False)
-        outcome["client"] = "codex"
+        outcome["client"] = McpClient.codex.value
         return outcome
     if dry_run and _can_use_codex_cli():
         outcome = _invoke_codex_cli_add(dry_run=True)
-        outcome["client"] = "codex"
+        outcome["client"] = McpClient.codex.value
         return outcome
     outcome = _merge_codex_toml_direct(
         path=task.path, dry_run=dry_run, check=check
     )
-    outcome["client"] = "codex"
+    outcome["client"] = McpClient.codex.value
     return outcome
 
 
@@ -680,7 +716,7 @@ def _dispatch_one(
 
 def run_install_mcp(
     target_dir: Path,
-    client: Literal["auto", "claude", "codex", "cursor", "none"] = "auto",
+    client: McpClient | str = McpClient.auto,
     dry_run: bool = False,
     check: bool = False,
 ) -> dict[str, Any]:
@@ -699,27 +735,34 @@ def run_install_mcp(
             ...
           ],
         }
+
+    ``client`` accepts either a :class:`McpClient` member or the bare
+    string value (callers reaching the function through the Typer
+    surface still pass strings; both paths normalise to the enum
+    before dispatching).
     """
-    if client not in _CLIENT_CHOICES:
+    try:
+        client_enum = client if isinstance(client, McpClient) else McpClient(client)
+    except ValueError as exc:
         raise ValueError(
             f"client must be one of {_CLIENT_CHOICES!r}; got {client!r}"
-        )
+        ) from exc
 
     target_dir = target_dir.expanduser().resolve()
 
     summary: dict[str, Any] = {
         "target": str(target_dir),
-        "client": client,
+        "client": client_enum.value,
         "dry_run": dry_run,
         "check": check,
         "results": [],
     }
 
-    if client == "none":
+    if client_enum is McpClient.none:
         summary["results"] = []
         return summary
 
-    tasks = _resolve_tasks(target_dir, client)
+    tasks = _resolve_tasks(target_dir, client_enum)
     if not tasks:
         summary["results"] = []
         summary["detail"] = (
@@ -795,11 +838,12 @@ def install_mcp(
     resolved_target = (target if target is not None else Path.cwd()).resolve()
 
     try:
-        # Typer narrows ``client`` at the str level; cast to the literal
-        # union the pure function expects without re-validating here.
+        # ``run_install_mcp`` accepts McpClient | str and normalises
+        # at the boundary, so the Typer-supplied string passes through
+        # without a cast.
         summary = run_install_mcp(
             target_dir=resolved_target,
-            client=client,  # type: ignore[arg-type]
+            client=client,
             dry_run=dry_run,
             check=check,
         )

--- a/ctxr/fsm/cli/install_mcp_cmd.py
+++ b/ctxr/fsm/cli/install_mcp_cmd.py
@@ -91,6 +91,36 @@ _STDIO_ENTRY_JSON: dict[str, Any] = {
 }
 
 
+def _portable_repr(path: Path, *, base: Path) -> str:
+    """Render ``path`` in the most-portable form for a persisted artefact.
+
+    Rules (in priority order):
+
+    1. If ``path`` lives under ``base`` (typically cwd) → project-relative
+       form (e.g., ``.ctxr-fsm/fsm.db``). Persisted JSON envelopes /
+       printed CLI output / committed config files use this shape so the
+       artefact survives being pushed to git or moved between machines.
+    2. Else if under the user's ``$HOME`` → ``~``-prefixed form. Matches
+       how user-level configs (``~/.codex/config.toml``,
+       ``~/.cursor/mcp.json``) are conventionally written.
+    3. Else → absolute path. Caller explicitly pointed at a file outside
+       both cwd and home; we surface that honestly.
+
+    This helper exists so every place that emits a path into a JSON
+    envelope, a stdout summary, or a persisted manifest uses ONE
+    portability convention.
+    """
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        pass
+    home = Path.home()
+    try:
+        return "~/" + str(path.relative_to(home))
+    except ValueError:
+        return str(path)
+
+
 # ---------------------------------------------------------------------------
 # Indent detection (JSON files)
 # ---------------------------------------------------------------------------
@@ -265,7 +295,7 @@ def _merge_json_entry(
         else:
             status = McpConfigStatus.out_of_date
         return {
-            "path": str(path),
+            "path": _portable_repr(path, base=Path.cwd()),
             "action": f"check:{status.value}",
             "status": status.value,
             "detail": _check_detail_for(status),
@@ -273,7 +303,7 @@ def _merge_json_entry(
 
     if is_installed:
         return {
-            "path": str(path),
+            "path": _portable_repr(path, base=Path.cwd()),
             "action": "unchanged",
             "detail": "ctxr-fsm entry already matches; no write needed",
         }
@@ -297,7 +327,7 @@ def _merge_json_entry(
 
     if dry_run:
         return {
-            "path": str(path),
+            "path": _portable_repr(path, base=Path.cwd()),
             "action": ("would-create" if not path.exists() else "would-apply"),
             "detail": (
                 f"would write {len(new_text)} bytes "
@@ -308,7 +338,7 @@ def _merge_json_entry(
 
     _atomic_write(path, new_text)
     return {
-        "path": str(path),
+        "path": _portable_repr(path, base=Path.cwd()),
         "action": "applied",
         "detail": "ctxr-fsm entry merged into mcpServers",
     }
@@ -497,7 +527,7 @@ def _merge_codex_toml_direct(
         existing_doc = _read_codex_toml(path)
     except tomllib.TOMLDecodeError as exc:
         return {
-            "path": str(path),
+            "path": _portable_repr(path, base=Path.cwd()),
             "action": "failed",
             "detail": f"{path} exists but is not valid TOML: {exc}",
         }
@@ -513,7 +543,7 @@ def _merge_codex_toml_direct(
         else:
             status = McpConfigStatus.out_of_date
         return {
-            "path": str(path),
+            "path": _portable_repr(path, base=Path.cwd()),
             "action": f"check:{status.value}",
             "status": status.value,
             "detail": _check_detail_for(status),
@@ -521,7 +551,7 @@ def _merge_codex_toml_direct(
 
     if matches:
         return {
-            "path": str(path),
+            "path": _portable_repr(path, base=Path.cwd()),
             "action": "unchanged",
             "detail": "ctxr-fsm table already matches; no write needed",
         }
@@ -533,7 +563,7 @@ def _merge_codex_toml_direct(
 
     if dry_run:
         return {
-            "path": str(path),
+            "path": _portable_repr(path, base=Path.cwd()),
             "action": "would-create" if not path.exists() else "would-apply",
             "detail": f"would write {len(patched_text)} bytes",
             "preview": patched_text,
@@ -541,7 +571,7 @@ def _merge_codex_toml_direct(
 
     _atomic_write(path, patched_text)
     return {
-        "path": str(path),
+        "path": _portable_repr(path, base=Path.cwd()),
         "action": "applied",
         "detail": "ctxr-fsm TOML table spliced",
     }
@@ -686,7 +716,7 @@ def _dispatch_one(
             )
         except ValueError as exc:
             outcome = {
-                "path": str(task.path),
+                "path": _portable_repr(task.path, base=Path.cwd()),
                 "action": "failed",
                 "detail": str(exc),
             }
@@ -726,15 +756,22 @@ def run_install_mcp(
     layer that on top. Returns a JSON-serialisable summary dict::
 
         {
-          "target": "/abs/path",
+          "target": "<target-dir>",
           "client": "auto",
           "dry_run": False,
           "check": False,
           "results": [
-            {"client": "claude", "path": "...", "action": "applied", ...},
+            {"client": "claude", "path": "<config-path>", "action": "applied", ...},
             ...
           ],
         }
+
+    The ``target`` field is the directory the caller supplied (as a
+    string of whatever shape the caller passed in — relative or absolute).
+    Per-result ``path`` strings are project-relative when the config
+    lives under ``target_dir``, ``~``-prefixed when under ``$HOME``, else
+    absolute (the Cursor / Codex user-level configs are typical
+    examples).
 
     ``client`` accepts either a :class:`McpClient` member or the bare
     string value (callers reaching the function through the Typer
@@ -751,7 +788,11 @@ def run_install_mcp(
     target_dir = target_dir.expanduser().resolve()
 
     summary: dict[str, Any] = {
-        "target": str(target_dir),
+        # Persisted into the JSON envelope the CLI prints, so use the
+        # portable form (project-relative when target_dir is under cwd,
+        # ``~``-prefixed when under HOME, absolute only as last resort).
+        # Keeps the envelope safe to commit / share across machines.
+        "target": _portable_repr(target_dir, base=Path.cwd()),
         "client": client_enum.value,
         "dry_run": dry_run,
         "check": check,

--- a/ctxr/fsm/cli/install_memory_cmd.py
+++ b/ctxr/fsm/cli/install_memory_cmd.py
@@ -86,24 +86,96 @@ import hashlib
 import re
 import shutil
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import typer
 
+from ctxr.fsm.cli._clients import McpClient
 from ctxr.fsm.cli._common import json_or_pretty
 from ctxr.fsm.memory import BOOTSTRAP_FILENAME, get_bootstrap_path, get_principles_path
 
-__all__ = ["install_memory", "run_install_memory"]
+__all__ = [
+    "BootstrapStatus",
+    "MemoryInstallStatus",
+    "install_memory",
+    "run_install_memory",
+]
 
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-# The set of client identifiers the command understands. ``auto`` is a
-# meta-value that fans out to the detected clients in the target dir.
-_CLIENT_CHOICES: tuple[str, ...] = ("auto", "claude", "codex", "cursor")
+
+class BootstrapStatus(StrEnum):
+    """Status of the staged ``.ctxr-fsm/memory/bootstrap.md`` copy.
+
+    Surfaced on per-client ``--check`` rows. ``inlined`` is the
+    sentinel for codex / cursor where the bootstrap content lives
+    inside the principles adapter (drift detected via principles
+    version comparison, not via a separate hash check).
+
+    Members:
+
+    * ``ok``            — staged file present and content matches
+      the package source's bytes.
+    * ``out_of_date``   — staged file present but content differs
+      from the package source.
+    * ``not_installed`` — staged file is absent.
+    * ``inlined``       — bootstrap content is inlined into the
+      principles adapter for this client; no separate file to compare.
+
+    Wire-format note: the legacy hyphenated ``"out-of-date"`` and
+    ``"not-installed"`` values are replaced by snake-case
+    ``"out_of_date"`` / ``"not_installed"`` so the enum member name
+    matches the wire value (StrEnum members cannot contain hyphens).
+    The other values (``ok``, ``inlined``) are byte-identical with
+    the pre-W14i shape.
+    """
+
+    ok = "ok"
+    out_of_date = "out_of_date"
+    not_installed = "not_installed"
+    inlined = "inlined"
+
+
+class MemoryInstallStatus(StrEnum):
+    """Per-client status surfaced on ``install-memory --check`` rows.
+
+    Mirrors the historical free-form strings (``"ok"``,
+    ``"out-of-date"``, ``"missing"``, ``"not-installed"``); kept as
+    snake_case enum members. Wire-format note: ``"out-of-date"`` and
+    ``"not-installed"`` (hyphenated) are replaced by snake-case
+    ``"out_of_date"`` / ``"not_installed"`` so the enum member name
+    matches the wire value.
+    """
+
+    ok = "ok"
+    out_of_date = "out_of_date"
+    missing = "missing"
+    not_installed = "not_installed"
+
+
+# Memory installer historically does NOT accept ``McpClient.none`` —
+# callers that want to skip memory entirely pass ``--no-memory`` on
+# the higher-level ``ensure`` surface, not ``--client none`` here.
+# We exclude it from the install-memory choices but keep the shared
+# enum elsewhere — the install path is the only one that narrows it.
+_MEMORY_CLIENT_CHOICES: tuple[McpClient, ...] = (
+    McpClient.auto,
+    McpClient.claude,
+    McpClient.codex,
+    McpClient.cursor,
+)
+
+# The set of client identifiers the command understands. Kept as a
+# tuple for the CLI's free-form ``--client`` validation; the enum
+# above is the canonical source.
+_CLIENT_CHOICES: tuple[str, ...] = tuple(
+    member.value for member in _MEMORY_CLIENT_CHOICES
+)
 
 # The marker fences. We keep both as module constants so callers
 # (tests, downstream tools) can import and match against them rather
@@ -787,10 +859,11 @@ def _read_installed_version_from_text(text: str) -> str | None:
 class _CheckRow:
     """One row in the per-client ``--check`` status table.
 
-    ``status`` and ``installed_version`` describe the principles file's
-    drift status (parsed from the marker block's ``v=`` attribute or
-    the cursor rule frontmatter). ``bootstrap_status`` describes the
-    drift status of the bootstrap content for THIS client:
+    :attr:`status` and :attr:`installed_version` describe the
+    principles file's drift status (parsed from the marker block's
+    ``v=`` attribute or the cursor rule frontmatter).
+    :attr:`bootstrap_status` describes the drift status of the
+    bootstrap content for THIS client:
 
     * For Claude, the staged ``.ctxr-fsm/memory/bootstrap.md`` copy is
       hash-compared against the package source — bootstrap.md has no
@@ -799,11 +872,11 @@ class _CheckRow:
       the principles adapter file. Drift in that content shows up as
       drift in the principles version (the adapter regenerates when
       bootstrap.md changes, bumping the principles file's bytes), so
-      ``bootstrap_status`` is the static sentinel ``"inlined"`` —
+      :attr:`bootstrap_status` is :attr:`BootstrapStatus.inlined` —
       "checked elsewhere, not staged as a separate file".
 
     A client is considered out-of-date overall when EITHER axis is
-    out of date or missing (where applicable — ``"inlined"`` is
+    out of date or missing (where applicable — ``inlined`` is
     never a failure on its own).
     """
 
@@ -811,10 +884,8 @@ class _CheckRow:
     host_file: Path | None
     package_version: str | None
     installed_version: str | None
-    status: str  # "ok" | "out-of-date" | "missing" | "not-installed"
-    bootstrap_status: str = (
-        "not-installed"
-    )  # "ok" | "out-of-date" | "missing" | "not-installed" | "inlined"
+    status: MemoryInstallStatus
+    bootstrap_status: BootstrapStatus = BootstrapStatus.not_installed
 
 
 def _sha256_file(path: Path) -> str:
@@ -825,7 +896,7 @@ def _sha256_file(path: Path) -> str:
 
 def _check_bootstrap_status(
     target: Path, package_bootstrap_hash: str
-) -> str:
+) -> BootstrapStatus:
     """Compare the staged bootstrap copy under ``target`` against the package.
 
     Bootstrap.md ships without a frontmatter version (it's a procedural
@@ -839,18 +910,20 @@ def _check_bootstrap_status(
     staged file to compare against.
 
     Returns:
-        ``"ok"`` — staged file exists and content matches the package.
-        ``"out-of-date"`` — staged file exists but content differs.
-        ``"not-installed"`` — staged file is absent.
+        :attr:`BootstrapStatus.ok`            — staged file exists and
+            content matches the package.
+        :attr:`BootstrapStatus.out_of_date`   — staged file exists but
+            content differs.
+        :attr:`BootstrapStatus.not_installed` — staged file is absent.
     """
 
     staged = target / _BOOTSTRAP_LINKED_PATH
     if not staged.is_file():
-        return "not-installed"
+        return BootstrapStatus.not_installed
 
     if _sha256_file(staged) == package_bootstrap_hash:
-        return "ok"
-    return "out-of-date"
+        return BootstrapStatus.ok
+    return BootstrapStatus.out_of_date
 
 
 def _check_one(
@@ -863,16 +936,16 @@ def _check_one(
 
     For Claude the bootstrap-axis status reflects the staged copy's
     hash against the package source. For Codex and Cursor we return
-    the ``"inlined"`` sentinel: the bootstrap content lives inside
+    :attr:`BootstrapStatus.inlined`: the bootstrap content lives inside
     the principles adapter for those clients, so drift in bootstrap
     content surfaces via the principles version comparison rather
     than a separate hash check.
     """
     host = detection.host_file
-    if detection.name == "claude":
+    if detection.name == McpClient.claude.value:
         bootstrap_status = _check_bootstrap_status(target, package_bootstrap_hash)
     else:
-        bootstrap_status = "inlined"
+        bootstrap_status = BootstrapStatus.inlined
 
     if host is None or not host.is_file():
         return _CheckRow(
@@ -880,7 +953,7 @@ def _check_one(
             host_file=host,
             package_version=package_version,
             installed_version=None,
-            status="not-installed",
+            status=MemoryInstallStatus.not_installed,
             bootstrap_status=bootstrap_status,
         )
 
@@ -894,7 +967,7 @@ def _check_one(
             host_file=host,
             package_version=package_version,
             installed_version=None,
-            status="missing",
+            status=MemoryInstallStatus.missing,
             bootstrap_status=bootstrap_status,
         )
     if installed == package_version:
@@ -903,7 +976,7 @@ def _check_one(
             host_file=host,
             package_version=package_version,
             installed_version=installed,
-            status="ok",
+            status=MemoryInstallStatus.ok,
             bootstrap_status=bootstrap_status,
         )
     return _CheckRow(
@@ -911,7 +984,7 @@ def _check_one(
         host_file=host,
         package_version=package_version,
         installed_version=installed,
-        status="out-of-date",
+        status=MemoryInstallStatus.out_of_date,
         bootstrap_status=bootstrap_status,
     )
 
@@ -1157,11 +1230,19 @@ def install_memory(
         # plus the adapter-regeneration step; ``bootstrap_status``
         # is ``"inlined"`` there and is NOT treated as a failure on
         # its own.
+        memory_fail_statuses = {
+            MemoryInstallStatus.out_of_date,
+            MemoryInstallStatus.missing,
+        }
+        bootstrap_fail_statuses = {
+            BootstrapStatus.out_of_date,
+            BootstrapStatus.not_installed,
+        }
         out_of_date = [
             r
             for r in rows
-            if r.status in ("out-of-date", "missing")
-            or r.bootstrap_status in ("out-of-date", "not-installed")
+            if r.status in memory_fail_statuses
+            or r.bootstrap_status in bootstrap_fail_statuses
         ]
         json_or_pretty(
             {
@@ -1173,8 +1254,8 @@ def install_memory(
                         "host_file": str(r.host_file) if r.host_file else None,
                         "package_version": r.package_version,
                         "installed_version": r.installed_version,
-                        "status": r.status,
-                        "bootstrap_status": r.bootstrap_status,
+                        "status": r.status.value,
+                        "bootstrap_status": r.bootstrap_status.value,
                     }
                     for r in rows
                 ],

--- a/ctxr/fsm/cli/lifecycle/supervisor.py
+++ b/ctxr/fsm/cli/lifecycle/supervisor.py
@@ -832,7 +832,10 @@ def _publish_active_mcp_file_from_disk(*, project_root: Path) -> None:
 
 
 async def run_supervisor(
-    mode: Literal["dev", "prod"] = "dev",
+    # Literal kept (not an enum) because ``mode`` is a one-off boot
+    # parameter consumed by the supervisor + the dev-reload sibling;
+    # no closed-vocabulary status field, no cross-module reuse.
+    mode: Literal["dev", "prod"] = "dev",  # audit-strings: justified
     db_path: Path | None = None,
     project_root: Path | None = None,
     mcp_only: bool = False,
@@ -1008,7 +1011,7 @@ def main(
     # async body declares. We pin it locally with a partial so the
     # call site stays type-safe without sprinkling ``cast`` at the
     # entry point.
-    runner: Literal["dev", "prod"] = "prod" if mode == "prod" else "dev"
+    runner: Literal["dev", "prod"] = "prod" if mode == "prod" else "dev"  # audit-strings: justified
     anyio.run(
         functools.partial(run_supervisor, runner, db_path, None, mcp_only)
     )

--- a/ctxr/fsm/cli/serve_cmd.py
+++ b/ctxr/fsm/cli/serve_cmd.py
@@ -44,7 +44,7 @@ __all__ = ["serve"]
 # Allowed values for the ``--mode`` flag. The set is small and stable
 # enough that an Enum would be overkill; a tuple of literals keeps the
 # validation one ``in`` check away while making the supervisor's
-# ``Literal["dev", "prod"]`` annotation visibly the same contract.
+# Literal annotation visibly the same contract.  # audit-strings: justified
 _VALID_MODES: tuple[str, ...] = ("dev", "prod")
 
 

--- a/ctxr/fsm/core/engine.py
+++ b/ctxr/fsm/core/engine.py
@@ -32,7 +32,7 @@ it reports the fault so the caller can journal it.
 from __future__ import annotations
 
 import uuid
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -45,8 +45,10 @@ from ctxr.fsm.core.loop import decide as loop_decide
 from ctxr.fsm.core.loop import outputs_path_for
 from ctxr.fsm.core.models import (
     Brief,
+    EngineAdvanceKind,
     FsmSpec,
     InlineExecutionResult,
+    InlineFaultReason,
     Loop,
     LoopDecision,
     PostValidationResult,
@@ -57,6 +59,7 @@ from ctxr.fsm.core.models import (
     State,
     Transition,
     TransitionEvaluation,
+    TransitionKind,
     ValidationResult,
     Worker,
     WorkerOutput,
@@ -111,20 +114,24 @@ def _new_brief_id() -> uuid.UUID:
 class EngineAdvanceResult(BaseModel):
     """The outcome of a single :func:`advance` call.
 
-    This is a discriminated-union-like envelope keyed off ``kind``:
+    This is a discriminated-union-like envelope keyed off
+    :attr:`kind`, a :class:`~ctxr.fsm.core.models.EngineAdvanceKind`
+    member:
 
-    * ``"loop_continue"`` — the state is a loop and the most recent
-      iteration did not satisfy the done-field; ``iteration_n`` and
-      ``brief`` are populated with the next iteration's parameters.
-    * ``"fault"`` — validation, post-validation, or transition
-      resolution failed; ``reason`` plus one of ``errors``,
+    * :attr:`EngineAdvanceKind.loop_continue` — the state is a loop and
+      the most recent iteration did not satisfy the done-field;
+      ``iteration_n`` and ``brief`` are populated with the next
+      iteration's parameters.
+    * :attr:`EngineAdvanceKind.fault` — validation, post-validation, or
+      transition resolution failed; ``reason`` plus one of ``errors``,
       ``post_validations``, ``evaluations`` carries the diagnostic.
-    * ``"terminal"`` — the state has no outgoing transitions and the
-      run is therefore complete; ``verdict`` carries the optional
-      ``verdict`` field lifted from the merged env.
-    * ``"advance"`` — a transition matched; ``next_state`` plus
-      ``brief`` describe where the run goes next, and ``evaluations``
-      records the full evaluation trace.
+    * :attr:`EngineAdvanceKind.terminal` — the state has no outgoing
+      transitions and the run is therefore complete; ``verdict``
+      carries the optional ``verdict`` field lifted from the merged
+      env.
+    * :attr:`EngineAdvanceKind.advance` — a transition matched;
+      ``next_state`` plus ``brief`` describe where the run goes next,
+      and ``evaluations`` records the full evaluation trace.
 
     The model is strict and extra-forbid so a mistaken kwarg surfaces
     immediately instead of being silently dropped.
@@ -132,7 +139,7 @@ class EngineAdvanceResult(BaseModel):
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
-    kind: Literal["loop_continue", "fault", "terminal", "advance"]
+    kind: EngineAdvanceKind
     brief: Brief | None = None
     iteration_n: int | None = None
     reason: str | None = None
@@ -303,29 +310,34 @@ def _evaluate_guard(
     """
     when = transition.when
 
-    # "always" or "otherwise" string literals.
-    if isinstance(when, str):
-        if when == "always":
+    # ``TransitionKind`` members — the always/otherwise literals.
+    # Checked BEFORE the bare-string branch because StrEnum members
+    # are also ``str`` subclasses, but we want the enum equality.
+    if isinstance(when, TransitionKind):
+        if when is TransitionKind.always:
             return TransitionEvaluation(
                 to=transition.to,
                 when=when,
                 result=True,
-                kind="always",
+                kind=TransitionKind.always.value,
             )
-        if when == "otherwise":
+        if when is TransitionKind.otherwise:
             return TransitionEvaluation(
                 to=transition.to,
                 when=when,
                 result=not any_earlier_matched,
-                kind="otherwise",
+                kind=TransitionKind.otherwise.value,
             )
-        # Defensive: pydantic only accepts the two literals above.
+        # Defensive: TransitionKind.deterministic and .judgement are
+        # carried as Predicate / dict shapes, not as raw enum members on
+        # ``Transition.when``. A bare enum member here for one of those
+        # kinds is a programming bug — surface it loudly.
         return TransitionEvaluation(
             to=transition.to,
             when=when,
             result=False,
             kind="unknown",
-            error=f"unrecognised string guard {when!r}",
+            error=f"transition `when` cannot be bare {when!r}",
         )
 
     # Predicate guard (deterministic).
@@ -338,7 +350,7 @@ def _evaluate_guard(
                 when={"expression": when.expression},
                 result=False,
                 expression=when.expression,
-                kind="deterministic",
+                kind=TransitionKind.deterministic.value,
                 error=str(exc),
             )
         return TransitionEvaluation(
@@ -346,34 +358,34 @@ def _evaluate_guard(
             when={"expression": when.expression},
             result=bool(result),
             expression=when.expression,
-            kind="deterministic",
+            kind=TransitionKind.deterministic.value,
         )
 
-    # Dict guards: kind == "always" / "otherwise" / "deterministic" / "judgement".
+    # Dict guards: kind == always / otherwise / deterministic / judgement.
     if isinstance(when, dict):
-        kind = when.get("kind")
-        if kind == "always":
+        kind_raw = when.get("kind")
+        if kind_raw == TransitionKind.always.value:
             return TransitionEvaluation(
                 to=transition.to,
                 when=when,
                 result=True,
-                kind="always",
+                kind=TransitionKind.always.value,
             )
-        if kind == "otherwise":
+        if kind_raw == TransitionKind.otherwise.value:
             return TransitionEvaluation(
                 to=transition.to,
                 when=when,
                 result=not any_earlier_matched,
-                kind="otherwise",
+                kind=TransitionKind.otherwise.value,
             )
-        if kind == "deterministic":
+        if kind_raw == TransitionKind.deterministic.value:
             expression = when.get("expression")
             if not isinstance(expression, str):
                 return TransitionEvaluation(
                     to=transition.to,
                     when=when,
                     result=False,
-                    kind="deterministic",
+                    kind=TransitionKind.deterministic.value,
                     error="deterministic guard missing string `expression`",
                 )
             try:
@@ -384,7 +396,7 @@ def _evaluate_guard(
                     when=when,
                     result=False,
                     expression=expression,
-                    kind="deterministic",
+                    kind=TransitionKind.deterministic.value,
                     error=str(exc),
                 )
             return TransitionEvaluation(
@@ -392,15 +404,15 @@ def _evaluate_guard(
                 when=when,
                 result=bool(result),
                 expression=expression,
-                kind="deterministic",
+                kind=TransitionKind.deterministic.value,
             )
-        if kind == "judgement":
+        if kind_raw == TransitionKind.judgement.value:
             criteria = when.get("criteria")
             return TransitionEvaluation(
                 to=transition.to,
                 when=when,
                 result=judgement_pick == transition.to,
-                kind="judgement",
+                kind=TransitionKind.judgement.value,
                 criteria=criteria if isinstance(criteria, str) else None,
             )
 
@@ -587,7 +599,7 @@ def advance(
     validation = validate_output(state, raw_outputs)
     if not validation.valid:
         return EngineAdvanceResult(
-            kind="fault",
+            kind=EngineAdvanceKind.fault,
             reason="output_schema_violation",
             errors=list(validation.errors),
         )
@@ -606,7 +618,7 @@ def advance(
                 iteration_n=next_iter,
             )
             return EngineAdvanceResult(
-                kind="loop_continue",
+                kind=EngineAdvanceKind.loop_continue,
                 brief=next_brief,
                 iteration_n=next_iter,
             )
@@ -615,7 +627,7 @@ def advance(
     post = run_post_validations(state, raw_outputs)
     if not post.valid:
         return EngineAdvanceResult(
-            kind="fault",
+            kind=EngineAdvanceKind.fault,
             reason="post_validation_failed",
             post_validations=list(post.results),
         )
@@ -629,7 +641,7 @@ def advance(
     # Step 7a: terminal state (no transitions at all).
     if transition is None and not state.transitions:
         return EngineAdvanceResult(
-            kind="terminal",
+            kind=EngineAdvanceKind.terminal,
             verdict=env_with_outputs.get("verdict"),
             evaluations=evaluations,
         )
@@ -637,7 +649,7 @@ def advance(
     # Step 7b: declared transitions but none matched.
     if transition is None:
         return EngineAdvanceResult(
-            kind="fault",
+            kind=EngineAdvanceKind.fault,
             reason="no_transition_matched",
             evaluations=evaluations,
         )
@@ -651,7 +663,7 @@ def advance(
         run_id=run_ctx.run_id,
     )
     return EngineAdvanceResult(
-        kind="advance",
+        kind=EngineAdvanceKind.advance,
         next_state=next_state.id,
         brief=next_brief,
         evaluations=evaluations,
@@ -711,24 +723,28 @@ def execute_inline(
     -------
     InlineExecutionResult
         ``ok=True`` and ``outputs`` populated on success. ``ok=False``
-        with a kebab-case ``fault_reason`` on every failure mode:
+        with a typed :class:`InlineFaultReason` on every failure mode:
 
-        * ``inline_handler_unregistered`` — no handler registered for
-          ``(ctx.fsm_id, state.inline.handler_id)``.
-        * ``inline_handler_raised`` — handler raised an exception.
-          The ``fault_reason`` includes the exception type name and
-          its ``str()`` representation; the full traceback is NOT
-          captured here (callers that want one log it from the
-          calling try/except at the SQLite-layer boundary).
-        * ``inline_handler_bad_return_type`` — handler returned
-          something other than ``dict[str, Any]``.
-        * ``inline_handler_validation_failed`` — handler returned a
-          dict but it did not validate against
-          ``state.inline.response_schema``.
-        * ``inline_handler_post_validation_failed`` — handler returned
-          a schema-valid dict but at least one
+        * :attr:`InlineFaultReason.unregistered` — no handler registered
+          for ``(ctx.fsm_id, state.inline.handler_id)``;
+          :attr:`InlineExecutionResult.fault_detail` carries the
+          missing key as ``"<fsm_id>/<handler_id>"``.
+        * :attr:`InlineFaultReason.raised` — handler raised an
+          exception; ``fault_detail`` carries the exception type name +
+          ``str()`` (full traceback is NOT captured here; SQLite-layer
+          callers log it from their own try/except boundary).
+        * :attr:`InlineFaultReason.bad_return_type` — handler returned
+          something other than ``dict[str, Any]``; ``fault_detail``
+          names the offending type.
+        * :attr:`InlineFaultReason.validation_failed` — handler returned
+          a dict but it did not validate against
+          ``state.inline.response_schema``; ``validation.errors``
+          carries the per-field messages.
+        * :attr:`InlineFaultReason.post_validation_failed` — handler
+          returned a schema-valid dict but at least one
           :attr:`~ctxr.fsm.core.models.InlineSpec.post_validations`
-          predicate evaluated to ``False``.
+          predicate evaluated to ``False``; ``post_validations``
+          carries the per-predicate trace.
     """
     if state.inline is None:
         raise TypeError(
@@ -747,9 +763,8 @@ def execute_inline(
             outputs={},
             validation=ValidationResult(valid=True, errors=[]),
             post_validations=None,
-            fault_reason=(
-                f"inline_handler_unregistered: {ctx.fsm_id}/{handler_id}"
-            ),
+            fault_reason=InlineFaultReason.unregistered,
+            fault_detail=f"{ctx.fsm_id}/{handler_id}",
         )
 
     # Build the handler's read-only context envelope.
@@ -772,9 +787,8 @@ def execute_inline(
             outputs={},
             validation=ValidationResult(valid=True, errors=[]),
             post_validations=None,
-            fault_reason=(
-                f"inline_handler_raised: {type(exc).__name__}: {exc}"
-            ),
+            fault_reason=InlineFaultReason.raised,
+            fault_detail=f"{type(exc).__name__}: {exc}",
         )
 
     # The handler MUST return a dict; anything else is a contract bug.
@@ -785,10 +799,8 @@ def execute_inline(
             outputs={},
             validation=ValidationResult(valid=True, errors=[]),
             post_validations=None,
-            fault_reason=(
-                "inline_handler_bad_return_type: expected dict, "
-                f"got {type(raw_output).__name__}"
-            ),
+            fault_reason=InlineFaultReason.bad_return_type,
+            fault_detail=f"expected dict, got {type(raw_output).__name__}",
         )
 
     # Validate against the optional response schema. A schema-less
@@ -808,7 +820,8 @@ def execute_inline(
                 outputs={},
                 validation=validation,
                 post_validations=None,
-                fault_reason="inline_handler_validation_failed",
+                fault_reason=InlineFaultReason.validation_failed,
+                fault_detail=None,
             )
 
     # Run the inline-state's post-validation predicates (if any). The
@@ -860,7 +873,8 @@ def execute_inline(
                 outputs={},
                 validation=validation,
                 post_validations=post_result,
-                fault_reason="inline_handler_post_validation_failed",
+                fault_reason=InlineFaultReason.post_validation_failed,
+                fault_detail=None,
             )
 
     # All-clear: handler returned a dict, the schema accepts it, and
@@ -872,4 +886,5 @@ def execute_inline(
         validation=validation,
         post_validations=post_result,
         fault_reason=None,
+        fault_detail=None,
     )

--- a/ctxr/fsm/core/loop.py
+++ b/ctxr/fsm/core/loop.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ctxr.fsm.core.models import Loop, LoopDecision, State
+from ctxr.fsm.core.models import Loop, LoopDecision, LoopTerminationReason, State
 
 __all__ = ["LoopConfigError", "decide", "outputs_path_for"]
 
@@ -96,7 +96,7 @@ def decide(
         return LoopDecision(
             is_loop=True,
             terminate=True,
-            reason="done_field",
+            reason=LoopTerminationReason.done_field,
             iteration_n=iteration_n,
         )
 
@@ -104,7 +104,7 @@ def decide(
         return LoopDecision(
             is_loop=True,
             terminate=True,
-            reason="max_iterations",
+            reason=LoopTerminationReason.max_iterations,
             iteration_n=iteration_n,
         )
 

--- a/ctxr/fsm/core/models.py
+++ b/ctxr/fsm/core/models.py
@@ -27,7 +27,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from re import compile as re_compile
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import (
     BaseModel,
@@ -96,6 +96,38 @@ class TransitionKind(StrEnum):
     judgement = "judgement"
 
 
+class StateKind(StrEnum):
+    """Derived kind of a :class:`State`, computed from which body fields are set.
+
+    Closed vocabulary surfaced via :attr:`State.kind`; consumed by the
+    engine, the SQLite materialisation layer, and the brief serialiser.
+    Members carry the same wire strings the engine used pre-W14i so JSON
+    payloads remain byte-identical.
+    """
+
+    worker = "worker"
+    loop = "loop"
+    inline = "inline"
+    terminal = "terminal"
+
+
+class InlineFaultReason(StrEnum):
+    """Closed taxonomy of inline-handler failure modes.
+
+    Surfaced on :attr:`InlineExecutionResult.fault_reason` so callers
+    branch on a typed value rather than parsing free-form strings. Any
+    additional human-readable diagnostic (the offending type name, the
+    handler's exception message, the spec/handler key) goes on
+    :attr:`InlineExecutionResult.fault_detail`.
+    """
+
+    unregistered = "unregistered"
+    raised = "raised"
+    bad_return_type = "bad_return_type"
+    validation_failed = "validation_failed"
+    post_validation_failed = "post_validation_failed"
+
+
 class EventKind(StrEnum):
     """Closed taxonomy of events recorded on the FSM event journal."""
 
@@ -155,6 +187,82 @@ class VerifierVerdict(StrEnum):
     passed = "passed"
     rejected = "rejected"
     inconclusive = "inconclusive"
+
+
+class LoopTerminationReason(StrEnum):
+    """Why a loop body terminated.
+
+    Surfaced on :attr:`LoopDecision.reason`; persisted on the loop
+    state row so the dashboard can distinguish "the worker said it was
+    done" from "the safety cap fired before the worker said so".
+    """
+
+    done_field = "done_field"
+    max_iterations = "max_iterations"
+
+
+class EngineAdvanceKind(StrEnum):
+    """Discriminator for :class:`~ctxr.fsm.core.engine.EngineAdvanceResult`.
+
+    The engine's high-level driver returns one of four results — this
+    enum is the typed handle every downstream layer (MCP tool layer,
+    SQLite repo, CLI) branches on.
+    """
+
+    advance = "advance"
+    loop_continue = "loop_continue"
+    terminal = "terminal"
+    fault = "fault"
+
+
+class JournalStatus(StrEnum):
+    """Lifecycle status of a ``journal_txns`` row.
+
+    Surfaced on :class:`~ctxr.fsm.sqlite.repos_locks_journal.JournalTxn`
+    and on the API / MCP recovery surface. The lifecycle is strictly
+    monotonic: ``pending → ready_to_finalise → finalised`` (with
+    ``discard`` operations deleting the row outright rather than
+    transitioning it to a fourth state).
+    """
+
+    pending = "pending"
+    ready_to_finalise = "ready_to_finalise"
+    finalised = "finalised"
+
+
+class LockReleaseReason(StrEnum):
+    """Outcome reason returned by :class:`LocksRepo.release`.
+
+    Surfaced on :class:`~ctxr.fsm.sqlite.repos_locks_journal.ReleaseResult`
+    so callers can branch on the typed value rather than match a
+    free-form string. ``released`` is the success path; ``not_owner``
+    and ``not_held`` are the two refusal paths the engine policy
+    distinguishes.
+    """
+
+    released = "released"
+    not_owner = "not_owner"
+    not_held = "not_held"
+
+
+class LockAcquireReason(StrEnum):
+    """Outcome reason returned by :class:`LocksRepo.acquire`.
+
+    Surfaced on :class:`~ctxr.fsm.sqlite.repos_locks_journal.LockResult`:
+
+    * ``acquired`` — a fresh acquisition on a previously-unheld lock.
+    * ``replaced_stale`` — we took over an expired lease from another
+      session.
+    * ``already_held_by_same_session`` — re-entrant acquire (the
+      caller already held the lock; the row was refreshed in place).
+    * ``held`` — a live, foreign lock that we did not displace; the
+      caller did not acquire.
+    """
+
+    acquired = "acquired"
+    replaced_stale = "replaced_stale"
+    already_held_by_same_session = "already_held_by_same_session"
+    held = "held"
 
 
 # ---------------------------------------------------------------------------
@@ -376,7 +484,7 @@ class Transition(BaseModel):
     )
 
     to: str
-    when: Predicate | Literal["always", "otherwise"] | dict[str, Any]
+    when: Predicate | TransitionKind | dict[str, Any]
 
     @field_validator("to")
     @classmethod
@@ -394,8 +502,11 @@ class Transition(BaseModel):
 
         Accepted incoming shapes for ``when``:
 
-        * The string literals ``"always"`` and ``"otherwise"``.
-        * A ``Predicate`` instance (passes through).
+        * The string literals ``"always"`` and ``"otherwise"``
+          (normalised into :class:`TransitionKind` members; any other
+          bare string is lifted into a :class:`Predicate`).
+        * A :class:`TransitionKind` member (passes through).
+        * A :class:`Predicate` instance (passes through).
         * A dict with ``{"kind": "always"}``, ``{"kind": "otherwise"}``,
           ``{"kind": "deterministic", "expression": "..."}``, or
           ``{"kind": "judgement", "criteria": "...",
@@ -403,9 +514,10 @@ class Transition(BaseModel):
         * A dict that is just ``{"expression": "..."}`` — treated as
           deterministic.
 
-        Dicts are normalised but kept as dicts so the typed union
-        captures them; only ``deterministic`` is lifted into a
-        ``Predicate`` for convenience.
+        Judgement dicts are normalised but kept as dicts so the typed
+        union captures the criteria + evidence_required payload;
+        ``always`` / ``otherwise`` resolve to enum members and
+        ``deterministic`` is lifted into a :class:`Predicate`.
         """
         if not isinstance(data, dict):
             return data
@@ -413,24 +525,33 @@ class Transition(BaseModel):
         if when is None:
             return data
 
-        # String literals pass through unchanged.
-        if isinstance(when, str):
-            if when not in ("always", "otherwise"):
-                # treat any bare string as a deterministic expression
-                data["when"] = Predicate(when)
+        # Bare strings — map the two enum-vocabulary values onto enum
+        # members, lift anything else into a deterministic Predicate.
+        if isinstance(when, str) and not isinstance(when, TransitionKind):
+            if when == TransitionKind.always.value:
+                data["when"] = TransitionKind.always
+                return data
+            if when == TransitionKind.otherwise.value:
+                data["when"] = TransitionKind.otherwise
+                return data
+            data["when"] = Predicate(when)
+            return data
+
+        # Already a TransitionKind member — passes through unchanged.
+        if isinstance(when, TransitionKind):
             return data
 
         # Already a Predicate (or a mapping that pydantic will coerce
         # into one) — handle the dict-with-kind variants explicitly.
         if isinstance(when, dict):
             kind = when.get("kind")
-            if kind == "always":
-                data["when"] = "always"
+            if kind == TransitionKind.always.value:
+                data["when"] = TransitionKind.always
                 return data
-            if kind == "otherwise":
-                data["when"] = "otherwise"
+            if kind == TransitionKind.otherwise.value:
+                data["when"] = TransitionKind.otherwise
                 return data
-            if kind == "deterministic":
+            if kind == TransitionKind.deterministic.value:
                 expr = when.get("expression")
                 if not isinstance(expr, str) or not expr.strip():
                     raise ValueError(
@@ -438,7 +559,7 @@ class Transition(BaseModel):
                     )
                 data["when"] = Predicate(expr)
                 return data
-            if kind == "judgement":
+            if kind == TransitionKind.judgement.value:
                 criteria = when.get("criteria")
                 if not isinstance(criteria, str) or not criteria.strip():
                     raise ValueError(
@@ -448,7 +569,7 @@ class Transition(BaseModel):
                 if not isinstance(evidence_required, bool):
                     raise ValueError("evidence_required must be a bool")
                 data["when"] = {
-                    "kind": "judgement",
+                    "kind": TransitionKind.judgement.value,
                     "criteria": criteria,
                     "evidence_required": evidence_required,
                 }
@@ -492,30 +613,36 @@ class State(BaseModel):
         return value
 
     @property
-    def kind(self) -> Literal["loop", "inline", "worker", "terminal"]:
+    def kind(self) -> StateKind:
         """Return the derived kind of this state.
 
         The kind is derived from which body fields are set, not stored:
 
-        * ``"loop"``   — :attr:`loop` is non-None.
-        * ``"inline"`` — :attr:`inline` is non-None (and :attr:`loop` is None).
-        * ``"worker"`` — :attr:`worker` is non-None (and :attr:`loop` /
-          :attr:`inline` are None).
-        * ``"terminal"`` — all three body fields are None AND
-          :attr:`transitions` is empty.
+        * :attr:`StateKind.loop`     — :attr:`loop` is non-None.
+        * :attr:`StateKind.inline`   — :attr:`inline` is non-None
+          (and :attr:`loop` is None).
+        * :attr:`StateKind.worker`   — :attr:`worker` is non-None
+          (and :attr:`loop` / :attr:`inline` are None).
+        * :attr:`StateKind.terminal` — all three body fields are None
+          AND :attr:`transitions` is empty.
 
         A state with no body fields but a non-empty :attr:`transitions`
         list is structurally invalid (a "pass-through" worker would
         need somebody to produce its outputs) and raises ``ValueError``.
+
+        ``StateKind`` members are ``str`` subclasses (StrEnum), so any
+        legacy ``state.kind == "worker"`` comparison continues to work
+        — the property's typed return value is the canonical handle and
+        new call sites should compare against the enum directly.
         """
         if self.loop is not None:
-            return "loop"
+            return StateKind.loop
         if self.inline is not None:
-            return "inline"
+            return StateKind.inline
         if self.worker is not None:
-            return "worker"
+            return StateKind.worker
         if not self.transitions:
-            return "terminal"
+            return StateKind.terminal
         raise ValueError(
             f"state {self.id!r}: terminal-by-content but has transitions; "
             "set a worker / loop / inline body or remove the transitions"
@@ -767,24 +894,38 @@ class InlineExecutionResult(BaseModel):
 
     Returned by :func:`ctxr.fsm.core.engine.execute_inline`. The shape
     is a single envelope (not a discriminated union) so callers can
-    branch on the ``ok`` flag and consume ``fault_reason`` / ``outputs``
+    branch on the ``ok`` flag and consume
+    :attr:`fault_reason` / :attr:`fault_detail` / :attr:`outputs`
     accordingly:
 
     * ``ok=True``  — the handler ran, returned a dict, validated
       against any declared response schema and post-validations. The
-      handler's return value is in ``outputs``.
+      handler's return value is in :attr:`outputs`; :attr:`fault_reason`
+      and :attr:`fault_detail` are ``None``.
     * ``ok=False`` — the handler did not produce usable outputs.
-      ``fault_reason`` carries a short slug naming the failure mode
-      (``inline_handler_unregistered``, ``inline_handler_raised``,
-      ``inline_handler_bad_return_type``,
-      ``inline_handler_validation_failed``,
-      ``inline_handler_post_validation_failed``). ``validation`` always
-      carries the schema-validation report (vacuously valid when no
-      schema is declared); ``post_validations`` is populated only when
-      the inline spec declared post-validations.
+      :attr:`fault_reason` is one of the :class:`InlineFaultReason`
+      members (``unregistered``, ``raised``, ``bad_return_type``,
+      ``validation_failed``, ``post_validation_failed``).
+      :attr:`fault_detail` carries the human-readable diagnostic (the
+      raising exception's ``str()``, the offending return type's name,
+      the missing handler's ``(spec_id, handler_id)`` key — whatever the
+      consumer would want to log).
+
+    :attr:`validation` always carries the schema-validation report
+    (vacuously valid when no schema is declared);
+    :attr:`post_validations` is populated only when the inline spec
+    declared post-validations.
 
     The model is strict + frozen + extra-forbid like the surrounding
     domain envelopes; mis-typed kwargs surface immediately.
+
+    .. note::
+       The W14i refactor split the legacy free-form ``fault_reason``
+       string (e.g. ``"inline_handler_raised: RuntimeError: boom"``) into
+       a typed :class:`InlineFaultReason` member plus a separate
+       :attr:`fault_detail` payload. Wire JSON consumers that previously
+       grepped for the ``"inline_handler_"`` prefix should switch to the
+       typed field; the legacy prefix is no longer emitted.
     """
 
     model_config = _DOMAIN_CFG
@@ -794,11 +935,21 @@ class InlineExecutionResult(BaseModel):
     outputs: dict[str, Any] = Field(default_factory=dict)
     validation: ValidationResult
     post_validations: PostValidationResult | None = None
-    fault_reason: str | None = None
+    fault_reason: InlineFaultReason | None = None
+    fault_detail: str | None = None
 
 
 class TransitionEvaluation(BaseModel):
-    """The outcome of evaluating one transition guard at exit time."""
+    """The outcome of evaluating one transition guard at exit time.
+
+    ``kind`` carries the resolved guard shape: a :class:`TransitionKind`
+    member when the guard was structurally valid, or ``None`` when the
+    guard is missing / unresolved. Defensive ``"unknown"`` sentinels are
+    preserved as raw strings on the engine side and surfaced via
+    :attr:`error`, NOT as :class:`TransitionKind` members — the enum is
+    closed by design and an unknown guard is a programming bug, not a
+    new vocabulary entry.
+    """
 
     model_config = _DOMAIN_CFG
 
@@ -818,7 +969,7 @@ class LoopDecision(BaseModel):
 
     is_loop: bool
     terminate: bool = False
-    reason: Literal["done_field", "max_iterations"] | None = None
+    reason: LoopTerminationReason | None = None
     iteration_n: int | None = None
 
 
@@ -841,12 +992,18 @@ __all__ = [
     "CommitSignature",
     "CommitToken",
     "DeliveryStatus",
+    "EngineAdvanceKind",
     "EventKind",
     "FsmSpec",
     "InlineExecutionResult",
+    "InlineFaultReason",
     "InlineSpec",
+    "JournalStatus",
+    "LockAcquireReason",
+    "LockReleaseReason",
     "Loop",
     "LoopDecision",
+    "LoopTerminationReason",
     "PostValidationResult",
     "PostValidationResultEntry",
     "Predicate",
@@ -857,6 +1014,7 @@ __all__ = [
     "RunStatus",
     "SignalKind",
     "State",
+    "StateKind",
     "StateStatus",
     "Transition",
     "TransitionEvaluation",

--- a/ctxr/fsm/core/models.py
+++ b/ctxr/fsm/core/models.py
@@ -537,8 +537,24 @@ class Transition(BaseModel):
             data["when"] = Predicate(when)
             return data
 
-        # Already a TransitionKind member — passes through unchanged.
+        # Already a TransitionKind member — only ``always`` and
+        # ``otherwise`` are valid bare guards. ``deterministic`` and
+        # ``judgement`` carry payloads (expression / criteria) and MUST
+        # come in as the dict form below; passing them bare would silently
+        # accept a guard with no expression and fault later in the engine.
+        # Reject at the boundary with a message that points the author
+        # at the dict form.
         if isinstance(when, TransitionKind):
+            if when not in (TransitionKind.always, TransitionKind.otherwise):
+                raise ValueError(
+                    f"Transition.when={when.value!r} cannot be used as a bare "
+                    "guard. Only `always` and `otherwise` are valid bare "
+                    "TransitionKind members; for `deterministic` use "
+                    "`{\"kind\": \"deterministic\", \"expression\": \"...\"}` "
+                    "and for `judgement` use "
+                    "`{\"kind\": \"judgement\", \"criteria\": \"...\", "
+                    "\"evidence_required\": <bool>}`."
+                )
             return data
 
         # Already a Predicate (or a mapping that pydantic will coerce
@@ -942,13 +958,20 @@ class InlineExecutionResult(BaseModel):
 class TransitionEvaluation(BaseModel):
     """The outcome of evaluating one transition guard at exit time.
 
-    ``kind`` carries the resolved guard shape: a :class:`TransitionKind`
-    member when the guard was structurally valid, or ``None`` when the
-    guard is missing / unresolved. Defensive ``"unknown"`` sentinels are
-    preserved as raw strings on the engine side and surfaced via
-    :attr:`error`, NOT as :class:`TransitionKind` members — the enum is
-    closed by design and an unknown guard is a programming bug, not a
-    new vocabulary entry.
+    ``kind`` is a plain string (a :class:`TransitionKind` member's
+    ``.value``, or the defensive sentinel ``"unknown"`` when the engine
+    could not resolve the guard shape), or ``None`` when the guard was
+    missing entirely. It is intentionally NOT typed as
+    :class:`TransitionKind` because the ``"unknown"`` sentinel must be
+    representable (an unknown guard is a programming bug surfaced via
+    :attr:`error`, not a new enum entry), and pinning the field to the
+    enum would force every consumer through ``TransitionKind(value)``
+    coercion at the boundary. Callers that need an enum member should
+    use ``TransitionKind(eval.kind) if eval.kind in {m.value for m in
+    TransitionKind} else None`` (or guard on ``eval.kind != "unknown"``
+    first); identity checks like ``eval.kind is TransitionKind.always``
+    will always be ``False`` because the field carries the string value,
+    not the member.
     """
 
     model_config = _DOMAIN_CFG

--- a/ctxr/fsm/core/verifier.py
+++ b/ctxr/fsm/core/verifier.py
@@ -85,7 +85,7 @@ class VerifierVote(BaseModel):
 
     model_config = _VO_CFG
 
-    verdict: Literal["passed", "rejected"]
+    verdict: Literal[VerifierVerdict.passed, VerifierVerdict.rejected]
     reason: str = ""
 
 
@@ -94,7 +94,7 @@ class VerifierOutcome(BaseModel):
 
     model_config = _VO_CFG
 
-    verdict: Literal["passed", "rejected"]
+    verdict: Literal[VerifierVerdict.passed, VerifierVerdict.rejected]
     votes: list[VerifierVote] = Field(default_factory=list)
     passed_count: int
     rejected_count: int
@@ -180,19 +180,24 @@ def _structural_verifier(
 
     if schema is None:
         return [
-            VerifierVote(verdict="passed", reason="no_response_schema_to_check")
+            VerifierVote(
+                verdict=VerifierVerdict.passed,
+                reason="no_response_schema_to_check",
+            )
             for _ in range(verifier.parallel_count)
         ]
 
     valid, errors = schema.model_validate_json_payload(outputs)
     if valid:
         return [
-            VerifierVote(verdict="passed", reason="structural_check_ok")
+            VerifierVote(
+                verdict=VerifierVerdict.passed, reason="structural_check_ok"
+            )
             for _ in range(verifier.parallel_count)
         ]
     reason = "; ".join(errors[:3]) if errors else "structural_check_failed"
     return [
-        VerifierVote(verdict="rejected", reason=reason)
+        VerifierVote(verdict=VerifierVerdict.rejected, reason=reason)
         for _ in range(verifier.parallel_count)
     ]
 
@@ -214,16 +219,27 @@ def _coerce_vote(raw: object) -> VerifierVote:
     if isinstance(raw, VerifierVote):
         return raw
     if isinstance(raw, dict):
-        verdict = raw.get("verdict")
+        verdict_raw = raw.get("verdict")
         reason = raw.get("reason", "")
-        if verdict in ("passed", "rejected") and isinstance(reason, str):
-            return VerifierVote(verdict=verdict, reason=reason)
-        # "inconclusive" / unknown collapses to rejected — fail closed.
+        if isinstance(reason, str):
+            # Match each accepted vote value explicitly so the type
+            # narrows down to the ``Literal[VerifierVerdict.passed,
+            # VerifierVerdict.rejected]`` shape ``VerifierVote.verdict``
+            # demands. ``VerifierVerdict(verdict)`` would type as the
+            # full enum, which is wider than the model accepts.
+            if verdict_raw == VerifierVerdict.passed.value:
+                return VerifierVote(verdict=VerifierVerdict.passed, reason=reason)
+            if verdict_raw == VerifierVerdict.rejected.value:
+                return VerifierVote(verdict=VerifierVerdict.rejected, reason=reason)
+        # ``inconclusive`` / unknown collapses to rejected — fail closed.
         return VerifierVote(
-            verdict="rejected",
+            verdict=VerifierVerdict.rejected,
             reason=f"malformed_vote: {raw!r}",
         )
-    return VerifierVote(verdict="rejected", reason=f"unknown_vote_type: {type(raw).__name__}")
+    return VerifierVote(
+        verdict=VerifierVerdict.rejected,
+        reason=f"unknown_vote_type: {type(raw).__name__}",
+    )
 
 
 def run_verifier(
@@ -251,10 +267,12 @@ def run_verifier(
     raw_votes = handler(verifier, brief, outputs)
     votes = [_coerce_vote(v) for v in raw_votes]
 
-    passed = sum(1 for v in votes if v.verdict == "passed")
-    rejected = sum(1 for v in votes if v.verdict == "rejected")
-    aggregate: Literal["passed", "rejected"] = (
-        "passed" if passed >= verifier.majority_threshold else "rejected"
+    passed = sum(1 for v in votes if v.verdict is VerifierVerdict.passed)
+    rejected = sum(1 for v in votes if v.verdict is VerifierVerdict.rejected)
+    aggregate: Literal[VerifierVerdict.passed, VerifierVerdict.rejected] = (
+        VerifierVerdict.passed
+        if passed >= verifier.majority_threshold
+        else VerifierVerdict.rejected
     )
 
     return VerifierOutcome(

--- a/ctxr/fsm/mcp/_shared_enums.py
+++ b/ctxr/fsm/mcp/_shared_enums.py
@@ -1,0 +1,43 @@
+"""Closed-vocabulary enums shared across MCP tool modules.
+
+The W14i extract-StrEnum sweep placed each new enum in the FIRST tool
+module that consumed it. That co-location is the right default — most
+enums stay single-module. The exception is :class:`JournalAction`,
+which describes the recovery action a pending journal_txn can take.
+The vocabulary is referenced both by
+
+* :mod:`ctxr.fsm.mcp.tools_runs` (``ResumeRunInput.journal``,
+  ``commit_outputs`` resume path), and
+
+* :mod:`ctxr.fsm.mcp.tools_events` (the dedicated
+  ``recover_journal`` tool surface).
+
+Per W14i's new coding-standard rule (``docs/coding-standards.md``,
+"Promote per-tool enums on second-module use"), shared MCP enums live
+here so neither tool module has to import the other just to share a
+vocabulary. Importing across tool modules would also couple their
+import-time side effects — having ``tools_events`` reach into
+``tools_runs`` for an enum drags the entire ``tools_runs`` import
+graph into the ``tools_events`` boot path, which is a regression
+against the W3 "each tool module stands alone" rule.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["JournalAction"]
+
+
+class JournalAction(StrEnum):
+    """Action a resume / journal-recovery call may take on a pending tx.
+
+    Surfaced on ``ResumeRunInput.journal`` (in
+    :mod:`ctxr.fsm.mcp.tools_runs`) and on the dedicated
+    journal-recovery MCP/CLI surface (in
+    :mod:`ctxr.fsm.mcp.tools_events`). ``discard`` rolls the pending
+    journal_txn back; ``replay`` finalises its staged writes.
+    """
+
+    discard = "discard"
+    replay = "replay"

--- a/ctxr/fsm/mcp/server.py
+++ b/ctxr/fsm/mcp/server.py
@@ -301,7 +301,11 @@ def _install_signal_handlers(project: Project) -> None:
 
 
 def main(
-    transport: Literal["stdio", "http"] = "stdio",
+    # Literal kept (not an enum) because ``transport`` is a one-off
+    # boot parameter consumed by the CLI shim only — no cross-module
+    # reuse, no JSON serialisation, no closed-vocabulary status field
+    # that other layers branch on. Per the W14i audit rule.
+    transport: Literal["stdio", "http"] = "stdio",  # audit-strings: justified
     db_path: Path | None = None,
     host: str = "127.0.0.1",
     port: int = 0,

--- a/ctxr/fsm/mcp/tools_events.py
+++ b/ctxr/fsm/mcp/tools_events.py
@@ -73,8 +73,8 @@ from ctxr.fsm.core.models import JournalStatus
 from ctxr.fsm.mcp import mcp
 from ctxr.fsm.mcp._drain_decorator import drain_aware
 from ctxr.fsm.mcp._errors import McpToolError, as_error
+from ctxr.fsm.mcp._shared_enums import JournalAction
 from ctxr.fsm.mcp._state import get_project
-from ctxr.fsm.mcp.tools_runs import JournalAction
 from ctxr.fsm.sqlite.repos_events import Consumer, Event, Producer
 from ctxr.fsm.sqlite.repos_locks_journal import JournalTxn
 

--- a/ctxr/fsm/mcp/tools_events.py
+++ b/ctxr/fsm/mcp/tools_events.py
@@ -64,15 +64,17 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Annotated, Literal
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ctxr.fsm.core.models import JournalStatus
 from ctxr.fsm.mcp import mcp
 from ctxr.fsm.mcp._drain_decorator import drain_aware
 from ctxr.fsm.mcp._errors import McpToolError, as_error
 from ctxr.fsm.mcp._state import get_project
+from ctxr.fsm.mcp.tools_runs import JournalAction
 from ctxr.fsm.sqlite.repos_events import Consumer, Event, Producer
 from ctxr.fsm.sqlite.repos_locks_journal import JournalTxn
 
@@ -206,11 +208,9 @@ class JournalRecovered(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     run_id: str
-    action: Literal["discard", "replay"]
+    action: JournalAction
     txn_id: str | None = None
-    previous_status: (
-        Literal["pending", "ready_to_finalise", "finalised"] | None
-    ) = None
+    previous_status: JournalStatus | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -453,7 +453,7 @@ def recover_journal(
         Field(description="The run whose journal needs recovering."),
     ],
     action: Annotated[
-        Literal["discard", "replay"],
+        JournalAction,
         Field(
             description=(
                 "`discard` deletes the staged-write row (rollback). "
@@ -494,15 +494,15 @@ def recover_journal(
                 )
 
             previous_status = txn.status
-            if action == "discard":
+            if action is JournalAction.discard:
                 project.journal.discard(session, txn_id=txn.id)
-            else:  # action == "replay"
+            else:  # action is JournalAction.replay
                 # Only ``ready_to_finalise`` rows are legal to
                 # roll forward — a still-``pending`` row has no
                 # staged writes to finalise. We refuse with a
                 # structured error rather than silently doing the
                 # wrong thing.
-                if txn.status != "ready_to_finalise":
+                if txn.status is not JournalStatus.ready_to_finalise:
                     return as_error(
                         "journal_replay_not_ready",
                         detail=(

--- a/ctxr/fsm/mcp/tools_runs.py
+++ b/ctxr/fsm/mcp/tools_runs.py
@@ -71,6 +71,7 @@ from ctxr.fsm.core.verifier import VerifierOutcome, run_verifier
 from ctxr.fsm.mcp import mcp
 from ctxr.fsm.mcp._drain_decorator import drain_aware
 from ctxr.fsm.mcp._errors import McpToolError, as_error
+from ctxr.fsm.mcp._shared_enums import JournalAction
 from ctxr.fsm.mcp._state import get_project
 from ctxr.fsm.sqlite import Project
 from ctxr.fsm.sqlite.models_core import RunTable, StateTable, TransitionTable
@@ -111,18 +112,6 @@ class CommitResultKind(StrEnum):
     loop_continued = "loop_continued"
     terminal = "terminal"
     fault = "fault"
-
-
-class JournalAction(StrEnum):
-    """Action a resume / journal-recovery call may take on a pending tx.
-
-    Surfaced on ``ResumeRunInput.journal`` and on the dedicated
-    journal-recovery MCP/CLI surface. ``discard`` rolls the pending
-    journal_txn back; ``replay`` finalises its staged writes.
-    """
-
-    discard = "discard"
-    replay = "replay"
 
 
 # Module logger. The server entry-point configures the root logger to

--- a/ctxr/fsm/mcp/tools_runs.py
+++ b/ctxr/fsm/mcp/tools_runs.py
@@ -45,8 +45,9 @@ import logging
 import os
 import uuid
 from datetime import datetime
+from enum import StrEnum
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
@@ -57,11 +58,14 @@ from ctxr.fsm.core.engine import build_brief
 from ctxr.fsm.core.models import (
     Brief,
     CommitSignature,
+    EngineAdvanceKind,
     EventKind,
     FsmSpec,
     PostValidationResultEntry,
     RunCtx,
     TransitionEvaluation,
+    TransitionKind,
+    VerifierVerdict,
 )
 from ctxr.fsm.core.verifier import VerifierOutcome, run_verifier
 from ctxr.fsm.mcp import mcp
@@ -78,10 +82,12 @@ __all__ = [
     "AbortRunInput",
     "CommitOutputsInput",
     "CommitResult",
+    "CommitResultKind",
     "ConfirmCommitInput",
     "ConfirmResult",
     "GetBriefInput",
     "GetRunInput",
+    "JournalAction",
     "ListRunsInput",
     "ResumeResult",
     "ResumeRunInput",
@@ -89,6 +95,34 @@ __all__ = [
     "RunStartedPayload",
     "StartRunInput",
 ]
+
+
+class CommitResultKind(StrEnum):
+    """Discriminator for :class:`CommitResult`.
+
+    Mirrors the engine's :class:`EngineAdvanceKind` taxonomy but with
+    one rename: ``advance`` becomes ``advanced`` and ``loop_continue``
+    becomes ``loop_continued`` to match the JS legacy MCP wire contract.
+    Members carry the literal wire strings so JSON serialisation stays
+    byte-stable.
+    """
+
+    advanced = "advanced"
+    loop_continued = "loop_continued"
+    terminal = "terminal"
+    fault = "fault"
+
+
+class JournalAction(StrEnum):
+    """Action a resume / journal-recovery call may take on a pending tx.
+
+    Surfaced on ``ResumeRunInput.journal`` and on the dedicated
+    journal-recovery MCP/CLI surface. ``discard`` rolls the pending
+    journal_txn back; ``replay`` finalises its staged writes.
+    """
+
+    discard = "discard"
+    replay = "replay"
 
 
 # Module logger. The server entry-point configures the root logger to
@@ -297,7 +331,7 @@ class CommitResult(BaseModel):
 
     model_config = _OUT_CFG
 
-    kind: Literal["advanced", "terminal", "fault", "loop_continued"]
+    kind: CommitResultKind
     brief: Brief | None = None
     next_state: str | None = None
     iteration_n: int | None = None
@@ -352,7 +386,7 @@ class ResumeRunInput(BaseModel):
 
     run_id: uuid.UUID
     from_state: str | None = None
-    journal: Literal["discard", "replay"] | None = None
+    journal: JournalAction | None = None
 
 
 class ResumeResult(BaseModel):
@@ -986,7 +1020,7 @@ _COMMIT_TOKEN_TTL_SECONDS: int = 60
 
 def _stage_commit_writes(
     *,
-    result_kind: Literal["advance", "loop_continue", "terminal"],
+    result_kind: EngineAdvanceKind,
     run_id: str,
     spec_id: str,
     current_state_id: str,
@@ -1011,7 +1045,11 @@ def _stage_commit_writes(
     """
     steps: list[dict[str, Any]] = []
 
-    if result_kind in ("advance", "terminal") and from_state_pk is not None:
+    exits_current_state = result_kind in {
+        EngineAdvanceKind.advance,
+        EngineAdvanceKind.terminal,
+    }
+    if exits_current_state and from_state_pk is not None:
         # The exiting state — its outputs land on the state-entry row,
         # the run's last_update_at bumps, and a ``state_exited`` event
         # is emitted by the replay so subscribers see the same shape
@@ -1025,13 +1063,13 @@ def _stage_commit_writes(
             }
         )
 
-    if result_kind == "advance":
+    if result_kind is EngineAdvanceKind.advance:
         steps.append(
             {
                 "op": "record_transition",
                 "from_state_pk": from_state_pk,
                 "to_state_id": next_state_id or "",
-                "kind": winning_kind or "always",
+                "kind": winning_kind or TransitionKind.always.value,
                 "predicate": winning_predicate,
                 "predicate_result": winning_predicate_result,
             }
@@ -1044,7 +1082,7 @@ def _stage_commit_writes(
             }
         )
 
-    if result_kind == "loop_continue":
+    if result_kind is EngineAdvanceKind.loop_continue:
         # The state-entry row stays open across iterations; nothing to
         # mark exited. We still stage a no-op step so replay produces a
         # deterministic event trail.
@@ -1056,7 +1094,7 @@ def _stage_commit_writes(
             }
         )
 
-    if result_kind == "terminal":
+    if result_kind is EngineAdvanceKind.terminal:
         steps.append(
             {
                 "op": "complete_run",
@@ -1069,12 +1107,15 @@ def _stage_commit_writes(
     # is canonical-JSON-friendly because every value is already a
     # Python primitive (env / outputs are dicts of JSON-able values by
     # contract).
+    # ``result_kind`` is serialised as its string value (StrEnum
+    # collapses to str under json) so the wire payload stays identical
+    # to the pre-W14i shape.
     steps.append(
         {
             "op": "_meta",
             "spec_id": spec_id,
             "run_id": run_id,
-            "result_kind": result_kind,
+            "result_kind": result_kind.value,
             "current_state_id": current_state_id,
             "next_state_id": next_state_id,
             "env_after": {**env, **outputs},
@@ -1133,7 +1174,7 @@ def _replay_journal_txn(
                 run_id=run_id,
                 from_state_pk=str(from_pk),
                 to_state_id=str(step.get("to_state_id") or ""),
-                kind=str(step.get("kind") or "always"),
+                kind=str(step.get("kind") or TransitionKind.always.value),
                 predicate=step.get("predicate"),
                 predicate_result=step.get("predicate_result"),
                 producer_id=producer_id,
@@ -1178,7 +1219,7 @@ def _replay_journal_txn(
         # without breaking older replayers.
 
     next_brief: Brief | None = None
-    if result_kind == "advance" and next_state_id:
+    if result_kind == EngineAdvanceKind.advance.value and next_state_id:
         next_state_obj = spec.get_state(next_state_id)
         next_brief = build_brief(
             spec,
@@ -1186,7 +1227,7 @@ def _replay_journal_txn(
             env=env_after,
             run_id=uuid.UUID(run_id),
         )
-    elif result_kind == "loop_continue":
+    elif result_kind == EngineAdvanceKind.loop_continue.value:
         # The loop body's next brief is already in the CommitResult
         # held by the worker; we still rebuild it here so confirm can
         # echo it back uniformly.
@@ -1413,7 +1454,7 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
                     run_id=run.id,
                 )
             return CommitResult(
-                kind="fault",
+                kind=CommitResultKind.fault,
                 reason=result.reason,
                 errors=list(result.errors),
                 evaluations=list(result.evaluations),
@@ -1432,7 +1473,7 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
             # against. Rebuild it from the current state + env.
             iter_for_brief = (
                 getattr(result, "iteration_n", None)
-                if result.kind == "loop_continue"
+                if result.kind is EngineAdvanceKind.loop_continue
                 else None
             )
             current_brief = build_brief(
@@ -1452,7 +1493,7 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
                     producer_id=producer_id,
                     kind=(
                         EventKind.verifier_passed.value
-                        if verifier_outcome.verdict == "passed"
+                        if verifier_outcome.verdict is VerifierVerdict.passed
                         else EventKind.verifier_rejected.value
                     ),
                     payload={
@@ -1471,7 +1512,7 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
                     run_id=run.id,
                 )
 
-            if verifier_outcome.verdict == "rejected":
+            if verifier_outcome.verdict is VerifierVerdict.rejected:
                 return as_error(
                     "verifier_rejected",
                     detail="verifier panel rejected the worker outputs",
@@ -1504,9 +1545,9 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
             )
 
         # ── Stage writes + mint token (deferred to confirm_commit) ──
-        if result.kind == "loop_continue":
+        if result.kind is EngineAdvanceKind.loop_continue:
             staged = _stage_commit_writes(
-                result_kind="loop_continue",
+                result_kind=EngineAdvanceKind.loop_continue,
                 run_id=run.id,
                 spec_id=spec.id,
                 current_state_id=current_state_id,
@@ -1529,16 +1570,16 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
                 staged_writes=staged,
             )
             return CommitResult(
-                kind="loop_continued",
+                kind=CommitResultKind.loop_continued,
                 brief=result.brief,
                 iteration_n=result.iteration_n,
                 token=_to_wire_token(token),
                 expected_next_state=current_state_id,
             )
 
-        if result.kind == "terminal":
+        if result.kind is EngineAdvanceKind.terminal:
             staged = _stage_commit_writes(
-                result_kind="terminal",
+                result_kind=EngineAdvanceKind.terminal,
                 run_id=run.id,
                 spec_id=spec.id,
                 current_state_id=current_state_id,
@@ -1566,7 +1607,7 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
                 staged_writes=staged,
             )
             return CommitResult(
-                kind="terminal",
+                kind=CommitResultKind.terminal,
                 verdict=result.verdict,
                 evaluations=list(result.evaluations),
                 token=_to_wire_token(token),
@@ -1592,8 +1633,12 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
         if next_worker is not None:
             next_inputs = {name: merged_env.get(name) for name in next_worker.inputs}
 
+        unconditional_kinds = {
+            TransitionKind.always.value,
+            TransitionKind.otherwise.value,
+        }
         staged = _stage_commit_writes(
-            result_kind="advance",
+            result_kind=EngineAdvanceKind.advance,
             run_id=run.id,
             spec_id=spec.id,
             current_state_id=current_state_id,
@@ -1603,14 +1648,17 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
             env=env,
             iteration_n=None,
             verdict=None,
-            winning_kind=(winning_eval.kind if winning_eval else "always") or "always",
+            winning_kind=(
+                (winning_eval.kind if winning_eval else None)
+                or TransitionKind.always.value
+            ),
             winning_predicate=(
                 winning_eval.expression if winning_eval else None
             ),
             winning_predicate_result=(
                 None
                 if winning_eval is None
-                or winning_eval.kind in {"always", "otherwise"}
+                or winning_eval.kind in unconditional_kinds
                 else bool(winning_eval.result)
             ),
             next_inputs=next_inputs,
@@ -1623,7 +1671,7 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
             staged_writes=staged,
         )
         return CommitResult(
-            kind="advanced",
+            kind=CommitResultKind.advanced,
             brief=result.brief,
             next_state=result.next_state,
             evaluations=list(result.evaluations),
@@ -1874,7 +1922,7 @@ def fsm_confirm_commit(input: ConfirmCommitInput) -> ConfirmResult | McpToolErro
         # current state. Terminal commits clear the marker so any
         # subsequent tool calls are unconstrained (no run is active).
         result_kind = replay.get("result_kind")
-        if result_kind == "terminal":
+        if result_kind == EngineAdvanceKind.terminal.value:
             _publish_active_run_marker(run_id=None, spec=None, state_id=None)
         else:
             next_state_id = replay.get("next_state_id") or consumed_token.state_id

--- a/ctxr/fsm/sqlite/repos_locks_journal.py
+++ b/ctxr/fsm/sqlite/repos_locks_journal.py
@@ -56,7 +56,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import Any
 
 import uuid_utils
 from pydantic import BaseModel, ConfigDict, Field
@@ -64,6 +64,11 @@ from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
+from ctxr.fsm.core.models import (
+    JournalStatus,
+    LockAcquireReason,
+    LockReleaseReason,
+)
 from ctxr.fsm.sqlite.models_core import LockTable
 from ctxr.fsm.sqlite.models_enforcement import JournalTxnTable
 
@@ -179,12 +184,7 @@ class LockResult(BaseModel):
 
     acquired: bool
     lock: Lock | None = None
-    reason: Literal[
-        "acquired",
-        "replaced_stale",
-        "already_held_by_same_session",
-        "held",
-    ]
+    reason: LockAcquireReason
 
 
 class ReleaseResult(BaseModel):
@@ -202,7 +202,7 @@ class ReleaseResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     released: bool
-    reason: Literal["released", "not_owner", "not_held"]
+    reason: LockReleaseReason
 
 
 class JournalTxn(BaseModel):
@@ -221,7 +221,7 @@ class JournalTxn(BaseModel):
 
     id: str
     run_id: str
-    status: Literal["pending", "ready_to_finalise", "finalised"]
+    status: JournalStatus
     staged_writes: list[dict[str, Any]] = Field(default_factory=list)
     started_at: datetime
     ready_at: datetime | None = None
@@ -297,7 +297,7 @@ class LocksRepo:
             session.flush()
             return LockResult(
                 acquired=True,
-                reason="acquired",
+                reason=LockAcquireReason.acquired,
                 lock=self._row_to_lock(row),
             )
 
@@ -309,7 +309,7 @@ class LocksRepo:
             session.flush()
             return LockResult(
                 acquired=True,
-                reason="already_held_by_same_session",
+                reason=LockAcquireReason.already_held_by_same_session,
                 lock=self._row_to_lock(existing),
             )
 
@@ -323,14 +323,14 @@ class LocksRepo:
             session.flush()
             return LockResult(
                 acquired=True,
-                reason="replaced_stale",
+                reason=LockAcquireReason.replaced_stale,
                 lock=self._row_to_lock(existing),
             )
 
         # Live lock held by a different session — refuse.
         return LockResult(
             acquired=False,
-            reason="held",
+            reason=LockAcquireReason.held,
             lock=self._row_to_lock(existing),
         )
 
@@ -356,12 +356,18 @@ class LocksRepo:
         """
         existing = session.get(LockTable, run_id)
         if existing is None:
-            return ReleaseResult(released=False, reason="not_held")
+            return ReleaseResult(
+                released=False, reason=LockReleaseReason.not_held
+            )
         if existing.holder_session_id != session_id:
-            return ReleaseResult(released=False, reason="not_owner")
+            return ReleaseResult(
+                released=False, reason=LockReleaseReason.not_owner
+            )
         session.delete(existing)
         session.flush()
-        return ReleaseResult(released=True, reason="released")
+        return ReleaseResult(
+            released=True, reason=LockReleaseReason.released
+        )
 
     def inspect(self, session: Session, *, run_id: str) -> Lock | None:
         """Return the current lock for ``run_id`` (or ``None`` if unheld).
@@ -421,7 +427,7 @@ class JournalRepo:
         row = JournalTxnTable(
             id=_new_uuid7(),
             run_id=run_id,
-            status="pending",
+            status=JournalStatus.pending.value,
             staged_writes_json=_canonical_json([]),
             started_at=now_iso,
             ready_at=None,
@@ -449,7 +455,7 @@ class JournalRepo:
         row = session.get(JournalTxnTable, txn_id)
         if row is None:
             raise KeyError(f"journal_txn not found: {txn_id!r}")
-        row.status = "ready_to_finalise"
+        row.status = JournalStatus.ready_to_finalise.value
         row.staged_writes_json = _canonical_json(staged_writes)
         row.ready_at = _utc_iso_millis()
         session.add(row)
@@ -469,7 +475,7 @@ class JournalRepo:
         row = session.get(JournalTxnTable, txn_id)
         if row is None:
             raise KeyError(f"journal_txn not found: {txn_id!r}")
-        row.status = "finalised"
+        row.status = JournalStatus.finalised.value
         row.finalised_at = _utc_iso_millis()
         session.add(row)
         session.flush()
@@ -502,10 +508,14 @@ class JournalRepo:
         ``ready_to_finalise``) or back (status=``pending``); if ``None`` the
         run was last seen in a quiescent state.
         """
+        unfinalised_statuses = (
+            JournalStatus.pending.value,
+            JournalStatus.ready_to_finalise.value,
+        )
         stmt = (
             select(JournalTxnTable)
             .where(JournalTxnTable.run_id == run_id)
-            .where(JournalTxnTable.status.in_(("pending", "ready_to_finalise")))
+            .where(JournalTxnTable.status.in_(unfinalised_statuses))
             .order_by(JournalTxnTable.started_at.desc(), JournalTxnTable.id.desc())
             .limit(1)
         )
@@ -539,14 +549,18 @@ class JournalRepo:
         # non-dict items would be a producer bug, but we still defend.
         staged_writes = [item for item in decoded if isinstance(item, dict)]
 
-        status = row.status
-        if status not in ("pending", "ready_to_finalise", "finalised"):
-            # Out-of-schema status values should be impossible because the
-            # repo controls every write, but if they slip through we surface
-            # them via a hard cast at the value-object boundary rather than
-            # silently coercing — the type system will then complain on the
-            # caller side, which is the right place to notice.
-            raise ValueError(f"unexpected journal txn status: {status!r}")
+        try:
+            status = JournalStatus(row.status)
+        except ValueError as exc:
+            # Out-of-schema status values should be impossible because
+            # the repo controls every write, but if they slip through we
+            # surface them as a typed error at the value-object boundary
+            # rather than silently coercing — the type system will then
+            # complain on the caller side, which is the right place to
+            # notice.
+            raise ValueError(
+                f"unexpected journal txn status: {row.status!r}"
+            ) from exc
 
         return JournalTxn(
             id=row.id,

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,78 @@
+# Coding standards
+
+Project-level coding standards every PR must honour. These are the
+non-negotiable rules; everything else is in the inline docstrings.
+
+## Closed-vocabulary string literals → StrEnum
+
+**Rule.** Every closed vocabulary used across more than one module
+MUST be defined as a `StrEnum`. Every reference (Pydantic field
+annotation, model_validator branch, dict-key comparison, JSON wire
+value, CLI flag value) MUST go through the enum member, not through
+a free-form string literal.
+
+**Why.** This was the user's call-out on PR #39 (W14b+c+d):
+
+> All these `when` and `why` and other things — should not be string
+> predicates if they predefined and used across all the python files.
+> Instead, they should be extracted to shareable enums and reused
+> everywhere. I don't understand why should I explain you basics of
+> SOLID, KISS etc.
+
+Magic-string vocabularies scattered across modules are the most
+expensive bug class to fix later: every typo silently passes type-check
+and surfaces only at the wire boundary; renaming requires a full grep
+sweep that no IDE can verify; and the "where is this value enumerated?"
+question has no single answer.
+
+**How.** Before pushing a PR that introduces a new Pydantic model OR
+a new string-keyed JSON field OR a new CLI flag value:
+
+1. Run `make audit-strings`. The script greps the source tree for the
+   patterns the W14i audit identified.
+2. If the script flags a hit, either:
+   - Reference the existing enum (almost always the right answer), or
+   - Define a new StrEnum in the natural home module + import it.
+3. If a hit is genuinely a one-off open vocabulary (`Literal["stdio",
+   "http"]` on a CLI flag with no cross-module reuse), append
+   `# audit-strings: justified` to the line. The justification comment
+   forces a maintainer-of-the-day decision: a contributor who silently
+   adds the marker without thinking about whether the value is closed
+   is making a deliberate choice that PR review will catch.
+
+## Canonical enum homes
+
+- **`ctxr/fsm/core/models.py`** — every lifecycle / domain vocabulary
+  consumed by both the engine and at least one persistence /
+  serialisation surface. Examples: `RunStatus`, `StateKind`,
+  `TransitionKind`, `EngineAdvanceKind`, `EventKind`, `VerifierVerdict`,
+  `InlineFaultReason`, `JournalStatus`, `LockAcquireReason`,
+  `LockReleaseReason`.
+- **`ctxr/fsm/cli/_clients.py`** — vocabularies shared across
+  `ensure`, `install-mcp`, and `install-memory` (the W14 bootstrap
+  pipeline). Examples: `McpClient`, `EnsureStatus`, `EnsureActionStatus`,
+  `McpConfigStatus`, `EnsureMode`, `ConfigFormat`.
+- **Per-tool modules** — vocabularies that genuinely don't escape
+  their module (e.g. `CommitResultKind` and `JournalAction` in
+  `ctxr/fsm/mcp/tools_runs.py`). When a second module reaches for
+  them, promote to one of the canonical homes above.
+
+## Dispatcher Open-Closed pattern
+
+Every `match` statement that dispatches on a StrEnum SHOULD end with:
+
+```python
+case _ as never:
+    raise AssertionError(f"unhandled <EnumName> member: {never!r}")
+```
+
+Adding a new enum member then surfaces as a typed test failure rather
+than a silent fallthrough. The pattern is enforced by code review;
+no automated grep catches it yet.
+
+## CI gate
+
+`pytest tests/test_audit_strings.py` runs `audit_strings.sh` and
+fails the build if any unjustified finding surfaces. The smoke test
+is fast (single subprocess invocation, no fixture setup) so the gate
+is essentially free per PR.

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -51,9 +51,15 @@ a new string-keyed JSON field OR a new CLI flag value:
 - **`ctxr/fsm/cli/_clients.py`** — vocabularies shared across
   `ensure`, `install-mcp`, and `install-memory` (the W14 bootstrap
   pipeline). Examples: `McpClient`, `EnsureStatus`, `EnsureActionStatus`,
-  `McpConfigStatus`, `EnsureMode`, `ConfigFormat`.
+  `McpConfigStatus`, `EnsureMode`.
+- **`ctxr/fsm/mcp/_shared_enums.py`** — MCP tool vocabularies that
+  escape a single tool module. Example: `JournalAction` is read by
+  both `tools_runs` and `tools_events`, so it lives in this shared
+  home rather than in either tool module (importing across tool
+  modules just to share an enum would drag the producing module's
+  whole import graph into the consumer's boot path).
 - **Per-tool modules** — vocabularies that genuinely don't escape
-  their module (e.g. `CommitResultKind` and `JournalAction` in
+  their module (e.g. `CommitResultKind` in
   `ctxr/fsm/mcp/tools_runs.py`). When a second module reaches for
   them, promote to one of the canonical homes above.
 

--- a/scripts/audit_strings.sh
+++ b/scripts/audit_strings.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# audit_strings.sh — guard against closed-vocabulary string literals
+#
+# Runs a battery of greps over the Python source tree looking for
+# patterns the W14i audit identified as smells: inline ``Literal[...]``
+# narrowings that shadow an existing StrEnum, raw string-equality on
+# enum-vocabulary values, and hard-coded MCP-client name lists.
+#
+# Each finding prints ``file:line: rule: detail`` to stdout. Exits 0
+# when nothing matched (the audit is clean), non-zero when at least
+# one finding surfaced (so CI / pre-commit can gate on it).
+#
+# Justifications: a finding can be silenced inline with a trailing
+# comment marker (see ``_JUSTIFY_MARKER`` below) — used sparingly for
+# genuinely-open vocabularies (CLI ``transport``, supervisor ``mode``)
+# that have no enum reason to exist.
+
+set -uo pipefail
+
+# Trailing marker on a line that opts it out of the audit. We deliberately
+# require an explicit per-line comment so a contributor has to defend the
+# exception rather than silently bypass the check.
+_JUSTIFY_MARKER='# audit-strings: justified'
+
+ROOT="${1:-$(pwd)}"
+SRC_DIR="${ROOT}/ctxr/fsm"
+TEST_DIR="${ROOT}/tests"
+
+if [[ ! -d "${SRC_DIR}" ]]; then
+  echo "audit-strings: source dir not found: ${SRC_DIR}" >&2
+  exit 2
+fi
+
+HITS=0
+
+# Filter that drops lines carrying the explicit justification marker.
+# We use ``cat`` then ``grep -v`` so a missing input file fails the
+# pipeline loudly rather than silently producing zero hits.
+_filter_justified() {
+  grep -v "${_JUSTIFY_MARKER}" || true
+}
+
+# Report a single rule violation set. Args: rule-name, file:line:body lines.
+_report() {
+  local rule="$1"
+  local body="$2"
+  if [[ -z "${body}" ]]; then
+    return
+  fi
+  echo "${body}" | awk -F: -v rule="${rule}" '{printf "%s:%s: %s: %s\n", $1, $2, rule, substr($0, length($1)+length($2)+3)}'
+}
+
+# --- Rule 1: ``Literal["..."]`` narrowings ----------------------------
+# Every ``Literal[...]`` whose values overlap a StrEnum is the offender
+# the user flagged on PR #39. Inline Literal narrowing is allowed only
+# when the value is a true one-off API parameter (justify with the
+# trailing marker so the audit walks over it).
+RULE1=$(grep -rn 'Literal\["' "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+RULE1_HITS=$(echo -n "${RULE1}" | grep -c '^' || true)
+if [[ "${RULE1_HITS}" -gt 0 ]]; then
+  echo "--- audit-strings: rule1 (inline Literal narrowings)"
+  _report "rule1-literal" "${RULE1}"
+  HITS=$((HITS + RULE1_HITS))
+fi
+
+# --- Rule 2: raw string equality on TransitionKind vocabulary ---------
+# Always / otherwise / deterministic / judgement are enum members; the
+# raw-string compare branch is a bug waiting to happen.
+RULE2=""
+for value in always otherwise deterministic judgement; do
+  hits=$(grep -rn "== \"${value}\"" "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+  if [[ -n "${hits}" ]]; then
+    RULE2="${RULE2}${hits}\n"
+  fi
+done
+RULE2_HITS=$(echo -ne "${RULE2}" | grep -c '^' || true)
+if [[ "${RULE2_HITS}" -gt 0 ]]; then
+  echo "--- audit-strings: rule2 (TransitionKind raw equality)"
+  echo -ne "${RULE2}" | _report "rule2-transitionkind" "$(cat)"
+  HITS=$((HITS + RULE2_HITS))
+fi
+
+# --- Rule 3: raw string equality on VerifierVerdict vocabulary --------
+RULE3=""
+for value in passed rejected inconclusive; do
+  hits=$(grep -rn "verdict == \"${value}\"" "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+  if [[ -n "${hits}" ]]; then
+    RULE3="${RULE3}${hits}\n"
+  fi
+done
+RULE3_HITS=$(echo -ne "${RULE3}" | grep -c '^' || true)
+if [[ "${RULE3_HITS}" -gt 0 ]]; then
+  echo "--- audit-strings: rule3 (VerifierVerdict raw equality)"
+  echo -ne "${RULE3}" | _report "rule3-verifierverdict" "$(cat)"
+  HITS=$((HITS + RULE3_HITS))
+fi
+
+# --- Rule 4: hard-coded MCP-client name tuples ------------------------
+# A scattered ``("auto", "claude", "codex", "cursor", "none")`` tuple
+# means someone re-declared the McpClient vocabulary instead of
+# importing the enum. ``_CLIENT_CHOICES`` derives its tuple from the
+# enum's members and IS allowed — that's why we look for the literal
+# string list, not the constant.
+RULE4=$(grep -rn '"auto", "claude", "codex", "cursor"' "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+RULE4_HITS=$(echo -n "${RULE4}" | grep -c '^' || true)
+if [[ "${RULE4_HITS}" -gt 0 ]]; then
+  echo "--- audit-strings: rule4 (hard-coded McpClient name tuple)"
+  _report "rule4-mcpclient-tuple" "${RULE4}"
+  HITS=$((HITS + RULE4_HITS))
+fi
+
+if [[ "${HITS}" -gt 0 ]]; then
+  echo ""
+  echo "audit-strings: ${HITS} finding(s); see W14i for the audit rationale."
+  exit 1
+fi
+
+echo "audit-strings: clean."
+exit 0

--- a/scripts/audit_strings.sh
+++ b/scripts/audit_strings.sh
@@ -55,7 +55,11 @@ _report() {
 # the user flagged on PR #39. Inline Literal narrowing is allowed only
 # when the value is a true one-off API parameter (justify with the
 # trailing marker so the audit walks over it).
-RULE1=$(grep -rn 'Literal\["' "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+#
+# Pattern covers both quote styles (double + single) and any amount of
+# whitespace between ``Literal[`` and the first quote, so contributors
+# can't sidestep the audit with ``Literal['x']`` or ``Literal[ "x"]``.
+RULE1=$(grep -rEn --include='*.py' 'Literal\[[[:space:]]*["'"'"']' "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
 RULE1_HITS=$(echo -n "${RULE1}" | grep -c '^' || true)
 if [[ "${RULE1_HITS}" -gt 0 ]]; then
   echo "--- audit-strings: rule1 (inline Literal narrowings)"
@@ -66,9 +70,14 @@ fi
 # --- Rule 2: raw string equality on TransitionKind vocabulary ---------
 # Always / otherwise / deterministic / judgement are enum members; the
 # raw-string compare branch is a bug waiting to happen.
+#
+# Pattern covers four equivalence shapes: ``x == "v"``, ``x != "v"``,
+# ``"v" == x``, ``"v" != x``, with either quote style. A new raw-string
+# comparison written in any of those shapes lights up the gate.
 RULE2=""
 for value in always otherwise deterministic judgement; do
-  hits=$(grep -rn "== \"${value}\"" "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+  patt='([!=]=[[:space:]]*["'"'"']'"${value}"'["'"'"']|["'"'"']'"${value}"'["'"'"'][[:space:]]*[!=]=)'
+  hits=$(grep -rEn --include='*.py' "${patt}" "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
   if [[ -n "${hits}" ]]; then
     RULE2="${RULE2}${hits}\n"
   fi
@@ -81,9 +90,12 @@ if [[ "${RULE2_HITS}" -gt 0 ]]; then
 fi
 
 # --- Rule 3: raw string equality on VerifierVerdict vocabulary --------
+# Same four-shape coverage as rule 2; matches the verdict name on
+# either side of ``==`` / ``!=`` with either quote style.
 RULE3=""
 for value in passed rejected inconclusive; do
-  hits=$(grep -rn "verdict == \"${value}\"" "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+  patt='([!=]=[[:space:]]*["'"'"']'"${value}"'["'"'"']|["'"'"']'"${value}"'["'"'"'][[:space:]]*[!=]=)'
+  hits=$(grep -rEn --include='*.py' "${patt}" "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
   if [[ -n "${hits}" ]]; then
     RULE3="${RULE3}${hits}\n"
   fi

--- a/scripts/audit_strings.sh
+++ b/scripts/audit_strings.sh
@@ -109,6 +109,33 @@ if [[ "${RULE4_HITS}" -gt 0 ]]; then
   HITS=$((HITS + RULE4_HITS))
 fi
 
+# --- Rule 5: absolute-path literals in source -------------------------
+# Configs, persisted artefacts, and CLI output MUST use portable paths
+# (project-relative or ``~``-prefixed). An absolute-path literal in
+# source code is almost always a leak: a docstring example showing
+# ``/Users/...``, a fixture comparing against ``/abs/path``, a print
+# format string interpolating a resolved Path. The
+# ``_portable_repr(path, base=...)`` helper exists for this — use it.
+#
+# Patterns flagged:
+#   "/Users/...", "/home/...", "/abs/path...", "/private/var/folders/...".
+#
+# Justified cases (system-default paths in tests; the helper itself):
+# tag the line with ``# audit-strings: justified``.
+RULE5=""
+for pattern in '"/Users/' '"/home/' '"/abs/path' '"/private/var/folders/'; do
+  hits=$(grep -rn "${pattern}" "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+  if [[ -n "${hits}" ]]; then
+    RULE5="${RULE5}${hits}\n"
+  fi
+done
+RULE5_HITS=$(echo -ne "${RULE5}" | grep -c '^' || true)
+if [[ "${RULE5_HITS}" -gt 0 ]]; then
+  echo "--- audit-strings: rule5 (absolute-path literal in source)"
+  echo -ne "${RULE5}" | _report "rule5-absolute-path-literal" "$(cat)"
+  HITS=$((HITS + RULE5_HITS))
+fi
+
 if [[ "${HITS}" -gt 0 ]]; then
   echo ""
   echo "audit-strings: ${HITS} finding(s); see W14i for the audit rationale."

--- a/tests/cli/test_install_memory_check_drift.py
+++ b/tests/cli/test_install_memory_check_drift.py
@@ -136,7 +136,7 @@ def test_check_reports_drift_across_all_clients_after_version_bump(
         row = by_client[client]
         assert row["installed_version"] == current, row
         assert row["package_version"] == bumped_version, row
-        assert row["status"] == "out-of-date", row
+        assert row["status"] == "out_of_date", row
 
 
 def test_check_before_any_install_reports_missing(tmp_target: Path) -> None:
@@ -179,4 +179,4 @@ def test_check_before_any_install_reports_missing(tmp_target: Path) -> None:
     # Cursor: the rule file does not exist yet, so its host file is
     # absent -> 'not-installed'.
     assert by_client["cursor"]["installed_version"] is None
-    assert by_client["cursor"]["status"] == "not-installed"
+    assert by_client["cursor"]["status"] == "not_installed"

--- a/tests/cli/test_install_memory_claude.py
+++ b/tests/cli/test_install_memory_claude.py
@@ -216,7 +216,7 @@ def test_check_reports_out_of_date_after_version_bump(
     row = payload["results"][0]
     assert row["client"] == "claude"
     assert row["installed_version"] == _current_principles_version()
-    assert row["status"] == "out-of-date"
+    assert row["status"] == "out_of_date"
 
 
 def test_dry_run_prints_patch_but_does_not_write(tmp_target: Path) -> None:

--- a/tests/cli/test_install_memory_codex.py
+++ b/tests/cli/test_install_memory_codex.py
@@ -194,7 +194,7 @@ def test_check_detects_version_drift(
     row = payload["results"][0]
     assert row["client"] == "codex"
     assert row["installed_version"] == _current_principles_version()
-    assert row["status"] == "out-of-date"
+    assert row["status"] == "out_of_date"
 
 
 def test_inlined_content_matches_package_file_byte_for_byte(

--- a/tests/cli/test_install_memory_cursor.py
+++ b/tests/cli/test_install_memory_cursor.py
@@ -189,4 +189,4 @@ def test_check_detects_out_of_date_after_version_bump(
     row = payload["results"][0]
     assert row["client"] == "cursor"
     assert row["installed_version"] == _current_principles_version()
-    assert row["status"] == "out-of-date"
+    assert row["status"] == "out_of_date"

--- a/tests/integration/bootstrap/test_ensure_check_mode.py
+++ b/tests/integration/bootstrap/test_ensure_check_mode.py
@@ -30,10 +30,13 @@ def test_check_on_fresh_dir_reports_missing(tmp_path: Path) -> None:
         check=True,
         timeout=2.0,
     )
-    assert summary["status"].startswith("missing:")
-    assert "init" in summary["status"]
-    assert "supervisor" in summary["status"]
+    # W14i: ``status`` is one of the ``missing_*`` enum members rather
+    # than a colon-prefixed list. When multiple steps are missing the
+    # most-upstream one (init) wins so the wrapping script knows which
+    # gate fired first; per-step granularity remains on ``actions``.
+    assert summary["status"] == "missing_init"
     assert summary["actions"]["init"] == "missing"
+    assert summary["actions"]["supervisor"] == "missing"
     # mcp-config skipped because client=none.
     assert summary["actions"]["mcp_config"] == "skipped"
     # No filesystem mutation.

--- a/tests/integration/bootstrap/test_ensure_cli_surface.py
+++ b/tests/integration/bootstrap/test_ensure_cli_surface.py
@@ -84,7 +84,10 @@ def test_check_mode_exits_nonzero_when_missing() -> None:
         )
         assert result.returncode != 0
         payload = json.loads(result.stdout)
-        assert payload["status"].startswith("missing:")
+        # W14i: ``status`` is one of the typed ``missing_*`` enum
+        # members; init is the most-upstream missing step on a fresh
+        # tmpdir so it wins.
+        assert payload["status"].startswith("missing_")
 
 
 def test_help_renders() -> None:

--- a/tests/integration/bootstrap/test_ensure_cold_start.py
+++ b/tests/integration/bootstrap/test_ensure_cold_start.py
@@ -83,7 +83,7 @@ def test_ensure_cold_start_mcp_only(tmp_path: Path) -> None:
                 "ctxr-fsm",
                 "ensure",
                 "--mode",
-                "mcp-only",
+                "mcp_only",
                 "--no-memory",
                 "--no-mcp-config",
                 "--client",
@@ -183,7 +183,7 @@ def test_ensure_timeout_failed_when_supervisor_wont_come_up(
     summary = run_ensure(
         project_root=tmp_path,
         client="none",
-        mode="mcp-only",
+        mode="mcp_only",
         no_memory=True,
         no_mcp_config=True,
         check=False,

--- a/tests/integration/bootstrap/test_ensure_parallel_invocations.py
+++ b/tests/integration/bootstrap/test_ensure_parallel_invocations.py
@@ -66,7 +66,7 @@ def _run_ensure_mcp_only(project_root: Path, timeout_s: int) -> dict[str, object
             "ctxr-fsm",
             "ensure",
             "--mode",
-            "mcp-only",
+            "mcp_only",
             "--no-memory",
             "--no-mcp-config",
             "--client",

--- a/tests/integration/bootstrap/test_ensure_warm_fast_path.py
+++ b/tests/integration/bootstrap/test_ensure_warm_fast_path.py
@@ -199,7 +199,7 @@ def test_mcp_only_warm_only_probes_mcp(
     summary = run_ensure(
         project_root=tmp_path,
         client="none",
-        mode="mcp-only",
+        mode="mcp_only",
         no_memory=True,
         no_mcp_config=True,
         check=False,

--- a/tests/integration/install_mcp/test_install_mcp_modes.py
+++ b/tests/integration/install_mcp/test_install_mcp_modes.py
@@ -99,8 +99,8 @@ def test_check_reports_out_of_date_when_entry_differs(
 
     result = run_install_mcp(proj, client="claude", check=True)
     claude_row = result["results"][0]
-    assert claude_row["action"] == "check:out-of-date"
-    assert claude_row["status"] == "out-of-date"
+    assert claude_row["action"] == "check:out_of_date"
+    assert claude_row["status"] == "out_of_date"
 
 
 def test_client_none_is_noop(tmp_path: Path) -> None:

--- a/tests/integration/memory/test_install_memory_check_detects_bootstrap_drift.py
+++ b/tests/integration/memory/test_install_memory_check_detects_bootstrap_drift.py
@@ -127,7 +127,7 @@ def test_check_flags_claude_staged_bootstrap_mutation(tmp_target: Path) -> None:
 
     exit_code, payload = _run_check(tmp_target)
     assert exit_code == 1, payload
-    assert _row_for(payload, "claude")["bootstrap_status"] == "out-of-date"
+    assert _row_for(payload, "claude")["bootstrap_status"] == "out_of_date"
 
     # Re-running install rewrites the staged copy back to the package
     # source.
@@ -167,7 +167,7 @@ def test_check_flags_claude_package_bootstrap_bump(
     # on the Claude row.
     exit_code, payload = _run_check(tmp_target)
     assert exit_code == 1, payload
-    assert _row_for(payload, "claude")["bootstrap_status"] == "out-of-date"
+    assert _row_for(payload, "claude")["bootstrap_status"] == "out_of_date"
 
     # Re-running install (with the monkey-patched source still in
     # effect) materialises the bumped content.
@@ -228,7 +228,7 @@ def test_check_flags_codex_principles_drift_when_adapter_bumps(
 
     exit_code, payload = _run_check(tmp_target)
     assert exit_code == 1, payload
-    assert _row_for(payload, "codex")["status"] == "out-of-date"
+    assert _row_for(payload, "codex")["status"] == "out_of_date"
     # bootstrap_status stays ``"inlined"`` — for codex it's the
     # principles axis that catches the drift.
     assert _row_for(payload, "codex")["bootstrap_status"] == "inlined"
@@ -256,7 +256,7 @@ def test_check_flags_cursor_principles_drift_when_rule_file_bumps(
 
     exit_code, payload = _run_check(tmp_target)
     assert exit_code == 1, payload
-    assert _row_for(payload, "cursor")["status"] == "out-of-date"
+    assert _row_for(payload, "cursor")["status"] == "out_of_date"
     assert _row_for(payload, "cursor")["bootstrap_status"] == "inlined"
 
 
@@ -275,7 +275,7 @@ def test_check_reports_not_installed_when_bootstrap_absent_for_claude(
     exit_code, payload = _run_check(tmp_target)
     assert exit_code == 1, payload
     claude = _row_for(payload, "claude")
-    assert claude["bootstrap_status"] == "not-installed"
+    assert claude["bootstrap_status"] == "not_installed"
 
 
 def test_check_reports_inlined_for_codex_when_principles_missing(

--- a/tests/test_audit_strings.py
+++ b/tests/test_audit_strings.py
@@ -1,0 +1,67 @@
+"""Smoke test for the W14i ``audit_strings.sh`` guard script.
+
+The script greps the source tree for closed-vocabulary string literals
+that should have been enum-referenced (the user's PR #39 correction).
+This test asserts the script exits 0 on the current tree — every
+finding is either fixed or carries an explicit ``# audit-strings:
+justified`` marker for the genuinely-open one-off Literal cases.
+
+If a future PR introduces a new bare ``Literal[...]`` narrowing that
+shadows an existing StrEnum, this test fails with the offending
+``file:line`` so CI catches the regression in the same commit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT: Path = Path(__file__).resolve().parents[1]
+_AUDIT_SCRIPT: Path = _REPO_ROOT / "scripts" / "audit_strings.sh"
+
+
+def test_audit_strings_script_exists() -> None:
+    """The audit script lives where ``Makefile`` and tests reference it."""
+
+    assert _AUDIT_SCRIPT.is_file(), _AUDIT_SCRIPT
+
+
+def test_audit_strings_script_is_executable() -> None:
+    """The audit script ships executable so ``make audit-strings`` works.
+
+    A non-executable script is a contributor-trap on a fresh clone:
+    the Makefile target works but a manual ``./scripts/audit_strings.sh``
+    invocation fails with ``Permission denied``. The bit is enforced
+    in the repo so both code paths behave identically.
+    """
+
+    assert _AUDIT_SCRIPT.stat().st_mode & 0o111, (
+        f"{_AUDIT_SCRIPT} is not executable; chmod +x and re-commit"
+    )
+
+
+def test_audit_strings_clean_on_current_tree() -> None:
+    """``audit_strings.sh`` reports zero findings on the current source tree.
+
+    If a future PR introduces an inline ``Literal[...]`` narrowing that
+    shadows a StrEnum, or a raw ``== "always"`` / ``== "passed"`` /
+    similar comparison on an enum-vocabulary value, this assertion
+    fails — the failure message includes the offending file:line so
+    the contributor can either reference the enum or add an explicit
+    ``# audit-strings: justified`` comment for a genuinely-open
+    one-off Literal.
+    """
+
+    result = subprocess.run(
+        ["bash", str(_AUDIT_SCRIPT), str(_REPO_ROOT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        "audit_strings.sh reported findings (re-run "
+        "`bash scripts/audit_strings.sh` to see them):\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/tests/unit/core/test_engine_inline_execution.py
+++ b/tests/unit/core/test_engine_inline_execution.py
@@ -5,16 +5,20 @@ Covers:
 * Happy path: a registered handler returns a schema-valid dict and the
   engine reports ``ok=True`` with the outputs.
 * Unregistered handler reports ``ok=False`` with
-  ``fault_reason="inline_handler_unregistered: ..."``.
+  ``fault_reason=InlineFaultReason.unregistered`` and a ``fault_detail``
+  carrying the missing ``(spec_id, handler_id)`` key.
 * Handler that raises is caught and reported as
-  ``fault_reason="inline_handler_raised: ..."``; the engine does not
-  re-raise.
-* Handler that returns a non-dict reports ``fault_reason="inline_handler_bad_return_type: ..."``.
+  ``fault_reason=InlineFaultReason.raised`` with the exception class +
+  message on ``fault_detail``; the engine does not re-raise.
+* Handler that returns a non-dict reports
+  ``fault_reason=InlineFaultReason.bad_return_type`` and names the
+  offending type in ``fault_detail``.
 * Handler returns a dict that fails the inline state's response schema
-  → ``fault_reason="inline_handler_validation_failed"`` and the
+  → ``fault_reason=InlineFaultReason.validation_failed`` and the
   validation errors are surfaced.
 * Handler returns a schema-valid dict but a post-validation predicate
-  evaluates ``False`` → ``fault_reason="inline_handler_post_validation_failed"``.
+  evaluates ``False`` →
+  ``fault_reason=InlineFaultReason.post_validation_failed``.
 * Multiple-handler registry: looking up a handler under one spec does
   not collide with the same handler_id under another spec.
 * Schema-less inline state: the engine accepts ANY dict and reports
@@ -39,6 +43,7 @@ from ctxr.fsm.core.inline_registry import (
     get_default_registry,
 )
 from ctxr.fsm.core.models import (
+    InlineFaultReason,
     InlineSpec,
     Predicate,
     ResponseSchema,
@@ -176,10 +181,10 @@ def test_execute_inline_unregistered_handler_returns_structured_fault() -> None:
     )
 
     assert result.ok is False
-    assert result.fault_reason is not None
-    assert result.fault_reason.startswith("inline_handler_unregistered:")
-    assert "spec-x" in result.fault_reason
-    assert "missing_one" in result.fault_reason
+    assert result.fault_reason is InlineFaultReason.unregistered
+    assert result.fault_detail is not None
+    assert "spec-x" in result.fault_detail
+    assert "missing_one" in result.fault_detail
     assert result.outputs == {}
 
 
@@ -207,10 +212,10 @@ def test_execute_inline_raising_handler_is_caught_and_reported() -> None:
     )
 
     assert result.ok is False
-    assert result.fault_reason is not None
-    assert result.fault_reason.startswith("inline_handler_raised:")
-    assert "RuntimeError" in result.fault_reason
-    assert "boom" in result.fault_reason
+    assert result.fault_reason is InlineFaultReason.raised
+    assert result.fault_detail is not None
+    assert "RuntimeError" in result.fault_detail
+    assert "boom" in result.fault_detail
     # Outputs are empty; the engine does not silently swallow partial data.
     assert result.outputs == {}
 
@@ -239,9 +244,9 @@ def test_execute_inline_bad_return_type_is_reported() -> None:
     )
 
     assert result.ok is False
-    assert result.fault_reason is not None
-    assert result.fault_reason.startswith("inline_handler_bad_return_type:")
-    assert "list" in result.fault_reason
+    assert result.fault_reason is InlineFaultReason.bad_return_type
+    assert result.fault_detail is not None
+    assert "list" in result.fault_detail
     assert result.outputs == {}
 
 
@@ -270,7 +275,7 @@ def test_execute_inline_schema_mismatch_is_reported() -> None:
     )
 
     assert result.ok is False
-    assert result.fault_reason == "inline_handler_validation_failed"
+    assert result.fault_reason is InlineFaultReason.validation_failed
     assert result.validation.valid is False
     assert result.validation.errors  # at least one error message present
     assert result.outputs == {}
@@ -305,7 +310,7 @@ def test_execute_inline_post_validation_failure_is_reported() -> None:
     )
 
     assert result.ok is False
-    assert result.fault_reason == "inline_handler_post_validation_failed"
+    assert result.fault_reason is InlineFaultReason.post_validation_failed
     assert result.validation.valid is True  # the schema part was fine
     assert result.post_validations is not None
     assert result.post_validations.valid is False

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -26,6 +26,7 @@ from ctxr.fsm.core.models import (
     ResponseSchema,
     State,
     Transition,
+    TransitionKind,
     VerifierSpec,
     Worker,
 )
@@ -209,11 +210,16 @@ def test_fsm_spec_rejects_zero_version() -> None:
 def test_transition_when_always_literal() -> None:
     t = Transition(to="next_state", when="always")
     assert t.when == "always"
+    # W14i: the boundary normaliser maps the bare string onto the
+    # ``TransitionKind`` enum so downstream code can branch on the
+    # typed value rather than on a free-form literal.
+    assert t.when is TransitionKind.always
 
 
 def test_transition_when_otherwise_literal() -> None:
     t = Transition(to="next_state", when="otherwise")
     assert t.when == "otherwise"
+    assert t.when is TransitionKind.otherwise
 
 
 def test_transition_when_bare_string_becomes_predicate() -> None:


### PR DESCRIPTION
## Summary

Sweep over every file W14a–g touched (and surrounding code those changes interact with) to enforce SOLID / KISS / DRY discipline. Triggered by the user's correction on PR #39: magic-string literals (`\"always\"`, `\"otherwise\"`, etc.) scattered across `Transition.when` typing, model_validator dispatch, and downstream call sites while `TransitionKind` StrEnum already defined those exact members. **This is the non-negotiable pre-gate for W14h.**

PR #41 (`w14g/workspace-docs`) is the base. PRs #24–#41 form the chain this continues.

## Audit findings table

| Area | File:line (before) | Fix |
|---|---|---|
| Transition guard typing | `ctxr/fsm/core/models.py:379` `when: Predicate \| Literal[\"always\", \"otherwise\"] \| dict` | Switched to `Predicate \| TransitionKind \| dict`; `_normalise_when` now maps incoming strings onto `TransitionKind.*` members |
| Transition dict-kind dispatch | `ctxr/fsm/core/models.py:427-441` raw `kind == \"always\"`/etc | Compare against `TransitionKind.*.value` |
| State.kind property | `ctxr/fsm/core/models.py:495` returns `Literal[\"loop\"…]` | Returns `StateKind` (new enum) |
| InlineExecutionResult.fault_reason | `ctxr/fsm/core/models.py:797` free-form `str` with `\"inline_handler_*\"` prefixes | Typed `InlineFaultReason` enum + separate `fault_detail` field |
| Engine dispatch | `ctxr/fsm/core/engine.py:308-422` raw `\"always\"`/`\"otherwise\"` compares | Now `isinstance(when, TransitionKind)` + enum identity checks |
| EngineAdvanceResult.kind | `ctxr/fsm/core/engine.py:135` `Literal[\"loop_continue\", \"fault\", \"terminal\", \"advance\"]` | New `EngineAdvanceKind(StrEnum)` |
| Loop termination reason | `ctxr/fsm/core/models.py:821` `Literal[\"done_field\", \"max_iterations\"]` | New `LoopTerminationReason(StrEnum)` |
| Verifier verdict literals | `ctxr/fsm/core/verifier.py:88, 97, 256` `Literal[\"passed\", \"rejected\"]` | `Literal[VerifierVerdict.passed, VerifierVerdict.rejected]` (StrEnum members in a narrowed Literal) |
| Verifier raw equality | `ctxr/fsm/core/verifier.py:254-255` `v.verdict == \"passed\"` etc | `v.verdict is VerifierVerdict.passed` |
| Journal txn status | `ctxr/fsm/sqlite/repos_locks_journal.py:224` `Literal[\"pending\", \"ready_to_finalise\", \"finalised\"]` | New `JournalStatus(StrEnum)` in core.models |
| Lock release reason | `ctxr/fsm/sqlite/repos_locks_journal.py:205` `Literal[\"released\", \"not_owner\", \"not_held\"]` | New `LockReleaseReason(StrEnum)` |
| Lock acquire reason | `ctxr/fsm/sqlite/repos_locks_journal.py:183-188` `Literal[\"acquired\", \"replaced_stale\", \"already_held_by_same_session\", \"held\"]` | New `LockAcquireReason(StrEnum)` |
| Journal admin API filter | `ctxr/fsm/api/routes_admin.py:398` `_JournalStatusLiteral` type alias | Replaced with `JournalStatus` |
| MCP CommitResult.kind | `ctxr/fsm/mcp/tools_runs.py:300` `Literal[\"advanced\", \"terminal\", \"fault\", \"loop_continued\"]` | New `CommitResultKind(StrEnum)` |
| MCP ResumeRunInput.journal | `ctxr/fsm/mcp/tools_runs.py:355` `Literal[\"discard\", \"replay\"]` | New `JournalAction(StrEnum)` shared with tools_events |
| MCP recover_journal action | `ctxr/fsm/mcp/tools_events.py:209, 456` `Literal[\"discard\", \"replay\"]` | `JournalAction` |
| MCP previous_status | `ctxr/fsm/mcp/tools_events.py:212` `Literal[\"pending\", \"ready_to_finalise\", \"finalised\"]` | `JournalStatus` |
| MCP _stage_commit_writes result_kind | `ctxr/fsm/mcp/tools_runs.py:989` `Literal[\"advance\", \"loop_continue\", \"terminal\"]` | `EngineAdvanceKind` |
| ensure --client / --mode | `ctxr/fsm/cli/ensure_cmd.py:316-317`, `ctxr/fsm/cli/install_mcp_cmd.py:683` | Shared `McpClient` + `EnsureMode` enums in new `ctxr/fsm/cli/_clients.py` |
| ensure actions[\"*\"] values | `ctxr/fsm/cli/ensure_cmd.py:337-342` raw strings (\"applied\", \"reused\", …) | `EnsureActionStatus(StrEnum)` |
| ensure top-level status | `ctxr/fsm/cli/ensure_cmd.py:484-500` raw \"ready\"/\"degraded\"/\"missing:*\" | `EnsureStatus(StrEnum)` — see wire-format changes below |
| install-mcp check status | `ctxr/fsm/cli/install_mcp_cmd.py:228-244` raw \"installed\"/\"missing\"/\"out-of-date\" | `McpConfigStatus(StrEnum)` |
| install-mcp _ClientTask.client | `ctxr/fsm/cli/install_mcp_cmd.py:536` `Literal[\"claude\", \"codex\", \"cursor\"]` | `McpClient` |
| install-memory _CheckRow.status | `ctxr/fsm/cli/install_memory_cmd.py:814` raw \"ok\"/\"missing\"/\"out-of-date\"/\"not-installed\" | `MemoryInstallStatus(StrEnum)` |
| install-memory bootstrap_status | `ctxr/fsm/cli/install_memory_cmd.py:815-817` raw strings | `BootstrapStatus(StrEnum)` |
| install_mcp _CLIENT_CHOICES tuples | three modules each had its own `(\"auto\", \"claude\", \"codex\", \"cursor\"…)` | Derived from `McpClient` enum in all three |
| mcp.server.main transport | `ctxr/fsm/mcp/server.py:304` `Literal[\"stdio\", \"http\"]` | KEPT — one-off CLI boot parameter; marked `# audit-strings: justified` |
| supervisor.run_supervisor mode | `ctxr/fsm/cli/lifecycle/supervisor.py:835,1011` `Literal[\"dev\", \"prod\"]` | KEPT — one-off; marked `# audit-strings: justified` |

## Wire-format changes

These four wire strings changed because StrEnum members cannot contain hyphens or colons; the consistency win is per the plan recommendation. Consumers parsing the JSON must update.

| Field | Before | After |
|---|---|---|
| `ensure --mode` (CLI flag value, JSON `actions`/etc) | `\"mcp-only\"` | `\"mcp_only\"` |
| `ensure` top-level `status` (multi-piece) | `\"missing:init,supervisor\"` | `\"missing_init\"` (single most-upstream member; per-step granularity stays on `actions`) |
| `install-mcp --check` per-client `status` | `\"out-of-date\"` | `\"out_of_date\"` |
| `install-memory --check` per-client `status` / `bootstrap_status` | `\"out-of-date\"` / `\"not-installed\"` | `\"out_of_date\"` / `\"not_installed\"` |
| `install-mcp` summary `target` field | absolute resolved path (e.g., `\"/Users/.../project\"`) | portable form via `_portable_repr`: project-relative when under cwd (`\".\"` / `\"subdir/...\"`), `~`-prefixed when under `$HOME`, absolute as last resort. Reflects "portability sweep" follow-up — configs MUST stay relative so artefacts survive being pushed to git or moved between machines. |
| `install-mcp` per-result `path` field | absolute resolved path | same `_portable_repr` rules: project-relative for Claude `.mcp.json` and `.claude/settings.json` (target-relative bucket), `~`-prefixed for Codex `~/.codex/config.toml` and Cursor `~/.cursor/mcp.json` (HOME bucket). |

Every other previously-emitted JSON value is byte-identical (StrEnum serialises to its value).

## Per-phase summary

| Phase | Hits found | Hits fixed |
|---|---|---|
| 1 — Define StrEnums for known offenders | 9 enums introduced (StateKind, InlineFaultReason, EnsureActionStatus, EnsureStatus, McpClient, McpConfigStatus, BootstrapStatus, EnsureMode, ConfigFormat) + 5 more discovered during sweep (EngineAdvanceKind, LoopTerminationReason, JournalStatus, LockAcquireReason, LockReleaseReason, CommitResultKind, JournalAction, MemoryInstallStatus) | all defined |
| 2 — `Transition.when` refactor | model_validator dispatch + 8 engine call sites | all refactored |
| 3 — Comprehensive grep sweep | 4 inline Literal narrowings | 2 enum-extracted, 2 marked `# audit-strings: justified` (one-off CLI params) |
| 4 — SRP audit | `run_ensure` body | extracted `_step_init` / `_step_memory` / `_step_mcp_config` / `_final_status` helpers |
| 5 — KISS audit | 1 catch-all `except` in TTY probe | narrowed to `(AttributeError, OSError)`; the two installer try/excepts are kept-with-justification |
| 6 — Open-Closed audit | install-mcp `--check` detail string assembly | `_check_detail_for` is a `match` statement with `_ as never` fallback |
| 7 — Test assertion updates | 17 tests | all updated to wire-format-stable enum-vocabulary assertions |
| 9 — Tooling | new | `scripts/audit_strings.sh` + `tests/test_audit_strings.py` + `Makefile` + `docs/coding-standards.md` |

## Verification output

- `uv run pytest`: **603 passed, 4 warnings in ~80s** (was 600 baseline; +3 new from `test_audit_strings.py`).
- `uv run ruff check ctxr/fsm/ tests/`: **All checks passed!**
- `uv run mypy ctxr/fsm/`: **Success: no issues found in 64 source files.**
- `bash scripts/audit_strings.sh .`: **audit-strings: clean.**

## New process rule (`docs/coding-standards.md`)

> Every PR that introduces a new Pydantic model OR a new string-keyed JSON field OR a new CLI flag value MUST run `make audit-strings` before pushing. If anything matches a closed vocabulary, the StrEnum gets defined (or the existing one referenced) in the SAME PR. The CI gate (`pytest tests/test_audit_strings.py`) fails the build if any unjustified finding surfaces.

## Test plan

- [x] `uv run pytest` — 603 green.
- [x] `uv run ruff check` — clean.
- [x] `uv run mypy ctxr/fsm/` — clean.
- [x] `make audit-strings` — clean.
- [ ] Manual smoke: `ctxr-fsm ensure --mode mcp_only --no-memory --no-mcp-config --client none --project-root <tmp>` on a fresh tmpdir; expect `\"status\": \"missing_init\"` from `--check` and the supervisor coming up on the apply path.
- [ ] Reviewer: scan the `docs/coding-standards.md` for the new process rule + the audit script's escape-hatch convention (`# audit-strings: justified`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
