### PR TITLE
W17: Playwright E2E tests + wire real UI routes (fixes empty UI)

### DIFF
--- a/ctxr/fsm/sqlite/project.py
+++ b/ctxr/fsm/sqlite/project.py
@@ -601,6 +601,301 @@ class Project:
         """
         return TransactionContext(self._engine, run_id=run_id)
 
+    def commit_and_advance(
+        self,
+        *,
+        run_id: str,
+        outputs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Persistence-complete worker-output commit + engine advance.
+
+        The Python-direct equivalent of MCP's ``fsm.commit_outputs`` +
+        ``fsm.confirm_commit`` pair (W14k). Drives the engine through
+        the current state's worker output, persists every state /
+        transition / event row the MCP path persists, walks any
+        following inline-state chain server-side via the W14a
+        ``execute_inline`` helper, and updates ``runs.status`` /
+        ``runs.current_state`` so the UI + REST API see a coherent
+        view of the run.
+
+        Why this exists: drivers that talk to the engine via the
+        Python facade (test harnesses, in-process consumers, the W14h
+        cycle battery) need the same DB hygiene MCP gives over the
+        wire. Previously they had to either reimplement the
+        persistence calls (error-prone) or accept that the runs/states/
+        transitions/events tables stayed empty (UI showed no data).
+        This method closes that gap.
+
+        Parameters
+        ----------
+        run_id:
+            The run's primary key (UUIDv7 string) returned by
+            :meth:`start_run`.
+        outputs:
+            The worker's structured output dict for the current state.
+            Validated against the state's ``response_schema`` if one
+            is declared.
+
+        Returns
+        -------
+        dict[str, Any]
+            ``{"result_kind": "advance"|"terminal"|"fault",
+               "next_state_id": str|None,
+               "next_brief": dict|None,
+               "chain_length": int}`` — the same shape the MCP path's
+            replay produces. ``chain_length`` reports how many inline
+            states the engine walked after the worker commit.
+
+        See also
+        --------
+        :func:`ctxr.fsm.mcp.tools_runs._drive_inline_chain` — the
+        canonical inline-chain walker this method shares.
+        """
+
+        # Lazy import: tools_runs imports the engine + repos heavily;
+        # importing it at module top would couple ``Project`` to the
+        # MCP layer, which violates the layer-dependency rule. The
+        # MCP layer can import the Project facade, never the other
+        # way around. Localising the import here keeps the dependency
+        # graph one-way while still letting us share the well-tested
+        # inline-driver implementation.
+        import uuid as _uuid
+
+        from ctxr.fsm.core import RunCtx
+        from ctxr.fsm.core.engine import advance as engine_advance
+        from ctxr.fsm.core.models import (
+            EngineAdvanceKind,
+            EventKind,
+            FsmSpec,
+            TransitionKind,
+        )
+        from ctxr.fsm.mcp.tools_runs import (
+            _drive_inline_chain,
+            _ensure_engine_producer,
+            _persist_state_entry,
+        )
+
+        run = self.get_run(run_id)
+        if run is None:
+            raise ValueError(f"unknown run_id: {run_id!r}")
+
+        with self.session_factory() as session:
+            registered = self.specs.get(session, run.fsm_spec_id)
+        if registered is None:
+            raise ValueError(
+                f"spec {run.fsm_spec_id!r} not registered for run {run_id!r}"
+            )
+        spec: FsmSpec = FsmSpec.model_validate(registered.definition)
+
+        producer_id = _ensure_engine_producer(self)
+
+        # Lazy entry-state persistence: ``Project.start_run`` leaves
+        # ``runs.current_state`` as None for backward compatibility
+        # with the MCP layer (which does its own ``_persist_state_entry``
+        # right after start_run). When ``commit_and_advance`` is the
+        # first thing that touches the run after ``start_run``, we
+        # persist the entry-state row here so the rest of the method
+        # has a valid ``current_state`` + an open state-entry PK to
+        # work with. Idempotent for runs whose current_state is
+        # already set (i.e., MCP-driven runs that already persisted).
+        current_state_id = run.current_state
+        if current_state_id is None:
+            entry_state_id = registered.definition.get("entry")
+            if not entry_state_id:
+                raise ValueError(
+                    f"spec {registered.id!r} has no entry state declared"
+                )
+            entry_state_obj = spec.get_state(entry_state_id)
+            entry_inputs: dict[str, Any] = {}
+            entry_worker = entry_state_obj.worker or (
+                entry_state_obj.loop.worker
+                if entry_state_obj.loop is not None
+                else None
+            )
+            if entry_worker is not None:
+                entry_inputs = {
+                    name: (run.args or {}).get(name) for name in entry_worker.inputs
+                }
+            _persist_state_entry(
+                self,
+                run_id=run_id,
+                state_id=entry_state_id,
+                inputs=entry_inputs,
+                producer_id=producer_id,
+            )
+            # Re-fetch so the rest of the method sees current_state set.
+            run = self.get_run(run_id)
+            assert run is not None and run.current_state == entry_state_id
+            current_state_id = entry_state_id
+
+        # Find the open state-entry PK for the current state (the row
+        # start_run / a prior commit_and_advance created).
+        with self.session_factory() as session:
+            entries = self.states.list_by_run(session, run_id)
+        from_state_pk: str | None = None
+        for entry in reversed(entries):
+            if entry.state_id == current_state_id and entry.status == "entered":
+                from_state_pk = entry.id
+                break
+
+        # Build the RunCtx the engine expects, threading the run's args
+        # through so transition predicates can read them.
+        run_ctx = RunCtx(
+            run_id=_uuid.UUID(run_id),
+            fsm_id=spec.id,
+            current_state=current_state_id,
+            env=dict(run.args or {}),
+        )
+
+        advance_result = engine_advance(spec, run_ctx, outputs)
+        result_kind = advance_result.kind.value
+
+        if advance_result.kind is EngineAdvanceKind.fault:
+            # Fault path: surface to caller without further persistence
+            # state mutations. The engine's contract guarantees no
+            # partial advance on fault.
+            return {
+                "result_kind": result_kind,
+                "next_state_id": current_state_id,
+                "next_brief": None,
+                "chain_length": 0,
+                "fault_reason": advance_result.reason,
+            }
+
+        # Mark the worker state's row as exited + emit state_exited
+        # + (if advancing) record the transition + persist the next
+        # state's entry row + emit transition_taken + state_entered.
+        # The transaction shape mirrors what MCP confirm_commit does.
+        if from_state_pk is not None:
+            with self.session_factory() as session, session.begin():
+                self.states.mark_exited(session, from_state_pk, outputs)
+                self.events.emit(
+                    session,
+                    producer_id=producer_id,
+                    kind=EventKind.state_exited.value,
+                    payload={"run_id": run_id, "state_pk": from_state_pk},
+                    run_id=run_id,
+                )
+
+        if advance_result.kind is EngineAdvanceKind.terminal:
+            from ctxr.fsm.sqlite.models_core import RunTable
+            from ctxr.fsm.sqlite.repos_core import _iso_now_ms
+
+            verdict_val = (
+                {**(run.args or {}), **outputs}.get("verdict")
+            )
+            with self.session_factory() as session, session.begin():
+                run_row = session.get(RunTable, run_id)
+                if run_row is not None:
+                    run_row.status = "completed"
+                    run_row.ended_at = _iso_now_ms()
+                    run_row.last_update_at = run_row.ended_at
+                    if verdict_val is not None:
+                        run_row.verdict = str(verdict_val)
+                    session.add(run_row)
+                self.events.emit(
+                    session,
+                    producer_id=producer_id,
+                    kind=EventKind.run_completed.value,
+                    payload={"run_id": run_id, "verdict": verdict_val},
+                    run_id=run_id,
+                )
+            return {
+                "result_kind": result_kind,
+                "next_state_id": None,
+                "next_brief": None,
+                "chain_length": 0,
+            }
+
+        # EngineAdvanceKind.advance: record transition + persist new entry.
+        next_state_id = advance_result.next_state
+        assert next_state_id is not None, "advance result must carry next_state"
+        # ``from_state_pk`` was set unless the run is in a malformed
+        # state — e.g. a state row went missing between start_run and
+        # the first commit_and_advance. We require it for the
+        # transition row's FK, so surface the malformed-state case
+        # rather than letting the type checker carry an Optional all
+        # the way into the repo.
+        assert from_state_pk is not None, (
+            f"no open state-entry row found for {current_state_id!r}"
+        )
+        next_state = spec.get_state(next_state_id)
+        next_inputs: dict[str, Any] = {}
+        worker = next_state.worker or (
+            next_state.loop.worker if next_state.loop is not None else None
+        )
+        if worker is not None:
+            env_after = {**(run.args or {}), **outputs}
+            next_inputs = {name: env_after.get(name) for name in worker.inputs}
+
+        with self.session_factory() as session, session.begin():
+            transition_eval = next(
+                iter(advance_result.evaluations or []), None
+            )
+            tkind = (
+                transition_eval.kind
+                if transition_eval is not None and transition_eval.kind is not None
+                else TransitionKind.always.value
+            )
+            self.transitions.create(
+                session,
+                run_id=run_id,
+                from_state_pk=from_state_pk,
+                to_state_id=next_state_id,
+                kind=tkind,
+                predicate=transition_eval.expression if transition_eval else None,
+                predicate_result=transition_eval.result if transition_eval else None,
+            )
+            self.events.emit(
+                session,
+                producer_id=producer_id,
+                kind=EventKind.transition_taken.value,
+                payload={
+                    "run_id": run_id,
+                    "from_state_pk": from_state_pk,
+                    "to_state_id": next_state_id,
+                    "kind": tkind,
+                },
+                run_id=run_id,
+            )
+
+        _persist_state_entry(
+            self,
+            run_id=run_id,
+            state_id=next_state_id,
+            inputs=next_inputs,
+            producer_id=producer_id,
+        )
+
+        # Walk any following inline-state chain server-side. The W14k
+        # inline-driver handles persistence + terminal detection for
+        # us, so a chain that ends at terminal correctly flips
+        # runs.status to completed without further work here.
+        env_for_chain = {**(run.args or {}), **outputs}
+        inline_result = _drive_inline_chain(
+            self,
+            spec=spec,
+            run_id=run_id,
+            producer_id=producer_id,
+            start_state_id=next_state_id,
+            env_at_entry=env_for_chain,
+        )
+
+        if inline_result.get("chain_length", 0) > 0:
+            return {
+                "result_kind": inline_result["result_kind"],
+                "next_state_id": inline_result["next_state_id"],
+                "next_brief": inline_result.get("next_brief"),
+                "chain_length": inline_result["chain_length"],
+            }
+
+        return {
+            "result_kind": result_kind,
+            "next_state_id": next_state_id,
+            "next_brief": None,
+            "chain_length": 0,
+        }
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------

--- a/ctxr/fsm/sqlite/project.py
+++ b/ctxr/fsm/sqlite/project.py
@@ -889,6 +889,50 @@ class Project:
                 "chain_length": inline_result["chain_length"],
             }
 
+        # Worker-direct-to-terminal: the engine reports the transition
+        # INTO a terminal-shaped state as ``advance`` (not ``terminal``)
+        # because ``EngineAdvanceKind.terminal`` is computed from the
+        # CURRENT state's body. When we have just landed at a state
+        # with no body and no transitions, finalise the run here.
+        # Mirrors the same fallback the inline-chain driver applies at
+        # the end of a chain. Skips when an inline chain already ran
+        # (it does its own terminal detection).
+        from ctxr.fsm.core.models import StateKind as _StateKind
+        from ctxr.fsm.sqlite.models_core import RunTable
+        from ctxr.fsm.sqlite.repos_core import _iso_now_ms
+
+        landed_state = spec.get_state(next_state_id)
+        landed_is_terminal = landed_state.kind is _StateKind.terminal or (
+            not landed_state.transitions
+            and landed_state.worker is None
+            and landed_state.loop is None
+            and landed_state.inline is None
+        )
+        if landed_is_terminal:
+            verdict_val = env_for_chain.get("verdict")
+            with self.session_factory() as session, session.begin():
+                run_row = session.get(RunTable, run_id)
+                if run_row is not None:
+                    run_row.status = "completed"
+                    run_row.ended_at = _iso_now_ms()
+                    run_row.last_update_at = run_row.ended_at
+                    if verdict_val is not None:
+                        run_row.verdict = str(verdict_val)
+                    session.add(run_row)
+                self.events.emit(
+                    session,
+                    producer_id=producer_id,
+                    kind=EventKind.run_completed.value,
+                    payload={"run_id": run_id, "verdict": verdict_val},
+                    run_id=run_id,
+                )
+            return {
+                "result_kind": EngineAdvanceKind.terminal.value,
+                "next_state_id": next_state_id,
+                "next_brief": None,
+                "chain_length": 0,
+            }
+
         return {
             "result_kind": result_kind,
             "next_state_id": next_state_id,

--- a/ctxr/fsm/testing/__init__.py
+++ b/ctxr/fsm/testing/__init__.py
@@ -1,0 +1,38 @@
+"""Public testing utilities for ctxr-fsm.
+
+Shipped as part of the ctxr-fsm wheel so the same helpers the fsm
+package's own E2E tests use are available to consumers writing their
+own integration suites.
+
+Public API:
+
+``materialise_fixture_project(dest)``
+    Copy the bundled fixture project (see ``fixture_project/README.md``)
+    into ``dest``, resolve ``gitignore.template`` to ``.gitignore``,
+    and seed two commits so the contents are diffable. Returns the
+    project root path.
+
+``drive_run_to_completion(project, spec_id, args, worker_outputs)``
+    Drive a run start-to-completion via
+    :meth:`ctxr.fsm.sqlite.project.Project.commit_and_advance`, looking
+    up the worker output to commit at each worker state from the
+    caller-supplied ``worker_outputs`` mapping. Returns a dict
+    summarising the run's terminal state, visited states, and final
+    DB-side counts.
+"""
+
+from __future__ import annotations
+
+from ctxr.fsm.testing.fixture_project_materialiser import (
+    materialise_fixture_project,
+)
+from ctxr.fsm.testing.run_driver import (
+    DriverResult,
+    drive_run_to_completion,
+)
+
+__all__ = [
+    "DriverResult",
+    "drive_run_to_completion",
+    "materialise_fixture_project",
+]

--- a/ctxr/fsm/testing/fixture_project/README.md
+++ b/ctxr/fsm/testing/fixture_project/README.md
@@ -1,0 +1,11 @@
+# fixture_project — seed material for ctxr-fsm E2E tests
+
+This directory is shipped INSIDE the `ctxr-fsm` Python package. The
+`ctxr.fsm.testing.materialise_fixture_project()` helper copies its
+contents (resolving `gitignore.template` to `.gitignore`) into a
+caller-supplied tmpdir, then runs `git init` and seeds a base + head
+commit so the contents are diffable.
+
+Do not treat this directory as a working consumer project. It is a
+**template**. Edit the files here when you want every E2E test fixture
+copy to change; never edit the materialised tmpdir copies.

--- a/ctxr/fsm/testing/fixture_project/gitignore.template
+++ b/ctxr/fsm/testing/fixture_project/gitignore.template
@@ -1,0 +1,10 @@
+.ctxr-fsm/
+.claude/
+.cursor/
+.mcp.json
+CLAUDE.md
+AGENTS.md
+node_modules/
+.runs/
+.skill-code-review/
+*.tmp

--- a/ctxr/fsm/testing/fixture_project/package.json
+++ b/ctxr/fsm/testing/fixture_project/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ctxr-fsm-fixture-project",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Fixture project materialised from ctxr/fsm/testing/fixture_project/. Used by the fsm package's E2E + cycle tests to drive a real skill-code-review pipeline against deterministic bad-code inputs."
+}

--- a/ctxr/fsm/testing/fixture_project/src/bad_type.ts
+++ b/ctxr/fsm/testing/fixture_project/src/bad_type.ts
@@ -1,0 +1,9 @@
+// bad_type.ts: type-incompatible assignment + console.log debug noise + any-typed param.
+export function totalPrice(items: any): number { // any param — bad
+  console.log("DEBUG: computing total for", items); // debug noise — bad
+  let total: number = "0" as unknown as number; // type-laundered assignment — bad
+  for (const item of items) {
+    total += item.price ?? 0;
+  }
+  return total;
+}

--- a/ctxr/fsm/testing/fixture_project/src/bad_unused.ts
+++ b/ctxr/fsm/testing/fixture_project/src/bad_unused.ts
@@ -1,0 +1,11 @@
+// Two deliberately-bad TS files to drive a real code review.
+// bad_unused.ts: unused variable + missing await + non-null assertion.
+import { readFile } from "fs/promises";
+
+const UNUSED_CONSTANT = 42; // unused — bad
+
+export async function loadConfig(path: string | null): Promise<string> {
+  // Non-null assertion on possibly-null param — bad.
+  const text = readFile(path!, "utf-8"); // missing await — bad
+  return text as unknown as string; // double-cast laundering — bad
+}

--- a/ctxr/fsm/testing/fixture_project/tsconfig.json
+++ b/ctxr/fsm/testing/fixture_project/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/ctxr/fsm/testing/fixture_project_materialiser.py
+++ b/ctxr/fsm/testing/fixture_project_materialiser.py
@@ -1,0 +1,143 @@
+"""Copy the bundled ``fixture_project/`` template into a caller tmpdir.
+
+Resolves ``gitignore.template`` to ``.gitignore`` so the materialised
+copy carries a real ignore file (the template ships under a renamed
+name to avoid the dotfile being suppressed by the surrounding repo's
+ignore patterns or the build backend's include filters).
+
+After copying, runs ``git init`` and creates two commits: a base
+commit holding the seed files unchanged, then a head commit appending
+a single ``// HEAD_DIFF_MARKER`` line to ``src/bad_type.ts`` so the
+fixture supports a non-empty ``HEAD~1..HEAD`` diff for skills that
+inspect the changeset.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from importlib import resources
+from pathlib import Path
+
+__all__ = ["materialise_fixture_project"]
+
+
+_GITIGNORE_TEMPLATE_NAME = "gitignore.template"
+_GITIGNORE_DESTINATION_NAME = ".gitignore"
+_HEAD_DIFF_TARGET = "src/bad_type.ts"
+_HEAD_DIFF_MARKER = "\n// HEAD_DIFF_MARKER: added on top of the base commit so the fixture has a non-empty HEAD~1..HEAD diff for skills that inspect the changeset.\n"
+
+
+def materialise_fixture_project(dest: Path) -> Path:
+    """Copy the bundled fixture project into ``dest``.
+
+    Parameters
+    ----------
+    dest:
+        Target directory. Must not already exist (the helper refuses
+        to overwrite a non-empty directory because every test fixture
+        should run against a known-clean tree). The parent must exist.
+
+    Returns
+    -------
+    Path
+        ``dest`` after the copy, as an absolute path.
+    """
+    dest = Path(dest).resolve()
+    if dest.exists():
+        raise FileExistsError(
+            f"{dest} already exists; refusing to overwrite a non-empty "
+            "fixture target. Pass a fresh tmpdir path."
+        )
+    if not dest.parent.exists():
+        raise FileNotFoundError(
+            f"{dest.parent} does not exist; create the parent before "
+            "calling materialise_fixture_project."
+        )
+
+    template_root = resources.files("ctxr.fsm.testing.fixture_project")
+
+    # ``importlib.resources`` returns a Traversable that may live
+    # inside a zipped wheel. Use ``as_file`` to obtain a real on-disk
+    # path even when installed in zip mode, then walk + copy. We do
+    # not use ``shutil.copytree(traversable, ...)`` directly because
+    # Traversables aren't always coercible to str on every Python
+    # build.
+    with resources.as_file(template_root) as template_dir:
+        shutil.copytree(template_dir, dest)
+
+    # Rename gitignore.template -> .gitignore.
+    template_ignore = dest / _GITIGNORE_TEMPLATE_NAME
+    if template_ignore.exists():
+        template_ignore.rename(dest / _GITIGNORE_DESTINATION_NAME)
+
+    # README.md is for human readers of the template directory in the
+    # source repo; do not ship it into the materialised copy.
+    readme = dest / "README.md"
+    if readme.exists():
+        readme.unlink()
+
+    _seed_git_history(dest)
+    return dest
+
+
+def _seed_git_history(project_root: Path) -> None:
+    """``git init`` + base commit + head-diff commit."""
+    env = {
+        "GIT_AUTHOR_NAME": "ctxr-fsm-fixture",
+        "GIT_AUTHOR_EMAIL": "fixture@ctxr-fsm.invalid",
+        "GIT_COMMITTER_NAME": "ctxr-fsm-fixture",
+        "GIT_COMMITTER_EMAIL": "fixture@ctxr-fsm.invalid",
+        # Pin commit timestamps to make the resulting SHAs deterministic
+        # across cycles, which the W14h consistency battery relies on
+        # when comparing report.md outputs byte-for-byte.
+        "GIT_AUTHOR_DATE": "2024-01-01T00:00:00Z",
+        "GIT_COMMITTER_DATE": "2024-01-01T00:00:00Z",
+    }
+    _git(project_root, ["init", "--quiet", "--initial-branch=main"], env)
+    _git(project_root, ["add", "."], env)
+    _git(
+        project_root,
+        ["commit", "--quiet", "-m", "base: seed deliberately-bad TS files"],
+        env,
+    )
+
+    head_file = project_root / _HEAD_DIFF_TARGET
+    head_file.write_text(head_file.read_text() + _HEAD_DIFF_MARKER)
+
+    env_head = {
+        **env,
+        "GIT_AUTHOR_DATE": "2024-01-02T00:00:00Z",
+        "GIT_COMMITTER_DATE": "2024-01-02T00:00:00Z",
+    }
+    _git(project_root, ["add", _HEAD_DIFF_TARGET], env_head)
+    _git(
+        project_root,
+        ["commit", "--quiet", "-m", "head: append HEAD_DIFF_MARKER for diffable fixture"],
+        env_head,
+    )
+
+
+def _git(cwd: Path, args: list[str], env: dict[str, str]) -> None:
+    """Run a git subcommand with the locked-down fixture env."""
+    full_env = {
+        # Strip the caller's HOME-derived git config so a user's
+        # ~/.gitconfig (signing keys, hooks, templates) cannot
+        # contaminate the fixture's deterministic shape.
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "HOME": str(cwd),  # forces git to not pick up the user's config
+        **env,
+    }
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=full_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {args} failed (rc={result.returncode}) in {cwd}:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )

--- a/ctxr/fsm/testing/run_driver.py
+++ b/ctxr/fsm/testing/run_driver.py
@@ -1,0 +1,131 @@
+"""Drive an FSM run start-to-completion via the Project facade.
+
+The Python-direct equivalent of an LLM-as-orchestrator loop, used by
+the fsm package's own E2E tests so they can seed a populated UI
+without spinning up Claude Code. Inline states advance server-side
+via the W17a ``Project.commit_and_advance`` facade; worker states get
+their outputs looked up from a caller-supplied mapping keyed by
+state-id.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ctxr.fsm.sqlite.project import Project
+
+__all__ = ["DriverResult", "drive_run_to_completion"]
+
+
+@dataclass(frozen=True)
+class DriverResult:
+    """Summary of a driver-completed run."""
+
+    run_id: str
+    status: str
+    verdict: str | None
+    visited_worker_states: list[str]
+    chain_length_total: int
+
+
+def drive_run_to_completion(
+    project: Project,
+    *,
+    spec_id: str,
+    entry_state_id: str,
+    args: dict[str, Any],
+    worker_outputs: dict[str, dict[str, Any]],
+    max_iterations: int = 200,
+) -> DriverResult:
+    """Run ``spec_id`` start-to-completion, committing canned outputs.
+
+    Each iteration:
+      1. Reads ``run.current_state`` (falling back to ``entry_state_id``
+         on the very first iteration, when ``Project.start_run`` has
+         left ``current_state=None`` for MCP-layer compatibility).
+      2. Looks up the worker output to commit from ``worker_outputs``.
+         A missing key raises ``KeyError`` — the test author wants to
+         know which state the driver hit and didn't have an output for.
+      3. Calls ``project.commit_and_advance(run_id, outputs)``. The
+         facade walks any following inline-state chain server-side, so
+         deterministic states never appear in ``visited_worker_states``.
+
+    Parameters
+    ----------
+    project:
+        An opened :class:`Project` instance.
+    spec_id:
+        The slug of the registered spec to run (e.g. ``"skill-code-review"``).
+    entry_state_id:
+        Required because ``Project.start_run`` doesn't yet eagerly
+        populate ``runs.current_state`` (the MCP layer historically
+        owned that step). The driver uses this to know which state's
+        output to commit on the first iteration.
+    args:
+        The run's input args dict.
+    worker_outputs:
+        A mapping of ``state_id -> canned worker output``. Inline
+        states do not appear here; they're handled server-side.
+    max_iterations:
+        Safety cap against an infinite loop. Set generously; the
+        consumer is expected to know their spec's bounded length.
+
+    Returns
+    -------
+    DriverResult
+        Final run summary. Raises if the run faults or exceeds the
+        iteration cap.
+    """
+    project_repo = project
+    with project_repo.session_factory() as session:
+        spec_row = project_repo.specs.get_latest_by_slug(session, spec_id)
+    if spec_row is None:
+        raise ValueError(f"spec {spec_id!r} is not registered in the project DB")
+
+    run = project_repo.start_run(spec_id=spec_row.id, args=args)
+    visited: list[str] = []
+    chain_total = 0
+
+    for _ in range(max_iterations):
+        run_now = project_repo.get_run(run.id)
+        if run_now is None:
+            raise RuntimeError(f"run {run.id!r} disappeared mid-drive")
+        current_state_id = run_now.current_state or entry_state_id
+        if current_state_id is None:
+            break
+        visited.append(current_state_id)
+
+        if current_state_id not in worker_outputs:
+            raise KeyError(
+                f"driver reached worker state {current_state_id!r} but "
+                f"no canned output was supplied. Worker outputs supplied "
+                f"for: {sorted(worker_outputs)!r}"
+            )
+
+        result = project_repo.commit_and_advance(
+            run_id=run.id, outputs=worker_outputs[current_state_id]
+        )
+        chain_total += int(result.get("chain_length") or 0)
+        if result.get("result_kind") == "fault":
+            raise RuntimeError(
+                f"engine faulted at state {current_state_id!r}: "
+                f"{result.get('fault_reason')!r}"
+            )
+        if result.get("result_kind") == "terminal":
+            break
+    else:  # for/else: ran out of iterations without breaking
+        raise RuntimeError(
+            f"driver did not reach a terminal state within "
+            f"{max_iterations} iterations (visited: {visited!r})"
+        )
+
+    final_run = project_repo.get_run(run.id)
+    assert final_run is not None
+    return DriverResult(
+        run_id=run.id,
+        status=final_run.status,
+        verdict=final_run.verdict,
+        visited_worker_states=visited,
+        chain_length_total=chain_total,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,23 @@ include = [
 
 [dependency-groups]
 dev = [
-  "pytest>=8.3",
-  "pytest-asyncio>=0.24",
+  # Pin pytest + pytest-asyncio to their 8.x / 0.x lines: pytest 9 +
+  # pytest-asyncio 1.x changed the default event-loop fixture scope,
+  # which breaks the existing tests that call ``anyio.run(...)``
+  # inside test bodies (they hit "Already running asyncio in this
+  # thread"). Holding back here avoids a parallel suite-wide refactor.
+  "pytest>=8.3,<9",
+  "pytest-asyncio>=0.24,<1",
   "ruff>=0.6",
   "mypy>=1.11",
   "hypothesis>=6.112",
   "types-jsonschema>=4.23",
+]
+e2e = [
+  "playwright>=1.50",
+  # pytest-playwright 0.7 supports pytest 8.x, which matches our
+  # pinned pytest version above.
+  "pytest-playwright>=0.7,<0.8",
 ]
 
 [tool.uv]
@@ -194,3 +205,6 @@ disable_error_code = [
 [tool.pytest.ini_options]
 addopts = "-ra -q --strict-markers"
 testpaths = ["tests"]
+markers = [
+  "e2e: end-to-end UI tests (Playwright). Require the 'e2e' dependency group and 'playwright install chromium'. Skipped automatically when those are not present.",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,20 @@ build-backend = "hatchling.build"
 packages = ["ctxr"]
 
 [tool.hatch.build]
-include = ["ctxr/**/*.py", "ctxr/**/*.md", "README.md", "LICENSE"]
+include = [
+  "ctxr/**/*.py",
+  "ctxr/**/*.md",
+  # Testing fixture-project template (W17b) ships INSIDE the wheel so
+  # ctxr.fsm.testing.materialise_fixture_project() can resolve its
+  # bundled resources at runtime. Covers the seed source files,
+  # tsconfig/package metadata, and the gitignore template (renamed
+  # from .gitignore so the build backend does not drop it).
+  "ctxr/fsm/testing/fixture_project/**/*.ts",
+  "ctxr/fsm/testing/fixture_project/**/*.json",
+  "ctxr/fsm/testing/fixture_project/**/*.template",
+  "README.md",
+  "LICENSE",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+"""Root pytest conftest: register the ``--run-e2e`` opt-in and the
+matching auto-skip for ``@pytest.mark.e2e`` tests.
+
+Why this lives at the root rather than under ``tests/integration/e2e/``:
+``pytest_addoption`` is only honoured when it appears in a plugin or a
+root-level conftest. Nested conftests register their CLI flags too late
+for ``pytest --help`` and (sometimes) for upstream option parsing,
+which means a user running ``uv run pytest --run-e2e`` from the
+project root would hit an "unrecognized arguments" error if the hook
+lived inside the e2e subpackage.
+
+Why E2E is opt-in: pytest-playwright's sync Playwright loop persists
+its greenlet event loop across the session, which collides with the
+``anyio.run(...)`` calls inside the unit + integration suites and
+provokes ``RuntimeError: Already running asyncio in this thread``.
+Running E2E in a separate pytest invocation isolates the two loops.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the ``--run-e2e`` opt-in flag for the E2E suite."""
+    parser.addoption(
+        "--run-e2e",
+        action="store_true",
+        default=False,
+        help=(
+            "Run E2E tests under tests/integration/e2e/ "
+            "(otherwise they are skipped to avoid pytest-playwright + "
+            "pytest-asyncio event-loop interference). Equivalent to "
+            "setting RUN_E2E=1 in the environment."
+        ),
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Auto-skip ``@pytest.mark.e2e`` tests unless the opt-in is on.
+
+    Opt-in is satisfied when ``--run-e2e`` is on the CLI OR when the
+    ``RUN_E2E=1`` env var is set. Either way, Playwright must also be
+    importable (it ships in the ``e2e`` dependency group).
+    """
+    try:
+        import playwright  # noqa: F401 -- presence check only
+    except ImportError:
+        playwright_available = False
+    else:
+        playwright_available = True
+
+    explicitly_enabled = (
+        config.getoption("--run-e2e", default=False)
+        or os.environ.get("RUN_E2E") == "1"
+    )
+    if explicitly_enabled and playwright_available:
+        return
+
+    if not playwright_available:
+        reason = (
+            "Playwright not installed. To run E2E tests: "
+            "`uv sync --all-extras --group e2e && uv run playwright install chromium && "
+            "uv run pytest tests/integration/e2e/ --run-e2e`."
+        )
+    else:
+        reason = (
+            "E2E tests skipped by default. Pass --run-e2e or set RUN_E2E=1 to enable. "
+            "Run them in a separate `uv run pytest tests/integration/e2e/ --run-e2e` "
+            "invocation to avoid event-loop interference with the unit + integration "
+            "suites."
+        )
+    skip_mark = pytest.mark.skip(reason=reason)
+    for item in items:
+        if "e2e" in item.keywords:
+            item.add_marker(skip_mark)

--- a/tests/integration/e2e/__init__.py
+++ b/tests/integration/e2e/__init__.py
@@ -1,0 +1,14 @@
+"""E2E tests: spawn the supervisor against a tmp-project fixture and
+drive the real UI through Playwright.
+
+Tests in this package require the ``e2e`` dependency group (Playwright
++ pytest-playwright) and ``playwright install chromium``. They are
+auto-skipped when those preconditions are not met, so the default
+``uv run pytest`` flow on a fresh checkout still goes green.
+
+To run them locally:
+
+    uv sync --all-extras --group e2e
+    uv run playwright install chromium
+    uv run pytest tests/integration/e2e/ -v
+"""

--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -1,0 +1,202 @@
+"""Shared E2E fixtures: tmp-project materialisation + supervisor lifecycle.
+
+The ``live_project`` fixture is the workhorse: it materialises the
+bundled fixture project into a session-scoped tmpdir, runs
+``ctxr-fsm ensure --json`` against it to bring up the MCP + API + UI
+subsystems, parses the JSON envelope, and yields a ``LiveProject``
+DTO carrying the project root and subsystem URLs. Teardown wipes the
+tmpdir and SIGKILLs any supervisor PID files that survive shutdown.
+
+Skips are surfaced with actionable hints rather than swallowed: a
+missing Playwright install reads as "install the e2e group + run
+playwright install chromium" instead of as a silent green.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+# Option registration + the ``@pytest.mark.e2e`` auto-skip live in the
+# root conftest (``tests/conftest.py``) so pytest discovers them
+# regardless of which path the user invoked the runner from. This file
+# only defines the e2e-specific fixtures.
+
+
+# ---------------------------------------------------------------------------
+# DTO + helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LiveProject:
+    """A materialised + supervised tmp project ready for E2E driving.
+
+    ``ui_url`` is the Vite dev-server URL the supervisor brought up
+    (e.g. ``http://127.0.0.1:5173``). ``api_url`` is the FastAPI base
+    URL (``http://127.0.0.1:<port>``); pair it with ``/api/v1/runs``
+    etc. for direct REST hits in tests that want to assert on
+    server-side state before exercising the UI.
+    """
+
+    project_root: Path
+    api_url: str
+    ui_url: str
+    mcp_http_url: str | None
+
+
+def _run_ensure(project_root: Path, timeout_s: float = 60.0) -> dict:
+    """Spawn ``ctxr-fsm ensure --no-table --json`` and parse the envelope."""
+    # ``--client none`` disables MCP-client config writes (we don't
+    # want the test fixture mutating the developer's CLAUDE/Codex/
+    # Cursor configs), and ``--no-memory`` skips the install-memory
+    # step (which is otherwise incompatible with ``--client none``).
+    # The combination keeps the test hermetic.
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "ctxr-fsm",
+            "ensure",
+            "--no-table",
+            "--json",
+            "--client",
+            "none",
+            "--no-memory",
+        ],
+        cwd=project_root,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ctxr-fsm ensure failed (rc={result.returncode}) in {project_root}:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    # ensure prints a single JSON document on stdout when --json is set.
+    return json.loads(result.stdout)
+
+
+def _wait_for_url(url: str, *, timeout_s: float, accept_status_below: int = 500) -> None:
+    """Poll ``url`` until it returns < ``accept_status_below`` or timeout.
+
+    Vite's dev server and uvicorn typically need 1-3s after the
+    supervisor reports them as "spawned" before they actually accept
+    sockets. The Vite ready signal in particular is asynchronous to
+    the child-process PID being live. We poll on a 100ms cadence.
+    """
+    deadline = time.monotonic() + timeout_s
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if resp.status < accept_status_below:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as exc:
+            last_error = exc
+        time.sleep(0.1)
+    raise TimeoutError(
+        f"timed out after {timeout_s}s waiting for {url} "
+        f"(last error: {last_error!r})"
+    )
+
+
+def _kill_supervisor(project_root: Path) -> None:
+    """Tear down any supervisor PIDs the ensure call left behind.
+
+    Best-effort: missing pid files / already-dead pids are non-errors.
+    """
+    pids_dir = project_root / ".ctxr-fsm" / "pids"
+    if not pids_dir.is_dir():
+        return
+    for pid_file in pids_dir.glob("*.pid"):
+        try:
+            pid = int(pid_file.read_text().split("\n", 1)[0].strip())
+        except (ValueError, OSError):
+            continue
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.kill(pid, sig)
+            except ProcessLookupError:
+                break
+            time.sleep(0.1)
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                break
+        with pid_file.open("a"):
+            pass
+        try:
+            pid_file.unlink()
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Public fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def live_project(tmp_path_factory: pytest.TempPathFactory) -> Generator[LiveProject]:
+    """Session-scoped supervised tmp project.
+
+    Materialises the bundled ``fixture_project/`` template, spins up
+    MCP + API + UI via ``ctxr-fsm ensure``, and yields URLs for the
+    test session. Tears the supervisor down + wipes the tmpdir at
+    session end.
+
+    Single fixture per session because supervisor spin-up takes
+    several seconds; sharing the live UI across tests is fine
+    because each test seeds its own runs (different run_ids, no
+    cross-test data dependencies in the queries the UI makes).
+    """
+    # Import lazily so this module is importable on machines without
+    # the e2e deps (the collection-time skip above relies on that).
+    from ctxr.fsm.testing import materialise_fixture_project
+
+    root_dir = tmp_path_factory.mktemp("ctxr_fsm_e2e_")
+    project_root = root_dir / "project"
+    materialise_fixture_project(project_root)
+
+    try:
+        envelope = _run_ensure(project_root)
+        subsystems = envelope.get("subsystems") or {}
+        api_block = subsystems.get("api") or {}
+        ui_block = subsystems.get("ui") or {}
+        mcp_block = subsystems.get("mcp") or {}
+        api_url = api_block.get("http_url")
+        ui_url = ui_block.get("http_url")
+        if not api_url or not ui_url:
+            raise RuntimeError(
+                f"ensure did not surface api/ui URLs; envelope: {envelope!r}"
+            )
+        # ensure reports subsystems as "spawned" once the child
+        # process is alive, but Vite + uvicorn need a moment more
+        # before they accept connections. Poll healthz before
+        # handing off to tests.
+        _wait_for_url(f"{api_url}/healthz", timeout_s=20.0)
+        _wait_for_url(ui_url, timeout_s=20.0)
+        yield LiveProject(
+            project_root=project_root,
+            api_url=api_url,
+            ui_url=ui_url,
+            mcp_http_url=mcp_block.get("http_url"),
+        )
+    finally:
+        _kill_supervisor(project_root)
+        shutil.rmtree(root_dir, ignore_errors=True)

--- a/tests/integration/e2e/test_live_project_fixture.py
+++ b/tests/integration/e2e/test_live_project_fixture.py
@@ -1,0 +1,31 @@
+"""Smoke test: the ``live_project`` fixture spins up real subsystems.
+
+Pure fixture exercise, no UI assertions. Sits in front of the heavier
+UI tests so a fixture-side regression (ensure failure, port collision,
+subsystem-not-started) surfaces with a clear error rather than as a
+cryptic Playwright timeout.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+
+import pytest
+
+from tests.integration.e2e.conftest import LiveProject
+
+
+@pytest.mark.e2e
+def test_live_project_yields_reachable_subsystems(live_project: LiveProject) -> None:
+    assert live_project.project_root.is_dir()
+    assert (live_project.project_root / ".ctxr-fsm" / "fsm.db").is_file()
+    assert live_project.api_url.startswith("http://")
+    assert live_project.ui_url.startswith("http://")
+
+    # Each subsystem must answer healthz.
+    with urllib.request.urlopen(f"{live_project.api_url}/healthz", timeout=10) as resp:
+        assert resp.status == 200
+    # UI dev server (Vite) does not have a /healthz route; we hit the
+    # root and accept any 2xx as proof it's serving.
+    with urllib.request.urlopen(live_project.ui_url, timeout=10) as resp:
+        assert 200 <= resp.status < 300

--- a/tests/integration/e2e/test_ui_full_route_coverage.py
+++ b/tests/integration/e2e/test_ui_full_route_coverage.py
@@ -1,0 +1,203 @@
+"""E2E coverage across every UI route.
+
+Each test seeds the project DB with the minimum data its route needs
+to render meaningfully, then asserts the rendered DOM. The coverage
+target is every ``<Route>`` declared in ``ui/src/app.tsx``:
+
+  /                   redirect target -> /runs (asserted indirectly)
+  /runs               run list
+  /runs/:id           run detail (state tree + events + journal)
+  /specs              registered FSM specs
+  /consumers          event-bus consumers
+  /settings           doctor report (db path, ports, drift config)
+  (404)               unknown route -> NotFoundRoute
+
+The ``live_project`` session-scoped fixture spins up the supervisor
+once; each test seeds its own run / spec so cross-test isolation is
+preserved without paying the supervisor-spin-up cost per test.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+
+import pytest
+
+from ctxr.fsm.core.models import (
+    FsmSpec,
+    ResponseSchema,
+    State,
+    Transition,
+    TransitionKind,
+    Worker,
+)
+from ctxr.fsm.sqlite.project import Project
+from ctxr.fsm.testing import drive_run_to_completion
+from tests.integration.e2e.conftest import LiveProject
+
+_COVERAGE_SPEC_ID = "e2e-coverage-fsm"
+
+
+def _coverage_spec() -> FsmSpec:
+    return FsmSpec(
+        id=_COVERAGE_SPEC_ID,
+        version=1,
+        entry="emit",
+        states=[
+            State(
+                id="emit",
+                worker=Worker(
+                    role="emitter",
+                    prompt_template="unused.md",
+                    inputs=[],
+                    response_schema=ResponseSchema(
+                        schema={
+                            "type": "object",
+                            "properties": {"verdict": {"type": "string"}},
+                            "required": ["verdict"],
+                            "additionalProperties": False,
+                        },
+                    ),
+                ),
+                outputs=["verdict"],
+                transitions=[
+                    Transition(to="done", when=TransitionKind.always.value),
+                ],
+            ),
+            State(id="done", outputs=[], transitions=[]),
+        ],
+    )
+
+
+def _ensure_seeded(live_project: LiveProject) -> str:
+    """Register the coverage spec + drive a run; return the run id.
+
+    Idempotent across tests: re-registering the same spec is a no-op
+    (the repo dedupes by hash); driving another run creates a fresh
+    row. We return the LATEST run id so each test can assert on a
+    known-fresh run.
+    """
+    db_path = live_project.project_root / ".ctxr-fsm" / "fsm.db"
+    project = Project.open(db_path)
+    try:
+        project.register_spec(_coverage_spec())
+        result = drive_run_to_completion(
+            project,
+            spec_id=_COVERAGE_SPEC_ID,
+            entry_state_id="emit",
+            args={"task": "coverage"},
+            worker_outputs={"emit": {"verdict": "GO"}},
+        )
+        assert result.status == "completed"
+        return result.run_id
+    finally:
+        project.close()
+
+
+# ---------------------------------------------------------------------------
+# /  (root redirect / default route)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_ui_root_renders_runs_page(live_project: LiveProject, page) -> None:
+    """``GET /`` mounts the Runs route (both ``/`` and ``/runs`` map there)."""
+    _ensure_seeded(live_project)
+    page.goto(f"{live_project.ui_url}/", wait_until="domcontentloaded")
+    # Sidebar Runs entry should be marked current.
+    page.wait_for_selector("text=Runs", timeout=10_000)
+
+
+# ---------------------------------------------------------------------------
+# /specs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_ui_specs_page_lists_registered_spec(
+    live_project: LiveProject, page
+) -> None:
+    """``/specs`` shows the registered ``e2e-coverage-fsm`` spec slug."""
+    _ensure_seeded(live_project)
+
+    # Sanity-check the API list first so a UI failure is unambiguous.
+    api_specs_url = f"{live_project.api_url}/api/v1/specs"
+    with urllib.request.urlopen(api_specs_url, timeout=10) as resp:
+        body = resp.read().decode("utf-8")
+    assert _COVERAGE_SPEC_ID in body, (
+        f"API specs list missing {_COVERAGE_SPEC_ID}; got: {body[:500]}"
+    )
+
+    page.goto(f"{live_project.ui_url}/specs", wait_until="domcontentloaded")
+    page.wait_for_selector("h1:has-text('Specs')", timeout=10_000)
+    page.wait_for_selector(f"text={_COVERAGE_SPEC_ID}", timeout=10_000)
+
+
+# ---------------------------------------------------------------------------
+# /consumers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_ui_consumers_page_renders_header(
+    live_project: LiveProject, page
+) -> None:
+    """``/consumers`` mounts the route header even when no consumer
+    has registered. The empty state is part of the UI contract."""
+    _ensure_seeded(live_project)
+    page.goto(f"{live_project.ui_url}/consumers", wait_until="domcontentloaded")
+    page.wait_for_selector("h1:has-text('Consumers')", timeout=10_000)
+
+
+# ---------------------------------------------------------------------------
+# /settings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_ui_settings_page_shows_doctor_report(
+    live_project: LiveProject, page
+) -> None:
+    """``/settings`` fetches the doctor report and renders the DB path."""
+    _ensure_seeded(live_project)
+    page.goto(f"{live_project.ui_url}/settings", wait_until="domcontentloaded")
+    page.wait_for_selector("h1:has-text('Settings')", timeout=10_000)
+    # The doctor report carries the project's fsm.db path under
+    # 'Project metadata'. Asserting on 'fsm.db' is enough to prove
+    # the panel is mounted and the doctor POST resolved.
+    page.wait_for_selector("text=fsm.db", timeout=15_000)
+
+
+# ---------------------------------------------------------------------------
+# 404 / NotFoundRoute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_ui_unknown_route_renders_not_found(
+    live_project: LiveProject, page
+) -> None:
+    """Any unmapped path renders the NotFoundRoute stub."""
+    page.goto(
+        f"{live_project.ui_url}/this-path-does-not-exist",
+        wait_until="domcontentloaded",
+    )
+    page.wait_for_selector("text=Not found", timeout=10_000)
+
+
+# ---------------------------------------------------------------------------
+# /runs/:id — deeper detail assertions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_ui_run_detail_shows_completed_status_and_verdict(
+    live_project: LiveProject, page
+) -> None:
+    """``/runs/:id`` header surfaces the status pill + verdict pill."""
+    run_id = _ensure_seeded(live_project)
+    page.goto(
+        f"{live_project.ui_url}/runs/{run_id}", wait_until="domcontentloaded"
+    )
+    page.wait_for_selector("text=completed", timeout=15_000)
+    page.wait_for_selector("text=GO", timeout=10_000)

--- a/tests/integration/e2e/test_ui_shows_seeded_run.py
+++ b/tests/integration/e2e/test_ui_shows_seeded_run.py
@@ -1,0 +1,138 @@
+"""Baseline E2E: seed a run via the Python facade, assert the real
+Vite-served UI shows it on /runs and on /runs/:id.
+
+This is the test the user asked for in W17: the user observed empty
+UI pages against ``dummy-fsm-test`` and demanded a Playwright suite
+that proves the UI actually displays runs / states / events. This
+file is the proof — a real Vite dev server, real FastAPI backend,
+real SQLite project, real browser, no mocks.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+
+import pytest
+
+from ctxr.fsm.core.models import (
+    FsmSpec,
+    ResponseSchema,
+    State,
+    Transition,
+    TransitionKind,
+    Worker,
+)
+from ctxr.fsm.sqlite.project import Project
+from ctxr.fsm.testing import drive_run_to_completion
+from tests.integration.e2e.conftest import LiveProject
+
+
+_SEED_SPEC_ID = "e2e-baseline-fsm"
+
+
+def _seed_spec() -> FsmSpec:
+    """A small worker -> terminal spec the driver can run end-to-end."""
+    return FsmSpec(
+        id=_SEED_SPEC_ID,
+        version=1,
+        entry="emit",
+        states=[
+            State(
+                id="emit",
+                worker=Worker(
+                    role="emitter",
+                    prompt_template="unused.md",
+                    inputs=[],
+                    response_schema=ResponseSchema(
+                        schema={
+                            "type": "object",
+                            "properties": {"verdict": {"type": "string"}},
+                            "required": ["verdict"],
+                            "additionalProperties": False,
+                        },
+                    ),
+                ),
+                outputs=["verdict"],
+                transitions=[
+                    Transition(to="done", when=TransitionKind.always.value),
+                ],
+            ),
+            State(id="done", outputs=[], transitions=[]),
+        ],
+    )
+
+
+def _seed_run_via_facade(live_project: LiveProject) -> str:
+    """Open the live project's DB, register the seed spec, drive a run.
+
+    Returns the run id so the UI test can assert on its presence.
+    """
+    db_path = live_project.project_root / ".ctxr-fsm" / "fsm.db"
+    project = Project.open(db_path)
+    try:
+        project.register_spec(_seed_spec())
+        result = drive_run_to_completion(
+            project,
+            spec_id=_SEED_SPEC_ID,
+            entry_state_id="emit",
+            args={"task": "baseline-e2e"},
+            worker_outputs={"emit": {"verdict": "GO"}},
+        )
+        assert result.status == "completed"
+        assert result.verdict == "GO"
+        return result.run_id
+    finally:
+        project.close()
+
+
+@pytest.mark.e2e
+def test_ui_runs_list_shows_seeded_run(live_project: LiveProject, page) -> None:
+    """``/runs`` lists the seeded run id and a completed status pill."""
+    run_id = _seed_run_via_facade(live_project)
+
+    # Sanity check the REST API first: if the API can't see the run,
+    # the UI failure is downstream and unactionable from the test.
+    runs_url = f"{live_project.api_url}/api/v1/runs"
+    with urllib.request.urlopen(runs_url, timeout=10) as resp:
+        body = resp.read().decode("utf-8")
+    assert run_id in body, (
+        f"API list at {runs_url} did not include {run_id}; got: {body[:500]}"
+    )
+
+    page.goto(f"{live_project.ui_url}/runs", wait_until="domcontentloaded")
+
+    # The UI shortens ids to the first 7 chars (git-style) in the
+    # list, but the full id lands in the row's ``title`` attribute.
+    short_id = run_id[:7]
+    page.wait_for_selector(f"text={short_id}", timeout=15_000)
+
+    # Status pill should read "completed" (semantic colour green).
+    page.wait_for_selector("text=completed", timeout=10_000)
+
+
+@pytest.mark.e2e
+def test_ui_run_detail_shows_state_tree_and_events(
+    live_project: LiveProject, page
+) -> None:
+    """``/runs/:id`` shows the state tree + event timeline for the seeded run."""
+    run_id = _seed_run_via_facade(live_project)
+
+    page.goto(
+        f"{live_project.ui_url}/runs/{run_id}", wait_until="domcontentloaded"
+    )
+
+    # The run id itself appears in the header.
+    page.wait_for_selector(f"text={run_id}", timeout=15_000)
+
+    # State tree must surface the worker state id.
+    page.wait_for_selector("text=emit", timeout=10_000)
+    # Terminal state id is also present.
+    page.wait_for_selector("text=done", timeout=10_000)
+
+    # Event timeline must surface at least one of the lifecycle event
+    # kinds the run produced. ``run_started`` is the safest pick because
+    # every run emits it.
+    page.wait_for_selector("text=run_started", timeout=10_000)
+    # And the run_completed event must be present too (this asserts
+    # commit_and_advance's terminal-detection fired).
+    page.wait_for_selector("text=run_completed", timeout=10_000)

--- a/tests/unit/testing/__init__.py
+++ b/tests/unit/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for ``ctxr.fsm.testing``: materialiser + run-driver helpers."""

--- a/tests/unit/testing/test_fixture_project_materialiser.py
+++ b/tests/unit/testing/test_fixture_project_materialiser.py
@@ -1,0 +1,56 @@
+"""Unit tests for ``ctxr.fsm.testing.materialise_fixture_project``."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ctxr.fsm.testing import materialise_fixture_project
+
+
+def test_materialiser_copies_expected_files(tmp_path: Path) -> None:
+    dest = tmp_path / "fixture"
+    root = materialise_fixture_project(dest)
+
+    assert root == dest.resolve()
+    assert (root / "package.json").is_file()
+    assert (root / "tsconfig.json").is_file()
+    assert (root / "src" / "bad_type.ts").is_file()
+    assert (root / "src" / "bad_unused.ts").is_file()
+    assert (root / ".gitignore").is_file()
+    # README is for human readers of the template directory; should
+    # NOT be copied into the materialised tree.
+    assert not (root / "README.md").exists()
+    # Template name should be renamed away.
+    assert not (root / "gitignore.template").exists()
+
+
+def test_materialiser_seeds_two_commits_with_diffable_head(tmp_path: Path) -> None:
+    root = materialise_fixture_project(tmp_path / "fixture")
+    log = subprocess.check_output(
+        ["git", "-C", str(root), "log", "--oneline"], text=True
+    ).splitlines()
+    assert len(log) == 2, f"expected 2 commits, got {log!r}"
+
+    # The HEAD~1..HEAD diff must be non-empty so skills that scan
+    # changed paths see something to review.
+    diff = subprocess.check_output(
+        ["git", "-C", str(root), "diff", "--name-only", "HEAD~1", "HEAD"],
+        text=True,
+    ).splitlines()
+    assert diff == ["src/bad_type.ts"]
+
+
+def test_materialiser_refuses_existing_dest(tmp_path: Path) -> None:
+    dest = tmp_path / "fixture"
+    dest.mkdir()
+    with pytest.raises(FileExistsError):
+        materialise_fixture_project(dest)
+
+
+def test_materialiser_refuses_missing_parent(tmp_path: Path) -> None:
+    dest = tmp_path / "missing-parent" / "fixture"
+    with pytest.raises(FileNotFoundError):
+        materialise_fixture_project(dest)

--- a/tests/unit/testing/test_run_driver.py
+++ b/tests/unit/testing/test_run_driver.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``ctxr.fsm.testing.drive_run_to_completion``.
+
+The driver helper is exercised against a small, hand-built
+two-state FSM (one worker -> one terminal) so the test does not
+depend on the skill-code-review package being installed in the test
+runtime.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ctxr.fsm.core.models import (
+    FsmSpec,
+    ResponseSchema,
+    State,
+    Transition,
+    TransitionKind,
+    Worker,
+)
+from ctxr.fsm.sqlite.project import Project
+from ctxr.fsm.testing import drive_run_to_completion
+
+
+def _make_spec() -> FsmSpec:
+    return FsmSpec(
+        id="driver-fixture",
+        version=1,
+        entry="emit",
+        states=[
+            State(
+                id="emit",
+                worker=Worker(
+                    role="emitter",
+                    prompt_template="unused.md",
+                    inputs=[],
+                    response_schema=ResponseSchema(
+                        schema={
+                            "type": "object",
+                            "properties": {"verdict": {"type": "string"}},
+                            "required": ["verdict"],
+                            "additionalProperties": False,
+                        },
+                    ),
+                ),
+                outputs=["verdict"],
+                transitions=[
+                    Transition(to="done", when=TransitionKind.always.value),
+                ],
+            ),
+            State(id="done", outputs=[], transitions=[]),
+        ],
+    )
+
+
+def test_drive_run_to_completion_commits_canned_output(tmp_path) -> None:
+    db = tmp_path / "fsm.db"
+    project = Project.open(db)
+    spec = _make_spec()
+    project.register_spec(spec)
+
+    result = drive_run_to_completion(
+        project,
+        spec_id="driver-fixture",
+        entry_state_id="emit",
+        args={"task": "x"},
+        worker_outputs={"emit": {"verdict": "GO"}},
+    )
+
+    assert result.status == "completed"
+    assert result.verdict == "GO"
+    assert result.visited_worker_states == ["emit"]
+
+
+def test_drive_run_to_completion_raises_on_missing_output(tmp_path) -> None:
+    db = tmp_path / "fsm.db"
+    project = Project.open(db)
+    spec = _make_spec()
+    project.register_spec(spec)
+
+    with pytest.raises(KeyError, match="emit"):
+        drive_run_to_completion(
+            project,
+            spec_id="driver-fixture",
+            entry_state_id="emit",
+            args={},
+            worker_outputs={},
+        )
+
+
+def test_drive_run_to_completion_raises_on_unknown_spec(tmp_path) -> None:
+    db = tmp_path / "fsm.db"
+    project = Project.open(db)
+    with pytest.raises(ValueError, match="not registered"):
+        drive_run_to_completion(
+            project,
+            spec_id="nope",
+            entry_state_id="x",
+            args={},
+            worker_outputs={},
+        )

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -56,6 +56,11 @@ import {
   connectionState,
   setConnectionState,
 } from './lib/store';
+import { Runs as RunsRoute } from './routes/runs';
+import { RunDetailRoute } from './routes/runDetail';
+import { SpecsRoute } from './routes/specs';
+import { ConsumersRoute } from './routes/consumers';
+import { SettingsRoute } from './routes/settings';
 
 // ---------------------------------------------------------------------------
 // SSE wiring
@@ -307,51 +312,6 @@ function RouteStub({
         {description}
       </p>
     </section>
-  );
-}
-
-function RunsRoute(): JSX.Element {
-  return (
-    <RouteStub
-      title="Runs"
-      description="Live and historical FSM runs grouped by status. Subsequent waves will render the runs list, filters, and inline actions here."
-    />
-  );
-}
-
-function RunDetailRoute({ id }: { id: string }): JSX.Element {
-  return (
-    <RouteStub
-      title={`Run ${id}`}
-      description="State tree, journal, lock, and live tape for a single run. The detail view will subscribe to per-run SSE filters in a later wave."
-    />
-  );
-}
-
-function SpecsRoute(): JSX.Element {
-  return (
-    <RouteStub
-      title="Specs"
-      description="Registered FSM specs and their version history. Future waves will surface diffs and lineage between versions."
-    />
-  );
-}
-
-function ConsumersRoute(): JSX.Element {
-  return (
-    <RouteStub
-      title="Consumers"
-      description="Event-bus topology — producers, consumers, and their last-seen heartbeats. Future waves will surface ack lag and per-consumer event tails."
-    />
-  );
-}
-
-function SettingsRoute(): JSX.Element {
-  return (
-    <RouteStub
-      title="Settings"
-      description="API base URL, bearer token, and dev-only affordances live here. Persisted to localStorage in a later wave."
-    />
   );
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -167,6 +167,79 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -289,6 +362,10 @@ dev = [
     { name = "ruff" },
     { name = "types-jsonschema" },
 ]
+e2e = [
+    { name = "playwright" },
+    { name = "pytest-playwright" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -315,10 +392,14 @@ provides-extras = ["mcp", "api", "sqlite", "all"]
 dev = [
     { name = "hypothesis", specifier = ">=6.112" },
     { name = "mypy", specifier = ">=1.11" },
-    { name = "pytest", specifier = ">=8.3" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest", specifier = ">=8.3,<9" },
+    { name = "pytest-asyncio", specifier = ">=0.24,<1" },
     { name = "ruff", specifier = ">=0.6" },
     { name = "types-jsonschema", specifier = ">=4.23" },
+]
+e2e = [
+    { name = "playwright", specifier = ">=1.50" },
+    { name = "pytest-playwright", specifier = ">=0.7,<0.8" },
 ]
 
 [[package]]
@@ -346,7 +427,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
     { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
@@ -354,7 +437,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
@@ -362,7 +447,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
     { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
     { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
     { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
     { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
     { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
     { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
@@ -370,14 +457,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
     { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
     { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
     { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
     { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
     { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
     { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
     { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
     { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
@@ -385,7 +476,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
     { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
     { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
     { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
     { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
     { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
     { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
@@ -784,6 +877,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -906,6 +1018,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -930,7 +1054,7 @@ crypto = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -939,22 +1063,49 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.4.0"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
+]
+
+[[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6b/913e36aa421b35689ec95ed953ff7e8df3f2ee1c7b8ab2a3f1fd39d95faf/pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770", size = 16928, upload-time = "2025-11-24T03:43:22.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/61/4d333d8354ea2bea2c2f01bad0a4aa3c1262de20e1241f78e73360e9b620/pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38", size = 16881, upload-time = "2025-11-24T03:43:24.423Z" },
 ]
 
 [[package]]
@@ -973,6 +1124,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -1049,6 +1212,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1299,6 +1477,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.26.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1344,6 +1531,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the missing Playwright E2E test suite the user demanded after observing empty UI pages in dummy-fsm-test, and fixes the actual root cause: `app.tsx` was still routing to inline `RouteStub` placeholders instead of the fully-implemented `routes/*.tsx` components.

## What changed

**W17a — `Project.commit_and_advance` facade** ([ed7f44f](https://github.com/ctxr-dev/fsm/commit/ed7f44f))
Python-direct equivalent of MCP's `commit_outputs` + `confirm_commit` pair. In-process drivers (test harnesses, E2E suites, the W14h cycle battery) now populate runs/states/transitions/events with the same DB hygiene the wire path produces. Lazy entry-state persistence handles the `current_state=None` case on first call. Worker-direct-to-terminal arrivals also finalise the run here (mirrors the inline-chain helper's tail logic).

**W17b — tmp-project template + run-driver helpers** ([e25bb36](https://github.com/ctxr-dev/fsm/commit/e25bb36))
New `ctxr.fsm.testing` package shipping `materialise_fixture_project(dest)` and `drive_run_to_completion(...)`. The fixture project (two deliberately-bad TS files + `package.json` + `tsconfig.json` + `.gitignore`) lives at `ctxr/fsm/testing/fixture_project/` and is copied into a tmpdir on demand. Pinned git author/committer dates produce deterministic SHAs across cycles.

**W17c + W17d — Playwright E2E infra + baseline tests** ([79ab9b3](https://github.com/ctxr-dev/fsm/commit/79ab9b3))
- New `e2e` dependency group: `playwright>=1.50` + `pytest-playwright<0.8`.
- Pinned `pytest<9` and `pytest-asyncio<1` so the existing `anyio.run(...)` tests stay green.
- Root `tests/conftest.py` registers `--run-e2e` (also honours `RUN_E2E=1`). E2E auto-skip by default to avoid pytest-playwright's sync loop bleeding into pytest-asyncio's fixtures.
- `live_project` session fixture materialises the W17b project + spawns the supervisor via `ctxr-fsm ensure --no-table --json --client none --no-memory`, polls api/ui healthz until ready, yields URLs.
- **`ui/src/app.tsx`: wire the real route components.** This is the actual fix for the user-reported empty UI: `app.tsx` was importing nothing from `routes/`, falling back to inline `RouteStub` placeholders. Replaced with real imports of `Runs` / `RunDetailRoute` / `SpecsRoute` / `ConsumersRoute` / `SettingsRoute`.

**W17e — full route coverage** ([3da6ade](https://github.com/ctxr-dev/fsm/commit/3da6ade))
6 more E2E tests covering `/`, `/specs`, `/consumers`, `/settings`, the 404 route, and deeper `/runs/:id` assertions (status pill + verdict pill).

## Verification

- Default suite: **662 passing**, 9 e2e auto-skipped, 0 failed.
- E2E suite (`uv run pytest tests/integration/e2e/ --run-e2e`): **9 passing**.
- UI vitest (`cd ui && npm run test`): **17 passing**.
- `dummy-fsm-test` regression check after W17a+b lands: `states:13 / transitions:12 / events:46 / status:completed / verdict:GO` (matches the MCP-driven shape).

## How to run E2E locally

```bash
uv sync --all-extras --group e2e
uv run playwright install chromium
uv run pytest tests/integration/e2e/ --run-e2e
```

## Test plan

- [ ] `uv run pytest` is green on a fresh checkout (e2e auto-skipped).
- [ ] `uv run pytest tests/integration/e2e/ --run-e2e` is green after `playwright install chromium`.
- [ ] `cd ui && npm run test` is green.
- [ ] Manual smoke: `cd dummy-fsm-test && uv run ctxr-fsm ensure` followed by browsing the UI shows the seeded run (not empty pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)