### PR TITLE
feat(w14j): Rich subsystem-URL table for ensure + doctor + serve (typer everywhere)

### DIFF
--- a/ctxr/fsm/cli/_render.py
+++ b/ctxr/fsm/cli/_render.py
@@ -1,0 +1,222 @@
+"""Rich renderers for the human-facing CLI surface.
+
+Every command that surfaces "where do I go" information uses
+:func:`render_subsystem_table` so the table shape stays consistent
+across ``ctxr-fsm ensure``, ``ctxr-fsm doctor``, and the
+``ctxr-fsm serve`` supervisor boot banner. JSON output paths in those
+commands stay untouched — wire-format compatibility for machine
+consumers is sacred.
+
+W14j (per the locked plan) collapses three previously-divergent
+pretty-print bodies (ensure's actions summary, doctor's free-form
+``rich.print`` of the report dict, and the supervisor's
+``[ctxr-fsm supervisor] booted: ...`` banner line) onto one shared
+table renderer so the human surface is byte-identical for "the same
+state" no matter which command surfaced it. The closed-vocabulary
+status mapping lives here as well so call sites do not scatter colour
+choices.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+__all__ = [
+    "print_subsystem_table",
+    "render_subsystem_table",
+]
+
+
+# Status display + Rich style mapping. Closed vocabulary, hosted here
+# so call sites never reach for ad-hoc colour strings. New subsystem
+# statuses must be added here (and only here) — the renderer falls
+# back to ``unknown`` for anything outside the table so a typo in a
+# caller surfaces visibly rather than silently.
+#
+# We deliberately do NOT introduce a ``Literal[...]`` typing on the
+# input ``status`` field: the renderer accepts whatever the per-call
+# site supplies (``EnsureActionStatus`` values, the supervisor's
+# ``"ready"`` literal, the doctor's ``"unreachable"``) and falls back
+# to ``unknown`` instead of raising. Keeping the surface forgiving
+# means a future caller can add a new status word without breaking
+# the renderer, and the per-call site keeps owning its own enum.
+_STATUS_GLYPHS: dict[str, tuple[str, str]] = {
+    "ready": ("ready", "bold green"),
+    "reused": ("reused", "bold yellow"),
+    "spawned": ("spawned", "bold green"),
+    "degraded": ("degraded", "bold yellow"),
+    "unreachable": ("unreachable", "bold red"),
+    "missing": ("missing", "bold red"),
+    "failed": ("failed", "bold red"),
+    "unknown": ("unknown", "dim white"),
+}
+
+
+def _format_status(status: str) -> tuple[str, str]:
+    """Look up display label + Rich style for a subsystem status.
+
+    Falls back to the ``unknown`` row so a brand-new status word from
+    a caller renders visibly (dim white) rather than crashing the
+    renderer. The fallback is the only place the renderer tolerates
+    drift; everything else is data-in / data-out.
+    """
+    return _STATUS_GLYPHS.get(status, _STATUS_GLYPHS["unknown"])
+
+
+def _portable_project_repr(project_root: Path, *, base: Path | None = None) -> str:
+    """Render ``project_root`` in the most-portable form for the table.
+
+    Mirrors :func:`ctxr.fsm.cli.install_mcp_cmd._portable_repr` so the
+    project row never bakes a machine-specific absolute path into
+    screen text either. Resolution order:
+
+    1. Relative-to-``base`` (default cwd) — printed as ``./<rel>`` so
+       a copy/paste from the terminal lands as a usable path. The
+       cwd-itself case collapses to a bare ``.`` for the same reason.
+    2. ``~``-prefixed when ``project_root`` lives under ``$HOME``.
+    3. Absolute path — the user explicitly pointed at a project
+       outside both cwd and ``$HOME``; we surface that honestly.
+    """
+    base = base or Path.cwd()
+    try:
+        rel = project_root.relative_to(base)
+    except ValueError:
+        pass
+    else:
+        rel_str = str(rel)
+        return "." if rel_str == "." else f"./{rel_str}"
+    home = Path.home()
+    try:
+        return "~/" + str(project_root.relative_to(home))
+    except ValueError:
+        return str(project_root)
+
+
+def render_subsystem_table(
+    active_mcp: dict[str, Any],
+    *,
+    project_root: Path,
+    title: str | None = None,
+) -> Table:
+    """Build a Rich :class:`Table` from the active-mcp.json payload.
+
+    Input ``active_mcp`` shape (W14c discovery document)::
+
+        {
+          "started_at": "...",
+          "supervisor_pid": int,
+          "version": str,
+          "subsystems": {
+            "mcp": {"http_url": str, "healthz_url": str, "pid": int,
+                    "status": str (optional)},
+            "api": {"http_url": str, "healthz_url": str, "pid": int,
+                    "docs_url": str (optional), "status": str (optional)},
+            "ui":  {"http_url": str, "healthz_url": str | None,
+                    "pid": int, "status": str (optional)},
+          }
+        }
+
+    Columns (locked order, W14j.a):
+
+    * **Subsystem** — ``Project`` for the leading row, then
+      ``mcp`` / ``api`` / ``ui`` in that fixed order.
+    * **URL** — ``http_url`` from the payload; verbatim so the
+      operator can copy-paste straight into a browser or curl.
+    * **Swagger** — ``docs_url`` if the payload carries one; otherwise
+      derived as ``http_url + /docs`` for the api row only. Blank for
+      other rows.
+    * **Health** — coloured + labelled per :data:`_STATUS_GLYPHS`.
+    * **PID** — right-aligned integer; ``-`` when the payload omits it
+      (the supervisor file has not been rewritten yet on a reload).
+
+    The leading **Project** row carries the portable project-root path
+    (relative-to-cwd, ``~``-prefixed, or absolute fallback) so an
+    operator juggling multiple checkouts can confirm which one this
+    table describes without scrolling back through their shell.
+    Project / blank / blank / blank / blank — the row is structural,
+    not a subsystem.
+    """
+    table = Table(
+        title=title or "ctxr-fsm subsystems",
+        show_lines=False,
+        title_style="bold",
+        header_style="bold cyan",
+    )
+    table.add_column("Subsystem", style="bold")
+    table.add_column("URL", overflow="fold")
+    table.add_column("Swagger", overflow="fold")
+    table.add_column("Health")
+    table.add_column("PID", justify="right")
+
+    # Leading project row — structural context, not a subsystem.
+    table.add_row(
+        "Project",
+        _portable_project_repr(project_root),
+        "",
+        "",
+        "",
+        style="dim",
+    )
+
+    subsystems_raw = active_mcp.get("subsystems") or {}
+    subsystems = subsystems_raw if isinstance(subsystems_raw, dict) else {}
+
+    # Fixed render order matches the supervisor's own boot order +
+    # the documented ``mcp / api / ui`` triple. We never iterate the
+    # dict directly: that would let a payload-mutation accidentally
+    # change column order between commands.
+    for name in ("mcp", "api", "ui"):
+        sub = subsystems.get(name)
+        if not isinstance(sub, dict):
+            continue
+        http_url = sub.get("http_url") or ""
+        # Swagger column: explicit ``docs_url`` wins; otherwise we
+        # derive ``<http_url>/docs`` for the api row only. Other rows
+        # stay blank.
+        docs_url_raw = sub.get("docs_url")
+        if isinstance(docs_url_raw, str) and docs_url_raw:
+            swagger = docs_url_raw
+        elif name == "api" and http_url:
+            swagger = http_url.rstrip("/") + "/docs"
+        else:
+            swagger = ""
+        status_value = sub.get("status", "unknown")
+        status_text, status_style = _format_status(
+            status_value if isinstance(status_value, str) else "unknown"
+        )
+        pid = sub.get("pid")
+        pid_repr = str(pid) if isinstance(pid, int) else "-"
+
+        table.add_row(
+            name,
+            http_url,
+            swagger,
+            f"[{status_style}]{status_text}[/{status_style}]",
+            pid_repr,
+        )
+
+    return table
+
+
+def print_subsystem_table(
+    active_mcp: dict[str, Any],
+    *,
+    project_root: Path,
+    title: str | None = None,
+    console: Console | None = None,
+) -> None:
+    """Render and print the subsystem table to ``console`` (or a fresh one).
+
+    Shorthand wrapper so call sites do not have to import :class:`Console`
+    themselves. Tests that need deterministic capture should pass their
+    own ``Console(file=StringIO(), force_terminal=True, width=120)``
+    instance and skip this helper.
+    """
+    console = console or Console()
+    console.print(
+        render_subsystem_table(active_mcp, project_root=project_root, title=title)
+    )

--- a/ctxr/fsm/cli/_render.py
+++ b/ctxr/fsm/cli/_render.py
@@ -19,6 +19,7 @@ choices.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -26,24 +27,29 @@ from rich.console import Console
 from rich.table import Table
 
 __all__ = [
+    "portable_project_repr",
     "print_subsystem_table",
     "render_subsystem_table",
 ]
 
 
 # Status display + Rich style mapping. Closed vocabulary, hosted here
-# so call sites never reach for ad-hoc colour strings. New subsystem
-# statuses must be added here (and only here) — the renderer falls
-# back to ``unknown`` for anything outside the table so a typo in a
-# caller surfaces visibly rather than silently.
+# so call sites never reach for ad-hoc colour strings.
 #
-# We deliberately do NOT introduce a ``Literal[...]`` typing on the
-# input ``status`` field: the renderer accepts whatever the per-call
-# site supplies (``EnsureActionStatus`` values, the supervisor's
-# ``"ready"`` literal, the doctor's ``"unreachable"``) and falls back
-# to ``unknown`` instead of raising. Keeping the surface forgiving
-# means a future caller can add a new status word without breaking
-# the renderer, and the per-call site keeps owning its own enum.
+# Canonical input vocabulary: ``EnsureActionStatus`` members
+# (``applied``, ``current``, ``skipped``, ``unchanged``, ``reused``,
+# ``spawned``, ``failed``, ``missing``) PLUS the supervisor's
+# ``"ready"`` post-boot literal and the doctor's ``"unreachable"``
+# probe outcome. Every member of that set MUST have an entry below.
+#
+# Soft-validation policy: the renderer never raises on a status word
+# outside the table — it falls back to the ``unknown`` row (dim white).
+# That keeps the renderer forgiving so a future caller can add a new
+# status word without breaking the table, BUT every unknown lookup
+# fires a one-line stderr warning so a typo in a caller surfaces
+# visibly during development rather than getting silently absorbed.
+# Adding a new permanent status word means adding it to the table
+# below; the warning is the alarm that says "do that now".
 _STATUS_GLYPHS: dict[str, tuple[str, str]] = {
     "ready": ("ready", "bold green"),
     "reused": ("reused", "bold yellow"),
@@ -62,12 +68,24 @@ def _format_status(status: str) -> tuple[str, str]:
     Falls back to the ``unknown`` row so a brand-new status word from
     a caller renders visibly (dim white) rather than crashing the
     renderer. The fallback is the only place the renderer tolerates
-    drift; everything else is data-in / data-out.
+    drift; everything else is data-in / data-out. An unknown lookup
+    also fires a one-line stderr warning so a typo in a caller's
+    status string is visible during development instead of being
+    silently absorbed — see the module-level ``_STATUS_GLYPHS``
+    comment for the soft-validation rationale.
     """
-    return _STATUS_GLYPHS.get(status, _STATUS_GLYPHS["unknown"])
+    glyph = _STATUS_GLYPHS.get(status)
+    if glyph is None:
+        sys.stderr.write(
+            f"_render: warning: status {status!r} not in _STATUS_GLYPHS; "
+            "falling back to 'unknown'. Add the new status word to the "
+            "table if it is a permanent vocabulary extension.\n"
+        )
+        return _STATUS_GLYPHS["unknown"]
+    return glyph
 
 
-def _portable_project_repr(project_root: Path, *, base: Path | None = None) -> str:
+def portable_project_repr(project_root: Path, *, base: Path | None = None) -> str:
     """Render ``project_root`` in the most-portable form for the table.
 
     Mirrors :func:`ctxr.fsm.cli.install_mcp_cmd._portable_repr` so the
@@ -91,9 +109,15 @@ def _portable_project_repr(project_root: Path, *, base: Path | None = None) -> s
         return "." if rel_str == "." else f"./{rel_str}"
     home = Path.home()
     try:
-        return "~/" + str(project_root.relative_to(home))
+        rel_home = project_root.relative_to(home)
     except ValueError:
         return str(project_root)
+    # ``project_root == home`` collapses ``relative_to(home)`` to
+    # ``Path(".")``; render that as a bare ``~`` instead of ``~/.``
+    # so the cell stays idiomatic (matching the cwd branch's bare
+    # ``.`` collapse above).
+    rel_home_str = str(rel_home)
+    return "~" if rel_home_str == "." else "~/" + rel_home_str
 
 
 def render_subsystem_table(
@@ -155,7 +179,7 @@ def render_subsystem_table(
     # Leading project row — structural context, not a subsystem.
     table.add_row(
         "Project",
-        _portable_project_repr(project_root),
+        portable_project_repr(project_root),
         "",
         "",
         "",

--- a/ctxr/fsm/cli/doctor_cmd.py
+++ b/ctxr/fsm/cli/doctor_cmd.py
@@ -55,6 +55,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from rich.console import Console
+from rich.panel import Panel
 from sqlalchemy import func, select, text
 
 from ctxr.fsm.cli._common import (
@@ -64,6 +66,7 @@ from ctxr.fsm.cli._common import (
     open_project_for_cli,
     resolve_db_path,
 )
+from ctxr.fsm.cli._render import _portable_project_repr, render_subsystem_table
 from ctxr.fsm.cli.lifecycle.primitives import (
     _probe_healthz,
     pid_is_alive,
@@ -253,6 +256,120 @@ def _supervisor_report(project_root: Path) -> dict[str, Any]:
     }
 
 
+def _active_mcp_for_table(
+    *, supervisor: dict[str, Any]
+) -> dict[str, Any]:
+    """Translate the doctor's supervisor report into the table input shape.
+
+    The renderer consumes the W14c discovery-document shape
+    (``{"subsystems": {<name>: {"http_url", "healthz_url", "pid",
+    "status"?}}, ...}``). The doctor's per-subsystem report already
+    carries those fields under different keys (``probe_url`` instead
+    of ``http_url``, an explicit ``healthz`` body, plus ``pid_alive``).
+    This helper bridges the two shapes so the renderer stays pure
+    (one input contract, no per-caller adapters).
+
+    Precedence for each block:
+
+    1. The live W14c discovery document if the supervisor wrote one
+       (``supervisor["active_mcp"]["subsystems"][name]``) — that
+       carries the canonical URLs the supervisor advertised. We layer
+       a status word on top derived from the doctor's own probe so
+       the colour reflects what doctor just observed (e.g. ``ready``
+       vs ``unreachable``) rather than the supervisor's last write.
+    2. The doctor's own pid/probe report when no discovery document
+       is present (cold supervisor; old project tree). The URL is
+       reconstructed from the recorded probe URL so the table is
+       still useful — only the ``docs_url`` derivation will trigger
+       (api row only).
+    """
+    active_doc = supervisor.get("active_mcp")
+    discovery_subs: dict[str, Any] = {}
+    if isinstance(active_doc, dict):
+        raw = active_doc.get("subsystems")
+        if isinstance(raw, dict):
+            discovery_subs = raw
+
+    doctor_subs_raw = supervisor.get("subsystems") or {}
+    doctor_subs = doctor_subs_raw if isinstance(doctor_subs_raw, dict) else {}
+
+    merged: dict[str, dict[str, Any]] = {}
+    for name in ("mcp", "api", "ui"):
+        report = doctor_subs.get(name)
+        if not isinstance(report, dict):
+            continue
+        pid_alive = bool(report.get("pid_alive"))
+        healthz_body = report.get("healthz")
+        # Decision tree for the status word:
+        # * pid down → ``missing``
+        # * pid up + healthz ok → ``ready``
+        # * pid up + healthz None for a subsystem that *should* probe
+        #   → ``unreachable``
+        # * UI (no /healthz) with a live pid → ``ready`` (the
+        #   supervisor's own contract — see the lifecycle module).
+        if not pid_alive:
+            status = "missing"
+        elif name == "ui" or healthz_body is not None:
+            status = "ready"
+        else:
+            status = "unreachable"
+
+        # Start from the discovery block if we have one — those
+        # fields are the supervisor's own publication. Fall back to
+        # the doctor's probe URL for the cold-supervisor case.
+        discovery_block = discovery_subs.get(name)
+        if isinstance(discovery_block, dict):
+            block = dict(discovery_block)
+        else:
+            probe_url = report.get("probe_url")
+            block = {
+                "http_url": probe_url if isinstance(probe_url, str) else "",
+                "healthz_url": (
+                    f"{probe_url.rstrip('/')}/healthz"
+                    if isinstance(probe_url, str) and probe_url and name != "ui"
+                    else None
+                ),
+                "pid": report.get("pid"),
+            }
+        block["status"] = status
+        merged[name] = block
+    return {"subsystems": merged}
+
+
+def _print_pretty_report(
+    *,
+    db_path: Path,
+    revision: str | None,
+    supervisor: dict[str, Any],
+    supervisor_root: Path,
+) -> None:
+    """Render the W14j Rich panel + subsystem table to stdout.
+
+    The panel is a two-line summary (DB path + alembic revision) so
+    the operator's first read confirms which DB this report describes
+    and that migrations are current. The table below sources its
+    rows from :func:`_active_mcp_for_table` so the column shape is
+    byte-identical to ``ctxr-fsm ensure`` and the supervisor banner.
+    """
+    console = Console()
+    db_repr = _portable_project_repr(db_path)
+    revision_line = revision or "(no alembic_version row)"
+    panel = Panel.fit(
+        f"[bold]DB[/bold]       {db_repr}\n"
+        f"[bold]Revision[/bold] {revision_line}",
+        title="ctxr-fsm doctor",
+        title_align="left",
+        border_style="cyan",
+    )
+    console.print(panel)
+    console.print(
+        render_subsystem_table(
+            _active_mcp_for_table(supervisor=supervisor),
+            project_root=supervisor_root,
+        )
+    )
+
+
 def doctor(
     db: Path | None = DB_OPTION,
     json_mode: bool = JSON_OPTION,
@@ -302,4 +419,21 @@ def doctor(
         "locks": {"count": locks},
         "supervisor": supervisor,
     }
-    json_or_pretty(report, json_mode)
+    if json_mode:
+        # JSON path is the wire contract every script depends on; we
+        # MUST emit the same shape every previous doctor invocation did.
+        json_or_pretty(report, json_mode)
+        return
+
+    # W14j: human-facing pretty-print is a Rich Panel (DB summary) +
+    # the shared subsystem table. This REPLACES the old free-form
+    # ``rich.print`` of the report dict — the dict-dump was useful
+    # for the early-W7 debugging window but is noisy now that the
+    # supervisor surface is the operator's first read. ``--json``
+    # callers still get the full report (see the early-return above).
+    _print_pretty_report(
+        db_path=db_path,
+        revision=revision,
+        supervisor=supervisor,
+        supervisor_root=supervisor_root,
+    )

--- a/ctxr/fsm/cli/doctor_cmd.py
+++ b/ctxr/fsm/cli/doctor_cmd.py
@@ -66,7 +66,7 @@ from ctxr.fsm.cli._common import (
     open_project_for_cli,
     resolve_db_path,
 )
-from ctxr.fsm.cli._render import _portable_project_repr, render_subsystem_table
+from ctxr.fsm.cli._render import portable_project_repr, render_subsystem_table
 from ctxr.fsm.cli.lifecycle.primitives import (
     _probe_healthz,
     pid_is_alive,
@@ -352,7 +352,7 @@ def _print_pretty_report(
     byte-identical to ``ctxr-fsm ensure`` and the supervisor banner.
     """
     console = Console()
-    db_repr = _portable_project_repr(db_path)
+    db_repr = portable_project_repr(db_path)
     revision_line = revision or "(no alembic_version row)"
     panel = Panel.fit(
         f"[bold]DB[/bold]       {db_repr}\n"

--- a/ctxr/fsm/cli/ensure_cmd.py
+++ b/ctxr/fsm/cli/ensure_cmd.py
@@ -59,6 +59,7 @@ from ctxr.fsm.cli._clients import (
     McpConfigStatus,
 )
 from ctxr.fsm.cli._common import json_or_pretty
+from ctxr.fsm.cli._render import print_subsystem_table
 from ctxr.fsm.cli.init_cmd import run_init
 from ctxr.fsm.cli.install_mcp_cmd import run_install_mcp
 from ctxr.fsm.cli.install_memory_cmd import run_install_memory
@@ -723,6 +724,15 @@ def ensure(
             "stdout is not a TTY, pretty otherwise."
         ),
     ),
+    no_table: bool = typer.Option(
+        False,
+        "--no-table",
+        help=(
+            "Skip the Rich subsystem URL table in TTY non-JSON mode. "
+            "The actions-summary dict still prints. JSON mode is "
+            "unaffected."
+        ),
+    ),
 ) -> None:
     """Ensure the project is fully bootstrapped + the supervisor is up.
 
@@ -749,6 +759,34 @@ def ensure(
         timeout=timeout,
     )
     json_or_pretty(summary, effective_json)
+
+    # W14j: in TTY non-JSON mode, follow the actions-summary dict
+    # with the Rich subsystem table so a human running ``ensure``
+    # interactively sees the URLs they almost certainly came here for
+    # (FastAPI + Swagger + UI + MCP). ``--no-table`` opts out for the
+    # rare caller that wants pretty output WITHOUT the table; JSON
+    # mode is unaffected (machine consumers stay byte-identical).
+    #
+    # The table is rendered from the ensure summary's own
+    # ``subsystems`` block (rather than re-reading ``active-mcp.json``)
+    # so the ``status`` column reflects the ``ready`` / ``reused`` /
+    # ``spawned`` decision ensure just made — that's the operator's
+    # mental model of "what happened" and matches the JSON shape the
+    # same call returned. When the block is empty (``--check`` against
+    # a cold project, or a failed spawn) the table is suppressed since
+    # there is nothing to show.
+    if not effective_json and not no_table:
+        try:
+            tty = sys.stdout.isatty()
+        except (AttributeError, OSError):
+            tty = False
+        if tty:
+            root = _resolve_project_root(project_root)
+            subsystems_block = summary.get("subsystems") or {}
+            if isinstance(subsystems_block, dict) and subsystems_block:
+                print_subsystem_table(
+                    {"subsystems": subsystems_block}, project_root=root
+                )
 
     # Exit non-zero on a failed / degraded run, or on --check that
     # surfaced any ``missing_*`` status, so wrapping scripts can react.

--- a/ctxr/fsm/cli/ensure_cmd.py
+++ b/ctxr/fsm/cli/ensure_cmd.py
@@ -42,6 +42,7 @@ status.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
@@ -67,6 +68,7 @@ from ctxr.fsm.cli.lifecycle.primitives import (
     pid_is_alive,
     read_active_mcp_file,
     read_pid_file,
+    sharded_log_path,
 )
 
 __all__ = ["ensure", "run_ensure"]
@@ -214,16 +216,19 @@ def _spawn_supervisor_detached(
 
     The supervisor runs in a new session (``start_new_session=True``)
     so a SIGINT in the ensuring shell doesn't take it down. stdout +
-    stderr are redirected to a per-day log file under
-    ``<project_root>/.ctxr-fsm/logs/`` so a later operator can
-    inspect what happened during the cold start.
+    stderr are redirected to a date-sharded log file under
+    ``<project_root>/.ctxr-fsm/logs/supervisor/YYYY/MM/DD/`` (see
+    :func:`sharded_log_path` for the convention) so a later operator
+    can inspect what happened during the cold start AND so the logs
+    directory doesn't grow into a flat accumulation that bottlenecks
+    the filesystem over months of dev sessions.
 
     Returns the spawned pid (for the ensure summary; ownership is
     transferred to the OS — the parent process is free to exit).
     """
-    logs_dir = project_root / ".ctxr-fsm" / "logs"
-    logs_dir.mkdir(parents=True, exist_ok=True)
-    log_path = logs_dir / f"supervisor-{time.strftime('%Y%m%d')}.log"
+    log_path = sharded_log_path(
+        "supervisor", project_root=project_root, pid=os.getpid()
+    )
     log_fp = open(log_path, "ab", buffering=0)  # noqa: SIM115
     cmd = [
         sys.executable or "python3",

--- a/ctxr/fsm/cli/lifecycle/primitives.py
+++ b/ctxr/fsm/cli/lifecycle/primitives.py
@@ -64,6 +64,7 @@ __all__ = [
     "remember_active_mcp_file",
     "remember_port",
     "remove_active_mcp_file",
+    "sharded_log_path",
     "write_active_run_marker",
     "write_pid_file",
 ]
@@ -123,6 +124,72 @@ def pid_file_for(name: str, *, project_root: Path) -> Path:
     ``.ctxr-fsm/pids/<name>.pid`` join themselves.
     """
     return _pids_dir(project_root) / f"{name}.pid"
+
+
+def sharded_log_path(
+    category: str,
+    *,
+    project_root: Path,
+    when: datetime | None = None,
+    pid: int | None = None,
+    extension: str = "log",
+) -> Path:
+    """Return the canonical date-sharded path for an accumulating log file.
+
+    Layout: ``<project_root>/.ctxr-fsm/logs/<category>/YYYY/MM/DD/<category>-<HHMMSS>-<pid>.<ext>``
+
+    Why nested: every directory that ACCUMULATES files over time would
+    otherwise grow without bound into a single flat folder, hitting the
+    classic FS bottleneck on directory enumeration (ext4 / APFS / NTFS
+    degrade past ~10k to 100k entries, and even `ls` / tab-completion
+    crawl for shells). The YYYY/MM/DD prefix caps any single leaf at
+    one day's worth of files for the same category.
+
+    Use cases:
+
+    * Supervisor stdout/stderr capture (``category="supervisor"``).
+    * Future per-subsystem operator logs (``category="mcp"`` etc.).
+    * Audit-trail dumps, telemetry exports, anything else that streams
+      files into ``.ctxr-fsm/`` over the project's lifetime.
+
+    Parameters
+    ----------
+    category:
+        Snake_case slug naming the log stream. Becomes both the top-level
+        subdir (``logs/<category>/...``) and the leading token of the
+        filename so a quick ``grep`` survives a casual operator's
+        ``cat .ctxr-fsm/logs/**/*.log`` invocation.
+    project_root:
+        The project root; the standard ``.ctxr-fsm/`` state dir lives
+        directly under it.
+    when:
+        UTC ``datetime`` that picks the date shard + the HHMMSS suffix.
+        Defaults to ``datetime.now(tz=UTC)`` so callers in the common
+        case can omit it.
+    pid:
+        Optional process id to disambiguate concurrent log files in the
+        same wall-clock second (e.g. two supervisors racing on startup).
+        When omitted, the suffix is just ``<HHMMSS>``.
+    extension:
+        File extension WITHOUT the leading dot. Defaults to ``"log"``.
+
+    Returns
+    -------
+    Path
+        The full resolved path with parent directories created (a
+        following ``open(path, "ab")`` finds the path ready). The file
+        itself is NOT created; the caller writes.
+
+    Convention: every caller that needs a log file MUST go through this
+    helper. Hand-rolling ``logs/<filename>`` is a portability and
+    scale bug — see the workspace memory lesson on flat-folder pitfalls.
+    """
+    now = when or datetime.now(tz=UTC)
+    date_dir = _state_dir(project_root) / "logs" / category / f"{now:%Y}" / f"{now:%m}" / f"{now:%d}"
+    date_dir.mkdir(parents=True, exist_ok=True)
+    pid_suffix = f"-{pid}" if pid is not None else ""
+    filename = f"{category}-{now:%H%M%S}{pid_suffix}.{extension}"
+    return date_dir / filename
 
 
 def _atomic_write_text(path: Path, text: str) -> None:

--- a/ctxr/fsm/cli/lifecycle/supervisor.py
+++ b/ctxr/fsm/cli/lifecycle/supervisor.py
@@ -79,6 +79,7 @@ import anyio
 import httpx
 from watchfiles import awatch
 
+from ctxr.fsm.cli._render import print_subsystem_table
 from ctxr.fsm.cli.lifecycle.primitives import (
     PidLock,
     ReusedSubsystem,
@@ -86,6 +87,7 @@ from ctxr.fsm.cli.lifecycle.primitives import (
     now_iso_ms,
     pick_port,
     pid_file_for,
+    read_active_mcp_file,
     read_pid_file,
     recall_port,
     release_singleton,
@@ -796,6 +798,33 @@ def _publish_active_mcp_file(
     remember_active_mcp_file(payload, project_root=project_root)
 
 
+def _augment_active_with_status(active: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of the W14c discovery doc with ``status='ready'`` per subsystem.
+
+    The discovery file itself never persists a ``status`` field (the
+    file describes "what the supervisor published", not "what the
+    last probe said"), but the W14j renderer's colour mapping is keyed
+    on ``status``. At supervisor boot time, by definition, every
+    subsystem in the file just passed its healthz / liveness check —
+    so injecting ``ready`` here produces a green-coloured first-boot
+    table without lying about the source-of-truth shape of the file.
+    """
+    subsystems = active.get("subsystems") or {}
+    if not isinstance(subsystems, dict):
+        return active
+    new_subs: dict[str, Any] = {}
+    for name, block in subsystems.items():
+        if isinstance(block, dict):
+            new_block = dict(block)
+            new_block.setdefault("status", "ready")
+            new_subs[name] = new_block
+        else:
+            new_subs[name] = block
+    augmented = dict(active)
+    augmented["subsystems"] = new_subs
+    return augmented
+
+
 def _publish_active_mcp_file_from_disk(*, project_root: Path) -> None:
     """Re-publish ``active-mcp.json`` after a reload, reading ports from disk.
 
@@ -929,6 +958,29 @@ async def run_supervisor(
                     f"ui=http://localhost:{ports['ui']}" if ports["ui"] else "ui=skipped"
                 )
             _log("[ctxr-fsm supervisor] booted: " + ", ".join(banner_bits))
+
+            # W14j: once every required healthz has passed (the publish
+            # gate above already enforces ``mcp_healthz_ok``), print the
+            # shared subsystem table to stdout exactly once so an
+            # operator running ``ctxr-fsm serve`` sees the FastAPI /
+            # Swagger / UI / MCP URLs at the moment the dashboard is
+            # actually reachable. NOT on every reload — the reload loop
+            # below re-publishes ``active-mcp.json`` from disk but does
+            # NOT re-print the table; one line per change in the
+            # operator's terminal is plenty. NOT on every healthz probe
+            # — that would spam the surface.
+            if mcp_healthz_ok and ports["mcp"] is not None:
+                active = read_active_mcp_file(project_root)
+                if active is not None:
+                    # ``print_subsystem_table`` writes to a fresh
+                    # ``rich.console.Console`` (i.e. stdout). The
+                    # supervisor's own log lines go to stderr, so the
+                    # operator sees the table on stdout and the
+                    # ``[ctxr-fsm supervisor] ...`` chatter on stderr
+                    # — two independent streams, easy to pipe
+                    # separately for downstream tooling.
+                    _augmented = _augment_active_with_status(active)
+                    print_subsystem_table(_augmented, project_root=project_root)
 
             # Dev-mode reload loop. Sibling task; cancellation of the
             # group tears it down with the rest. anyio's

--- a/ctxr/fsm/cli/lifecycle/supervisor.py
+++ b/ctxr/fsm/cli/lifecycle/supervisor.py
@@ -979,8 +979,8 @@ async def run_supervisor(
                     # ``[ctxr-fsm supervisor] ...`` chatter on stderr
                     # — two independent streams, easy to pipe
                     # separately for downstream tooling.
-                    _augmented = _augment_active_with_status(active)
-                    print_subsystem_table(_augmented, project_root=project_root)
+                    augmented = _augment_active_with_status(active)
+                    print_subsystem_table(augmented, project_root=project_root)
 
             # Dev-mode reload loop. Sibling task; cancellation of the
             # group tears it down with the rest. anyio's

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -76,3 +76,39 @@ no automated grep catches it yet.
 fails the build if any unjustified finding surfaces. The smoke test
 is fast (single subprocess invocation, no fixture setup) so the gate
 is essentially free per PR.
+
+## CLI parsing + pretty-printing (W14j)
+
+**Rule.** Every CLI command in `ctxr-fsm` is a typer subcommand.
+Every human-facing pretty-print path uses Rich (via typer's bundled
+integration). JSON output uses `json.dumps(sort_keys=True, indent=2)`.
+
+* No `argparse` — fragments the CLI shape (different `--help` style,
+  different error handling, different test harness).
+* No `click` direct imports — typer wraps click and exposes the
+  pieces we need; the project's CLI surface MUST go through typer
+  so the decorator vocabulary, default-handling, and Rich integration
+  stay consistent across commands.
+* No bespoke pretty-printers — `print(...)` of dicts, hand-rolled ANSI
+  escapes, `tabulate`, `colorama`, etc. Rich (`rich.console.Console`,
+  `rich.table.Table`, `rich.panel.Panel`) is the only allowed pretty
+  surface so the look/feel stays uniform.
+
+**Why.** The user explicitly locked this in W14j:
+
+> I want you to add to the plan, to print out to the console (this
+> is console command) — with beautiful python typer table — all the
+> addresses with ports where I can go to see: fastapi with it's
+> swagger, ui, etc. In general, I want you to use typer library for
+> all commands, and for pretty printing (if we suppose to pretty
+> print anywhere and mode is not json).
+
+One CLI parser + one pretty-print library means a future contributor
+can read any subcommand and know which patterns are available.
+
+**How.** `scripts/audit_strings.sh` rule 6 greps the `ctxr/fsm/cli/`
+tree for `import argparse` / `from argparse` / `import click` /
+`from click`. A genuinely-justified exception (none currently exist)
+takes the `# audit-strings: justified` marker. Shared Rich renderers
+that surface across commands live in `ctxr/fsm/cli/_render.py` so the
+column shape / colour mapping is owned in one place.

--- a/scripts/audit_strings.sh
+++ b/scripts/audit_strings.sh
@@ -148,29 +148,6 @@ if [[ "${RULE5_HITS}" -gt 0 ]]; then
   HITS=$((HITS + RULE5_HITS))
 fi
 
-# --- Rule 7: flat-folder log/artefact paths ---------------------------
-# Any directory that ACCUMULATES files over time (logs, exports, audit
-# trails, telemetry dumps) MUST live under a YYYY/MM/DD sharded tree
-# (use ``sharded_log_path`` from lifecycle.primitives) so the folder
-# doesn't grow into a flat bottleneck (ext4 / APFS / NTFS all degrade
-# past ~10k–100k entries per directory; even ``ls`` and tab-completion
-# crawl). The user flagged this on W14j when ensure_cmd wrote
-# ``.ctxr-fsm/logs/supervisor-YYYYMMDD.log`` directly.
-#
-# Patterns flagged: any literal ``.ctxr-fsm/logs/`` followed by a
-# filename token (not by a sub-shard name like a year, ``${category}``,
-# or a typed Path expression).
-#
-# This rule looks at the SOURCE tree (ctxr/fsm/); test fixtures that
-# hand-craft a path to assert the layout are justified.
-RULE7=$(grep -rn '\.ctxr-fsm/logs/[a-z]\{1,\}-' "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
-RULE7_HITS=$(echo -n "${RULE7}" | grep -c '^' || true)
-if [[ "${RULE7_HITS}" -gt 0 ]]; then
-  echo "--- audit-strings: rule7 (flat .ctxr-fsm/logs/<file> bypasses sharded_log_path)"
-  _report "rule7-flat-logs-folder" "${RULE7}"
-  HITS=$((HITS + RULE7_HITS))
-fi
-
 # --- Rule 6: argparse / click in CLI surface --------------------------
 # Every CLI command in ctxr-fsm is a typer subcommand. Other parsers
 # fragment the CLI shape; bespoke pretty-print primitives fragment the
@@ -191,6 +168,29 @@ if [[ "${RULE6_HITS}" -gt 0 ]]; then
   echo "--- audit-strings: rule6 (argparse/click forbidden in cli/)"
   echo -ne "${RULE6}" | _report "rule6-non-typer-parser" "$(cat)"
   HITS=$((HITS + RULE6_HITS))
+fi
+
+# --- Rule 7: flat-folder log/artefact paths ---------------------------
+# Any directory that ACCUMULATES files over time (logs, exports, audit
+# trails, telemetry dumps) MUST live under a YYYY/MM/DD sharded tree
+# (use ``sharded_log_path`` from lifecycle.primitives) so the folder
+# doesn't grow into a flat bottleneck (ext4 / APFS / NTFS all degrade
+# past ~10k to 100k entries per directory; even ``ls`` and tab-completion
+# crawl). The user flagged this on W14j when ensure_cmd wrote
+# ``.ctxr-fsm/logs/supervisor-YYYYMMDD.log`` directly.
+#
+# Patterns flagged: any literal ``.ctxr-fsm/logs/`` followed by a
+# filename token (not by a sub-shard name like a year, ``${category}``,
+# or a typed Path expression).
+#
+# This rule looks at the SOURCE tree (ctxr/fsm/); test fixtures that
+# hand-craft a path to assert the layout are justified.
+RULE7=$(grep -rn '\.ctxr-fsm/logs/[a-z]\{1,\}-' "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+RULE7_HITS=$(echo -n "${RULE7}" | grep -c '^' || true)
+if [[ "${RULE7_HITS}" -gt 0 ]]; then
+  echo "--- audit-strings: rule7 (flat .ctxr-fsm/logs/<file> bypasses sharded_log_path)"
+  _report "rule7-flat-logs-folder" "${RULE7}"
+  HITS=$((HITS + RULE7_HITS))
 fi
 
 if [[ "${HITS}" -gt 0 ]]; then

--- a/scripts/audit_strings.sh
+++ b/scripts/audit_strings.sh
@@ -136,6 +136,28 @@ if [[ "${RULE5_HITS}" -gt 0 ]]; then
   HITS=$((HITS + RULE5_HITS))
 fi
 
+# --- Rule 6: argparse / click in CLI surface --------------------------
+# Every CLI command in ctxr-fsm is a typer subcommand. Other parsers
+# fragment the CLI shape; bespoke pretty-print primitives fragment the
+# human surface. The ``rich`` integration ships with typer — that's the
+# ONLY pretty-print primitive we allow. Justify a genuine exception
+# (extremely rare) with the trailing ``# audit-strings: justified``
+# marker. Added in W14j alongside the typer-everywhere rule in
+# docs/coding-standards.md.
+RULE6=""
+for pattern in '^import argparse' '^from argparse' '^import click' '^from click'; do
+  hits=$(grep -rn "${pattern}" "${SRC_DIR}/cli" 2>/dev/null | _filter_justified || true)
+  if [[ -n "${hits}" ]]; then
+    RULE6="${RULE6}${hits}\n"
+  fi
+done
+RULE6_HITS=$(echo -ne "${RULE6}" | grep -c '^' || true)
+if [[ "${RULE6_HITS}" -gt 0 ]]; then
+  echo "--- audit-strings: rule6 (argparse/click forbidden in cli/)"
+  echo -ne "${RULE6}" | _report "rule6-non-typer-parser" "$(cat)"
+  HITS=$((HITS + RULE6_HITS))
+fi
+
 if [[ "${HITS}" -gt 0 ]]; then
   echo ""
   echo "audit-strings: ${HITS} finding(s); see W14i for the audit rationale."

--- a/scripts/audit_strings.sh
+++ b/scripts/audit_strings.sh
@@ -136,6 +136,29 @@ if [[ "${RULE5_HITS}" -gt 0 ]]; then
   HITS=$((HITS + RULE5_HITS))
 fi
 
+# --- Rule 7: flat-folder log/artefact paths ---------------------------
+# Any directory that ACCUMULATES files over time (logs, exports, audit
+# trails, telemetry dumps) MUST live under a YYYY/MM/DD sharded tree
+# (use ``sharded_log_path`` from lifecycle.primitives) so the folder
+# doesn't grow into a flat bottleneck (ext4 / APFS / NTFS all degrade
+# past ~10k–100k entries per directory; even ``ls`` and tab-completion
+# crawl). The user flagged this on W14j when ensure_cmd wrote
+# ``.ctxr-fsm/logs/supervisor-YYYYMMDD.log`` directly.
+#
+# Patterns flagged: any literal ``.ctxr-fsm/logs/`` followed by a
+# filename token (not by a sub-shard name like a year, ``${category}``,
+# or a typed Path expression).
+#
+# This rule looks at the SOURCE tree (ctxr/fsm/); test fixtures that
+# hand-craft a path to assert the layout are justified.
+RULE7=$(grep -rn '\.ctxr-fsm/logs/[a-z]\{1,\}-' "${SRC_DIR}" 2>/dev/null | _filter_justified || true)
+RULE7_HITS=$(echo -n "${RULE7}" | grep -c '^' || true)
+if [[ "${RULE7_HITS}" -gt 0 ]]; then
+  echo "--- audit-strings: rule7 (flat .ctxr-fsm/logs/<file> bypasses sharded_log_path)"
+  _report "rule7-flat-logs-folder" "${RULE7}"
+  HITS=$((HITS + RULE7_HITS))
+fi
+
 # --- Rule 6: argparse / click in CLI surface --------------------------
 # Every CLI command in ctxr-fsm is a typer subcommand. Other parsers
 # fragment the CLI shape; bespoke pretty-print primitives fragment the

--- a/tests/cli/test_cli_doctor.py
+++ b/tests/cli/test_cli_doctor.py
@@ -44,15 +44,27 @@ def _init_project(db_path: Path) -> None:
 
 # ---------------------------------------------------------------------------
 # Pretty (default) output
+#
+# As of W14j the pretty surface is a Rich Panel (DB summary) + the
+# shared subsystem table. The earlier free-form ``rich.print`` of the
+# full report dict is gone — operators who need the table-row /
+# PRAGMA / journal_txns sections script against the unchanged
+# ``--json`` shape. The three tests below pin the *new* surface so a
+# regression that drops the panel or the table trips loudly; the
+# parallel ``test_doctor_table_replaces_old_pretty_print.py`` file
+# pins the negative half (the old format is GONE).
 # ---------------------------------------------------------------------------
 
 
-def test_doctor_after_init_prints_db_path() -> None:
-    """The pretty output must include the resolved DB path verbatim.
+def test_doctor_pretty_prints_db_path_in_panel() -> None:
+    """The Rich panel header must include the resolved DB path.
 
     Operators rely on this line to confirm which file the report
     describes — especially when juggling multiple project DBs through
-    ``$CTXR_FSM_DB``.
+    ``$CTXR_FSM_DB``. The path is portable-rendered (relative-to-cwd
+    or ``~``-prefixed when possible), so the assertion compares
+    against either the resolved absolute path OR the file name —
+    whichever the renderer chose for this tempdir layout.
     """
     with tempfile.TemporaryDirectory() as tmp:
         db_path = Path(tmp) / "fsm.db"
@@ -61,18 +73,22 @@ def test_doctor_after_init_prints_db_path() -> None:
         result = runner.invoke(app, ["doctor", "--db", str(db_path)])
 
         assert result.exit_code == 0, result.stderr
-        # ``Path.resolve`` (used inside resolve_db_path) may add a /private prefix
-        # on macOS temp dirs, so check against the resolved string the CLI itself
-        # would compute rather than the raw tempdir input.
-        assert str(db_path.resolve()) in result.stdout
+        # The panel header is always present.
+        assert "ctxr-fsm doctor" in result.stdout
+        assert "DB" in result.stdout
+        # Either the absolute path (when not under cwd) or the basename
+        # (when relative rendering kicked in) appears in the panel body.
+        stdout = result.stdout
+        assert str(db_path.resolve()) in stdout or "fsm.db" in stdout
 
 
-def test_doctor_after_init_prints_pragma_values() -> None:
-    """The pretty output must surface the PRAGMAs that determine correctness.
+def test_doctor_pretty_prints_alembic_revision_in_panel() -> None:
+    """The panel must show the alembic revision so operators see migration state.
 
-    The connect-time listener applies ``WAL``, ``foreign_keys=ON`` and
-    friends; doctor surfaces them so an operator can confirm the
-    listener actually ran on this DB.
+    Replaces the old "PRAGMAs visible in pretty output" expectation:
+    PRAGMA debugging is a JSON-mode concern (operators script against
+    it); the pretty surface only needs the one-line "schema is
+    current at revision <X>" signal.
     """
     with tempfile.TemporaryDirectory() as tmp:
         db_path = Path(tmp) / "fsm.db"
@@ -81,25 +97,22 @@ def test_doctor_after_init_prints_pragma_values() -> None:
         result = runner.invoke(app, ["doctor", "--db", str(db_path)])
 
         assert result.exit_code == 0, result.stderr
-        # Each PRAGMA we configure at connect time must be visible in the
-        # rendered output. ``rich.print`` renders the dict literally, so a
-        # plain substring check on the key name is sufficient.
-        for pragma in ("journal_mode", "busy_timeout", "foreign_keys", "synchronous"):
-            assert pragma in result.stdout, f"missing pragma {pragma!r} in: {result.stdout}"
-        # The applied values should also appear (WAL for journal_mode, the
-        # busy-timeout integer, etc.). We assert on the most diagnostic two:
-        # WAL flips a default, and foreign_keys=ON is the one SQLite ships
-        # OFF by default.
-        assert "wal" in result.stdout.lower()
+        assert "Revision" in result.stdout
+        # The W2 migration revision label is part of the migrations
+        # directory's filename — pin to the prefix the migration ships
+        # with so a future migration revision still satisfies the
+        # assertion (the prefix changes between revisions).
+        assert "0001" in result.stdout
 
 
-def test_doctor_after_init_lists_tables_with_row_counts() -> None:
-    """Doctor must list user tables alongside their row counts.
+def test_doctor_pretty_renders_subsystem_table_header() -> None:
+    """Doctor's pretty output must render the W14j subsystem table.
 
-    After ``init`` the schema is populated but empty, so every reported
-    count should be ``0`` and the ``alembic_version`` bookkeeping table
-    should be present (it holds the migration revision and is the only
-    table guaranteed to be non-empty post-init).
+    Replaces the old "lists every user table with row counts"
+    expectation. Operators who need the table-name dump script
+    against ``--json`` (still unchanged); the pretty surface answers
+    the higher-frequency "where are my subsystems" question with the
+    Rich table.
     """
     with tempfile.TemporaryDirectory() as tmp:
         db_path = Path(tmp) / "fsm.db"
@@ -108,12 +121,17 @@ def test_doctor_after_init_lists_tables_with_row_counts() -> None:
         result = runner.invoke(app, ["doctor", "--db", str(db_path)])
 
         assert result.exit_code == 0, result.stderr
-        # alembic_version is the bookkeeping table; if it's missing the
-        # migration didn't run, which would invalidate every other check.
-        assert "alembic_version" in result.stdout
-        # The core domain tables created by the W2 migration must appear.
-        for table in ("fsm_specs", "runs", "states"):
-            assert table in result.stdout, f"missing table {table!r} in: {result.stdout}"
+        # Subsystem table header + the leading Project row are always
+        # rendered (rows for individual subsystems depend on whether a
+        # supervisor has booted in this fixture; we only pin the
+        # invariant skeleton here).
+        assert "ctxr-fsm subsystems" in result.stdout
+        assert "Subsystem" in result.stdout
+        assert "URL" in result.stdout
+        assert "Swagger" in result.stdout
+        assert "Health" in result.stdout
+        assert "PID" in result.stdout
+        assert "Project" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_doctor_table_replaces_old_pretty_print.py
+++ b/tests/cli/test_doctor_table_replaces_old_pretty_print.py
@@ -1,0 +1,141 @@
+"""Pin the W14j doctor pretty-print migration (panel + subsystem table).
+
+The doctor command's pretty surface (W14j) is the Rich Panel
+summarising DB path + alembic revision, followed by the shared
+subsystem table. The earlier free-form ``rich.print(report)`` dict
+dump is gone — these tests pin the NEW shape AND the absence of the
+OLD format so a regression that brought back the dict dump trips
+loudly.
+
+The ``--json`` surface is unchanged and is covered by the existing
+``tests/cli/test_cli_doctor.py`` battery; we deliberately do NOT
+re-assert any JSON contracts here.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from ctxr.fsm.cli import app
+
+runner = CliRunner()
+
+
+def _init_project(db_path: Path) -> None:
+    """Land a fresh project DB at ``db_path``."""
+    result = runner.invoke(app, ["init", "--db", str(db_path), "--json"])
+    assert result.exit_code == 0, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# New pretty surface present (Panel + Table)
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_pretty_renders_rich_panel_header() -> None:
+    """The Rich Panel carries the ``ctxr-fsm doctor`` title + DB + Revision rows."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        _init_project(db_path)
+
+        result = runner.invoke(app, ["doctor", "--db", str(db_path)])
+
+        assert result.exit_code == 0, result.stderr
+        assert "ctxr-fsm doctor" in result.stdout
+        # The panel body labels are present (the values themselves
+        # vary by tempdir layout / migration revision).
+        assert "DB" in result.stdout
+        assert "Revision" in result.stdout
+
+
+def test_doctor_pretty_renders_subsystem_table_skeleton() -> None:
+    """The shared subsystem-table headers + the Project row are always present."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        _init_project(db_path)
+
+        result = runner.invoke(app, ["doctor", "--db", str(db_path)])
+
+        assert result.exit_code == 0, result.stderr
+        for header in ("Subsystem", "URL", "Swagger", "Health", "PID"):
+            assert header in result.stdout, (
+                f"missing header {header!r} in:\n{result.stdout}"
+            )
+        assert "Project" in result.stdout
+        assert "ctxr-fsm subsystems" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Old free-form dict dump is gone
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_pretty_omits_legacy_dict_dump_keys() -> None:
+    """The pre-W14j ``rich.print(report)`` exposed every report key directly.
+
+    Specifically: ``file_size_bytes``, ``sqlite_version``, ``pragmas``,
+    ``tables``, ``journal_txns``, ``locks``, ``supervisor`` appeared as
+    dict-key substrings in the pretty output. The W14j surface drops
+    all of these from the human-facing path (operators script the
+    JSON surface for these; the pretty surface is dashboard-style).
+
+    Pinning the absence of these keys here means a regression that
+    re-introduces the dict dump trips immediately.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        _init_project(db_path)
+
+        result = runner.invoke(app, ["doctor", "--db", str(db_path)])
+
+        assert result.exit_code == 0, result.stderr
+
+        # Keys that were dict-dumped in the old pretty surface and
+        # MUST NOT appear in the new one. We pin a handful — enough
+        # to surface a regression without coupling to every key.
+        legacy_keys = (
+            "file_size_bytes",
+            "sqlite_version",
+            "journal_txns",
+            "pragmas",
+        )
+        for key in legacy_keys:
+            assert key not in result.stdout, (
+                f"legacy report key {key!r} leaked into pretty output:\n{result.stdout}"
+            )
+
+
+def test_doctor_json_surface_unchanged() -> None:
+    """``--json`` still emits the full report shape (wire-format compatibility).
+
+    Belt-and-braces: even though the dedicated battery in
+    ``test_cli_doctor.py`` covers the JSON surface, we keep one
+    smoke-check here so a regression that migrated the JSON path
+    too aggressively shows up in this file as well.
+    """
+    import json as _json
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        _init_project(db_path)
+
+        result = runner.invoke(app, ["doctor", "--db", str(db_path), "--json"])
+
+        assert result.exit_code == 0, result.stderr
+        payload = _json.loads(result.stdout)
+        # The shape every script depends on:
+        for key in (
+            "db_path",
+            "file_size_bytes",
+            "sqlite_version",
+            "pragmas",
+            "alembic_revision",
+            "tables",
+            "journal_txns",
+            "locks",
+            "supervisor",
+        ):
+            assert key in payload, f"json surface lost key {key!r}: {payload}"

--- a/tests/integration/bootstrap/test_ensure_prints_table_in_tty.py
+++ b/tests/integration/bootstrap/test_ensure_prints_table_in_tty.py
@@ -1,0 +1,302 @@
+"""Integration coverage for the W14j Rich subsystem table in ``ensure``.
+
+The ensure command's pretty surface gained (W14j) a shared Rich table
+that lists every subsystem URL + Swagger + status + PID. These tests
+pin the matrix of TTY-detection + ``--json`` + ``--no-table`` flag
+combinations so a regression in any axis trips loudly.
+
+Pattern (mirrors ``test_ensure_warm_fast_path.py``):
+
+1. Real ``run_init`` to land the DB + alembic head.
+2. Stage live ``pids/<name>.pid`` records pointing at this process so
+   the liveness probe trivially succeeds.
+3. Stage an ``active-mcp.json`` discovery document with all three
+   subsystem blocks.
+4. Mock ``httpx.get`` to always return 200 so the warm-path probes
+   succeed without a real listener.
+5. Force ``sys.stdout.isatty`` to return ``True`` (or ``False``) so
+   the TTY-detect branch picks the table-on or table-off path.
+6. Drive ``ctxr-fsm ensure`` through the typer ``CliRunner`` and
+   assert on the captured stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from ctxr.fsm.cli import app
+from ctxr.fsm.cli.init_cmd import run_init
+from ctxr.fsm.cli.lifecycle.primitives import remember_active_mcp_file
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixture staging (duplicated from test_ensure_warm_fast_path so this file
+# stays self-contained; the helpers are ~10 lines each and SRP-aligned).
+# ---------------------------------------------------------------------------
+
+
+def _stage_pids(project_root: Path, names: list[str]) -> None:
+    pids_dir = project_root / ".ctxr-fsm" / "pids"
+    pids_dir.mkdir(parents=True, exist_ok=True)
+    self_pid = os.getpid()
+    for name in names:
+        (pids_dir / f"{name}.pid").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "pid": self_pid,
+                    "probe_url": "http://127.0.0.1:65000",
+                    "acquired_at": "2026-05-30T00:00:00.000+00:00",
+                },
+                sort_keys=True,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+
+def _stage_active_mcp_doc(project_root: Path, *, subsystems: list[str]) -> None:
+    sub_payload: dict[str, Any] = {}
+    for name in subsystems:
+        block: dict[str, Any] = {
+            "http_url": f"http://127.0.0.1:65000{'/sse' if name == 'mcp' else ''}",
+            "healthz_url": (
+                "http://127.0.0.1:65000/healthz" if name != "ui" else None
+            ),
+            "pid": os.getpid(),
+        }
+        if name == "api":
+            block["docs_url"] = "http://127.0.0.1:65000/docs"
+        sub_payload[name] = block
+    remember_active_mcp_file(
+        {
+            "started_at": "2026-05-30T00:00:00.000+00:00",
+            "supervisor_pid": os.getpid(),
+            "version": "0.0.0-test",
+            "subsystems": sub_payload,
+        },
+        project_root=project_root,
+    )
+
+
+def _mock_httpx_get_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Resp:
+        status_code = 200
+        text = "ok"
+
+    def _fake_get(url: str, *args: Any, **kwargs: Any) -> _Resp:
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+
+
+def _force_tty(monkeypatch: pytest.MonkeyPatch, *, is_tty: bool) -> None:
+    """Make ``ensure_cmd``'s view of ``sys.stdout.isatty()`` return ``is_tty``.
+
+    ``typer.testing.CliRunner`` replaces ``sys.stdout`` for the duration
+    of an invocation, so a naive ``monkeypatch.setattr(sys, "stdout",
+    ...)`` is clobbered the moment ``runner.invoke`` starts. We patch
+    the helpers ensure_cmd uses to make the TTY decision directly:
+
+    * ``ensure_cmd._json_default`` — returns ``False`` when a TTY is
+      claimed, so the default JSON-on-pipe behaviour matches an
+      interactive terminal.
+    * ``ensure_cmd.sys.stdout.isatty`` — the W14j table-render branch
+      probes this independently of ``--json``. We patch ``sys`` in
+      the module's namespace with a shim whose ``stdout.isatty()``
+      returns our chosen value, so the module's import-time reference
+      to ``sys`` resolves through us regardless of what CliRunner has
+      done to the real ``sys.stdout``.
+    """
+    import sys as _real_sys
+
+    from ctxr.fsm.cli import ensure_cmd
+
+    class _StdoutShim:
+        def isatty(self) -> bool:
+            return is_tty
+
+        def __getattr__(self, item: str) -> Any:
+            return getattr(_real_sys.stdout, item)
+
+    class _SysShim:
+        stdout = _StdoutShim()
+
+        def __getattr__(self, item: str) -> Any:
+            return getattr(_real_sys, item)
+
+    monkeypatch.setattr(ensure_cmd, "sys", _SysShim())
+    monkeypatch.setattr(ensure_cmd, "_json_default", lambda: not is_tty)
+
+
+def _stage_warm_project(
+    tmp_path: Path, *, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Land DB + pids + discovery doc + httpx mock; return the project root."""
+    run_init(
+        db_path=tmp_path / ".ctxr-fsm" / "fsm.db",
+        no_memory=True,
+        cwd=tmp_path,
+    )
+    _stage_pids(tmp_path, names=["mcp", "api", "ui"])
+    _stage_active_mcp_doc(tmp_path, subsystems=["mcp", "api", "ui"])
+    _mock_httpx_get_ok(monkeypatch)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests — matrix coverage
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_tty_non_json_prints_subsystem_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TTY + ``--no-json`` renders the Rich subsystem table after the actions summary.
+
+    The actions-summary dict still prints (so operators see init /
+    memory / mcp_config / supervisor status); the table appears
+    below. Headers + at least one URL substring must survive in the
+    captured stdout.
+    """
+    _stage_warm_project(tmp_path, monkeypatch=monkeypatch)
+    _force_tty(monkeypatch, is_tty=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "ensure",
+            "--project-root",
+            str(tmp_path),
+            "--client",
+            "none",
+            "--mode",
+            "full",
+            "--no-memory",
+            "--no-mcp-config",
+            "--no-json",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    # Table headers are present.
+    for header in ("Subsystem", "URL", "Swagger", "Health", "PID"):
+        assert header in result.stdout, (
+            f"missing header {header!r} in:\n{result.stdout}"
+        )
+    # At least one staged URL appears in the rendered table.
+    assert "127.0.0.1:65000" in result.stdout
+
+
+def test_ensure_json_mode_does_not_print_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--json`` (regardless of TTY) skips the table entirely.
+
+    The JSON wire contract is the machine consumer's surface — adding
+    table characters to that stream would break every script that
+    pipes ``ensure --json | jq``.
+    """
+    _stage_warm_project(tmp_path, monkeypatch=monkeypatch)
+    _force_tty(monkeypatch, is_tty=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "ensure",
+            "--project-root",
+            str(tmp_path),
+            "--client",
+            "none",
+            "--mode",
+            "full",
+            "--no-memory",
+            "--no-mcp-config",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    # No Rich table characters in the output. The Subsystem column
+    # header is the cleanest single sentinel.
+    assert "Subsystem" not in result.stdout
+    assert "Swagger" not in result.stdout
+    # The captured stdout is parseable JSON.
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ready"
+
+
+def test_ensure_no_table_flag_suppresses_table_in_tty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--no-table`` in TTY non-JSON mode keeps the actions summary but drops the table."""
+    _stage_warm_project(tmp_path, monkeypatch=monkeypatch)
+    _force_tty(monkeypatch, is_tty=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "ensure",
+            "--project-root",
+            str(tmp_path),
+            "--client",
+            "none",
+            "--mode",
+            "full",
+            "--no-memory",
+            "--no-mcp-config",
+            "--no-json",
+            "--no-table",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    # Actions-summary text path still prints (the dict goes through
+    # rich.print so the action keys appear as string substrings).
+    assert "actions" in result.stdout or "supervisor" in result.stdout
+    # The table header is absent.
+    assert "Subsystem" not in result.stdout
+    assert "Swagger" not in result.stdout
+
+
+def test_ensure_no_tty_defaults_to_json_without_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-TTY stdout: ``_json_default`` returns True → JSON only, no table.
+
+    Pipe-from-script case. The default ``--json`` flip means the
+    table-render branch never fires either way (JSON mode short-
+    circuits before the TTY check), but we keep this test to lock the
+    contract from the *script consumer's* angle.
+    """
+    _stage_warm_project(tmp_path, monkeypatch=monkeypatch)
+    _force_tty(monkeypatch, is_tty=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "ensure",
+            "--project-root",
+            str(tmp_path),
+            "--client",
+            "none",
+            "--mode",
+            "full",
+            "--no-memory",
+            "--no-mcp-config",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    # JSON parses, table is absent.
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ready"
+    assert "Subsystem" not in result.stdout

--- a/tests/integration/lifecycle/test_supervisor_prints_boot_table.py
+++ b/tests/integration/lifecycle/test_supervisor_prints_boot_table.py
@@ -1,0 +1,301 @@
+"""End-to-end coverage for W14j: supervisor prints the boot table ONCE.
+
+W14j wired the shared Rich subsystem table into ``run_supervisor`` so
+an operator running ``ctxr-fsm serve`` sees the FastAPI / Swagger /
+UI / MCP URLs immediately after every required healthz passes. The
+contract is **exactly one** table per boot — NOT on every reload,
+NOT on every healthz probe.
+
+This test:
+
+1. Spawns a real ``uv run ctxr-fsm serve`` against a stub project
+   (mirrors the test_active_mcp_json.py pattern so the integration
+   contract is exercised end-to-end).
+2. Waits for the boot banner on stderr (the supervisor's own log
+   line).
+3. Captures stdout (where Rich prints the table).
+4. Asserts the table headers appear exactly once.
+5. SIGTERMs the supervisor; asserts no second table was printed
+   between boot and shutdown.
+
+We pipe the supervisor's stdout (not stderr) because
+:func:`print_subsystem_table` writes to a fresh
+:class:`rich.console.Console` which targets stdout by default. The
+``_log`` helper used by the supervisor's banner writes to stderr —
+two independent streams, which is what we want operators to be able
+to pipe separately for downstream tooling.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Tunables (mirror test_active_mcp_json.py — kept in sync deliberately)
+# ---------------------------------------------------------------------------
+
+_BOOT_TIMEOUT_S: float = 90.0
+_SHUTDOWN_TIMEOUT_S: float = 30.0
+_BOOT_BANNER_PREFIX: str = "[ctxr-fsm supervisor] booted:"
+
+# After the banner lands the supervisor still has to (a) publish the
+# discovery file and (b) call ``print_subsystem_table``. Give it
+# plenty of slack on a cold-CI ``uv run``.
+_TABLE_PRINT_WAIT_S: float = 10.0
+
+
+_STUB_UI_PACKAGE_JSON: str = json.dumps(
+    {
+        "name": "ctxr-fsm-test-stub-ui",
+        "private": True,
+        "version": "0.0.0",
+        "scripts": {
+            "dev": "python3 -c \"import sys, time; sys.stdout.flush(); time.sleep(3600)\"",
+        },
+    },
+    indent=2,
+)
+
+
+def _stage_project_root(tmpdir: Path) -> Path:
+    """Build the minimal tree the supervisor's boot path walks."""
+    (tmpdir / ".ctxr-fsm" / "pids").mkdir(parents=True, exist_ok=True)
+    (tmpdir / "ctxr" / "fsm").mkdir(parents=True, exist_ok=True)
+    (tmpdir / "ui").mkdir(parents=True, exist_ok=True)
+    (tmpdir / "ui" / "package.json").write_text(
+        _STUB_UI_PACKAGE_JSON, encoding="utf-8"
+    )
+    return tmpdir
+
+
+class _StreamDrain:
+    """Background pump that copies a subprocess stream into a buffer.
+
+    Slimmed clone of ``test_active_mcp_json._StderrDrain``; we keep a
+    private copy so this integration file stays self-contained and
+    its assertions only depend on its own fixtures.
+    """
+
+    def __init__(self, stream: object, label: str) -> None:
+        self._stream = stream
+        self._label = label
+        self._lock = threading.Lock()
+        self._buffer: list[str] = []
+        self._event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._pump, daemon=True, name=f"drain[{label}]"
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _pump(self) -> None:
+        stream = self._stream
+        if stream is None:
+            return
+        try:
+            for raw in iter(stream.readline, b""):
+                try:
+                    line = raw.decode("utf-8", errors="replace")
+                except Exception:  # pragma: no cover - decode defensive
+                    line = repr(raw)
+                with self._lock:
+                    self._buffer.append(line)
+                self._event.set()
+        except (ValueError, OSError):
+            return
+
+    def wait_for(self, substring: str, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        while True:
+            with self._lock:
+                joined = "".join(self._buffer)
+            if substring in joined:
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            self._event.clear()
+            self._event.wait(timeout=min(remaining, 0.5))
+
+    def snapshot(self) -> str:
+        with self._lock:
+            return "".join(self._buffer)
+
+
+def _supervisor_argv(db_path: Path, *, mode: str = "dev") -> list[str]:
+    return [
+        "uv",
+        "run",
+        "ctxr-fsm",
+        "serve",
+        "--mode",
+        mode,
+        "--db",
+        str(db_path),
+    ]
+
+
+@contextmanager
+def _spawn_supervisor(
+    *, project_root: Path, db_path: Path, label: str, mode: str = "dev"
+) -> Iterator[tuple[subprocess.Popen[bytes], _StreamDrain, _StreamDrain]]:
+    """Yield ``(proc, stderr_drain, stdout_drain)`` scoped to a single supervisor."""
+    env = os.environ.copy()
+    proc = subprocess.Popen(
+        _supervisor_argv(db_path, mode=mode),
+        cwd=str(project_root),
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    err = _StreamDrain(proc.stderr, label=f"{label}.stderr")
+    out = _StreamDrain(proc.stdout, label=f"{label}.stdout")
+    err.start()
+    out.start()
+    try:
+        yield proc, err, out
+    finally:
+        if proc.poll() is None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+        except subprocess.TimeoutExpired:  # pragma: no cover
+            proc.kill()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+
+
+def _count_table_renderings(stdout_text: str) -> int:
+    """Count how many subsystem-table renderings appear in ``stdout_text``.
+
+    Rich draws the table title on its own line followed by the header
+    row; the ``ctxr-fsm subsystems`` title is the most reliable
+    once-per-table sentinel (the column headers also appear once per
+    table but their tokens could in principle show up in other log
+    surfaces).
+    """
+    return stdout_text.count("ctxr-fsm subsystems")
+
+
+def test_supervisor_prints_boot_table_exactly_once() -> None:
+    """``ctxr-fsm serve`` prints the W14j subsystem table once after boot.
+
+    Walks the full lifecycle: boot → wait for banner → wait for table
+    to land on stdout → confirm exactly one rendering → SIGTERM →
+    re-check no second rendering arrived during the steady-state
+    window.
+    """
+    with tempfile.TemporaryDirectory(prefix="ctxr-fsm-boot-table-") as tmpdir:
+        project_root = _stage_project_root(Path(tmpdir))
+        db_path = project_root / "fsm.db"
+
+        with _spawn_supervisor(
+            project_root=project_root, db_path=db_path, label="serve"
+        ) as (proc, err, out):
+            # Wait for the supervisor's own banner on stderr — that
+            # tells us boot is done and the publish gate has been
+            # evaluated.
+            booted = err.wait_for(_BOOT_BANNER_PREFIX, timeout=_BOOT_TIMEOUT_S)
+            assert booted, (
+                f"supervisor never emitted {_BOOT_BANNER_PREFIX!r} within "
+                f"{_BOOT_TIMEOUT_S:.0f}s.\n--- stderr ---\n{err.snapshot()}"
+            )
+            assert proc.poll() is None, (
+                f"supervisor died after boot (rc={proc.returncode}).\n"
+                f"--- stderr ---\n{err.snapshot()}"
+            )
+
+            # Wait for the table to land on stdout. Rich flushes per
+            # ``console.print`` call so the title appears immediately.
+            assert out.wait_for(
+                "ctxr-fsm subsystems", timeout=_TABLE_PRINT_WAIT_S
+            ), (
+                f"subsystem table never printed within "
+                f"{_TABLE_PRINT_WAIT_S:.0f}s of boot.\n"
+                f"--- stdout ---\n{out.snapshot()}\n"
+                f"--- stderr ---\n{err.snapshot()}"
+            )
+
+            # Exactly one table at this point.
+            first_count = _count_table_renderings(out.snapshot())
+            assert first_count == 1, (
+                f"expected exactly 1 boot table, saw {first_count}.\n"
+                f"--- stdout ---\n{out.snapshot()}"
+            )
+
+            # Give the supervisor a steady-state window. The reload
+            # loop watches ``ctxr/fsm`` — we don't touch any source
+            # files, so no reload should fire, so no second table
+            # should appear.
+            time.sleep(2.0)
+
+            second_count = _count_table_renderings(out.snapshot())
+            assert second_count == 1, (
+                f"table re-printed during steady state "
+                f"(count went {first_count}→{second_count}); "
+                f"the boot-table contract is once-per-boot.\n"
+                f"--- stdout ---\n{out.snapshot()}"
+            )
+
+
+def test_supervisor_boot_table_headers_visible_on_stdout() -> None:
+    """The boot table on stdout carries the locked column headers + Project row.
+
+    A focused header-presence check separated from the once-per-boot
+    test so a regression that mangled column ordering surfaces in its
+    own failure (rather than getting confused with the count check).
+    """
+    with tempfile.TemporaryDirectory(prefix="ctxr-fsm-boot-table-hdr-") as tmpdir:
+        project_root = _stage_project_root(Path(tmpdir))
+        db_path = project_root / "fsm.db"
+
+        with _spawn_supervisor(
+            project_root=project_root, db_path=db_path, label="serve-hdr"
+        ) as (_proc, err, out):
+            assert err.wait_for(_BOOT_BANNER_PREFIX, timeout=_BOOT_TIMEOUT_S), (
+                f"supervisor never booted.\n--- stderr ---\n{err.snapshot()}"
+            )
+            # The Rich table prints in several pipe-buffered chunks
+            # (title, then header row, then data rows, then footer).
+            # We wait for the LAST data row's sentinel ("Project" is
+            # the leading row but the table footer line lands after
+            # every row has flushed) before snapshotting. Picking
+            # "Project" + the trailing newline guarantees the whole
+            # body reached our buffer.
+            assert out.wait_for(
+                "ctxr-fsm subsystems", timeout=_TABLE_PRINT_WAIT_S
+            ), (
+                f"table title never printed.\n--- stdout ---\n{out.snapshot()}"
+            )
+            assert out.wait_for("Project", timeout=_TABLE_PRINT_WAIT_S), (
+                f"table body never printed.\n--- stdout ---\n{out.snapshot()}"
+            )
+            # The header row arrives between the title and the Project
+            # row but rich may chunk pipes so we explicitly wait for
+            # the rightmost column header too — once "PID" landed,
+            # every header to its left has also landed by definition.
+            assert out.wait_for("PID", timeout=_TABLE_PRINT_WAIT_S), (
+                f"table header row never fully printed.\n"
+                f"--- stdout ---\n{out.snapshot()}"
+            )
+
+            captured = out.snapshot()
+            for header in ("Subsystem", "URL", "Swagger", "Health", "PID"):
+                assert header in captured, (
+                    f"missing header {header!r} in:\n{captured}"
+                )
+            assert "Project" in captured

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -4,8 +4,9 @@ The renderer (:mod:`ctxr.fsm.cli._render`) is shared by ``ensure``,
 ``doctor``, and the ``serve`` supervisor banner. These tests pin the
 column ordering, the project-row content, the swagger-derivation
 rule for the ``api`` row, the "skip missing subsystems" semantics
-(``--mode mcp-only`` only ships an ``mcp`` block), and the colour
-mapping per status.
+(``--mode mcp_only`` only ships an ``mcp`` block; W14i renamed the
+wire value from the hyphenated ``mcp-only``), and the colour mapping
+per status.
 
 ANSI capture pattern
 --------------------
@@ -158,9 +159,9 @@ def test_render_subsystem_table_swagger_derived_for_api(tmp_path: Path) -> None:
 
 
 def test_render_subsystem_table_skips_missing_subsystems(tmp_path: Path) -> None:
-    """In ``--mode mcp-only`` only the mcp row appears (plus the project row)."""
+    """In ``--mode mcp_only`` only the mcp row appears (plus the project row)."""
     payload = _full_active_mcp()
-    # Drop api + ui as the mcp-only mode would.
+    # Drop api + ui as the mcp_only mode would.
     del payload["subsystems"]["api"]
     del payload["subsystems"]["ui"]
 
@@ -219,12 +220,14 @@ def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
         }
     }
     green_output = _render_to_string(green_payload, project_root=tmp_path, force_terminal=True)
-    # Rich emits SGR escapes; bold-green starts with ``\x1b[1;32m``
-    # on truecolor terminals. The leading ``\x1b[`` + the ``32`` /
-    # ``green`` substring suffices to identify the colour without
-    # over-coupling to the exact SGR sequence shape.
-    assert "\x1b[" in green_output
-    assert "32" in green_output  # green channel
+    # Rich emits a specific SGR sequence for ``bold green`` on a
+    # truecolor terminal: ``\x1b[1;32m``. Pinning the full sequence
+    # rather than just ``"32"`` keeps the test from passing silently
+    # when any other column happens to contain the digits 32 (a PID,
+    # a port number, a future timestamp); a colour regression that
+    # drops the bold-green styling cannot accidentally still satisfy
+    # the assertion.
+    assert "\x1b[1;32m" in green_output
 
     # Yellow (reused / degraded).
     yellow_payload = {
@@ -238,7 +241,7 @@ def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
         }
     }
     yellow_output = _render_to_string(yellow_payload, project_root=tmp_path, force_terminal=True)
-    assert "33" in yellow_output  # yellow channel
+    assert "\x1b[1;33m" in yellow_output
 
     # Red (missing / unreachable / failed).
     red_payload = {
@@ -252,7 +255,7 @@ def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
         }
     }
     red_output = _render_to_string(red_payload, project_root=tmp_path, force_terminal=True)
-    assert "31" in red_output  # red channel
+    assert "\x1b[1;31m" in red_output
 
 
 def test_render_subsystem_table_unknown_status_falls_back(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -1,0 +1,331 @@
+"""Unit tests for the W14j Rich subsystem-URL renderer.
+
+The renderer (:mod:`ctxr.fsm.cli._render`) is shared by ``ensure``,
+``doctor``, and the ``serve`` supervisor banner. These tests pin the
+column ordering, the project-row content, the swagger-derivation
+rule for the ``api`` row, the "skip missing subsystems" semantics
+(``--mode mcp-only`` only ships an ``mcp`` block), and the colour
+mapping per status.
+
+ANSI capture pattern
+--------------------
+
+Rich detects TTY-ness from the underlying file. To capture coloured
+output deterministically every test constructs a private
+``rich.console.Console(file=io.StringIO(), force_terminal=True,
+width=120)`` and prints the table to that console — that way the
+ANSI escape codes survive in the captured string regardless of how
+pytest is configured. Tests that only need the structural skeleton
+(headers, row text) skip ``force_terminal`` so the captured string
+stays human-readable.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from rich.console import Console
+
+from ctxr.fsm.cli._render import (
+    _portable_project_repr,
+    render_subsystem_table,
+)
+
+
+def _render_to_string(table_input: dict, *, project_root: Path, force_terminal: bool = False) -> str:
+    """Build a Console-backed StringIO, render the table, return the captured text."""
+    buf = io.StringIO()
+    console = Console(
+        file=buf,
+        force_terminal=force_terminal,
+        color_system="truecolor" if force_terminal else None,
+        width=160,
+        legacy_windows=False,
+    )
+    console.print(render_subsystem_table(table_input, project_root=project_root))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Fixture payloads
+# ---------------------------------------------------------------------------
+
+
+def _full_active_mcp() -> dict:
+    """Representative payload with mcp + api + ui all present (status=ready)."""
+    return {
+        "started_at": "2026-05-30T12:00:00.000Z",
+        "supervisor_pid": 9999,
+        "version": "0.1.0a1",
+        "subsystems": {
+            "mcp": {
+                "http_url": "http://127.0.0.1:8770/sse",
+                "healthz_url": "http://127.0.0.1:8770/healthz",
+                "pid": 1001,
+                "status": "ready",
+            },
+            "api": {
+                "http_url": "http://127.0.0.1:8765",
+                "healthz_url": "http://127.0.0.1:8765/healthz",
+                "pid": 1002,
+                "docs_url": "http://127.0.0.1:8765/docs",
+                "status": "ready",
+            },
+            "ui": {
+                "http_url": "http://127.0.0.1:5173",
+                "healthz_url": None,
+                "pid": 1003,
+                "status": "ready",
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Column ordering + project-row content
+# ---------------------------------------------------------------------------
+
+
+def test_render_subsystem_table_columns_in_order(tmp_path: Path) -> None:
+    """Headers appear in the locked order: Subsystem | URL | Swagger | Health | PID.
+
+    The order is part of the operator's mental model — a regression
+    that reshuffled the columns would silently change every screenshot
+    in the docs. We capture the rendered text and assert the columns
+    appear left-to-right in the right order.
+    """
+    output = _render_to_string(_full_active_mcp(), project_root=tmp_path)
+    # Each header is its own substring; pinning indices makes the
+    # order-property explicit.
+    idx_subsystem = output.index("Subsystem")
+    idx_url = output.index("URL")
+    idx_swagger = output.index("Swagger")
+    idx_health = output.index("Health")
+    idx_pid = output.index("PID")
+    assert idx_subsystem < idx_url < idx_swagger < idx_health < idx_pid, (
+        f"unexpected column order in:\n{output}"
+    )
+
+
+def test_render_subsystem_table_includes_project_row(tmp_path: Path) -> None:
+    """First data row is ``Project`` with a portable-rendered path.
+
+    The project row gives the operator the context ("this table is
+    about *this* checkout") before listing subsystems. The path uses
+    the portable repr (relative-to-cwd / ``~``-prefixed / absolute)
+    so multi-project terminals stay legible.
+    """
+    output = _render_to_string(_full_active_mcp(), project_root=tmp_path)
+    # The project row appears before any subsystem name.
+    idx_project = output.index("Project")
+    idx_mcp = output.index("mcp")
+    assert idx_project < idx_mcp
+    # The portable repr appears verbatim in the project row.
+    expected_repr = _portable_project_repr(tmp_path)
+    assert expected_repr in output
+
+
+# ---------------------------------------------------------------------------
+# Swagger derivation
+# ---------------------------------------------------------------------------
+
+
+def test_render_subsystem_table_swagger_derived_for_api(tmp_path: Path) -> None:
+    """When ``docs_url`` is absent on the api payload, derive ``http_url + /docs``.
+
+    The W14c discovery doc historically carried ``docs_url`` for
+    api; the renderer must still cope when a future payload variant
+    omits it (e.g. a check-mode run that only fills the URL). Other
+    rows (mcp / ui) MUST stay blank — Swagger is api-specific.
+    """
+    payload = _full_active_mcp()
+    del payload["subsystems"]["api"]["docs_url"]  # force derivation
+
+    output = _render_to_string(payload, project_root=tmp_path)
+    # The derived swagger URL appears for api.
+    assert "http://127.0.0.1:8765/docs" in output
+    # The mcp row has no swagger column content (we cannot grep for
+    # "empty cell" but the mcp http_url and the api swagger URL are
+    # different strings, so the per-row content stays unambiguous).
+    # We additionally check that no swagger appears for the mcp URL:
+    assert "http://127.0.0.1:8770/sse/docs" not in output
+
+
+# ---------------------------------------------------------------------------
+# Missing-subsystem semantics
+# ---------------------------------------------------------------------------
+
+
+def test_render_subsystem_table_skips_missing_subsystems(tmp_path: Path) -> None:
+    """In ``--mode mcp-only`` only the mcp row appears (plus the project row)."""
+    payload = _full_active_mcp()
+    # Drop api + ui as the mcp-only mode would.
+    del payload["subsystems"]["api"]
+    del payload["subsystems"]["ui"]
+
+    output = _render_to_string(payload, project_root=tmp_path)
+    assert "Project" in output
+    assert "mcp" in output
+    # api / ui rows are absent. We assert on the URL substrings rather
+    # than the bare names ("api" / "ui" are tiny tokens that could be
+    # part of other words like "swagger" or "subsystems").
+    assert "127.0.0.1:8765" not in output  # api URL absent
+    assert "127.0.0.1:5173" not in output  # ui URL absent
+
+
+def test_render_subsystem_table_handles_empty_subsystems(tmp_path: Path) -> None:
+    """An empty ``subsystems`` block leaves the table with just the project row.
+
+    Defensive coverage for the case where ``active-mcp.json`` exists
+    but has not been populated yet (a supervisor mid-boot, or a stale
+    file from a previous crash). The renderer MUST NOT raise; it
+    surfaces a project-only table the operator can still read.
+    """
+    payload = {"subsystems": {}}
+    output = _render_to_string(payload, project_root=tmp_path)
+    assert "Project" in output
+    assert "mcp" not in output
+    assert "api" not in output
+
+
+# ---------------------------------------------------------------------------
+# Status colours (ANSI capture)
+# ---------------------------------------------------------------------------
+
+
+def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
+    """Each closed-vocabulary status maps to its expected Rich colour.
+
+    Rich uses ANSI escape codes for colours; we ``force_terminal``
+    so they survive the StringIO capture. Specific colour codes:
+
+    * green: ``\\x1b[1;32m`` (bold green)
+    * yellow: ``\\x1b[1;33m``
+    * red: ``\\x1b[1;31m``
+
+    We capture three rendered tables (one per colour-class) and
+    assert the matching ANSI prefix appears in the captured string.
+    """
+    # Green (ready / spawned).
+    green_payload = {
+        "subsystems": {
+            "mcp": {
+                "http_url": "http://127.0.0.1:8770/sse",
+                "healthz_url": "http://127.0.0.1:8770/healthz",
+                "pid": 1,
+                "status": "ready",
+            }
+        }
+    }
+    green_output = _render_to_string(green_payload, project_root=tmp_path, force_terminal=True)
+    # Rich emits SGR escapes; bold-green starts with ``\x1b[1;32m``
+    # on truecolor terminals. The leading ``\x1b[`` + the ``32`` /
+    # ``green`` substring suffices to identify the colour without
+    # over-coupling to the exact SGR sequence shape.
+    assert "\x1b[" in green_output
+    assert "32" in green_output  # green channel
+
+    # Yellow (reused / degraded).
+    yellow_payload = {
+        "subsystems": {
+            "mcp": {
+                "http_url": "http://127.0.0.1:8770/sse",
+                "healthz_url": "http://127.0.0.1:8770/healthz",
+                "pid": 1,
+                "status": "reused",
+            }
+        }
+    }
+    yellow_output = _render_to_string(yellow_payload, project_root=tmp_path, force_terminal=True)
+    assert "33" in yellow_output  # yellow channel
+
+    # Red (missing / unreachable / failed).
+    red_payload = {
+        "subsystems": {
+            "mcp": {
+                "http_url": "",
+                "healthz_url": None,
+                "pid": None,
+                "status": "missing",
+            }
+        }
+    }
+    red_output = _render_to_string(red_payload, project_root=tmp_path, force_terminal=True)
+    assert "31" in red_output  # red channel
+
+
+def test_render_subsystem_table_unknown_status_falls_back(tmp_path: Path) -> None:
+    """An unrecognised status word renders as ``unknown`` (dim white), not a crash."""
+    payload = {
+        "subsystems": {
+            "mcp": {
+                "http_url": "http://127.0.0.1:8770/sse",
+                "healthz_url": "http://127.0.0.1:8770/healthz",
+                "pid": 1,
+                "status": "totally-made-up",
+            }
+        }
+    }
+    output = _render_to_string(payload, project_root=tmp_path)
+    # The literal "unknown" appears in the rendered table.
+    assert "unknown" in output
+
+
+# ---------------------------------------------------------------------------
+# PID column behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_render_subsystem_table_missing_pid_shows_dash(tmp_path: Path) -> None:
+    """When the payload omits ``pid``, the column renders ``-`` (not crash, not blank).
+
+    The supervisor briefly leaves ``pid`` unset between
+    ``acquire_singleton`` and the child-pid rewrite; a fresh
+    ``--check`` invocation can hit the file in that window. The
+    renderer must produce a stable column value.
+    """
+    payload = {
+        "subsystems": {
+            "mcp": {
+                "http_url": "http://127.0.0.1:8770/sse",
+                "healthz_url": "http://127.0.0.1:8770/healthz",
+                "pid": None,
+                "status": "ready",
+            }
+        }
+    }
+    output = _render_to_string(payload, project_root=tmp_path)
+    # Project row has empty PID; the mcp row's PID column should show "-".
+    assert " - " in output or "-\n" in output or "│ -" in output
+
+
+# ---------------------------------------------------------------------------
+# Portable project repr (helper)
+# ---------------------------------------------------------------------------
+
+
+def test_portable_project_repr_under_cwd(tmp_path: Path) -> None:
+    """``project_root`` under ``base`` renders as ``./<rel>``."""
+    nested = tmp_path / "inner" / "project"
+    nested.mkdir(parents=True)
+    assert _portable_project_repr(nested, base=tmp_path) == "./inner/project"
+
+
+def test_portable_project_repr_equal_to_base(tmp_path: Path) -> None:
+    """``project_root`` equal to ``base`` collapses to ``.`` (not ``./``)."""
+    assert _portable_project_repr(tmp_path, base=tmp_path) == "."
+
+
+def test_portable_project_repr_absolute_fallback(tmp_path: Path) -> None:
+    """An outside-of-base + outside-of-home path renders as an absolute path."""
+    # tmp_path is typically under /private/var or /tmp — but we pass a
+    # base that's *under* tmp_path so tmp_path itself becomes "outside"
+    # base. tmp_path is also outside ``Path.home()`` in CI sandboxes,
+    # so the absolute fallback kicks in.
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    rendered = _portable_project_repr(tmp_path, base=inner)
+    # When tmp_path is also under Path.home() (some test runners),
+    # the ``~``-prefixed form wins; otherwise the absolute path.
+    assert rendered.startswith("~/") or rendered == str(tmp_path)

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -5,8 +5,9 @@ The renderer (:mod:`ctxr.fsm.cli._render`) is shared by ``ensure``,
 column ordering, the project-row content, the swagger-derivation
 rule for the ``api`` row, the "skip missing subsystems" semantics
 (``--mode mcp_only`` only ships an ``mcp`` block; W14i renamed the
-wire value from the hyphenated ``mcp-only``), and the colour mapping
-per status.
+wire value from the legacy hyphenated form, which Typer still accepts
+with a deprecation warning via ``ensure_cmd._MODE_ALIASES``), and the
+colour mapping per status.
 
 ANSI capture pattern
 --------------------
@@ -29,7 +30,7 @@ from pathlib import Path
 from rich.console import Console
 
 from ctxr.fsm.cli._render import (
-    _portable_project_repr,
+    portable_project_repr,
     render_subsystem_table,
 )
 
@@ -123,7 +124,7 @@ def test_render_subsystem_table_includes_project_row(tmp_path: Path) -> None:
     idx_mcp = output.index("mcp")
     assert idx_project < idx_mcp
     # The portable repr appears verbatim in the project row.
-    expected_repr = _portable_project_repr(tmp_path)
+    expected_repr = portable_project_repr(tmp_path)
     assert expected_repr in output
 
 
@@ -199,15 +200,47 @@ def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
     """Each closed-vocabulary status maps to its expected Rich colour.
 
     Rich uses ANSI escape codes for colours; we ``force_terminal``
-    so they survive the StringIO capture. Specific colour codes:
-
-    * green: ``\\x1b[1;32m`` (bold green)
-    * yellow: ``\\x1b[1;33m``
-    * red: ``\\x1b[1;31m``
-
-    We capture three rendered tables (one per colour-class) and
-    assert the matching ANSI prefix appears in the captured string.
+    so they survive the StringIO capture. We assert on the SGR
+    PARAMETER tokens (``1`` for bold, ``32`` / ``33`` / ``31`` for the
+    8-colour green / yellow / red foregrounds) regex-matched inside a
+    ``CSI ... m`` escape sequence, NOT on a fixed concatenation like
+    ``\\x1b[1;32m``. Rich's emit format varies across versions and
+    color-system settings (combined ``\\x1b[1;32m`` vs split
+    ``\\x1b[1m\\x1b[32m`` vs reordered parameters), so a regex that
+    accepts either ordering survives Rich upgrades while still pinning
+    the actual SGR intent (bold AND the specific colour code on the
+    same status row, not just any digit pair that happens to appear).
     """
+    # Helper: parse out every SGR escape's parameter set into a frozenset.
+    # An SGR escape is ``CSI <params> m`` where params is a ``;``-joined
+    # decimal list. We collect every SGR set that appears in the output
+    # so the assertion can ask "did some SGR include both 1 (bold) and N
+    # (the target colour code)?" without caring about parameter order or
+    # whether Rich split bold + colour into two consecutive escapes.
+    import re as _re
+    from itertools import pairwise as _pairwise
+
+    sgr_re = _re.compile(r"\x1b\[([\d;]*)m")
+
+    def _styling_sets(output: str) -> list[frozenset[str]]:
+        """Return one parameter-set per SGR escape in ``output``."""
+        return [frozenset(m.group(1).split(";")) for m in sgr_re.finditer(output)]
+
+    def _has_bold_color(output: str, color: str) -> bool:
+        """True iff some SGR includes BOTH the bold flag (1) AND ``color``.
+
+        Covers the combined form (``\\x1b[1;32m`` -> ``{1, 32}``) AND the
+        split form (``\\x1b[1m\\x1b[32m`` -> ``{1}`` then ``{32}``,
+        which we accept when adjacent in the output's SGR sequence).
+        """
+        sets = _styling_sets(output)
+        for params in sets:
+            if "1" in params and color in params:
+                return True
+        # Split form: find a ``{1}``-only SGR immediately followed by a
+        # ``{color}``-only SGR.
+        return any("1" in prev and color in curr for prev, curr in _pairwise(sets))
+
     # Green (ready / spawned).
     green_payload = {
         "subsystems": {
@@ -220,14 +253,7 @@ def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
         }
     }
     green_output = _render_to_string(green_payload, project_root=tmp_path, force_terminal=True)
-    # Rich emits a specific SGR sequence for ``bold green`` on a
-    # truecolor terminal: ``\x1b[1;32m``. Pinning the full sequence
-    # rather than just ``"32"`` keeps the test from passing silently
-    # when any other column happens to contain the digits 32 (a PID,
-    # a port number, a future timestamp); a colour regression that
-    # drops the bold-green styling cannot accidentally still satisfy
-    # the assertion.
-    assert "\x1b[1;32m" in green_output
+    assert _has_bold_color(green_output, "32"), "expected bold-green SGR"
 
     # Yellow (reused / degraded).
     yellow_payload = {
@@ -241,7 +267,7 @@ def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
         }
     }
     yellow_output = _render_to_string(yellow_payload, project_root=tmp_path, force_terminal=True)
-    assert "\x1b[1;33m" in yellow_output
+    assert _has_bold_color(yellow_output, "33"), "expected bold-yellow SGR"
 
     # Red (missing / unreachable / failed).
     red_payload = {
@@ -255,7 +281,7 @@ def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
         }
     }
     red_output = _render_to_string(red_payload, project_root=tmp_path, force_terminal=True)
-    assert "\x1b[1;31m" in red_output
+    assert _has_bold_color(red_output, "31"), "expected bold-red SGR"
 
 
 def test_render_subsystem_table_unknown_status_falls_back(tmp_path: Path) -> None:
@@ -308,19 +334,19 @@ def test_render_subsystem_table_missing_pid_shows_dash(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_portable_project_repr_under_cwd(tmp_path: Path) -> None:
+def testportable_project_repr_under_cwd(tmp_path: Path) -> None:
     """``project_root`` under ``base`` renders as ``./<rel>``."""
     nested = tmp_path / "inner" / "project"
     nested.mkdir(parents=True)
-    assert _portable_project_repr(nested, base=tmp_path) == "./inner/project"
+    assert portable_project_repr(nested, base=tmp_path) == "./inner/project"
 
 
-def test_portable_project_repr_equal_to_base(tmp_path: Path) -> None:
+def testportable_project_repr_equal_to_base(tmp_path: Path) -> None:
     """``project_root`` equal to ``base`` collapses to ``.`` (not ``./``)."""
-    assert _portable_project_repr(tmp_path, base=tmp_path) == "."
+    assert portable_project_repr(tmp_path, base=tmp_path) == "."
 
 
-def test_portable_project_repr_absolute_fallback(tmp_path: Path) -> None:
+def testportable_project_repr_absolute_fallback(tmp_path: Path) -> None:
     """An outside-of-base + outside-of-home path renders as an absolute path."""
     # tmp_path is typically under /private/var or /tmp — but we pass a
     # base that's *under* tmp_path so tmp_path itself becomes "outside"
@@ -328,7 +354,7 @@ def test_portable_project_repr_absolute_fallback(tmp_path: Path) -> None:
     # so the absolute fallback kicks in.
     inner = tmp_path / "inner"
     inner.mkdir()
-    rendered = _portable_project_repr(tmp_path, base=inner)
+    rendered = portable_project_repr(tmp_path, base=inner)
     # When tmp_path is also under Path.home() (some test runners),
     # the ``~``-prefixed form wins; otherwise the absolute path.
     assert rendered.startswith("~/") or rendered == str(tmp_path)

--- a/tests/unit/lifecycle/test_sharded_log_path.py
+++ b/tests/unit/lifecycle/test_sharded_log_path.py
@@ -1,0 +1,105 @@
+"""Unit tests for the sharded log-path convention.
+
+Lives next to the other lifecycle-primitives tests. Guards the
+"never flat-folder logs" rule: every persistent log file in
+``.ctxr-fsm/`` MUST go through :func:`sharded_log_path` and land
+under a YYYY/MM/DD nested tree so the directory can't accumulate
+into one bottlenecked flat folder.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ctxr.fsm.cli.lifecycle.primitives import sharded_log_path
+
+
+def test_path_is_nested_under_yyyy_mm_dd(tmp_path: Path) -> None:
+    """The returned path lives under ``logs/<category>/YYYY/MM/DD/`` exactly."""
+    when = datetime(2026, 5, 30, 18, 14, 55, tzinfo=UTC)
+    path = sharded_log_path("supervisor", project_root=tmp_path, when=when)
+
+    expected = (
+        tmp_path / ".ctxr-fsm" / "logs" / "supervisor" / "2026" / "05" / "30"
+    )
+    assert path.parent == expected
+    assert path.name.startswith("supervisor-")
+    assert path.suffix == ".log"
+
+
+def test_parent_directory_is_created(tmp_path: Path) -> None:
+    """The helper materialises the nested tree so the caller can open() immediately."""
+    when = datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC)
+    path = sharded_log_path("supervisor", project_root=tmp_path, when=when)
+    assert path.parent.is_dir()
+
+
+def test_filename_includes_hhmmss(tmp_path: Path) -> None:
+    """The basename embeds the wall-clock HHMMSS so concurrent boots don't collide."""
+    when = datetime(2026, 5, 30, 9, 7, 3, tzinfo=UTC)
+    path = sharded_log_path("supervisor", project_root=tmp_path, when=when)
+    assert path.name.startswith("supervisor-090703")
+
+
+def test_pid_suffix_appended_when_supplied(tmp_path: Path) -> None:
+    """A pid disambiguates concurrent writers within the same second."""
+    when = datetime(2026, 5, 30, 18, 14, 55, tzinfo=UTC)
+    path = sharded_log_path("supervisor", project_root=tmp_path, when=when, pid=42)
+    assert path.name == "supervisor-181455-42.log"
+
+
+def test_pid_suffix_absent_when_omitted(tmp_path: Path) -> None:
+    """When the caller doesn't pass a pid, the suffix is just HHMMSS."""
+    when = datetime(2026, 5, 30, 18, 14, 55, tzinfo=UTC)
+    path = sharded_log_path("supervisor", project_root=tmp_path, when=when)
+    assert path.name == "supervisor-181455.log"
+
+
+def test_alternate_category_changes_top_level_subdir(tmp_path: Path) -> None:
+    """A different category writes under its own subtree, not the supervisor one."""
+    when = datetime(2026, 5, 30, 18, 14, 55, tzinfo=UTC)
+    path = sharded_log_path("audit", project_root=tmp_path, when=when)
+    assert "logs/audit/2026/05/30" in str(path)
+    assert "logs/supervisor" not in str(path)
+
+
+def test_extension_can_be_overridden(tmp_path: Path) -> None:
+    """Callers that emit JSONL audit dumps can swap ``log`` for ``jsonl``."""
+    when = datetime(2026, 5, 30, 18, 14, 55, tzinfo=UTC)
+    path = sharded_log_path(
+        "audit", project_root=tmp_path, when=when, extension="jsonl"
+    )
+    assert path.suffix == ".jsonl"
+
+
+def test_default_when_uses_current_utc(tmp_path: Path) -> None:
+    """Omitting ``when`` snapshots the current UTC moment for the shard."""
+    before = datetime.now(tz=UTC)
+    path = sharded_log_path("supervisor", project_root=tmp_path)
+    after = datetime.now(tz=UTC)
+
+    # The YYYY/MM/DD shard must be one of the two wall-clock days that
+    # bracket the call (handles the once-per-decade UTC midnight race).
+    matched = False
+    for candidate in (before, after):
+        expected_dir = (
+            tmp_path
+            / ".ctxr-fsm"
+            / "logs"
+            / "supervisor"
+            / f"{candidate:%Y}"
+            / f"{candidate:%m}"
+            / f"{candidate:%d}"
+        )
+        if path.parent == expected_dir:
+            matched = True
+            break
+    assert matched, f"path {path} doesn't match either {before} or {after}"
+
+
+def test_file_itself_is_not_created(tmp_path: Path) -> None:
+    """The helper materialises the parent dir; the caller writes the file."""
+    when = datetime(2026, 5, 30, 18, 14, 55, tzinfo=UTC)
+    path = sharded_log_path("supervisor", project_root=tmp_path, when=when)
+    assert not path.exists()


### PR DESCRIPTION
## Summary

Adds a single shared Rich renderer for "where do I go" subsystem URLs (FastAPI / Swagger / UI / MCP) and wires it into the three commands that surface that information so the table shape is byte-identical across the operator surface. JSON output paths for ensure + doctor stay unchanged (wire-format compatibility for machine consumers is sacred). Extends scripts/audit_strings.sh with rule 6 so any future argparse/click drift in cli/ trips a CI failure, and pins the typer-everywhere + Rich-for-pretty-print discipline in docs/coding-standards.md.

Lands on top of #42 (W14i enum-extract + portability addendum); validation battery W14h will run against this table-augmented surface.

## What landed

- New `ctxr/fsm/cli/_render.py` — `render_subsystem_table(active_mcp, *, project_root, title=None) -> rich.table.Table` + `print_subsystem_table` shorthand. Closed-vocabulary status -> (label, Rich style) mapping hosted in one place; renderer accepts the W14c `active-mcp.json` shape verbatim; project row leads with the portable project-root path (relative-to-cwd / `~`-prefixed / absolute fallback).
- `ctxr/fsm/cli/ensure_cmd.py` — when TTY + `--no-json`, follows the actions-summary dict with the table. New `--no-table` flag opts out of the table while keeping the dict summary. `--json` (including the default-when-piped path) unchanged.
- `ctxr/fsm/cli/doctor_cmd.py` — pretty mode replaces the legacy `rich.print(report)` dict dump with a Rich Panel (DB path + alembic revision) followed by the shared table; status word per row is derived from the doctor's own pid-alive + healthz probe so the colour matches what doctor just observed. `--json` path unchanged.
- `ctxr/fsm/cli/lifecycle/supervisor.py` — prints the table once on stdout after every required healthz passes; NOT on reload, NOT per-probe. stdout/stderr stay independent so operators can pipe each separately.
- `scripts/audit_strings.sh` rule 6 — fails on any `import argparse` / `from argparse` / `import click` / `from click` under `ctxr/fsm/cli/`; first-run clean.
- `docs/coding-standards.md` — pins the typer-everywhere + Rich-only pretty-print rule with the user's W14j quote as rationale.

## Test counts (delta from 603 baseline → 624 final)

- `tests/unit/cli/test_render.py` — 11 unit tests (column order, project-row content, swagger derivation, missing-subsystem skip, ANSI-captured status colours, PID fallback, portable repr edges).
- `tests/cli/test_doctor_table_replaces_old_pretty_print.py` — 4 tests (panel headers present, table skeleton present, legacy dict-dump keys absent, JSON surface unchanged).
- `tests/cli/test_cli_doctor.py` — 3 stale pretty-mode tests migrated to the new shape (every JSON-mode test stays as-is).
- `tests/integration/bootstrap/test_ensure_prints_table_in_tty.py` — 4 matrix tests (TTY+pretty, TTY+JSON, TTY+--no-table, non-TTY default JSON).
- `tests/integration/lifecycle/test_supervisor_prints_boot_table.py` — 2 subprocess-driven tests (table once per boot, headers visible on stdout).

Total: +21 tests, 603 -> 624 passed.

## Sample of doctor pretty output (after W14j)

```
╭─ ctxr-fsm doctor ────────────────────────────────╮
│ DB       /private/tmp/w14j-demo/.ctxr-fsm/fsm.db │
│ Revision 0001_initial                            │
╰──────────────────────────────────────────────────╯
                              ctxr-fsm subsystems
┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┓
┃ Subsystem ┃ URL                    ┃ Swagger                ┃ Health ┃   PID ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━┩
│ Project   │ .                      │                        │        │       │
│ mcp       │ http://127.0.0.1:8770/ │                        │ ready  │  9566 │
│           │ sse                    │                        │        │       │
│ api       │ http://127.0.0.1:8765  │ http://127.0.0.1:8765/ │ ready  │  9571 │
│           │                        │ docs                   │        │       │
│ ui        │ http://127.0.0.1:5173  │                        │ ready  │ 92289 │
└───────────┴────────────────────────┴────────────────────────┴────────┴───────┘
```

Before W14j: same data was a `rich.print(report_dict)` dump that fanned out every PRAGMA, every table row count, and the whole nested supervisor section — operators had to scroll past ~40 lines of unrelated state to find the URLs.

## Verification

- `uv run pytest`: 624 passed in 97.84s.
- `uv run ruff check ctxr/fsm/`: All checks passed.
- `uv run mypy ctxr/fsm/`: Success: no issues found in 65 source files.
- `bash scripts/audit_strings.sh .`: clean (rule 6 surfaces 0 hits on first run).

## Test plan

- [x] `uv run pytest tests/unit/cli/test_render.py -v` — 11 / 11 green.
- [x] `uv run pytest tests/cli/test_cli_doctor.py tests/cli/test_doctor_table_replaces_old_pretty_print.py -v` — 15 / 15 green.
- [x] `uv run pytest tests/integration/bootstrap/test_ensure_prints_table_in_tty.py -v` — 4 / 4 green.
- [x] `uv run pytest tests/integration/lifecycle/` -v — 6 / 6 green (incl. 2 new boot-table tests).
- [x] Full suite: 624 / 624 green.
- [x] `bash scripts/audit_strings.sh .` — clean.
- [x] Manual: `ctxr-fsm doctor` against a fresh project tree, `ctxr-fsm ensure --no-json` in TTY mode, `ctxr-fsm serve` boot table.

## Locked decisions (not revisited here)

- Table renders in all three commands using one helper (decision 8 of W14j brief).
- Status colour mapping lives in one place (`_STATUS_GLYPHS`) — `EnsureActionStatus` / `McpConfigStatus` enums from W14i keep owning their own vocabularies; the renderer just looks the word up.
- `--no-table` is on the ensure CLI; doctor and serve do not need it (their pretty mode is the table).
- Wire format for ensure / doctor / install-mcp / install-memory JSON is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)