### PR TITLE
W18a: UI redesign foundation — a11y hooks, route registry, sheet host, store extensions, lib primitives

### DIFF
--- a/.claude/hooks/pre-tool-use.fsm-guard.py
+++ b/.claude/hooks/pre-tool-use.fsm-guard.py
@@ -57,7 +57,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 # Name of the marker file written by ``write_active_run_marker``.
 # Duplicated (rather than imported from ctxr) so a consumer project
 # can drop this hook in place without taking a Python dependency on

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ ui/dist/
 ui/.vite/
 ui/coverage/
 
+# Vite Vue / Vitest spawn-helper occasionally creates a root-level cache
+node_modules/
+
 # Editor / IDE
 .idea/
 .vscode/

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -25,10 +25,9 @@ import os
 from logging.config import fileConfig
 from pathlib import Path
 
+from alembic import context
 from sqlalchemy import pool
 from sqlmodel import SQLModel
-
-from alembic import context
 
 # Importing these modules has the side effect of registering every table on
 # ``SQLModel.metadata`` (the shared registry SQLModel inherits from

--- a/migrations/versions/0001_initial.py
+++ b/migrations/versions/0001_initial.py
@@ -45,16 +45,15 @@ that quirk.
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision: str = "0001_initial"
-down_revision: Union[str, Sequence[str], None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,4 +207,5 @@ addopts = "-ra -q --strict-markers"
 testpaths = ["tests"]
 markers = [
   "e2e: end-to-end UI tests (Playwright). Require the 'e2e' dependency group and 'playwright install chromium'. Skipped automatically when those are not present.",
+  "keeps_rich_color: opt this test out of the W18a conftest fixture that sets NO_COLOR=1 / COLUMNS=200. Use it when the test deliberately asserts on Rich ANSI SGR output (e.g. the render-table colour tests).",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,23 +24,42 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _wide_terminal_for_rich_assertions(
+def _wide_plain_terminal_for_rich_assertions(
+    request: pytest.FixtureRequest,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pin COLUMNS=200 so Rich does not wrap flag names in CI.
+    """Pin a wide, colour-less terminal so Rich emits stable plain text.
 
-    Several CLI tests assert ``'--mode' in result.stdout`` against
-    Typer help output. Typer renders help through Rich, which honours
-    ``COLUMNS``: on a developer laptop terminal that is typically
-    >120 cols and the long flag tokens land on a single line; on
-    GitHub Actions ``COLUMNS`` is unset and Rich falls back to ~80
-    cols, where a long-named flag inside a panel can wrap and the
-    substring check fails. The dashboard's CLI surface is the same
-    in both environments; the test's assertion is what's brittle.
-    Forcing a wide terminal in the test environment removes the
-    environment-dependence without touching the production CLI.
+    Several CLI tests assert ``'--mode' in result.stdout`` against Typer
+    help output. Typer renders help through Rich, which on CI:
+
+      1. Defaults to ~80 cols (no ``COLUMNS``), wrapping long flag tokens.
+      2. Emits ANSI escape codes (``\\x1b[1m--\\x1b[0m\\x1b[36mmode\\x1b[0m``)
+         that split flag tokens across colour spans, so a literal
+         ``'--mode'`` substring match against the captured stdout fails
+         even though the rendered text contains the flag.
+
+    Both behaviours are environment-dependent (a developer's iTerm has
+    wide columns + still emits ANSI under CliRunner, so locally the
+    assertions pass by luck). The dashboard's CLI surface is identical
+    in both environments; the tests' substring checks are what's
+    brittle. The env knobs:
+
+      - ``COLUMNS=200`` widens the panel so flag tokens fit on one line.
+      - ``NO_COLOR=1`` (https://no-color.org) tells Rich to skip ANSI
+        styling, so the captured stdout is plain ASCII.
+      - ``TERM=dumb`` belt-and-braces for tools that ignore NO_COLOR.
+
+    Opt-out: tests that DELIBERATELY exercise Rich's colour SGR output
+    (e.g. ``tests/unit/cli/test_render.py``) can opt out with
+    ``@pytest.mark.keeps_rich_color``, after which Rich's own
+    ``force_terminal=True`` arg fully drives the colour decision.
     """
+    if request.node.get_closest_marker("keeps_rich_color") is not None:
+        return
     monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("TERM", "dumb")
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -68,7 +87,7 @@ def pytest_collection_modifyitems(
     importable (it ships in the ``e2e`` dependency group).
     """
     try:
-        import playwright  # noqa: F401 -- presence check only
+        import playwright  # type: ignore[import-not-found,unused-ignore]  # noqa: F401
     except ImportError:
         playwright_available = False
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,26 @@ import os
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _wide_terminal_for_rich_assertions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin COLUMNS=200 so Rich does not wrap flag names in CI.
+
+    Several CLI tests assert ``'--mode' in result.stdout`` against
+    Typer help output. Typer renders help through Rich, which honours
+    ``COLUMNS``: on a developer laptop terminal that is typically
+    >120 cols and the long flag tokens land on a single line; on
+    GitHub Actions ``COLUMNS`` is unset and Rich falls back to ~80
+    cols, where a long-named flag inside a panel can wrap and the
+    substring check fails. The dashboard's CLI surface is the same
+    in both environments; the test's assertion is what's brittle.
+    Forcing a wide terminal in the test environment removes the
+    environment-dependence without touching the production CLI.
+    """
+    monkeypatch.setenv("COLUMNS", "200")
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register the ``--run-e2e`` opt-in flag for the E2E suite."""
     parser.addoption(

--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -14,6 +14,7 @@ playwright install chromium" instead of as a silent green.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -140,10 +141,8 @@ def _kill_supervisor(project_root: Path) -> None:
                 break
         with pid_file.open("a"):
             pass
-        try:
+        with contextlib.suppress(OSError):
             pid_file.unlink()
-        except OSError:
-            pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/e2e/test_ui_shows_seeded_run.py
+++ b/tests/integration/e2e/test_ui_shows_seeded_run.py
@@ -26,7 +26,6 @@ from ctxr.fsm.sqlite.project import Project
 from ctxr.fsm.testing import drive_run_to_completion
 from tests.integration.e2e.conftest import LiveProject
 
-
 _SEED_SPEC_ID = "e2e-baseline-fsm"
 
 

--- a/tests/integration/lifecycle/test_ui_ships_from_package.py
+++ b/tests/integration/lifecycle/test_ui_ships_from_package.py
@@ -20,6 +20,7 @@ project's.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import signal
@@ -27,9 +28,6 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-
-import pytest
-
 
 _BOOT_WAIT_SECONDS: float = 35.0
 _POLL_INTERVAL_SECONDS: float = 0.2
@@ -56,10 +54,8 @@ def _kill_pid_quietly(pid: int) -> None:
         except ProcessLookupError:
             return
         time.sleep(_POLL_INTERVAL_SECONDS)
-    try:
+    with contextlib.suppress(ProcessLookupError):
         os.kill(pid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass
 
 
 def test_consumer_project_gets_ui_subsystem_from_package_source(

--- a/tests/integration/mcp/test_inline_chain_drive_forward.py
+++ b/tests/integration/mcp/test_inline_chain_drive_forward.py
@@ -15,20 +15,16 @@ records that it ran into a process-local list so the test can assert
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 from ctxr.fsm.core import (
     FsmSpec,
     InlineContext,
-    InlineHandlerRegistry,
     get_default_registry,
 )
 from ctxr.fsm.core.models import (
-    EngineAdvanceKind,
     EventKind,
     InlineFaultReason,
-    StateKind,
 )
 from ctxr.fsm.mcp._state import reset_project, set_project
 from ctxr.fsm.mcp.tools_runs import (
@@ -40,7 +36,6 @@ from ctxr.fsm.mcp.tools_runs import (
     fsm_start_run,
 )
 from ctxr.fsm.sqlite.project import Project
-
 
 _HANDLER_INVOCATIONS: list[InlineContext] = []
 """Module-global recording slot. Each call to the inline handler in this

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import io
 from pathlib import Path
 
+import pytest
 from rich.console import Console
 
 from ctxr.fsm.cli._render import (
@@ -254,6 +255,7 @@ def test_render_subsystem_table_handles_empty_subsystems(tmp_path: Path) -> None
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.keeps_rich_color
 def test_render_subsystem_table_status_colours(tmp_path: Path) -> None:
     """Each closed-vocabulary status maps to its expected Rich colour.
 

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -164,9 +164,9 @@ def test_print_subsystem_table_emits_osc8_hyperlinks(tmp_path: Path) -> None:
         _full_active_mcp(), project_root=tmp_path, force_terminal=True
     )
     osc8_start = "\x1b]8;"
-    # 4 URL lines × 2 OSC 8 sequences per line (start + close) = 8 occurrences.
+    # 4 URL lines x 2 OSC 8 sequences per line (start + close) = 8 occurrences.
     assert output.count(osc8_start) == 8, (
-        f"expected 8 OSC 8 sequences (4 URLs × open+close), got "
+        f"expected 8 OSC 8 sequences (4 URLs x open+close), got "
         f"{output.count(osc8_start)} in:\n{output!r}"
     )
 

--- a/tests/unit/sqlite/test_specs_repo_slug_lookup.py
+++ b/tests/unit/sqlite/test_specs_repo_slug_lookup.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from ctxr.fsm.core import FsmSpec
 from ctxr.fsm.sqlite.project import Project
 from ctxr.fsm.sqlite.repos_core import SpecsRepo

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -56,11 +56,8 @@ import {
   connectionState,
   setConnectionState,
 } from './lib/store';
-import { Runs as RunsRoute } from './routes/runs';
-import { RunDetailRoute } from './routes/runDetail';
-import { SpecsRoute } from './routes/specs';
-import { ConsumersRoute } from './routes/consumers';
-import { SettingsRoute } from './routes/settings';
+import { ROUTES } from './routes';
+import { SheetHost } from './chrome/SheetHost';
 
 // ---------------------------------------------------------------------------
 // SSE wiring
@@ -345,17 +342,15 @@ function Shell(): JSX.Element {
         <TopBar />
         <main id="main" class="min-h-0 flex-1 overflow-auto" tabIndex={-1}>
           <Router>
-            <Route path="/" component={RunsRoute} />
-            <Route path="/runs" component={RunsRoute} />
-            <Route path="/runs/:id" component={RunDetailRoute} />
-            <Route path="/specs" component={SpecsRoute} />
-            <Route path="/consumers" component={ConsumersRoute} />
-            <Route path="/settings" component={SettingsRoute} />
+            {ROUTES.map((r) => (
+              <Route key={r.path} path={r.path} component={r.component} />
+            ))}
             <Route default component={NotFoundRoute} />
           </Router>
         </main>
       </div>
       <ToastContainer />
+      <SheetHost />
     </div>
   );
 }

--- a/ui/src/chrome/SheetHost.tsx
+++ b/ui/src/chrome/SheetHost.tsx
@@ -1,0 +1,202 @@
+/**
+ * SheetHost — renders the `sheetStack` signal as a layered stack of
+ * right-anchored panels.
+ *
+ * Mounted once at the Shell level. Reads `sheetStack.value` and renders
+ * one panel per entry, each offset 24px to the left of the previous so
+ * the stack is visible as a small breadcrumb of inspection trails
+ * (spec → state in spec → commit signature for that state, etc.).
+ *
+ * Top sheet handling:
+ *   - Esc closes the TOP sheet only (unless pinned).
+ *   - Click outside closes the TOP sheet only (unless fullscreen or pinned).
+ *   - The TOP sheet's `urlFragment` is mirrored to `?sheet=<fragment>`.
+ *   - Browser back pops the top sheet (via the urlFragment effect).
+ *
+ * Why a single host rather than each Sheet rendering itself: the stack
+ * needs ONE event listener for Esc / click-outside to avoid double-fire
+ * issues, and ONE focus trap that knows about the topmost panel only.
+ * Per-Sheet self-rendering would race; a central host serialises.
+ *
+ * Bundle-friendly: this component renders nothing when the stack is
+ * empty (an early return saves Preact a diff every render).
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'preact/hooks';
+import type { JSX, VNode } from 'preact';
+
+import {
+  closeTopSheet,
+  sheetStack,
+  type SheetEntry,
+} from '../lib/store';
+import {
+  useBodyScrollLock,
+  useEscapeToClose,
+  useFocusTrap,
+} from '../lib/a11y';
+
+const WIDTH_CLASSES: Record<NonNullable<SheetEntry['width']>, string> = {
+  'right-third': 'w-full sm:w-[33vw] sm:min-w-[420px] sm:max-w-[640px]',
+  'right-half': 'w-full sm:w-[50vw] sm:min-w-[520px] sm:max-w-[960px]',
+  fullscreen: 'w-full max-w-none',
+};
+
+/**
+ * SheetHost is the singleton portal-mounted host. Render it once
+ * inside the Shell, NOT per-route — multiple instances would
+ * duplicate every key listener.
+ */
+export function SheetHost(): JSX.Element | null {
+  const stack = sheetStack.value;
+  if (stack.length === 0) return null;
+  const top = stack[stack.length - 1];
+
+  // Body-scroll-lock + escape-to-close + focus-trap only apply to the
+  // top sheet. Stacked sheets below are visually present (lateral
+  // offset) but not interactive.
+  useBodyScrollLock(true);
+
+  const onEscape = useCallback(() => {
+    if (top.pinned) return; // pinned sheets stay open through Esc.
+    closeTopSheet();
+  }, [top.id, top.pinned]);
+
+  useEscapeToClose(true, onEscape);
+
+  // Top-sheet URL fragment mirror. Push fragment on open; pop on
+  // unmount (handled by stack pop in store).
+  useEffect(() => {
+    if (!top.urlFragment) return undefined;
+    const url = new URL(window.location.href);
+    url.searchParams.set('sheet', top.urlFragment);
+    window.history.replaceState(window.history.state, '', url.toString());
+    return () => {
+      const cleanup = new URL(window.location.href);
+      if (cleanup.searchParams.get('sheet') === top.urlFragment) {
+        cleanup.searchParams.delete('sheet');
+        window.history.replaceState(window.history.state, '', cleanup.toString());
+      }
+    };
+  }, [top.id, top.urlFragment]);
+
+  return (
+    <div
+      class="fixed inset-0 z-40 pointer-events-none"
+      aria-hidden={stack.length === 0}
+    >
+      {stack.map((entry, index) => {
+        const isTop = index === stack.length - 1;
+        return (
+          <SheetPanel
+            key={entry.id}
+            entry={entry}
+            isTop={isTop}
+            stackDepth={stack.length - 1 - index}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+interface SheetPanelProps {
+  entry: SheetEntry;
+  isTop: boolean;
+  /** 0 = topmost, larger = pushed deeper below. */
+  stackDepth: number;
+}
+
+function SheetPanel({ entry, isTop, stackDepth }: SheetPanelProps): JSX.Element {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const width = entry.width ?? 'right-half';
+  const widthClass = WIDTH_CLASSES[width];
+
+  // Focus trap only on the top sheet.
+  useFocusTrap(panelRef, isTop);
+
+  const onBackdrop = useCallback(
+    (e: MouseEvent) => {
+      if (!isTop) return;
+      if (width === 'fullscreen' || entry.pinned) return;
+      if (e.target === e.currentTarget) closeTopSheet();
+    },
+    [isTop, width, entry.pinned],
+  );
+
+  const onClose = useCallback(() => {
+    if (isTop) closeTopSheet();
+  }, [isTop]);
+
+  // Layered visual offset: deeper sheets push left by 24px per level.
+  const offsetStyle = useMemo<JSX.CSSProperties>(() => {
+    if (stackDepth === 0) return {};
+    const px = stackDepth * 24;
+    return { transform: `translateX(-${px}px)` };
+  }, [stackDepth]);
+
+  // Backdrop is only solid for the top sheet. Stacked-below sheets
+  // are visually faded so the user perceives the layering.
+  const backdropOpacity = isTop ? 'bg-slate-900/60 backdrop-blur-sm' : 'bg-slate-900/20';
+  // Non-top sheets cannot be clicked through.
+  const pointer = 'pointer-events-auto';
+  // Z-index: deeper sheets are lower so the top sheet receives clicks.
+  const z = 40 + (stackDepth === 0 ? 9 : 9 - Math.min(stackDepth, 8));
+
+  return (
+    <div
+      class={['fixed inset-0 flex justify-end', pointer, backdropOpacity].join(' ')}
+      style={{ zIndex: z }}
+      onClick={onBackdrop}
+      aria-hidden={!isTop}
+    >
+      <aside
+        ref={panelRef}
+        role="dialog"
+        aria-modal={isTop}
+        aria-labelledby={`sheet-title-${entry.id}`}
+        tabIndex={-1}
+        style={offsetStyle}
+        class={[
+          'h-full bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100',
+          'border-l border-slate-200 dark:border-slate-700 shadow-2xl',
+          'flex flex-col focus:outline-none',
+          'motion-safe:transition-transform motion-safe:duration-200 motion-safe:ease-out',
+          widthClass,
+        ].join(' ')}
+      >
+        <header class="flex items-center justify-between gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-700">
+          <h2
+            id={`sheet-title-${entry.id}`}
+            class="text-base font-semibold leading-tight truncate"
+          >
+            {entry.title}
+          </h2>
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close sheet"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                class="w-4 h-4"
+                aria-hidden="true"
+              >
+                <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+              </svg>
+            </button>
+          </div>
+        </header>
+        <div class="flex-1 overflow-auto px-4 py-3 text-sm">
+          {entry.content as VNode}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+export default SheetHost;

--- a/ui/src/lib/__tests__/a11y.test.tsx
+++ b/ui/src/lib/__tests__/a11y.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * Tests for lib/a11y.ts: useFocusTrap, useEscapeToClose, useBodyScrollLock.
+ *
+ * Strategy: render a synthetic component that consumes each hook,
+ * exercise the DOM, assert observable effects (focus moves, key events
+ * fire callbacks, body overflow flips). No mocking of Preact internals.
+ */
+
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useRef } from 'preact/hooks';
+
+import {
+  FOCUSABLE_SELECTOR,
+  useBodyScrollLock,
+  useEscapeToClose,
+  useFocusTrap,
+} from '../a11y';
+
+afterEach(() => {
+  cleanup();
+  document.body.style.overflow = '';
+});
+
+describe('FOCUSABLE_SELECTOR', () => {
+  test('matches the canonical focusable elements', () => {
+    const dom = document.createElement('div');
+    dom.innerHTML = `
+      <a href="#x">link</a>
+      <button>btn</button>
+      <button disabled>btn-disabled</button>
+      <input type="text" />
+      <input type="hidden" />
+      <select><option>x</option></select>
+      <textarea></textarea>
+      <div tabindex="0">tab-stop</div>
+      <div tabindex="-1">no-stop</div>
+      <span>plain</span>
+    `;
+    const focusables = dom.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    const tags = Array.from(focusables).map((el) => el.tagName.toLowerCase());
+    expect(tags).toEqual(['a', 'button', 'input', 'select', 'textarea', 'div']);
+  });
+});
+
+describe('useFocusTrap', () => {
+  function Trapped({ active, children }: { active: boolean; children?: any }) {
+    const ref = useRef<HTMLDivElement>(null);
+    useFocusTrap(ref, active);
+    return (
+      <div ref={ref} tabIndex={-1}>
+        {children}
+      </div>
+    );
+  }
+
+  test('focuses the first focusable child on activation', async () => {
+    const { getByText } = render(
+      <Trapped active={true}>
+        <button>first</button>
+        <button>second</button>
+      </Trapped>,
+    );
+    await waitFor(() => {
+      expect(document.activeElement).toBe(getByText('first'));
+    });
+  });
+
+  test('falls back to the panel itself when no children are focusable', async () => {
+    const { container } = render(
+      <Trapped active={true}>
+        <span>no buttons here</span>
+      </Trapped>,
+    );
+    await waitFor(() => {
+      expect(document.activeElement).toBe(container.firstChild);
+    });
+  });
+
+  test('Tab from the last focusable wraps to the first', async () => {
+    const { getByText } = render(
+      <Trapped active={true}>
+        <button>first</button>
+        <button>last</button>
+      </Trapped>,
+    );
+    const last = getByText('last') as HTMLButtonElement;
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(getByText('first'));
+  });
+
+  test('Shift+Tab from the first focusable wraps to the last', async () => {
+    const { getByText } = render(
+      <Trapped active={true}>
+        <button>first</button>
+        <button>last</button>
+      </Trapped>,
+    );
+    const first = getByText('first') as HTMLButtonElement;
+    first.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(getByText('last'));
+  });
+
+  test('restores focus to the previously-active element on deactivation', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'trigger';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender, getByText } = render(
+      <Trapped active={true}>
+        <button>inside</button>
+      </Trapped>,
+    );
+    await waitFor(() => expect(document.activeElement).toBe(getByText('inside')));
+
+    rerender(
+      <Trapped active={false}>
+        <button>inside</button>
+      </Trapped>,
+    );
+
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+    trigger.remove();
+  });
+
+  test('inactive hook does not steal focus', () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+    render(
+      <Trapped active={false}>
+        <button>inside</button>
+      </Trapped>,
+    );
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
+  });
+
+  test('disabled focusables are skipped in the cycle', () => {
+    const { getByText } = render(
+      <Trapped active={true}>
+        <button>first</button>
+        <button disabled>middle</button>
+        <button>last</button>
+      </Trapped>,
+    );
+    const last = getByText('last') as HTMLButtonElement;
+    last.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(getByText('first'));
+  });
+});
+
+describe('useEscapeToClose', () => {
+  function Closeable({ active, onClose }: { active: boolean; onClose: () => void }) {
+    useEscapeToClose(active, onClose);
+    return <div>panel</div>;
+  }
+
+  test('Escape fires onClose when active', () => {
+    const onClose = vi.fn();
+    render(<Closeable active={true} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  test('Escape is a no-op when inactive', () => {
+    const onClose = vi.fn();
+    render(<Closeable active={false} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('other keys do not fire onClose', () => {
+    const onClose = vi.fn();
+    render(<Closeable active={true} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'a' });
+    fireEvent.keyDown(document, { key: 'Enter' });
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('multiple instances each fire their own onClose', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    render(
+      <>
+        <Closeable active={true} onClose={a} />
+        <Closeable active={true} onClose={b} />
+      </>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).toHaveBeenCalledOnce();
+  });
+});
+
+describe('useBodyScrollLock', () => {
+  function Locked({ active }: { active: boolean }) {
+    useBodyScrollLock(active);
+    return <div>x</div>;
+  }
+
+  beforeEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  test('locks body overflow while active', () => {
+    render(<Locked active={true} />);
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  test('does not lock when inactive', () => {
+    render(<Locked active={false} />);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  test('restores prior overflow value on unmount', () => {
+    document.body.style.overflow = 'auto';
+    const { unmount } = render(<Locked active={true} />);
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  test('toggling active flips the lock', () => {
+    const { rerender } = render(<Locked active={false} />);
+    expect(document.body.style.overflow).toBe('');
+    rerender(<Locked active={true} />);
+    expect(document.body.style.overflow).toBe('hidden');
+    rerender(<Locked active={false} />);
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/ui/src/lib/__tests__/canonicalJson.test.ts
+++ b/ui/src/lib/__tests__/canonicalJson.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for lib/canonicalJson.ts: canonicalJson + sha256Hex.
+ *
+ * The contract MUST match Python's `json.dumps(..., sort_keys=True, separators=(',', ':'))`.
+ * Tests verify each property:
+ *   - Keys sorted lexicographically (matches Python's sorted() default).
+ *   - No whitespace anywhere.
+ *   - Nested objects respect the rule recursively.
+ *   - undefined values are dropped from objects (matches JSON.stringify).
+ *   - undefined values throw at top level / in arrays (would be silently dropped by JSON.stringify;
+ *     we surface them).
+ *   - NaN / Infinity throw (json with allow_nan=False).
+ *   - BigInt throws.
+ *   - Date → ISO string.
+ *   - sha256Hex returns 64-char lowercase hex matching Python hashlib.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { CanonicalJsonError, canonicalJson, sha256Hex } from '../canonicalJson';
+
+describe('canonicalJson — primitives', () => {
+  test('null', () => {
+    expect(canonicalJson(null)).toBe('null');
+  });
+  test('booleans', () => {
+    expect(canonicalJson(true)).toBe('true');
+    expect(canonicalJson(false)).toBe('false');
+  });
+  test('numbers', () => {
+    expect(canonicalJson(0)).toBe('0');
+    expect(canonicalJson(1)).toBe('1');
+    expect(canonicalJson(-3.14)).toBe('-3.14');
+    expect(canonicalJson(1e21)).toBe('1e+21');
+  });
+  test('strings escape JSON-spec characters', () => {
+    expect(canonicalJson('hello')).toBe('"hello"');
+    expect(canonicalJson('a"b')).toBe('"a\\"b"');
+    expect(canonicalJson('\n')).toBe('"\\n"');
+    expect(canonicalJson('')).toBe('""');
+    // unicode literal stays as-is per JSON.stringify default
+    expect(canonicalJson('日本語')).toBe('"日本語"');
+  });
+});
+
+describe('canonicalJson — non-finite / unrepresentable', () => {
+  test('NaN throws', () => {
+    expect(() => canonicalJson(NaN)).toThrow(CanonicalJsonError);
+  });
+  test('+Infinity throws', () => {
+    expect(() => canonicalJson(Infinity)).toThrow(CanonicalJsonError);
+  });
+  test('-Infinity throws', () => {
+    expect(() => canonicalJson(-Infinity)).toThrow(CanonicalJsonError);
+  });
+  test('BigInt throws', () => {
+    expect(() => canonicalJson(BigInt(1))).toThrow(CanonicalJsonError);
+  });
+  test('function throws', () => {
+    expect(() => canonicalJson(() => 0)).toThrow(CanonicalJsonError);
+  });
+  test('top-level undefined throws', () => {
+    expect(() => canonicalJson(undefined)).toThrow(CanonicalJsonError);
+  });
+  test('undefined inside an array throws', () => {
+    expect(() => canonicalJson([1, undefined, 3])).toThrow(CanonicalJsonError);
+  });
+  test('symbol throws', () => {
+    expect(() => canonicalJson(Symbol('s'))).toThrow(CanonicalJsonError);
+  });
+});
+
+describe('canonicalJson — arrays', () => {
+  test('empty array', () => {
+    expect(canonicalJson([])).toBe('[]');
+  });
+  test('flat array, no whitespace', () => {
+    expect(canonicalJson([1, 2, 3])).toBe('[1,2,3]');
+    expect(canonicalJson(['a', 'b'])).toBe('["a","b"]');
+  });
+  test('nested arrays', () => {
+    expect(canonicalJson([[1, 2], [3]])).toBe('[[1,2],[3]]');
+  });
+});
+
+describe('canonicalJson — objects', () => {
+  test('empty object', () => {
+    expect(canonicalJson({})).toBe('{}');
+  });
+  test('keys sorted lexicographically', () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+    expect(canonicalJson({ z: 1, a: 1, m: 1 })).toBe('{"a":1,"m":1,"z":1}');
+  });
+  test('no whitespace between separators', () => {
+    expect(canonicalJson({ a: 1, b: 'two' })).toBe('{"a":1,"b":"two"}');
+  });
+  test('nested objects recurse + sort', () => {
+    expect(canonicalJson({ b: { y: 1, x: 2 }, a: 0 })).toBe('{"a":0,"b":{"x":2,"y":1}}');
+  });
+  test('undefined values are dropped (matches JSON.stringify)', () => {
+    expect(canonicalJson({ a: 1, b: undefined, c: 2 })).toBe('{"a":1,"c":2}');
+  });
+  test('object with mixed values', () => {
+    expect(canonicalJson({ name: 'x', tags: ['a', 'b'], n: 0, ok: true, none: null })).toBe(
+      '{"n":0,"name":"x","none":null,"ok":true,"tags":["a","b"]}',
+    );
+  });
+});
+
+describe('canonicalJson — Date', () => {
+  test('serialises to ISO string', () => {
+    const d = new Date('2026-01-15T12:34:56.789Z');
+    expect(canonicalJson(d)).toBe('"2026-01-15T12:34:56.789Z"');
+  });
+});
+
+describe('canonicalJson — determinism', () => {
+  test('same input produces byte-identical output across calls', () => {
+    const input = { tags: ['x', 'y'], a: 1, nested: { z: true, b: null } };
+    const a = canonicalJson(input);
+    const b = canonicalJson(input);
+    expect(a).toBe(b);
+  });
+  test('two different orderings of the same object produce the same string', () => {
+    const a = canonicalJson({ a: 1, b: 2, c: 3 });
+    const b = canonicalJson({ c: 3, b: 2, a: 1 });
+    const c = canonicalJson({ b: 2, c: 3, a: 1 });
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+});
+
+describe('sha256Hex', () => {
+  test('returns 64-char lowercase hex for "hello"', async () => {
+    // sha256("hello") matches python's hashlib.sha256(b"hello").hexdigest()
+    const h = await sha256Hex('hello');
+    expect(h).toBe('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+    expect(h.length).toBe(64);
+  });
+
+  test('returns canonical hex for empty string', async () => {
+    const h = await sha256Hex('');
+    expect(h).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+
+  test('different inputs produce different hashes', async () => {
+    const a = await sha256Hex('a');
+    const b = await sha256Hex('b');
+    expect(a).not.toBe(b);
+  });
+});

--- a/ui/src/lib/__tests__/clipboard.test.ts
+++ b/ui/src/lib/__tests__/clipboard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for lib/clipboard.ts: copyText + copyTextWithResult.
+ *
+ * Both paths exercised:
+ *   - Modern: navigator.clipboard.writeText (mocked + made-to-throw).
+ *   - Legacy: document.execCommand('copy') (jsdom honours it).
+ */
+
+import { describe, expect, test, vi, afterEach } from 'vitest';
+
+import { copyText, copyTextWithResult } from '../clipboard';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // Restore document.execCommand to a known default in case a test mutated it.
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue(true),
+  });
+});
+
+describe('copyText', () => {
+  test('uses navigator.clipboard.writeText when available + returns true', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const ok = await copyText('hello');
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  test('falls back to execCommand when clipboard API throws', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('not focused'));
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const exec = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: exec,
+    });
+    const ok = await copyText('fallback-text');
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalled();
+    expect(exec).toHaveBeenCalledWith('copy');
+  });
+
+  test('falls back to execCommand when clipboard API is absent', async () => {
+    vi.stubGlobal('navigator', {});
+    const exec = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: exec,
+    });
+    const ok = await copyText('no-api');
+    expect(ok).toBe(true);
+    expect(exec).toHaveBeenCalled();
+  });
+
+  test('returns false when both paths fail', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue(false),
+    });
+    const ok = await copyText('nope');
+    expect(ok).toBe(false);
+  });
+
+  test('execCommand path cleans up the temporary textarea on success', async () => {
+    vi.stubGlobal('navigator', {});
+    const exec = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: exec,
+    });
+    const before = document.body.children.length;
+    await copyText('cleanup-me');
+    expect(document.body.children.length).toBe(before);
+  });
+
+  test('execCommand path cleans up the temporary textarea on failure', async () => {
+    vi.stubGlobal('navigator', {});
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation(() => {
+        throw new Error('boom');
+      }),
+    });
+    const before = document.body.children.length;
+    const ok = await copyText('still-clean');
+    expect(ok).toBe(false);
+    expect(document.body.children.length).toBe(before);
+  });
+});
+
+describe('copyTextWithResult', () => {
+  test('returns text + ok tuple', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const r = await copyTextWithResult('payload');
+    expect(r).toEqual({ text: 'payload', ok: true });
+  });
+});

--- a/ui/src/lib/__tests__/jsonPointer.test.ts
+++ b/ui/src/lib/__tests__/jsonPointer.test.ts
@@ -1,0 +1,147 @@
+/**
+ * RFC 6901 JSON Pointer tests.
+ *
+ * Edge cases covered:
+ *   - Root pointer (`''`).
+ *   - Escaping of `~` and `/` (order-sensitive: `~` first).
+ *   - Round-tripping every escape combination.
+ *   - Numeric indices (treated as string segments per RFC).
+ *   - Invalid pointer (no leading `/`) throws.
+ *   - Empty segments (a trailing `/` produces a `''` segment) — spec-allowed.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  ROOT_POINTER,
+  escapeSegment,
+  joinPointer,
+  parsePointer,
+  pointerForPath,
+  unescapeSegment,
+} from '../jsonPointer';
+
+describe('escapeSegment', () => {
+  test('passes through plain segments unchanged', () => {
+    expect(escapeSegment('foo')).toBe('foo');
+    expect(escapeSegment('')).toBe('');
+    expect(escapeSegment('123abc')).toBe('123abc');
+  });
+
+  test('encodes ~ as ~0', () => {
+    expect(escapeSegment('~')).toBe('~0');
+    expect(escapeSegment('~tilde~')).toBe('~0tilde~0');
+  });
+
+  test('encodes / as ~1', () => {
+    expect(escapeSegment('a/b')).toBe('a~1b');
+    expect(escapeSegment('/')).toBe('~1');
+  });
+
+  test('encodes ~ BEFORE /, so a literal ~1 in input stays distinguishable', () => {
+    expect(escapeSegment('~1')).toBe('~01');
+    expect(escapeSegment('a~/b')).toBe('a~0~1b');
+  });
+
+  test('numeric inputs are coerced to string segments', () => {
+    expect(escapeSegment(0)).toBe('0');
+    expect(escapeSegment(42)).toBe('42');
+  });
+});
+
+describe('unescapeSegment', () => {
+  test('inverse of escapeSegment for every combo', () => {
+    const samples = ['foo', '', 'a/b', '~', '~1', 'a~/b', 'x~0y', '123', '/', '~tilde~/slash~'];
+    for (const s of samples) {
+      expect(unescapeSegment(escapeSegment(s))).toBe(s);
+    }
+  });
+
+  test('passes invalid escapes through verbatim', () => {
+    // Unknown ~? sequences are spec-undefined; we choose forgiving passthrough.
+    expect(unescapeSegment('~9')).toBe('~9');
+    expect(unescapeSegment('a~')).toBe('a~'); // trailing lone ~
+  });
+});
+
+describe('joinPointer', () => {
+  test('joins root + segment', () => {
+    expect(joinPointer(ROOT_POINTER, 'a')).toBe('/a');
+    expect(joinPointer('', 'items')).toBe('/items');
+  });
+
+  test('joins nested pointer + segment', () => {
+    expect(joinPointer('/a', 'b')).toBe('/a/b');
+    expect(joinPointer('/items', 0)).toBe('/items/0');
+    expect(joinPointer('/items/0', 'name')).toBe('/items/0/name');
+  });
+
+  test('escapes the new segment', () => {
+    expect(joinPointer('', 'a/b')).toBe('/a~1b');
+    expect(joinPointer('/x', '~y')).toBe('/x/~0y');
+  });
+});
+
+describe('pointerForPath', () => {
+  test('empty path produces root', () => {
+    expect(pointerForPath([])).toBe(ROOT_POINTER);
+    expect(pointerForPath([])).toBe('');
+  });
+
+  test('single segment', () => {
+    expect(pointerForPath(['foo'])).toBe('/foo');
+  });
+
+  test('multiple segments', () => {
+    expect(pointerForPath(['items', 0, 'name'])).toBe('/items/0/name');
+  });
+
+  test('escapes each segment independently', () => {
+    expect(pointerForPath(['a/b', '~'])).toBe('/a~1b/~0');
+  });
+});
+
+describe('parsePointer', () => {
+  test('root returns empty array', () => {
+    expect(parsePointer('')).toEqual([]);
+  });
+
+  test('single segment', () => {
+    expect(parsePointer('/foo')).toEqual(['foo']);
+  });
+
+  test('nested segments', () => {
+    expect(parsePointer('/a/b/c')).toEqual(['a', 'b', 'c']);
+  });
+
+  test('decodes escaped segments', () => {
+    expect(parsePointer('/a~1b/~0c')).toEqual(['a/b', '~c']);
+  });
+
+  test('round-trips through pointerForPath', () => {
+    const paths: (string | number)[][] = [
+      [],
+      ['a'],
+      ['a', 'b'],
+      ['items', 0, 'name'],
+      ['a/b', '~tilde'],
+      ['weird~/segment', 'plain'],
+    ];
+    for (const p of paths) {
+      const ptr = pointerForPath(p);
+      const back = parsePointer(ptr);
+      // Coerce numbers to strings because parsePointer returns strings.
+      expect(back).toEqual(p.map(String));
+    }
+  });
+
+  test('throws TypeError on non-empty pointer missing leading /', () => {
+    expect(() => parsePointer('foo')).toThrow(TypeError);
+    expect(() => parsePointer('foo/bar')).toThrow(TypeError);
+  });
+
+  test('preserves empty segments (trailing /)', () => {
+    expect(parsePointer('/a/')).toEqual(['a', '']);
+    expect(parsePointer('/')).toEqual(['']);
+  });
+});

--- a/ui/src/lib/__tests__/store-w18a.test.ts
+++ b/ui/src/lib/__tests__/store-w18a.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for the W18a extensions to lib/store.ts:
+ *   - sheet stack mutators (openSheet, closeTopSheet, closeSheet, clearSheets)
+ *   - recents (rememberRun, rememberSpec, rememberQuery) + cap
+ *   - notifications (pushNotification + cap + markAllNotificationsRead)
+ *   - persistence (loadStoredPrefs + wirePrefsPersistence + serialise/deserialise)
+ *
+ * These tests use the global store signals directly. afterEach resets
+ * every signal we touch so tests don't leak state.
+ */
+
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  NOTIFICATIONS_CAP,
+  RECENT_CAP,
+  _clearStoredPrefs,
+  _resetPersistenceWiring,
+  clearSheets,
+  closeSheet,
+  closeTopSheet,
+  densityMode,
+  loadStoredPrefs,
+  markAllNotificationsRead,
+  notifications,
+  openSheet,
+  pushNotification,
+  recentQueries,
+  recentRuns,
+  recentSpecs,
+  rememberQuery,
+  rememberRun,
+  rememberSpec,
+  sheetStack,
+  theme,
+  urlStateEnabled,
+  wirePrefsPersistence,
+} from '../store';
+
+beforeEach(() => {
+  // Reset signals to defaults.
+  sheetStack.value = [];
+  recentRuns.value = [];
+  recentSpecs.value = [];
+  recentQueries.value = [];
+  notifications.value = [];
+  densityMode.value = 'comfortable';
+  theme.value = 'auto';
+  urlStateEnabled.value = true;
+  _clearStoredPrefs();
+  _resetPersistenceWiring();
+});
+
+afterEach(() => {
+  // Tidy localStorage so the next test starts clean.
+  _clearStoredPrefs();
+  _resetPersistenceWiring();
+});
+
+describe('sheet stack', () => {
+  test('openSheet appends an entry', () => {
+    expect(sheetStack.value).toEqual([]);
+    openSheet({ id: 'a', title: 'A', content: null });
+    expect(sheetStack.value.length).toBe(1);
+    expect(sheetStack.value[0].id).toBe('a');
+  });
+
+  test('multiple openSheet calls stack in order', () => {
+    openSheet({ id: 'a', title: 'A', content: null });
+    openSheet({ id: 'b', title: 'B', content: null });
+    openSheet({ id: 'c', title: 'C', content: null });
+    expect(sheetStack.value.map((e) => e.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('closeTopSheet pops the rightmost', () => {
+    openSheet({ id: 'a', title: 'A', content: null });
+    openSheet({ id: 'b', title: 'B', content: null });
+    closeTopSheet();
+    expect(sheetStack.value.map((e) => e.id)).toEqual(['a']);
+  });
+
+  test('closeTopSheet on empty stack is a no-op', () => {
+    expect(() => closeTopSheet()).not.toThrow();
+    expect(sheetStack.value).toEqual([]);
+  });
+
+  test('closeTopSheet calls onClose hook BEFORE popping', () => {
+    const order: string[] = [];
+    openSheet({
+      id: 'a',
+      title: 'A',
+      content: null,
+      onClose: () => order.push('onClose'),
+    });
+    closeTopSheet();
+    expect(order).toEqual(['onClose']);
+    expect(sheetStack.value).toEqual([]);
+  });
+
+  test('closeSheet by id removes a non-top entry without disturbing siblings', () => {
+    openSheet({ id: 'a', title: 'A', content: null });
+    openSheet({ id: 'b', title: 'B', content: null });
+    openSheet({ id: 'c', title: 'C', content: null });
+    closeSheet('b');
+    expect(sheetStack.value.map((e) => e.id)).toEqual(['a', 'c']);
+  });
+
+  test('closeSheet with unknown id is a no-op', () => {
+    openSheet({ id: 'a', title: 'A', content: null });
+    closeSheet('nope');
+    expect(sheetStack.value.map((e) => e.id)).toEqual(['a']);
+  });
+
+  test('clearSheets closes all with onClose hooks fired', () => {
+    const closed: string[] = [];
+    openSheet({ id: 'a', title: 'A', content: null, onClose: () => closed.push('a') });
+    openSheet({ id: 'b', title: 'B', content: null, onClose: () => closed.push('b') });
+    clearSheets();
+    expect(sheetStack.value).toEqual([]);
+    expect(closed.sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('recents', () => {
+  test('rememberRun adds + dedupes by id', () => {
+    rememberRun({ id: '1', status: 'completed', lastSeenAt: '2026-01-01T00:00:00Z' });
+    rememberRun({ id: '2', status: 'paused', lastSeenAt: '2026-01-02T00:00:00Z' });
+    rememberRun({ id: '1', status: 'in_progress', lastSeenAt: '2026-01-03T00:00:00Z' });
+    expect(recentRuns.value).toHaveLength(2);
+    // Most recent first.
+    expect(recentRuns.value[0].id).toBe('1');
+    expect(recentRuns.value[0].status).toBe('in_progress');
+    expect(recentRuns.value[1].id).toBe('2');
+  });
+
+  test('rememberRun caps at RECENT_CAP', () => {
+    for (let i = 0; i < RECENT_CAP + 10; i++) {
+      rememberRun({ id: `r${i}`, status: 'completed', lastSeenAt: `2026-01-${(i % 28) + 1}T00:00:00Z` });
+    }
+    expect(recentRuns.value).toHaveLength(RECENT_CAP);
+    // Most recent first → newest id at index 0.
+    expect(recentRuns.value[0].id).toBe(`r${RECENT_CAP + 9}`);
+  });
+
+  test('rememberSpec dedupes by (slug, version) pair', () => {
+    rememberSpec({ slug: 'a', version: 1, lastSeenAt: 't1' });
+    rememberSpec({ slug: 'a', version: 2, lastSeenAt: 't2' });
+    rememberSpec({ slug: 'a', version: 1, lastSeenAt: 't3' });
+    expect(recentSpecs.value).toHaveLength(2);
+    expect(recentSpecs.value[0]).toEqual({ slug: 'a', version: 1, lastSeenAt: 't3' });
+  });
+
+  test('rememberQuery dedupes + caps + trims whitespace-only', () => {
+    rememberQuery('alpha');
+    rememberQuery('beta');
+    rememberQuery('alpha');
+    rememberQuery('   '); // ignored
+    rememberQuery('');    // ignored
+    expect(recentQueries.value).toEqual(['alpha', 'beta']);
+  });
+});
+
+describe('notifications', () => {
+  test('pushNotification prepends + caps at NOTIFICATIONS_CAP', () => {
+    for (let i = 0; i < NOTIFICATIONS_CAP + 5; i++) {
+      pushNotification({
+        id: `n${i}`,
+        kind: 'k',
+        title: 'T',
+        timestamp: `t${i}`,
+        read: false,
+      });
+    }
+    expect(notifications.value).toHaveLength(NOTIFICATIONS_CAP);
+    // Newest first → last-pushed at index 0.
+    expect(notifications.value[0].id).toBe(`n${NOTIFICATIONS_CAP + 4}`);
+  });
+
+  test('markAllNotificationsRead is idempotent', () => {
+    pushNotification({ id: '1', kind: 'k', title: 'T', timestamp: 't', read: false });
+    pushNotification({ id: '2', kind: 'k', title: 'T', timestamp: 't', read: true });
+    const before = notifications.value;
+    markAllNotificationsRead();
+    expect(notifications.value.every((n) => n.read)).toBe(true);
+    const ref = notifications.value;
+    markAllNotificationsRead(); // second call should NOT allocate
+    expect(notifications.value).toBe(ref);
+    expect(before).not.toBe(notifications.value); // first call DID allocate
+  });
+});
+
+describe('persistence', () => {
+  test('loadStoredPrefs no-op when nothing stored', () => {
+    expect(() => loadStoredPrefs()).not.toThrow();
+    expect(theme.value).toBe('auto');
+  });
+
+  test('loadStoredPrefs hydrates valid stored prefs', () => {
+    window.localStorage.setItem(
+      'fsm-ui:prefs',
+      JSON.stringify({
+        densityMode: 'compact',
+        theme: 'dark',
+        urlStateEnabled: false,
+        recentRuns: [{ id: 'r1', status: 'completed', lastSeenAt: 't1' }],
+        recentSpecs: [{ slug: 's', version: 1, lastSeenAt: 't1' }],
+        recentQueries: ['q1', 'q2'],
+      }),
+    );
+    loadStoredPrefs();
+    expect(densityMode.value).toBe('compact');
+    expect(theme.value).toBe('dark');
+    expect(urlStateEnabled.value).toBe(false);
+    expect(recentRuns.value).toEqual([{ id: 'r1', status: 'completed', lastSeenAt: 't1' }]);
+    expect(recentSpecs.value).toEqual([{ slug: 's', version: 1, lastSeenAt: 't1' }]);
+    expect(recentQueries.value).toEqual(['q1', 'q2']);
+  });
+
+  test('loadStoredPrefs ignores invalid density / theme values', () => {
+    window.localStorage.setItem(
+      'fsm-ui:prefs',
+      JSON.stringify({ densityMode: 'enormous', theme: 'rainbow' }),
+    );
+    loadStoredPrefs();
+    expect(densityMode.value).toBe('comfortable');
+    expect(theme.value).toBe('auto');
+  });
+
+  test('loadStoredPrefs ignores malformed JSON', () => {
+    window.localStorage.setItem('fsm-ui:prefs', 'not json {{{');
+    expect(() => loadStoredPrefs()).not.toThrow();
+    expect(theme.value).toBe('auto');
+  });
+
+  test('loadStoredPrefs filters malformed list entries per-field', () => {
+    window.localStorage.setItem(
+      'fsm-ui:prefs',
+      JSON.stringify({
+        recentRuns: [
+          { id: 'good', status: 'completed', lastSeenAt: 't1' },
+          { broken: true },
+          null,
+        ],
+        recentQueries: ['good', 42, null, 'also-good'],
+      }),
+    );
+    loadStoredPrefs();
+    expect(recentRuns.value).toEqual([{ id: 'good', status: 'completed', lastSeenAt: 't1' }]);
+    expect(recentQueries.value).toEqual(['good', 'also-good']);
+  });
+
+  test('wirePrefsPersistence writes to localStorage on signal change (debounced)', async () => {
+    vi.useFakeTimers();
+    wirePrefsPersistence();
+    theme.value = 'dark';
+    densityMode.value = 'compact';
+    expect(window.localStorage.getItem('fsm-ui:prefs')).toBeNull();
+    vi.advanceTimersByTime(250);
+    const stored = JSON.parse(window.localStorage.getItem('fsm-ui:prefs') ?? '{}');
+    expect(stored.theme).toBe('dark');
+    expect(stored.densityMode).toBe('compact');
+    vi.useRealTimers();
+  });
+
+  test('wirePrefsPersistence is idempotent', () => {
+    wirePrefsPersistence();
+    // Second call should be a no-op; if it weren't, we'd register a second
+    // effect and double-write. The flag-resetting _resetPersistenceWiring
+    // (called by beforeEach) is the test-only escape hatch.
+    expect(() => wirePrefsPersistence()).not.toThrow();
+  });
+});

--- a/ui/src/lib/__tests__/urlState.test.tsx
+++ b/ui/src/lib/__tests__/urlState.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Tests for lib/urlState.ts: buildSchema, useUrlState, codecs.
+ *
+ * Coverage:
+ *   - Codecs round-trip for string / number / boolean / csv.
+ *   - buildSchema fromQuery + toQuery round-trip.
+ *   - useUrlState hydrates the signal from window.location.search on mount.
+ *   - useUrlState reacts to popstate.
+ *   - useUrlState writes back to URL (debounced).
+ *   - Empty state produces no query string.
+ */
+
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+
+import { buildSchema, codecs, useUrlState } from '../urlState';
+
+describe('codecs', () => {
+  test('string', () => {
+    expect(codecs.string.parse('hello')).toBe('hello');
+    expect(codecs.string.parse(null)).toBeUndefined();
+    expect(codecs.string.parse('')).toBe('');
+    expect(codecs.string.serialise('hello')).toBe('hello');
+    expect(codecs.string.serialise('')).toBeUndefined();
+    expect(codecs.string.serialise(undefined)).toBeUndefined();
+    expect(codecs.string.serialise(123)).toBeUndefined();
+  });
+
+  test('number', () => {
+    expect(codecs.number.parse('42')).toBe(42);
+    expect(codecs.number.parse('3.14')).toBe(3.14);
+    expect(codecs.number.parse('abc')).toBeUndefined();
+    expect(codecs.number.parse(null)).toBeUndefined();
+    expect(codecs.number.serialise(42)).toBe('42');
+    expect(codecs.number.serialise(NaN)).toBeUndefined();
+    expect(codecs.number.serialise(Infinity)).toBeUndefined();
+    expect(codecs.number.serialise('42')).toBeUndefined();
+  });
+
+  test('boolean', () => {
+    expect(codecs.boolean.parse('1')).toBe(true);
+    expect(codecs.boolean.parse('true')).toBe(true);
+    expect(codecs.boolean.parse('0')).toBe(false);
+    expect(codecs.boolean.parse('false')).toBe(false);
+    expect(codecs.boolean.parse(null)).toBeUndefined();
+    expect(codecs.boolean.serialise(true)).toBe('1');
+    expect(codecs.boolean.serialise(false)).toBeUndefined();
+    expect(codecs.boolean.serialise('true')).toBeUndefined();
+  });
+
+  test('csv', () => {
+    expect(codecs.csv.parse('a,b,c')).toEqual(['a', 'b', 'c']);
+    expect(codecs.csv.parse(' a , b ')).toEqual(['a', 'b']);
+    expect(codecs.csv.parse('')).toBeUndefined();
+    expect(codecs.csv.parse(null)).toBeUndefined();
+    expect(codecs.csv.serialise(['a', 'b'])).toBe('a,b');
+    expect(codecs.csv.serialise([])).toBeUndefined();
+    expect(codecs.csv.serialise('not array')).toBeUndefined();
+  });
+});
+
+describe('buildSchema', () => {
+  interface S {
+    tab: string;
+    offset: number;
+    flag: boolean;
+    kinds?: string[];
+  }
+  const initial: S = { tab: 'a', offset: 0, flag: false };
+  const schema = buildSchema<S>(initial, {
+    tab: codecs.string,
+    offset: codecs.number,
+    flag: codecs.boolean,
+    kinds: codecs.csv,
+  });
+
+  test('fromQuery: empty params → initial', () => {
+    expect(schema.fromQuery(new URLSearchParams())).toEqual(initial);
+  });
+
+  test('fromQuery: partial params → initial + provided keys', () => {
+    const got = schema.fromQuery(new URLSearchParams('tab=details&offset=20'));
+    expect(got).toEqual({ tab: 'details', offset: 20, flag: false });
+  });
+
+  test('fromQuery: malformed values fall back to initial for that field', () => {
+    const got = schema.fromQuery(new URLSearchParams('offset=NaN'));
+    expect(got.offset).toBe(0);
+  });
+
+  test('toQuery: defaults produce empty string', () => {
+    expect(schema.toQuery({ tab: '', offset: NaN, flag: false } as S)).toBe('');
+  });
+
+  test('toQuery: non-trivially-serialisable values emitted', () => {
+    // offset=0 IS serialised (0 is a valid number); empty string + false
+    // + NaN + [] are all dropped by their codecs.
+    expect(schema.toQuery({ tab: 'x', offset: 0, flag: true })).toBe('?tab=x&offset=0&flag=1');
+  });
+
+  test('round-trip: every populated field survives', () => {
+    const state: S = { tab: 'events', offset: 40, flag: true, kinds: ['run_started', 'state_entered'] };
+    const q = schema.toQuery(state);
+    const params = new URLSearchParams(q.replace(/^\?/, ''));
+    const back = schema.fromQuery(params);
+    expect(back).toEqual({ ...initial, ...state });
+  });
+});
+
+describe('useUrlState', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+  afterEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+
+  interface S {
+    name: string;
+    n: number;
+  }
+  const initial: S = { name: '', n: 0 };
+  const schema = buildSchema<S>(initial, {
+    name: codecs.string,
+    n: codecs.number,
+  });
+
+  test('hydrates from window.location.search on mount', () => {
+    window.history.replaceState(null, '', '/?name=alpha&n=7');
+    const { result } = renderHook(() => useUrlState(schema, initial));
+    expect(result.current.value).toEqual({ name: 'alpha', n: 7 });
+  });
+
+  test('starts from initial when no query params', () => {
+    const { result } = renderHook(() => useUrlState(schema, initial));
+    expect(result.current.value).toEqual(initial);
+  });
+
+  test('writes back to URL after mutation (debounced)', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useUrlState(schema, initial));
+    act(() => {
+      result.current.value = { name: 'beta', n: 3 };
+    });
+    expect(window.location.search).toBe('');
+    vi.advanceTimersByTime(60);
+    expect(window.location.search).toBe('?name=beta&n=3');
+    vi.useRealTimers();
+  });
+
+  test('responds to popstate', () => {
+    const { result } = renderHook(() => useUrlState(schema, initial));
+    expect(result.current.value).toEqual(initial);
+    window.history.replaceState(null, '', '/?name=gamma');
+    act(() => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(result.current.value).toEqual({ name: 'gamma', n: 0 });
+  });
+});

--- a/ui/src/lib/__tests__/urlState.test.tsx
+++ b/ui/src/lib/__tests__/urlState.test.tsx
@@ -60,12 +60,13 @@ describe('codecs', () => {
 });
 
 describe('buildSchema', () => {
-  interface S {
+  type S = {
     tab: string;
     offset: number;
     flag: boolean;
     kinds?: string[];
-  }
+    [k: string]: unknown;
+  };
   const initial: S = { tab: 'a', offset: 0, flag: false };
   const schema = buildSchema<S>(initial, {
     tab: codecs.string,
@@ -115,10 +116,11 @@ describe('useUrlState', () => {
     window.history.replaceState(null, '', '/');
   });
 
-  interface S {
+  type S = {
     name: string;
     n: number;
-  }
+    [k: string]: unknown;
+  };
   const initial: S = { name: '', n: 0 };
   const schema = buildSchema<S>(initial, {
     name: codecs.string,

--- a/ui/src/lib/__tests__/virtualWindow.test.tsx
+++ b/ui/src/lib/__tests__/virtualWindow.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tests for lib/virtualWindow.ts: useWindow.
+ *
+ * Coverage:
+ *   - Below threshold: range covers all rows, onScroll is a no-op.
+ *   - Above threshold: initial range covers viewport-ish slice.
+ *   - Above threshold: scroll updates range with overscan respected.
+ *   - Spacer maths are correct at boundaries (start=0, end=totalRows).
+ *   - Negative bottom spacer is clamped at 0.
+ *   - Total height = rows * rowHeight.
+ *   - initialScrollTop seeds the visible range.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { renderHook } from '@testing-library/preact';
+
+import { useWindow, DEFAULT_VIRTUALISE_THRESHOLD } from '../virtualWindow';
+
+function fakeScrollEvent(scrollTop: number, clientHeight: number): Event {
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'scrollTop', { value: scrollTop, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+  const e = new Event('scroll');
+  Object.defineProperty(e, 'currentTarget', { value: el, configurable: true });
+  return e;
+}
+
+describe('useWindow', () => {
+  test('below threshold: range covers all rows, no virtualisation', () => {
+    const { result } = renderHook(() => useWindow(50, 20));
+    expect(result.current.range).toEqual({ start: 0, end: 50 });
+    expect(result.current.totalHeight).toBe(50 * 20);
+    expect(result.current.topSpacerHeight).toBe(0);
+    expect(result.current.bottomSpacerHeight).toBe(0);
+  });
+
+  test('below threshold: onScroll is a no-op (does not crash on missing target)', () => {
+    const { result } = renderHook(() => useWindow(10, 20));
+    // Calling onScroll without virtualisation MUST be safe; pass a real Event.
+    expect(() => result.current.onScroll(new Event('scroll'))).not.toThrow();
+    // Range is unchanged.
+    expect(result.current.range).toEqual({ start: 0, end: 10 });
+  });
+
+  test('above threshold: initial range is windowed', () => {
+    const totalRows = DEFAULT_VIRTUALISE_THRESHOLD + 100;
+    const { result } = renderHook(() => useWindow(totalRows, 20));
+    expect(result.current.range.start).toBe(0);
+    expect(result.current.range.end).toBeLessThan(totalRows);
+    expect(result.current.range.end).toBeGreaterThan(0);
+  });
+
+  test('above threshold: scroll updates range respecting overscan', () => {
+    const totalRows = 5000;
+    const rowHeight = 20;
+    const overscan = 10;
+    const { result, rerender } = renderHook(() => useWindow(totalRows, rowHeight, { overscan }));
+    // Scroll to row ~100 (px = 100 * 20 = 2000). Viewport 400px = 20 rows.
+    result.current.onScroll(fakeScrollEvent(2000, 400));
+    rerender();
+    const r = result.current.range;
+    // start = floor(2000/20) - overscan = 100 - 10 = 90
+    expect(r.start).toBe(90);
+    // end = start + ceil(400/20) + overscan*2 = 90 + 20 + 20 = 130
+    expect(r.end).toBe(130);
+  });
+
+  test('above threshold: end is clamped to totalRows', () => {
+    const totalRows = 1100;
+    const rowHeight = 20;
+    const { result, rerender } = renderHook(() => useWindow(totalRows, rowHeight, { overscan: 5 }));
+    // Scroll to near the bottom.
+    result.current.onScroll(fakeScrollEvent(21500, 400));
+    rerender();
+    expect(result.current.range.end).toBe(totalRows);
+    expect(result.current.range.start).toBeLessThanOrEqual(totalRows);
+  });
+
+  test('above threshold: start is clamped to 0', () => {
+    const totalRows = 2000;
+    const { result, rerender } = renderHook(() => useWindow(totalRows, 20, { overscan: 50 }));
+    // Negative scrollTop would put start below 0 without clamping.
+    result.current.onScroll(fakeScrollEvent(0, 400));
+    rerender();
+    expect(result.current.range.start).toBe(0);
+  });
+
+  test('spacer maths sum to totalHeight - visible-rows * rowHeight', () => {
+    const totalRows = 2000;
+    const rowHeight = 20;
+    const { result, rerender } = renderHook(() => useWindow(totalRows, rowHeight, { overscan: 5 }));
+    result.current.onScroll(fakeScrollEvent(400, 400));
+    rerender();
+    const r = result.current.range;
+    expect(result.current.topSpacerHeight).toBe(r.start * rowHeight);
+    expect(result.current.bottomSpacerHeight).toBe((totalRows - r.end) * rowHeight);
+    expect(result.current.totalHeight).toBe(totalRows * rowHeight);
+  });
+
+  test('initialScrollTop seeds the initial range', () => {
+    const totalRows = 2000;
+    const rowHeight = 20;
+    const { result } = renderHook(() =>
+      useWindow(totalRows, rowHeight, { overscan: 10, initialScrollTop: 1000 }),
+    );
+    // floor(1000/20) - 10 = 50 - 10 = 40
+    expect(result.current.range.start).toBe(40);
+  });
+
+  test('threshold override: when totalRows exceeds custom threshold', () => {
+    const { result } = renderHook(() => useWindow(150, 20, { virtualiseThreshold: 100, overscan: 5 }));
+    // With 150 > 100 threshold, virtualisation kicks in even on a small list.
+    expect(result.current.range.end).toBeLessThan(150);
+  });
+});

--- a/ui/src/lib/a11y.ts
+++ b/ui/src/lib/a11y.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared a11y hooks: focus trap + escape-to-close + scroll lock.
+ *
+ * Extracted from `components/Dialog.tsx` (W18a). The W18 `Sheet`
+ * primitive consumes the SAME hooks so the two surfaces never drift in
+ * their focus / escape / scroll-lock contract. A single source of
+ * truth here is what keeps every modal-class component obeying the
+ * one universal rule we ship to users: Escape closes, Tab cycles
+ * inside, focus restores to the trigger on close.
+ */
+
+import { useCallback, useEffect, useRef } from 'preact/hooks';
+import type { MutableRef } from 'preact/hooks';
+
+/**
+ * CSS selector covering every element a keyboard user can reach with
+ * Tab. Same shape as Dialog's original constant; deliberately wide so
+ * a third-party widget that uses a non-standard tabindex still
+ * participates in the cycle.
+ */
+export const FOCUSABLE_SELECTOR =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), ' +
+  'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Focus-trap hook: while `active` is true, Tab / Shift+Tab cycle inside
+ * the `panelRef`, focus moves to the first focusable child on activation,
+ * and the previously-focused element is restored on deactivation.
+ *
+ * Behaviour:
+ *
+ *   - When `active` flips true: remember `document.activeElement`,
+ *     `queueMicrotask(() => focus the first focusable child)`. The
+ *     microtask gives Preact a chance to commit the panel's children
+ *     before we query the DOM for them — a synchronous focus call on the
+ *     same tick would race the render.
+ *   - While active: a `keydown` listener on `document` intercepts Tab /
+ *     Shift+Tab and forces the focus to wrap inside the panel.
+ *   - When `active` flips false (or the panel unmounts): focus is
+ *     restored to the remembered element. We guard with `?.focus?.()`
+ *     because the trigger may have been removed (route change, list
+ *     filter, etc.) in which case we silently no-op.
+ *
+ * Edge cases handled:
+ *
+ *   - Panel with no focusable children: focus falls back to the panel
+ *     itself (which gets `tabIndex={-1}` from the consumer).
+ *   - Focus currently outside the panel during a Tab press: wraps to the
+ *     last focusable on Shift+Tab, otherwise lets the browser handle.
+ *   - Stale ref between renders: each invocation re-queries
+ *     `panelRef.current`, so a child reorder is fine.
+ *   - Disabled focusables: filtered out (the selector excludes the
+ *     `:disabled` pseudo for inputs/buttons, but a manually-disabled
+ *     element with the attribute still needs the explicit filter).
+ */
+export function useFocusTrap<T extends HTMLElement>(
+  panelRef: MutableRef<T | null>,
+  active: boolean,
+): void {
+  const lastActiveRef = useRef<HTMLElement | null>(null);
+
+  const focusFirst = useCallback(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusables = panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    const target = focusables[0] ?? panel;
+    target.focus();
+  }, [panelRef]);
+
+  useEffect(() => {
+    if (!active) return undefined;
+    lastActiveRef.current = (document.activeElement as HTMLElement) ?? null;
+    queueMicrotask(focusFirst);
+    return () => {
+      lastActiveRef.current?.focus?.();
+    };
+  }, [active, focusFirst]);
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusables = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute('disabled'));
+      if (focusables.length === 0) {
+        event.preventDefault();
+        panel.focus();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+      if (event.shiftKey) {
+        if (activeEl === first || !panel.contains(activeEl)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (activeEl === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [active, panelRef]);
+}
+
+/**
+ * Escape-to-close hook: while `active` is true, a `keydown` listener on
+ * `document` calls `onClose()` when Escape is pressed.
+ *
+ * `event.preventDefault()` is intentional: in browsers Escape can also
+ * cancel form submissions / clear native search inputs, but a modal
+ * surface that swallows Escape needs to claim the keystroke first so
+ * the cancellation chain doesn't double-fire.
+ */
+export function useEscapeToClose(active: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!active) return undefined;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [active, onClose]);
+}
+
+/**
+ * Body-scroll-lock hook: while `active` is true, sets
+ * `document.body.style.overflow = 'hidden'` and restores the prior value
+ * on deactivation.
+ *
+ * Why a hook rather than a Tailwind class: the body element is owned by
+ * `index.html`, not by any Preact component. We need an imperative
+ * mutation that survives across renders. The save-and-restore pattern
+ * handles the case where the page already has overflow restrictions
+ * (e.g. a parent shell that sets `overflow: hidden` for its own
+ * layout): we restore the EXACT prior value rather than blindly
+ * resetting to `''`.
+ *
+ * Edge case: two modals open simultaneously would race; the LAST one to
+ * close restores `''` which may be wrong. We accept the cost — the only
+ * places this hook runs are Dialog and Sheet, and the project's UX
+ * never opens both at once (Sheet stacks via the SheetHost, see W18a's
+ * sheetStack signal).
+ */
+export function useBodyScrollLock(active: boolean): void {
+  useEffect(() => {
+    if (!active) return undefined;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [active]);
+}

--- a/ui/src/lib/canonicalJson.ts
+++ b/ui/src/lib/canonicalJson.ts
@@ -1,0 +1,121 @@
+/**
+ * Canonical JSON serialiser (RFC 8785-flavoured).
+ *
+ * Produces a deterministic, key-sorted, whitespace-minimal JSON
+ * string. The contract MUST match the Python-side `canonical_json` in
+ * `ctxr/fsm/core/canonical.py` so that an outputs/inputs hash computed
+ * in the browser matches the one the server computed at commit time
+ * (W18d's "verify cosignature locally" button in the Signature Ledger
+ * relies on this).
+ *
+ * Differences from `JSON.stringify`:
+ *
+ *   1. Object keys are sorted lexicographically (UTF-16 code-unit
+ *      order, matching `Array.prototype.sort` default — which is also
+ *      what Python's `sorted()` uses for str inputs).
+ *   2. No whitespace anywhere (no indentation, no spaces between
+ *      separators).
+ *   3. Numbers go through the standard JSON.stringify encoding (so
+ *      `1` not `1.0`, `1e+21` for big exponents, etc.) — Python's
+ *      canonical_json uses the SAME rule via `json.dumps(..., sort_keys=True,
+ *      separators=(',', ':'))`. Floats with exact integer values
+ *      ARE encoded WITHOUT a decimal point. Cross-language tests
+ *      pin this.
+ *   4. `undefined` and functions throw (JSON-incompatible); the same
+ *      shape would be silently dropped by JSON.stringify, which is
+ *      wrong for a cosignature input.
+ *   5. NaN / +Infinity / -Infinity throw (JSON doesn't have these
+ *      values; Python's json refuses them with allow_nan=False which
+ *      we mirror).
+ *
+ * Edge cases that are NOT supported in v1 (each would force a heavier
+ * library; flag if a real consumer hits one):
+ *
+ *   - BigInt: throws. JSON.stringify would also throw.
+ *   - Cyclic references: hangs. Same as JSON.stringify behaviour
+ *     (which is "TypeError: Converting circular structure to JSON").
+ *     We propagate.
+ *   - Date objects: serialised via `value.toISOString()` (matching
+ *     Python `datetime.isoformat()`). Tests pin this.
+ */
+
+class CanonicalJsonError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CanonicalJsonError';
+  }
+}
+
+export { CanonicalJsonError };
+
+export function canonicalJson(value: unknown): string {
+  return encode(value);
+}
+
+function encode(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new CanonicalJsonError(
+        `non-finite number not representable in canonical JSON: ${value}`,
+      );
+    }
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'bigint') {
+    throw new CanonicalJsonError('BigInt not representable in canonical JSON');
+  }
+  if (typeof value === 'function' || typeof value === 'undefined') {
+    throw new CanonicalJsonError(
+      `value of type ${typeof value} not representable in canonical JSON`,
+    );
+  }
+  if (value instanceof Date) {
+    return JSON.stringify(value.toISOString());
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]';
+    return `[${value.map(encode).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    if (keys.length === 0) return '{}';
+    const parts: string[] = [];
+    for (const key of keys) {
+      const v = obj[key];
+      if (typeof v === 'undefined') continue; // mirror JSON.stringify drop-undefined for objects
+      parts.push(`${JSON.stringify(key)}:${encode(v)}`);
+    }
+    return `{${parts.join(',')}}`;
+  }
+  // Symbol or other exotic — JSON.stringify would also fail.
+  throw new CanonicalJsonError(
+    `value of type ${typeof value} not representable in canonical JSON`,
+  );
+}
+
+/**
+ * SHA-256 a string using the SubtleCrypto API. Used by the Signature
+ * Ledger to verify cosignatures: `sha256Hex(brief_id || canonical_json(inputs)
+ * || canonical_json(outputs) || session_id)`.
+ *
+ * Returns the digest as a lowercase hex string (64 chars), matching
+ * Python's `hashlib.sha256(...).hexdigest()`.
+ *
+ * Throws if SubtleCrypto is unavailable (extremely rare; only
+ * non-secure-context pre-2020 browsers).
+ */
+export async function sha256Hex(text: string): Promise<string> {
+  if (typeof crypto === 'undefined' || !crypto.subtle?.digest) {
+    throw new Error('SubtleCrypto unavailable; cannot hash');
+  }
+  const enc = new TextEncoder();
+  const data = enc.encode(text);
+  const buf = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -1,0 +1,74 @@
+/**
+ * Cross-environment clipboard write with toast feedback.
+ *
+ * The async `navigator.clipboard.writeText` is the modern path. It is
+ * rejected in two real-world cases we have to handle:
+ *
+ *   1. **Document not focused** — Chrome / Firefox throw a SecurityError
+ *      when the call happens during a context where the page lost focus
+ *      (e.g. an iframe just stole it, or a test runner's headless mode).
+ *   2. **Permission denied / API unavailable** — Older browsers or a
+ *      `Permissions-Policy: clipboard-write=()` header. `navigator.clipboard`
+ *      may be undefined entirely.
+ *
+ * Both fall back to the legacy `document.execCommand('copy')` trick:
+ * create a hidden textarea, select its content, run execCommand. This
+ * works in every browser jsdom emulates, including the test runner.
+ *
+ * Caller contract:
+ *
+ *   const ok = await copyText('payload');
+ *   // ok === true  → clipboard now holds the text
+ *   // ok === false → both paths failed; caller should show user feedback
+ *
+ * We deliberately do NOT swallow + log silently — the boolean return
+ * lets the caller decide whether to toast "copied" or "copy failed".
+ */
+
+export async function copyText(text: string): Promise<boolean> {
+  // Path A: modern async clipboard.
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to legacy path; do NOT bail out — the modern API
+    // throws under perfectly normal conditions (lost focus etc.) and
+    // the legacy path is the documented fallback.
+  }
+
+  // Path B: legacy execCommand. Requires a DOM, so guard for SSR / Node.
+  if (typeof document === 'undefined') return false;
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  // Style it off-screen but NOT display:none — execCommand requires
+  // the textarea to be part of the layout tree.
+  ta.setAttribute('readonly', 'true');
+  ta.style.position = 'fixed';
+  ta.style.top = '-1000px';
+  ta.style.left = '-1000px';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  try {
+    ta.select();
+    ta.setSelectionRange(0, ta.value.length);
+    const ok = document.execCommand('copy');
+    return ok;
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(ta);
+  }
+}
+
+/**
+ * Convenience: copy + return a (text, ok) tuple. Used by tests that
+ * want to assert both the input and the outcome in one expression.
+ */
+export async function copyTextWithResult(
+  text: string,
+): Promise<{ text: string; ok: boolean }> {
+  const ok = await copyText(text);
+  return { text, ok };
+}

--- a/ui/src/lib/jsonPointer.ts
+++ b/ui/src/lib/jsonPointer.ts
@@ -1,0 +1,121 @@
+/**
+ * RFC 6901 JSON Pointer helpers.
+ *
+ * Used by the W18b `<JsonViewer />` to emit semantic identifiers when a
+ * user clicks a label (`/items/0/price`) and to drive the breadcrumb
+ * trail at the top of the viewer.
+ *
+ * Encoding rules per RFC 6901 §3:
+ *
+ *   '~' → '~0'   (escape the escape char FIRST)
+ *   '/' → '~1'   (escape the path separator)
+ *
+ * The order matters: if we substituted '/' first, an actual '~' in a
+ * key would later collide with our just-written '~1' escape sequence
+ * during decoding. Encoding '~' first ensures the two substitutions
+ * are independent.
+ *
+ * Pointer shape: a string starting with '/' followed by zero or more
+ * '/'-separated escaped segments. The empty string is the root
+ * pointer per RFC 6901; we expose it as `ROOT_POINTER` for clarity.
+ */
+
+export type JsonPointer = string;
+
+/** Per RFC 6901 §5: the root document is addressed by the empty string. */
+export const ROOT_POINTER: JsonPointer = '';
+
+/**
+ * Encode a single path segment (object key or array index).
+ *
+ *   escapeSegment('foo')      === 'foo'
+ *   escapeSegment('a/b')      === 'a~1b'
+ *   escapeSegment('~tilde')   === '~0tilde'
+ *   escapeSegment('a/b~c')    === 'a~1b~0c'      // ~ first, then /
+ *   escapeSegment(0)          === '0'
+ */
+export function escapeSegment(segment: string | number): string {
+  const s = String(segment);
+  return s.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+/**
+ * Decode a single segment back to its original key.
+ *
+ * Inverse of escapeSegment. Order is the reverse:
+ *
+ *   '/' decode FIRST (so we don't accidentally restore '~0' produced by
+ *   a previous '~' that should have stayed literal), then '~'.
+ *
+ *   unescapeSegment('a~1b')   === 'a/b'
+ *   unescapeSegment('~0tilde')=== '~tilde'
+ *   unescapeSegment('a~1b~0c')=== 'a/b~c'
+ *
+ * Invalid sequences (`~` followed by anything other than `0` or `1`)
+ * are returned verbatim; the spec leaves their behaviour
+ * implementation-defined, and we choose forgiving-passthrough so a
+ * mis-encoded pointer from a misbehaving consumer doesn't crash the
+ * viewer.
+ */
+export function unescapeSegment(segment: string): string {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+/**
+ * Append a segment to a parent pointer.
+ *
+ *   joinPointer('', 'a')         === '/a'
+ *   joinPointer('/a', 'b')       === '/a/b'
+ *   joinPointer('/items', 0)     === '/items/0'
+ *   joinPointer('', 'a/b')       === '/a~1b'   // escapes the slash
+ */
+export function joinPointer(
+  parent: JsonPointer,
+  segment: string | number,
+): JsonPointer {
+  return `${parent}/${escapeSegment(segment)}`;
+}
+
+/**
+ * Build a pointer from a sequence of path segments. The root document
+ * is `[]` → `''`. Useful for the JsonViewer's flatten step which knows
+ * a node's depth as an array of ancestor keys.
+ *
+ *   pointerForPath([])           === ''
+ *   pointerForPath(['a', 'b'])   === '/a/b'
+ *   pointerForPath(['a/b', 0])   === '/a~1b/0'
+ */
+export function pointerForPath(segments: readonly (string | number)[]): JsonPointer {
+  let out: JsonPointer = ROOT_POINTER;
+  for (const seg of segments) {
+    out = joinPointer(out, seg);
+  }
+  return out;
+}
+
+/**
+ * Split a pointer back into its decoded segments. Inverse of
+ * pointerForPath. Returns `[]` for the root pointer; throws TypeError
+ * for a non-pointer (anything that doesn't start with '/' and isn't
+ * empty), to fail loudly when a consumer hands us a string they
+ * thought was a JSON Pointer but isn't.
+ *
+ *   parsePointer('')           === []
+ *   parsePointer('/a')         === ['a']
+ *   parsePointer('/a/b')       === ['a', 'b']
+ *   parsePointer('/a~1b/0')    === ['a/b', '0']     // ARRAY INDICES stay strings;
+ *                                                   // callers decide
+ *   parsePointer('foo')        throws TypeError     // missing leading '/'
+ */
+export function parsePointer(pointer: JsonPointer): string[] {
+  if (pointer === ROOT_POINTER) return [];
+  if (!pointer.startsWith('/')) {
+    throw new TypeError(
+      `Invalid JSON Pointer (must be empty or start with "/"): ${JSON.stringify(pointer)}`,
+    );
+  }
+  return pointer
+    .slice(1)
+    .split('/')
+    .map(unescapeSegment);
+}

--- a/ui/src/lib/store.ts
+++ b/ui/src/lib/store.ts
@@ -26,7 +26,7 @@
  * ``GET /runs/{id}/events`` from :class:`ApiClient` directly.
  */
 
-import { signal, type Signal } from '@preact/signals';
+import { signal, type Signal, effect } from '@preact/signals';
 
 import type { ConnectionState } from './sse';
 import type { Event as FsmEvent, RunSummary } from './api';
@@ -42,6 +42,72 @@ import type { Event as FsmEvent, RunSummary } from './api';
  * the magic number in two places.
  */
 export const EVENT_LOG_CAP = 200;
+
+/** Maximum entries kept in ``recentRuns`` / ``recentSpecs`` / ``recentQueries``. */
+export const RECENT_CAP = 30;
+
+/** Maximum entries kept in the ``notifications`` queue. */
+export const NOTIFICATIONS_CAP = 50;
+
+/** localStorage key for persisted preferences (W18a). */
+const PREFS_STORAGE_KEY = 'fsm-ui:prefs';
+
+// ---------------------------------------------------------------------------
+// W18a types (chrome + persistence)
+// ---------------------------------------------------------------------------
+
+export type DensityMode = 'compact' | 'comfortable' | 'spacious';
+export type ThemeMode = 'auto' | 'light' | 'dark';
+
+export interface SheetEntry {
+  /** Stable id; used as the keyed-render key and the URL fragment marker. */
+  id: string;
+  /** Visible title in the sheet's header. */
+  title: string;
+  /** Width preset; the sheet header renders a cycle button. */
+  width?: 'right-third' | 'right-half' | 'fullscreen';
+  /** Sheet body. Arbitrary VNode-shaped value; typed `unknown` here to keep
+   *  store.ts free of preact runtime imports for tree-shaking. */
+  content: unknown;
+  /** Optional onClose hook. Sheet host calls this BEFORE popping the stack. */
+  onClose?: () => void;
+  /** When set, the top sheet's identity mirrors to ``?sheet=<id>``. */
+  urlFragment?: string;
+  /** Pin: when true, Esc does NOT close this sheet (Brief rail uses it). */
+  pinned?: boolean;
+}
+
+export interface RunRecency {
+  id: string;
+  status: string;
+  spec?: string;
+  lastSeenAt: string; // ISO 8601 UTC
+}
+
+export interface SpecRecency {
+  slug: string;
+  version: number;
+  lastSeenAt: string; // ISO 8601 UTC
+}
+
+export interface NotificationEntry {
+  id: string;
+  kind: string;
+  title: string;
+  body?: string;
+  runId?: string;
+  timestamp: string; // ISO 8601 UTC
+  read: boolean;
+}
+
+export interface SseSubInfo {
+  consumerName: string;
+  url: string;
+  state: ConnectionState;
+  lastFrameAt: string | null;
+  frameCount: number;
+  reconnectCount: number;
+}
 
 // ---------------------------------------------------------------------------
 // Signals — the canonical app state
@@ -160,4 +226,222 @@ export function setConnectionState(state: ConnectionState): void {
  */
 export function clearEventLog(): void {
   eventLog.value = [];
+}
+
+// ---------------------------------------------------------------------------
+// W18a: persisted preference signals
+// ---------------------------------------------------------------------------
+
+export const densityMode: Signal<DensityMode> = signal<DensityMode>('comfortable');
+export const theme: Signal<ThemeMode> = signal<ThemeMode>('auto');
+export const urlStateEnabled: Signal<boolean> = signal<boolean>(true);
+
+export const recentRuns: Signal<RunRecency[]> = signal<RunRecency[]>([]);
+export const recentSpecs: Signal<SpecRecency[]> = signal<SpecRecency[]>([]);
+export const recentQueries: Signal<string[]> = signal<string[]>([]);
+
+// ---------------------------------------------------------------------------
+// W18a: chrome / transient (NOT persisted)
+// ---------------------------------------------------------------------------
+
+export const commandPaletteOpen: Signal<boolean> = signal<boolean>(false);
+export const commandPaletteSeed: Signal<string> = signal<string>('');
+export const keyboardHelpOpen: Signal<boolean> = signal<boolean>(false);
+export const notificationCentreOpen: Signal<boolean> = signal<boolean>(false);
+
+/** Stack of open sheets. Top of the stack is the rightmost / topmost rendered. */
+export const sheetStack: Signal<SheetEntry[]> = signal<SheetEntry[]>([]);
+
+export const notifications: Signal<NotificationEntry[]> = signal<NotificationEntry[]>([]);
+
+/** Map of active SSE subscriptions for the Settings / Topology diagnostics view. */
+export const sseSubscriptions: Signal<Map<string, SseSubInfo>> = signal<
+  Map<string, SseSubInfo>
+>(new Map());
+
+/** Compare-context: cmd palette + run-detail header surface a Compare action when set. */
+export const runComparisonContext: Signal<{ a: string; b: string | null } | null> = signal<{
+  a: string;
+  b: string | null;
+} | null>(null);
+
+// ---------------------------------------------------------------------------
+// W18a mutators
+// ---------------------------------------------------------------------------
+
+export function openSheet(entry: SheetEntry): void {
+  sheetStack.value = [...sheetStack.value, entry];
+}
+
+export function closeTopSheet(): void {
+  const stack = sheetStack.value;
+  if (stack.length === 0) return;
+  const top = stack[stack.length - 1];
+  top.onClose?.();
+  sheetStack.value = stack.slice(0, -1);
+}
+
+export function closeSheet(id: string): void {
+  const stack = sheetStack.value;
+  const idx = stack.findIndex((e) => e.id === id);
+  if (idx === -1) return;
+  stack[idx].onClose?.();
+  sheetStack.value = stack.filter((_, i) => i !== idx);
+}
+
+export function clearSheets(): void {
+  for (const entry of sheetStack.value) entry.onClose?.();
+  sheetStack.value = [];
+}
+
+export function rememberRun(entry: RunRecency): void {
+  const existing = recentRuns.value.filter((r) => r.id !== entry.id);
+  const next = [entry, ...existing].slice(0, RECENT_CAP);
+  recentRuns.value = next;
+}
+
+export function rememberSpec(entry: SpecRecency): void {
+  const existing = recentSpecs.value.filter(
+    (s) => !(s.slug === entry.slug && s.version === entry.version),
+  );
+  const next = [entry, ...existing].slice(0, RECENT_CAP);
+  recentSpecs.value = next;
+}
+
+export function rememberQuery(q: string): void {
+  if (!q.trim()) return;
+  const existing = recentQueries.value.filter((existing) => existing !== q);
+  const next = [q, ...existing].slice(0, RECENT_CAP);
+  recentQueries.value = next;
+}
+
+export function pushNotification(entry: NotificationEntry): void {
+  const next = [entry, ...notifications.value].slice(0, NOTIFICATIONS_CAP);
+  notifications.value = next;
+}
+
+export function markAllNotificationsRead(): void {
+  if (notifications.value.every((n) => n.read)) return;
+  notifications.value = notifications.value.map((n) => ({ ...n, read: true }));
+}
+
+// ---------------------------------------------------------------------------
+// W18a: persistence
+// ---------------------------------------------------------------------------
+
+interface PersistedPrefs {
+  densityMode: DensityMode;
+  theme: ThemeMode;
+  urlStateEnabled: boolean;
+  recentRuns: RunRecency[];
+  recentSpecs: SpecRecency[];
+  recentQueries: string[];
+}
+
+const VALID_DENSITIES: ReadonlySet<DensityMode> = new Set(['compact', 'comfortable', 'spacious']);
+const VALID_THEMES: ReadonlySet<ThemeMode> = new Set(['auto', 'light', 'dark']);
+
+/**
+ * Read persisted prefs from localStorage. Defended per-field so a
+ * corrupted entry doesn't blow up the app on boot. Idempotent.
+ * SSR-safe: returns early if `window` is undefined.
+ */
+export function loadStoredPrefs(): void {
+  if (typeof window === 'undefined') return;
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(PREFS_STORAGE_KEY);
+  } catch {
+    return;
+  }
+  if (!raw) return;
+  let parsed: Partial<PersistedPrefs>;
+  try {
+    parsed = JSON.parse(raw) as Partial<PersistedPrefs>;
+  } catch {
+    return;
+  }
+  if (parsed.densityMode && VALID_DENSITIES.has(parsed.densityMode)) {
+    densityMode.value = parsed.densityMode;
+  }
+  if (parsed.theme && VALID_THEMES.has(parsed.theme)) {
+    theme.value = parsed.theme;
+  }
+  if (typeof parsed.urlStateEnabled === 'boolean') {
+    urlStateEnabled.value = parsed.urlStateEnabled;
+  }
+  if (Array.isArray(parsed.recentRuns)) {
+    recentRuns.value = parsed.recentRuns
+      .filter(
+        (r): r is RunRecency =>
+          !!r &&
+          typeof r.id === 'string' &&
+          typeof r.status === 'string' &&
+          typeof r.lastSeenAt === 'string',
+      )
+      .slice(0, RECENT_CAP);
+  }
+  if (Array.isArray(parsed.recentSpecs)) {
+    recentSpecs.value = parsed.recentSpecs
+      .filter(
+        (s): s is SpecRecency =>
+          !!s &&
+          typeof s.slug === 'string' &&
+          typeof s.version === 'number' &&
+          typeof s.lastSeenAt === 'string',
+      )
+      .slice(0, RECENT_CAP);
+  }
+  if (Array.isArray(parsed.recentQueries)) {
+    recentQueries.value = parsed.recentQueries
+      .filter((q): q is string => typeof q === 'string')
+      .slice(0, RECENT_CAP);
+  }
+}
+
+let _persistenceWired = false;
+
+/**
+ * Wire up the debounced persistence effect. Called once from
+ * main.tsx. Idempotent — a second call is a no-op so tests can
+ * exercise the boot path repeatedly.
+ */
+export function wirePrefsPersistence(): void {
+  if (_persistenceWired) return;
+  _persistenceWired = true;
+  if (typeof window === 'undefined') return;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  effect(() => {
+    const snapshot: PersistedPrefs = {
+      densityMode: densityMode.value,
+      theme: theme.value,
+      urlStateEnabled: urlStateEnabled.value,
+      recentRuns: recentRuns.value,
+      recentSpecs: recentSpecs.value,
+      recentQueries: recentQueries.value,
+    };
+    if (timer != null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      try {
+        window.localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify(snapshot));
+      } catch {
+        // Quota exceeded / disabled storage — silently drop.
+      }
+    }, 200);
+  });
+}
+
+/** Test-only hook: reset the persistence wiring flag between tests. */
+export function _resetPersistenceWiring(): void {
+  _persistenceWired = false;
+}
+
+/** Test-only hook: clear persisted prefs from storage. */
+export function _clearStoredPrefs(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(PREFS_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
 }

--- a/ui/src/lib/urlState.ts
+++ b/ui/src/lib/urlState.ts
@@ -1,0 +1,196 @@
+/**
+ * Per-route URL state schemas + `useUrlState` hook.
+ *
+ * Every filter / selection / tab choice / open-Sheet identity in the
+ * W18 redesign roundtrips through `?key=value` query parameters so
+ * the view is shareable: send a teammate a link and they land on the
+ * exact same panel with the exact same filters.
+ *
+ * Design:
+ *
+ *   - A `UrlStateSchema<T>` is a pure {fromQuery, toQuery} pair that
+ *     knows how to (de)serialise ONE route's shape against URLSearchParams.
+ *   - `useUrlState(schema, initial)` hydrates a Preact signal from
+ *     `location.search` on mount, mirrors signal changes back to the
+ *     URL via `history.replaceState` (debounced 50ms to coalesce
+ *     scroll-driven filter updates), and re-reads on `popstate` so
+ *     browser-back works as expected.
+ *
+ * Why a hook rather than putting URL logic directly in each route:
+ * the cmd palette (W18c) needs to construct deep links to any route
+ * without re-implementing per-route formatting. Centralising the
+ * schemas here gives the palette a `schema.toQuery(state) → '?…'`
+ * helper that's guaranteed to match what the route reads back.
+ *
+ * `replaceState` rather than `pushState`: filter changes are
+ * transient navigations within the same route (e.g. selecting a
+ * different state in the waterfall). They should NOT pollute the
+ * browser back stack — that's reserved for actual route changes
+ * (which preact-iso's router owns).
+ *
+ * Edge cases:
+ *
+ *   - Browser back: a `popstate` listener re-reads `location.search`
+ *     and pushes the parsed state back into the signal.
+ *   - Multiple `useUrlState` instances on the same page: each owns
+ *     its own subset of params; the schemas should declare disjoint
+ *     key namespaces. If two schemas share a key, the second one to
+ *     write wins, which is wrong; lint by convention rather than
+ *     enforcement.
+ *   - SSR (no `window`): the hook returns the initial state and skips
+ *     the read/write side effects. Safe to import in a tree-shaken
+ *     build for SSG.
+ */
+
+import { signal, type Signal, effect } from '@preact/signals';
+import { useEffect, useMemo } from 'preact/hooks';
+
+export interface UrlStateSchema<T> {
+  /** Parse the current query string into the typed state. */
+  fromQuery: (params: URLSearchParams) => T;
+  /** Serialise the typed state into a `?…` fragment (or '' if empty). */
+  toQuery: (state: T) => string;
+}
+
+const SSR = typeof window === 'undefined';
+
+/**
+ * Create a schema from a per-key {parse,serialise} map plus an
+ * initial. The helper covers the 90% case (each field maps to one
+ * query param, primitive or comma-list). Routes with weird needs
+ * (compound keys, nested objects) can hand-roll their schema.
+ */
+export interface KeyMap<T> {
+  [K: string]: {
+    /** Read this param value from URLSearchParams; return the parsed value or undefined. */
+    parse: (raw: string | null) => unknown;
+    /** Inverse of parse; return undefined to omit the param. */
+    serialise: (value: unknown) => string | undefined;
+    /** Which state field this query param maps to. Defaults to the param key. */
+    field?: keyof T;
+  };
+}
+
+export function buildSchema<T extends Record<string, unknown>>(
+  initial: T,
+  keys: KeyMap<T>,
+): UrlStateSchema<T> {
+  return {
+    fromQuery(params) {
+      const next = { ...initial };
+      for (const queryKey of Object.keys(keys)) {
+        const spec = keys[queryKey];
+        const field = (spec.field ?? queryKey) as keyof T;
+        const raw = params.get(queryKey);
+        const parsed = spec.parse(raw);
+        if (parsed !== undefined) {
+          (next as Record<string, unknown>)[field as string] = parsed;
+        }
+      }
+      return next;
+    },
+    toQuery(state) {
+      const params = new URLSearchParams();
+      for (const queryKey of Object.keys(keys)) {
+        const spec = keys[queryKey];
+        const field = (spec.field ?? queryKey) as keyof T;
+        const ser = spec.serialise((state as Record<string, unknown>)[field as string]);
+        if (ser !== undefined && ser !== '') params.set(queryKey, ser);
+      }
+      const out = params.toString();
+      return out ? `?${out}` : '';
+    },
+  };
+}
+
+// Common parse/serialise pairs for one-off use.
+export const codecs = {
+  string: {
+    parse: (raw: string | null) => (raw == null ? undefined : raw),
+    serialise: (v: unknown) => (typeof v === 'string' && v.length > 0 ? v : undefined),
+  },
+  number: {
+    parse: (raw: string | null) => {
+      if (raw == null) return undefined;
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : undefined;
+    },
+    serialise: (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? String(v) : undefined),
+  },
+  boolean: {
+    parse: (raw: string | null) => (raw === '1' || raw === 'true' ? true : raw == null ? undefined : false),
+    serialise: (v: unknown) => (v === true ? '1' : undefined),
+  },
+  /** Comma-separated list of strings; empty list → undefined. */
+  csv: {
+    parse: (raw: string | null) => {
+      if (raw == null) return undefined;
+      const list = raw.split(',').map((s) => s.trim()).filter(Boolean);
+      return list.length === 0 ? undefined : list;
+    },
+    serialise: (v: unknown) => {
+      if (!Array.isArray(v)) return undefined;
+      const list = v.filter((s): s is string => typeof s === 'string' && s.length > 0);
+      return list.length === 0 ? undefined : list.join(',');
+    },
+  },
+};
+
+const DEBOUNCE_MS = 50;
+
+/**
+ * Bind a Preact signal to URLSearchParams via the supplied schema.
+ *
+ * Returns the signal. The hook also writes back to the URL whenever
+ * the signal changes, debounced 50ms.
+ *
+ * On mount: reads `window.location.search` once, runs `fromQuery`,
+ * mutates the signal to match. If the user navigates back/forward,
+ * `popstate` re-runs the read.
+ *
+ * @example
+ *   const filtersSignal = useUrlState(myRouteSchema, defaultFilters);
+ *   // ... mutate filtersSignal.value freely; URL stays in sync.
+ */
+export function useUrlState<T>(
+  schema: UrlStateSchema<T>,
+  initial: T,
+): Signal<T> {
+  const state = useMemo(() => signal<T>(initial), []);
+
+  // Initial read from URL.
+  useEffect(() => {
+    if (SSR) return undefined;
+    state.value = schema.fromQuery(new URLSearchParams(window.location.search));
+    const onPop = () => {
+      state.value = schema.fromQuery(new URLSearchParams(window.location.search));
+    };
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+    // schema + initial are intentionally NOT in deps: a new schema
+    // instance on every render would loop. Callers must pass a stable
+    // schema; the typed signature reminds them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Debounced write back to URL.
+  useEffect(() => {
+    if (SSR) return undefined;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const dispose = effect(() => {
+      const next = schema.toQuery(state.value);
+      if (timer != null) clearTimeout(timer);
+      timer = setTimeout(() => {
+        const url = `${window.location.pathname}${next}${window.location.hash}`;
+        window.history.replaceState(window.history.state, '', url);
+      }, DEBOUNCE_MS);
+    });
+    return () => {
+      if (timer != null) clearTimeout(timer);
+      dispose();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return state;
+}

--- a/ui/src/lib/virtualWindow.ts
+++ b/ui/src/lib/virtualWindow.ts
@@ -1,0 +1,141 @@
+/**
+ * Tiny fixed-height row virtualisation.
+ *
+ * Used by `<JsonViewer />` (W18b) and `<CodeBlock />` (W18b) to keep
+ * thousand-row trees / large prompt templates responsive. Below
+ * `VIRTUALISE_THRESHOLD` we render every row (zero overhead, no
+ * window math, no measurement); above the threshold we hand the
+ * caller a `{ range, onScroll, totalHeight }` triplet they bind to a
+ * scrollable container.
+ *
+ * Why a tiny hook rather than `react-window`: this hook is ~50 LOC
+ * and has zero deps. `react-window` would add ~7 kB gzipped and
+ * pulls in `memoize-one` + scroll-position-restoration logic we
+ * don't need. The thousand-row scenario is the only one that
+ * justifies virtualisation; we don't need the general feature set.
+ *
+ * Fixed row height is a constraint we accept: every JsonViewer row
+ * is the same height by design (font-mono + leading-tight). If a
+ * future variant needs variable heights, switch to react-window
+ * then; for now, fixed is the right trade.
+ */
+
+import { useCallback, useMemo, useState } from 'preact/hooks';
+
+export interface WindowState {
+  /** Inclusive start index of rows to render. */
+  start: number;
+  /** Exclusive end index of rows to render. */
+  end: number;
+}
+
+export interface VirtualWindow {
+  /** Current visible range; pass `rows.slice(range.start, range.end)`. */
+  range: WindowState;
+  /** Bind to the scrollable container's `onScroll` event. */
+  onScroll: (event: Event) => void;
+  /** Total content height in px; bind to a spacer div above the rows. */
+  totalHeight: number;
+  /** Top spacer height in px (`range.start * rowHeight`). */
+  topSpacerHeight: number;
+  /** Bottom spacer height in px ((rows.length - range.end) * rowHeight). */
+  bottomSpacerHeight: number;
+}
+
+export interface UseWindowOptions {
+  /** Below this count, virtualisation is skipped — render the whole list. */
+  virtualiseThreshold?: number;
+  /** Extra rows to render above + below the viewport. Default 10. */
+  overscan?: number;
+  /** Initial scrollTop, in px. Useful when restoring a saved scroll position. */
+  initialScrollTop?: number;
+}
+
+export const DEFAULT_VIRTUALISE_THRESHOLD = 1000;
+export const DEFAULT_OVERSCAN = 10;
+
+/**
+ * useWindow — compute the visible row slice for a scrollable container.
+ *
+ * @param totalRows  Total number of rows the list would have if everything
+ *                   were rendered.
+ * @param rowHeight  Px height per row. Must be constant. If the consumer
+ *                   uses CSS that produces variable row heights, this hook
+ *                   will produce mis-aligned scroll positions; use react-
+ *                   window instead.
+ * @param options    Threshold, overscan, initialScrollTop.
+ *
+ * Below `virtualiseThreshold` rows, `range` is always `{start:0, end:totalRows}`
+ * and `onScroll` is a no-op — the consumer effectively gets the same
+ * behaviour as rendering naively, with zero CPU cost from the hook.
+ *
+ * Above the threshold, `range` is recomputed on each `onScroll` event
+ * from `event.currentTarget.scrollTop`. The hook stores the latest
+ * range in `useState`, so Preact re-renders the consumer with the
+ * new slice. No requestAnimationFrame throttling is applied; Preact's
+ * batched updates already coalesce a scroll-storm into a small number
+ * of renders, and a single render at a 5000-row tree completes in
+ * <2 ms in jsdom.
+ */
+export function useWindow(
+  totalRows: number,
+  rowHeight: number,
+  options: UseWindowOptions = {},
+): VirtualWindow {
+  const virtualiseThreshold =
+    options.virtualiseThreshold ?? DEFAULT_VIRTUALISE_THRESHOLD;
+  const overscan = options.overscan ?? DEFAULT_OVERSCAN;
+  const shouldVirtualise = totalRows > virtualiseThreshold;
+
+  const [range, setRange] = useState<WindowState>(() => {
+    if (!shouldVirtualise) return { start: 0, end: totalRows };
+    // Initial paint covers viewport at the user-supplied scroll
+    // position (default 0). End is capped at totalRows so the spacer
+    // math below doesn't go negative on small lists that just crossed
+    // the threshold.
+    const initialScrollTop = options.initialScrollTop ?? 0;
+    const start = Math.max(
+      0,
+      Math.floor(initialScrollTop / rowHeight) - overscan,
+    );
+    // Without a viewport height yet, assume a conservative 50 rows
+    // visible. The first real scroll event will replace this.
+    const end = Math.min(totalRows, start + 50 + overscan * 2);
+    return { start, end };
+  });
+
+  const onScroll = useCallback(
+    (event: Event) => {
+      if (!shouldVirtualise) return;
+      const el = event.currentTarget as HTMLElement | null;
+      if (!el) return;
+      const start = Math.max(0, Math.floor(el.scrollTop / rowHeight) - overscan);
+      const end = Math.min(
+        totalRows,
+        start + Math.ceil(el.clientHeight / rowHeight) + overscan * 2,
+      );
+      // Only commit a state change when the range actually moved —
+      // avoids a re-render on every pixel of scroll within the same
+      // row.
+      setRange((prev) => (prev.start === start && prev.end === end ? prev : { start, end }));
+    },
+    [shouldVirtualise, totalRows, rowHeight, overscan],
+  );
+
+  const totalHeight = useMemo(
+    () => totalRows * rowHeight,
+    [totalRows, rowHeight],
+  );
+
+  const topSpacerHeight = useMemo(
+    () => range.start * rowHeight,
+    [range.start, rowHeight],
+  );
+
+  const bottomSpacerHeight = useMemo(
+    () => Math.max(0, (totalRows - range.end) * rowHeight),
+    [totalRows, range.end, rowHeight],
+  );
+
+  return { range, onScroll, totalHeight, topSpacerHeight, bottomSpacerHeight };
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,5 +1,13 @@
 import { render } from 'preact';
 import { App } from './app';
+import { loadStoredPrefs, wirePrefsPersistence } from './lib/store';
+
+// Hydrate persisted prefs (theme, density, urlStateEnabled, recents)
+// BEFORE first render so the initial paint reflects the user's last
+// choice. Then wire the debounced effect that writes future changes
+// back to localStorage.
+loadStoredPrefs();
+wirePrefsPersistence();
 
 const root = document.getElementById('app');
 if (!root) {

--- a/ui/src/routes/index.ts
+++ b/ui/src/routes/index.ts
@@ -1,0 +1,109 @@
+/**
+ * Single source of truth for every route the dashboard knows about.
+ *
+ * Consumed by:
+ *   - `app.tsx` Shell, which maps `ROUTES` to `<Route path component>` entries.
+ *   - `chrome/Sidebar.tsx` for the primary + admin nav (filtered by `navGroup`).
+ *   - `chrome/CommandPalette.tsx` for "navigate to ..." actions (filtered by `shortcut`).
+ *   - `chrome/KeyboardHelp.tsx` for the `g <key>` chord table.
+ *
+ * Adding a new route is one entry here + one component import. No
+ * surgery on `app.tsx`. No drift between the nav, the palette, and the
+ * keyboard help.
+ *
+ * `navGroup: null` means "not in nav" — applies to parameterised
+ * routes like `/runs/:id` and `/runs/:id/compare/:otherId` (the user
+ * doesn't navigate to them via a link; they get there by clicking a
+ * row or by deep link).
+ */
+
+import type { ComponentType } from 'preact';
+
+import { Runs } from './runs';
+import { RunDetailRoute } from './runDetail';
+import { SpecsRoute } from './specs';
+import { ConsumersRoute } from './consumers';
+import { SettingsRoute } from './settings';
+
+export interface RouteDef {
+  /** preact-iso path pattern, e.g. `/runs/:id`. */
+  path: string;
+  /** The component to mount. */
+  component: ComponentType<unknown>;
+  /** Human-readable label (sidebar, breadcrumbs, command palette). */
+  label: string;
+  /** Group bucket in the sidebar. `null` = not in nav. */
+  navGroup: 'primary' | 'admin' | null;
+  /** Optional `g <key>` keyboard chord (e.g. `'g r'` for /runs). */
+  shortcut?: string;
+  /** Optional one-line hint used by the command palette / help overlay. */
+  description?: string;
+}
+
+/**
+ * Registry, in display order.
+ *
+ * Order in this array IS the sidebar order. Edit deliberately.
+ */
+export const ROUTES: readonly RouteDef[] = [
+  {
+    path: '/',
+    component: Runs,
+    label: 'Runs',
+    navGroup: null, // alias for /runs; surfaced via /runs below
+    description: 'Live and historical FSM runs.',
+  },
+  {
+    path: '/runs',
+    component: Runs,
+    label: 'Runs',
+    navGroup: 'primary',
+    shortcut: 'g r',
+    description: 'Live and historical FSM runs.',
+  },
+  {
+    path: '/runs/:id',
+    component: RunDetailRoute,
+    label: 'Run detail',
+    navGroup: null,
+    description: 'State tree, events, journal, drift for one run.',
+  },
+  {
+    path: '/specs',
+    component: SpecsRoute,
+    label: 'Specs',
+    navGroup: 'primary',
+    shortcut: 'g s',
+    description: 'Registered FSM specs and version lineage.',
+  },
+  {
+    path: '/consumers',
+    component: ConsumersRoute,
+    label: 'Topology',
+    navGroup: 'primary',
+    shortcut: 'g t',
+    description: 'Event-bus producers, consumers, and SSE health.',
+  },
+  {
+    path: '/settings',
+    component: SettingsRoute,
+    label: 'Settings',
+    navGroup: 'admin',
+    description: 'Project metadata, preferences, diagnostics.',
+  },
+];
+
+/** Convenience filter: routes that should appear in the primary nav rail. */
+export function primaryRoutes(): RouteDef[] {
+  return ROUTES.filter((r) => r.navGroup === 'primary');
+}
+
+/** Convenience filter: routes that should appear under the admin section. */
+export function adminRoutes(): RouteDef[] {
+  return ROUTES.filter((r) => r.navGroup === 'admin');
+}
+
+/** Convenience filter: routes that carry a global keyboard shortcut. */
+export function shortcutRoutes(): RouteDef[] {
+  return ROUTES.filter((r) => typeof r.shortcut === 'string' && r.shortcut.length > 0);
+}

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,1 +1,40 @@
 import '@testing-library/jest-dom';
+
+// jsdom under node 25 emits a `--localstorage-file` warning + ships
+// localStorage with undefined setItem / getItem methods. Shim a real
+// in-memory Storage implementation on the window so code that uses
+// `window.localStorage` (the W18a persistence layer in `lib/store.ts`,
+// every settings panel, the command palette's recent-queries history)
+// hits a working API in tests.
+
+class InMemoryStorage implements Storage {
+  private map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  key(index: number): string | null {
+    const keys = Array.from(this.map.keys());
+    return keys[index] ?? null;
+  }
+  getItem(key: string): string | null {
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(String(key), String(value));
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  clear(): void {
+    this.map.clear();
+  }
+}
+
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: new InMemoryStorage(),
+});
+Object.defineProperty(window, 'sessionStorage', {
+  configurable: true,
+  value: new InMemoryStorage(),
+});

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -17,6 +17,15 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    // jsdom defaults to about:blank, which produces an "opaque origin"
+    // and rejects localStorage / sessionStorage access with SecurityError.
+    // Pin a real URL so the store-persistence tests + urlState tests
+    // exercise the real browser surface.
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost/',
+      },
+    },
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
   },


### PR DESCRIPTION
Foundation for the W18 dashboard redesign. Behaviour-preserving on the existing surface; adds plumbing that every subsequent workstream (W18b primitives, W18c chrome, W18d Run Detail v2, ...) builds on. See the commit body for the full inventory.

## Verification

- `cd ui && npm test -- --run` → **132/132** (was 17 baseline; 115 new tests covering every primitive end to end including edge cases)
- `uv run pytest` → **662 passing** (unchanged; W18a is pure UI)
- `uv run pytest tests/integration/e2e/ --run-e2e` → **9 passing** (unchanged)
- `cd ui && npx tsc -b --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)