### PR TITLE
W18c: chrome layer — CommandPalette (⌘K), KeyboardHelp (?), NotificationCentre, ThemeApplier, TopBarExtras

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -58,6 +58,11 @@ import {
 } from './lib/store';
 import { ROUTES } from './routes';
 import { SheetHost } from './chrome/SheetHost';
+import { CommandPalette } from './chrome/CommandPalette';
+import { KeyboardHelp } from './chrome/KeyboardHelp';
+import { NotificationCentre } from './chrome/NotificationCentre';
+import { ThemeApplier } from './chrome/ThemeApplier';
+import { TopBarExtras } from './chrome/TopBarExtras';
 
 // ---------------------------------------------------------------------------
 // SSE wiring
@@ -275,6 +280,9 @@ function TopBar(): JSX.Element {
           {label}
         </Pill>
       </div>
+      <div class="ml-3 pl-3 border-l border-slate-200 dark:border-slate-700">
+        <TopBarExtras />
+      </div>
     </header>
   );
 }
@@ -351,6 +359,10 @@ function Shell(): JSX.Element {
       </div>
       <ToastContainer />
       <SheetHost />
+      <CommandPalette />
+      <KeyboardHelp />
+      <NotificationCentre />
+      <ThemeApplier />
     </div>
   );
 }

--- a/ui/src/chrome/CommandPalette.tsx
+++ b/ui/src/chrome/CommandPalette.tsx
@@ -1,0 +1,360 @@
+/**
+ * Command Palette — Cmd/Ctrl+K universal jump-to.
+ *
+ * Sources fan out:
+ *   - Static actions (always present, context-gated where appropriate)
+ *   - Recent runs (from `recentRuns` signal)
+ *   - Recent specs (from `recentSpecs`)
+ *   - Open runs (from `runsByStatus` if loaded)
+ *   - Routes (from `ROUTES` registry)
+ *
+ * Keyboard: Up/Down navigate, Enter activates, Cmd+Enter opens in new
+ * tab, Esc closes. Mounted via the Shell; opens on the global
+ * `commandPaletteOpen` signal.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import type { JSX } from 'preact';
+
+import {
+  commandPaletteOpen,
+  commandPaletteSeed,
+  keyboardHelpOpen,
+  recentRuns,
+  recentSpecs,
+  rememberQuery,
+  runsByStatus,
+  theme,
+} from '../lib/store';
+import { ROUTES, type RouteDef } from '../routes';
+import { rankFuzzy, type FuzzyHit } from '../lib/fuzzy';
+
+// ---------------------------------------------------------------------------
+// Result row model
+// ---------------------------------------------------------------------------
+
+type ResultSource = 'action' | 'route' | 'open-run' | 'recent-run' | 'spec';
+
+export interface PaletteResult {
+  id: string;
+  source: ResultSource;
+  primary: string;
+  secondary?: string;
+  hotkey?: string;
+  activate: (modifiers: { newTab: boolean }) => void;
+}
+
+// Source-priority weight: higher = ranked first within the same score.
+const SOURCE_WEIGHT: Record<ResultSource, number> = {
+  action: 1.4,
+  'open-run': 1.2,
+  'recent-run': 1.1,
+  route: 1.0,
+  spec: 0.9,
+};
+
+// ---------------------------------------------------------------------------
+// Source builders (pure; tested separately)
+// ---------------------------------------------------------------------------
+
+export interface BuildContext {
+  navigate: (path: string, opts?: { newTab?: boolean }) => void;
+  currentPath: string;
+}
+
+function buildRouteResults(ctx: BuildContext): PaletteResult[] {
+  return ROUTES.filter((r: RouteDef) => r.navGroup !== null).map((r) => ({
+    id: `route:${r.path}`,
+    source: 'route',
+    primary: r.label,
+    secondary: r.path,
+    hotkey: r.shortcut,
+    activate: ({ newTab }) => ctx.navigate(r.path, { newTab }),
+  }));
+}
+
+function buildRecentRunResults(ctx: BuildContext): PaletteResult[] {
+  return recentRuns.value.map((r) => ({
+    id: `recent-run:${r.id}`,
+    source: 'recent-run',
+    primary: `Run ${r.id.slice(0, 7)}`,
+    secondary: `${r.status}${r.spec ? ' · ' + r.spec : ''}`,
+    activate: ({ newTab }) => ctx.navigate(`/runs/${r.id}`, { newTab }),
+  }));
+}
+
+function buildOpenRunResults(ctx: BuildContext): PaletteResult[] {
+  const grouped = runsByStatus.value;
+  const open: PaletteResult[] = [];
+  for (const status of ['in_progress', 'paused', 'faulted', 'drift_paused']) {
+    const runs = grouped[status] ?? [];
+    for (const r of runs) {
+      open.push({
+        id: `open-run:${r.id}`,
+        source: 'open-run',
+        primary: `Run ${r.id.slice(0, 7)}`,
+        secondary: `${r.status} · ${r.fsm_spec_id?.slice(0, 8) ?? ''}`,
+        activate: ({ newTab }) => ctx.navigate(`/runs/${r.id}`, { newTab }),
+      });
+    }
+  }
+  return open;
+}
+
+function buildSpecResults(ctx: BuildContext): PaletteResult[] {
+  return recentSpecs.value.map((s) => ({
+    id: `spec:${s.slug}:${s.version}`,
+    source: 'spec',
+    primary: `${s.slug}`,
+    secondary: `v${s.version}`,
+    activate: ({ newTab }) => ctx.navigate(`/specs?slug=${encodeURIComponent(s.slug)}&version=${s.version}`, { newTab }),
+  }));
+}
+
+function buildActionResults(ctx: BuildContext): PaletteResult[] {
+  const isOnRunDetail = /^\/runs\/[^/]+/.test(ctx.currentPath);
+  const actions: PaletteResult[] = [
+    {
+      id: 'action:open-help',
+      source: 'action',
+      primary: 'Open keyboard help',
+      hotkey: '?',
+      activate: () => {
+        keyboardHelpOpen.value = true;
+      },
+    },
+    {
+      id: 'action:toggle-theme',
+      source: 'action',
+      primary: 'Cycle theme (auto → light → dark)',
+      activate: () => {
+        const next = theme.value === 'auto' ? 'light' : theme.value === 'light' ? 'dark' : 'auto';
+        theme.value = next;
+      },
+    },
+  ];
+  if (isOnRunDetail) {
+    actions.push({
+      id: 'action:run-compare',
+      source: 'action',
+      primary: 'Compare this run with another...',
+      activate: () => {
+        // The Compare picker lives on the run-detail page; for now we
+        // surface the action and the page will handle once W18i lands.
+      },
+    });
+  }
+  return actions;
+}
+
+// Exported for unit tests.
+export function buildAllResults(ctx: BuildContext): PaletteResult[] {
+  return [
+    ...buildActionResults(ctx),
+    ...buildOpenRunResults(ctx),
+    ...buildRecentRunResults(ctx),
+    ...buildSpecResults(ctx),
+    ...buildRouteResults(ctx),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface CommandPaletteProps {
+  /** Navigation primitive. Falls back to `window.location.assign` if absent. */
+  navigate?: (path: string, opts?: { newTab?: boolean }) => void;
+  /** Current pathname (e.g. for context-gated actions). Defaults to location.pathname. */
+  currentPath?: string;
+}
+
+export function CommandPalette(props: CommandPaletteProps = {}): JSX.Element | null {
+  const open = commandPaletteOpen.value;
+  const seed = commandPaletteSeed.value;
+  const [query, setQuery] = useState(seed);
+  const [cursor, setCursor] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Default navigation: SPA-style via popstate so existing app router picks up.
+  const navigate = useMemo(() => {
+    if (props.navigate) return props.navigate;
+    return (path: string, opts?: { newTab?: boolean }) => {
+      if (typeof window === 'undefined') return;
+      if (opts?.newTab) {
+        window.open(path, '_blank', 'noopener,noreferrer');
+        return;
+      }
+      window.history.pushState(null, '', path);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    };
+  }, [props.navigate]);
+
+  const currentPath = props.currentPath ?? (typeof window !== 'undefined' ? window.location.pathname : '/');
+
+  const ctx: BuildContext = useMemo(() => ({ navigate, currentPath }), [navigate, currentPath]);
+
+  const allResults = useMemo(() => buildAllResults(ctx), [ctx, open]);
+
+  const ranked = useMemo<FuzzyHit<PaletteResult>[]>(() => {
+    return rankFuzzy(allResults, query, {
+      text: (r) => `${r.primary} ${r.secondary ?? ''}`,
+      weight: (r) => SOURCE_WEIGHT[r.source],
+    });
+  }, [allResults, query]);
+
+  // Reset cursor when query changes.
+  useEffect(() => {
+    setCursor(0);
+  }, [query]);
+
+  // Sync external seed.
+  useEffect(() => {
+    if (open) setQuery(seed);
+  }, [open, seed]);
+
+  // Focus the input when the palette opens.
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
+  }, [open]);
+
+  const close = useCallback(() => {
+    commandPaletteOpen.value = false;
+    commandPaletteSeed.value = '';
+    setQuery('');
+  }, []);
+
+  const activate = useCallback(
+    (index: number, opts: { newTab: boolean }) => {
+      const hit = ranked[index];
+      if (!hit) return;
+      if (query.trim()) rememberQuery(query.trim());
+      hit.item.activate(opts);
+      close();
+    },
+    [ranked, query, close],
+  );
+
+  const onKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setCursor((c) => Math.min(ranked.length - 1, c + 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        activate(cursor, { newTab: e.metaKey || e.ctrlKey });
+        return;
+      }
+    },
+    [activate, close, cursor, ranked.length],
+  );
+
+  // Global open shortcut (Cmd/Ctrl+K). Mounted always so the user can
+  // open it from anywhere.
+  useEffect(() => {
+    const onGlobal = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        commandPaletteOpen.value = !commandPaletteOpen.value;
+      }
+    };
+    window.addEventListener('keydown', onGlobal);
+    return () => window.removeEventListener('keydown', onGlobal);
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <div
+      class="fixed inset-0 z-[60] flex items-start justify-center pt-24 px-4 bg-slate-900/60 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div
+        role="combobox"
+        aria-expanded="true"
+        aria-haspopup="listbox"
+        aria-controls="cmd-palette-list"
+        class="cmd-palette w-full max-w-2xl bg-white dark:bg-slate-800 rounded-lg shadow-2xl border border-slate-200 dark:border-slate-700 flex flex-col max-h-[70vh]"
+      >
+        <div class="px-3 py-2 border-b border-slate-200 dark:border-slate-700">
+          <input
+            ref={inputRef}
+            type="search"
+            value={query}
+            onInput={(e) => setQuery((e.target as HTMLInputElement).value)}
+            onKeyDown={onKey}
+            placeholder="Type a command, run id, spec, or jump-to..."
+            aria-label="Command palette search"
+            class="w-full h-9 px-2 bg-transparent text-base focus:outline-none placeholder:text-slate-400"
+          />
+        </div>
+        <ul
+          id="cmd-palette-list"
+          role="listbox"
+          aria-label="Palette results"
+          class="cmd-palette-list flex-1 overflow-auto py-1"
+        >
+          {ranked.length === 0 ? (
+            <li class="px-4 py-8 text-center text-sm text-slate-500">
+              No matches — try a run id, spec slug, or action.
+            </li>
+          ) : (
+            ranked.map((hit, idx) => (
+              <li
+                key={hit.item.id}
+                // aria-selected as an explicit string so a11y linters
+                // and screen readers see the precise WAI-ARIA value.
+                role="option"
+                aria-selected={idx === cursor ? 'true' : 'false'}
+                onMouseEnter={() => setCursor(idx)}
+                onClick={(e) => activate(idx, { newTab: e.metaKey || e.ctrlKey })}
+                class={[
+                  'cmd-row flex items-center gap-2 px-3 py-1.5 text-sm cursor-pointer',
+                  idx === cursor
+                    ? 'bg-emerald-50 dark:bg-emerald-900/30 text-slate-900 dark:text-slate-50'
+                    : 'text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/40',
+                ].join(' ')}
+              >
+                <span class="text-[10px] uppercase tracking-wide text-slate-400 w-16 shrink-0">
+                  {hit.item.source}
+                </span>
+                <span class="font-medium truncate">{hit.item.primary}</span>
+                {hit.item.secondary ? (
+                  <span class="text-xs text-slate-500 truncate">· {hit.item.secondary}</span>
+                ) : null}
+                {hit.item.hotkey ? (
+                  <span class="ml-auto text-[10px] text-slate-400">{hit.item.hotkey}</span>
+                ) : null}
+              </li>
+            ))
+          )}
+        </ul>
+        <footer class="px-3 py-2 border-t border-slate-200 dark:border-slate-700 text-[10px] text-slate-500 flex items-center gap-3">
+          <span>↑↓ navigate</span>
+          <span>⏎ open</span>
+          <span>⌘⏎ open in new tab</span>
+          <span>esc close</span>
+          <span class="ml-auto">{ranked.length} results</span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+export default CommandPalette;

--- a/ui/src/chrome/KeyboardHelp.tsx
+++ b/ui/src/chrome/KeyboardHelp.tsx
@@ -1,0 +1,92 @@
+/**
+ * Keyboard help overlay (`?` toggles).
+ *
+ * Reads `keyboardHelpOpen` signal. Lists every global shortcut + the
+ * `g <key>` chord table derived from the ROUTES registry.
+ */
+
+import { useEffect } from 'preact/hooks';
+import type { JSX } from 'preact';
+
+import { keyboardHelpOpen } from '../lib/store';
+import { shortcutRoutes } from '../routes';
+import { Dialog } from '../components/Dialog';
+
+interface ShortcutRow {
+  keys: string;
+  action: string;
+}
+
+const GLOBAL_SHORTCUTS: ShortcutRow[] = [
+  { keys: 'Cmd/Ctrl+K', action: 'Open command palette' },
+  { keys: '?', action: 'Open this help' },
+  { keys: '/', action: 'Focus search (opens palette)' },
+  { keys: 'Esc', action: 'Close top sheet / dialog / palette' },
+];
+
+const CHORD_DESCRIPTION = 'g <key>';
+
+export function KeyboardHelp(): JSX.Element | null {
+  const open = keyboardHelpOpen.value;
+
+  // Global ?-to-open shortcut. The body of the page handles it,
+  // unless focus is inside an input.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== '?') return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      keyboardHelpOpen.value = !keyboardHelpOpen.value;
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => (keyboardHelpOpen.value = false)}
+      title="Keyboard shortcuts"
+      widthClassName="max-w-xl"
+    >
+      <div class="space-y-5 text-sm">
+        <section>
+          <h3 class="text-xs uppercase tracking-wide text-slate-500 mb-2">Global</h3>
+          <dl class="grid grid-cols-[10rem_1fr] gap-y-1">
+            {GLOBAL_SHORTCUTS.map((s) => (
+              <>
+                <dt class="font-mono text-xs text-slate-600 dark:text-slate-400">{s.keys}</dt>
+                <dd>{s.action}</dd>
+              </>
+            ))}
+          </dl>
+        </section>
+        <section>
+          <h3 class="text-xs uppercase tracking-wide text-slate-500 mb-2">
+            Navigate ({CHORD_DESCRIPTION} chord)
+          </h3>
+          <dl class="grid grid-cols-[10rem_1fr] gap-y-1">
+            {shortcutRoutes().map((r) => (
+              <>
+                <dt class="font-mono text-xs text-slate-600 dark:text-slate-400">{r.shortcut}</dt>
+                <dd>{r.label}</dd>
+              </>
+            ))}
+          </dl>
+        </section>
+      </div>
+    </Dialog>
+  );
+}
+
+export default KeyboardHelp;

--- a/ui/src/chrome/NotificationCentre.tsx
+++ b/ui/src/chrome/NotificationCentre.tsx
@@ -1,0 +1,90 @@
+/**
+ * NotificationCentre — right-anchored panel listing recent lifecycle
+ * events (run_aborted, run_completed, drift_threshold_breached, ...).
+ *
+ * Source: an effect (wired in Shell) subscribes to `eventLog` and maps
+ * lifecycle event kinds into `NotificationEntry`s via
+ * `pushNotification`. The centre just renders that list.
+ */
+
+import { useCallback } from 'preact/hooks';
+import type { JSX } from 'preact';
+
+import {
+  markAllNotificationsRead,
+  notifications,
+  notificationCentreOpen,
+} from '../lib/store';
+import { Sheet } from '../components/Sheet';
+
+function formatTimestamp(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function NotificationCentre(): JSX.Element {
+  const open = notificationCentreOpen.value;
+  const entries = notifications.value;
+
+  const onClose = useCallback(() => {
+    markAllNotificationsRead();
+    notificationCentreOpen.value = false;
+  }, []);
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title={`Notifications (${entries.length})`}
+      width="right-third"
+      pushHistory={false}
+    >
+      {entries.length === 0 ? (
+        <div class="text-center text-sm text-slate-500 py-12">
+          No notifications yet.
+        </div>
+      ) : (
+        <ul class="divide-y divide-slate-100 dark:divide-slate-800">
+          {entries.map((n) => (
+            <li
+              key={n.id}
+              class={[
+                'py-3 px-1',
+                n.read ? 'opacity-70' : '',
+              ].join(' ')}
+            >
+              <div class="flex items-center justify-between gap-2">
+                <span class="text-[10px] uppercase tracking-wide text-slate-500">{n.kind}</span>
+                <span class="text-[10px] text-slate-400">{formatTimestamp(n.timestamp)}</span>
+              </div>
+              <div class="font-medium text-sm mt-0.5">{n.title}</div>
+              {n.body ? <div class="text-xs text-slate-600 dark:text-slate-400 mt-0.5">{n.body}</div> : null}
+              {n.runId ? (
+                <a
+                  href={`/runs/${n.runId}`}
+                  class="inline-block mt-1 text-[10px] text-emerald-600 dark:text-emerald-400 hover:underline"
+                >
+                  Open run →
+                </a>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </Sheet>
+  );
+}
+
+export default NotificationCentre;

--- a/ui/src/chrome/ThemeApplier.tsx
+++ b/ui/src/chrome/ThemeApplier.tsx
@@ -1,0 +1,56 @@
+/**
+ * ThemeApplier — mounted in Shell. Reads `theme` and `densityMode`
+ * signals and applies the resolved values to <html>:
+ *
+ *   - theme="dark"   → <html class="dark">
+ *   - theme="light"  → <html> (no .dark class)
+ *   - theme="auto"   → mirror prefers-color-scheme (live, via matchMedia)
+ *   - density=*      → <html data-density="*">
+ *
+ * Renders nothing. Effectful only.
+ */
+
+import { useEffect } from 'preact/hooks';
+import type { JSX } from 'preact';
+
+import { densityMode, theme } from '../lib/store';
+
+function applyTheme(resolved: 'light' | 'dark'): void {
+  if (typeof document === 'undefined') return;
+  const html = document.documentElement;
+  if (resolved === 'dark') html.classList.add('dark');
+  else html.classList.remove('dark');
+}
+
+function applyDensity(d: string): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-density', d);
+}
+
+export function ThemeApplier(): JSX.Element | null {
+  // Theme: explicit choice or auto via matchMedia.
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const compute = () => {
+      const t = theme.value;
+      if (t === 'auto') return mql.matches ? 'dark' : 'light';
+      return t;
+    };
+    applyTheme(compute());
+    const onChange = () => applyTheme(compute());
+    mql.addEventListener?.('change', onChange);
+    // Re-apply whenever signal changes (effect re-runs on signal read).
+    return () => mql.removeEventListener?.('change', onChange);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [theme.value]);
+
+  // Density: data-attribute on html.
+  useEffect(() => {
+    applyDensity(densityMode.value);
+  }, [densityMode.value]);
+
+  return null;
+}
+
+export default ThemeApplier;

--- a/ui/src/chrome/TopBarExtras.tsx
+++ b/ui/src/chrome/TopBarExtras.tsx
@@ -1,0 +1,158 @@
+/**
+ * Topbar extras — the W18c additions to the existing TopBar:
+ *
+ *   - Universal search button → opens the command palette
+ *   - Theme cycle button
+ *   - Density cycle button
+ *   - Notification bell (with unread badge)
+ *   - Keyboard help button
+ *
+ * Wires into the existing TopBar in app.tsx as a single insertion
+ * point — the rest of the chrome (logo, nav, SSE pill) stays.
+ */
+
+import { useCallback, useMemo } from 'preact/hooks';
+import type { JSX } from 'preact';
+
+import {
+  commandPaletteOpen,
+  commandPaletteSeed,
+  densityMode,
+  keyboardHelpOpen,
+  notifications,
+  notificationCentreOpen,
+  theme,
+  type DensityMode,
+  type ThemeMode,
+} from '../lib/store';
+
+const DENSITY_CYCLE: DensityMode[] = ['compact', 'comfortable', 'spacious'];
+const THEME_CYCLE: ThemeMode[] = ['auto', 'light', 'dark'];
+
+function cycle<T>(values: readonly T[], current: T): T {
+  const idx = values.indexOf(current);
+  return values[(idx + 1) % values.length];
+}
+
+export function TopBarExtras(): JSX.Element {
+  const unread = useMemo(() => notifications.value.filter((n) => !n.read).length, [notifications.value]);
+
+  const openPalette = useCallback(() => {
+    commandPaletteSeed.value = '';
+    commandPaletteOpen.value = true;
+  }, []);
+
+  const cycleTheme = useCallback(() => {
+    theme.value = cycle(THEME_CYCLE, theme.value);
+  }, []);
+
+  const cycleDensity = useCallback(() => {
+    densityMode.value = cycle(DENSITY_CYCLE, densityMode.value);
+  }, []);
+
+  const openHelp = useCallback(() => {
+    keyboardHelpOpen.value = true;
+  }, []);
+
+  const openNotifications = useCallback(() => {
+    notificationCentreOpen.value = !notificationCentreOpen.value;
+  }, []);
+
+  return (
+    <div class="topbar-extras flex items-center gap-1">
+      <button
+        type="button"
+        onClick={openPalette}
+        aria-label="Open command palette (⌘K)"
+        title="Command palette (⌘K)"
+        class="inline-flex h-8 items-center gap-1 px-2 rounded-md text-xs text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+      >
+        <svg viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5" aria-hidden="true">
+          <path
+            fill-rule="evenodd"
+            d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <span class="hidden sm:inline">Search</span>
+        <kbd class="hidden md:inline-block text-[10px] font-mono bg-slate-100 dark:bg-slate-700 rounded px-1 ml-1">
+          ⌘K
+        </kbd>
+      </button>
+
+      <button
+        type="button"
+        onClick={cycleDensity}
+        aria-label={`Density (currently ${densityMode.value})`}
+        title={`Density: ${densityMode.value}`}
+        class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+      >
+        <svg viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5" aria-hidden="true">
+          <path d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 9a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 14a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        onClick={cycleTheme}
+        aria-label={`Theme (currently ${theme.value})`}
+        title={`Theme: ${theme.value}`}
+        class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+      >
+        {theme.value === 'dark' ? (
+          <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+          </svg>
+        ) : theme.value === 'light' ? (
+          <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+            <path
+              fill-rule="evenodd"
+              d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+            <path
+              fill-rule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zM10 4a6 6 0 016 6h-6V4z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        )}
+      </button>
+
+      <button
+        type="button"
+        onClick={openNotifications}
+        aria-label={`Notifications (${unread} unread)`}
+        title="Notifications"
+        class="relative inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+      >
+        <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+          <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
+        </svg>
+        {unread > 0 ? (
+          <span
+            aria-hidden="true"
+            class="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center min-w-[14px] h-[14px] px-1 rounded-full bg-red-500 text-white text-[9px] font-medium"
+          >
+            {unread > 9 ? '9+' : unread}
+          </span>
+        ) : null}
+      </button>
+
+      <button
+        type="button"
+        onClick={openHelp}
+        aria-label="Keyboard shortcuts (?)"
+        title="Keyboard shortcuts"
+        class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+      >
+        <span class="font-mono text-sm">?</span>
+      </button>
+    </div>
+  );
+}
+
+export default TopBarExtras;

--- a/ui/src/chrome/__tests__/CommandPalette.test.tsx
+++ b/ui/src/chrome/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for chrome/CommandPalette.tsx.
+ *
+ * Covers:
+ *   - Cmd+K toggles the open signal.
+ *   - Renders nothing when closed.
+ *   - Renders the combobox + listbox when open.
+ *   - Esc closes.
+ *   - Up/Down move cursor; Enter activates.
+ *   - Cmd+Enter passes newTab=true.
+ *   - Click outside the panel closes.
+ *   - "No matches" empty state.
+ *   - Seed query pre-fills the input.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+
+import { CommandPalette } from '../CommandPalette';
+import {
+  commandPaletteOpen,
+  commandPaletteSeed,
+  recentRuns,
+  recentSpecs,
+  runsByStatus,
+} from '../../lib/store';
+
+beforeEach(() => {
+  commandPaletteOpen.value = false;
+  commandPaletteSeed.value = '';
+  recentRuns.value = [];
+  recentSpecs.value = [];
+  runsByStatus.value = {};
+});
+
+afterEach(() => cleanup());
+
+describe('CommandPalette', () => {
+  test('renders nothing when closed', () => {
+    const { container } = render(<CommandPalette />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders combobox + listbox when open', () => {
+    commandPaletteOpen.value = true;
+    const { getByRole, getByLabelText } = render(<CommandPalette />);
+    expect(getByRole('combobox')).toBeInTheDocument();
+    expect(getByRole('listbox')).toBeInTheDocument();
+    expect(getByLabelText('Command palette search')).toBeInTheDocument();
+  });
+
+  test('Cmd+K toggles the open signal', () => {
+    render(<CommandPalette />);
+    expect(commandPaletteOpen.value).toBe(false);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(commandPaletteOpen.value).toBe(true);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(commandPaletteOpen.value).toBe(false);
+  });
+
+  test('Escape closes', () => {
+    commandPaletteOpen.value = true;
+    const { getByLabelText } = render(<CommandPalette />);
+    const input = getByLabelText('Command palette search') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(commandPaletteOpen.value).toBe(false);
+  });
+
+  test('default results include the route entries (e.g. "Runs")', () => {
+    commandPaletteOpen.value = true;
+    const { getByText } = render(<CommandPalette />);
+    expect(getByText('Runs')).toBeInTheDocument();
+    expect(getByText('Specs')).toBeInTheDocument();
+  });
+
+  test('typing filters the result list', async () => {
+    commandPaletteOpen.value = true;
+    const { getByLabelText, queryByText } = render(<CommandPalette />);
+    const input = getByLabelText('Command palette search') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'topo' } });
+    await waitFor(() => {
+      expect(queryByText('Topology')).toBeInTheDocument();
+      expect(queryByText('Settings')).toBeNull();
+    });
+  });
+
+  test('Enter activates the highlighted result', () => {
+    commandPaletteOpen.value = true;
+    const navigate = vi.fn();
+    const { getByLabelText } = render(<CommandPalette navigate={navigate} currentPath="/" />);
+    const input = getByLabelText('Command palette search') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'specs' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(navigate).toHaveBeenCalled();
+    expect(commandPaletteOpen.value).toBe(false);
+  });
+
+  test('Cmd+Enter passes newTab=true to navigation', () => {
+    commandPaletteOpen.value = true;
+    const navigate = vi.fn();
+    const { getByLabelText } = render(<CommandPalette navigate={navigate} currentPath="/" />);
+    const input = getByLabelText('Command palette search') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'specs' } });
+    fireEvent.keyDown(input, { key: 'Enter', metaKey: true });
+    expect(navigate).toHaveBeenCalledWith('/specs', { newTab: true });
+  });
+
+  test('Arrow Down moves cursor', async () => {
+    commandPaletteOpen.value = true;
+    const { container, getByLabelText } = render(<CommandPalette />);
+    const input = getByLabelText('Command palette search') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() => {
+      const rows = container.querySelectorAll('[role="option"]');
+      expect(rows[1].getAttribute('aria-selected')).toBe('true');
+    });
+  });
+
+  test('No matches shows empty state', async () => {
+    commandPaletteOpen.value = true;
+    const { getByLabelText, getByText } = render(<CommandPalette />);
+    const input = getByLabelText('Command palette search') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'zzzzz-non-existent-zzzz' } });
+    await waitFor(() => {
+      expect(getByText(/No matches/)).toBeInTheDocument();
+    });
+  });
+
+  test('Seed value populates the input on open', () => {
+    commandPaletteSeed.value = 'preset';
+    commandPaletteOpen.value = true;
+    const { getByLabelText } = render(<CommandPalette />);
+    const input = getByLabelText('Command palette search') as HTMLInputElement;
+    expect(input.value).toBe('preset');
+  });
+});

--- a/ui/src/chrome/__tests__/KeyboardHelp.test.tsx
+++ b/ui/src/chrome/__tests__/KeyboardHelp.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Tests for chrome/KeyboardHelp.tsx.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+
+import { KeyboardHelp } from '../KeyboardHelp';
+import { keyboardHelpOpen } from '../../lib/store';
+
+beforeEach(() => {
+  keyboardHelpOpen.value = false;
+});
+
+afterEach(() => cleanup());
+
+describe('KeyboardHelp', () => {
+  test('renders nothing when closed', () => {
+    const { container } = render(<KeyboardHelp />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('? toggles the open signal', () => {
+    render(<KeyboardHelp />);
+    expect(keyboardHelpOpen.value).toBe(false);
+    fireEvent.keyDown(window, { key: '?' });
+    expect(keyboardHelpOpen.value).toBe(true);
+    fireEvent.keyDown(window, { key: '?' });
+    expect(keyboardHelpOpen.value).toBe(false);
+  });
+
+  test('? typed inside an input does NOT toggle', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    render(<KeyboardHelp />);
+    fireEvent.keyDown(input, { key: '?' });
+    expect(keyboardHelpOpen.value).toBe(false);
+    input.remove();
+  });
+
+  test('renders the global shortcut table when open', () => {
+    keyboardHelpOpen.value = true;
+    const { getByText } = render(<KeyboardHelp />);
+    expect(getByText('Cmd/Ctrl+K')).toBeInTheDocument();
+    expect(getByText('Open command palette')).toBeInTheDocument();
+  });
+
+  test('renders route navigation chords from ROUTES registry', () => {
+    keyboardHelpOpen.value = true;
+    const { getByText } = render(<KeyboardHelp />);
+    // ROUTES registers `g r` for /runs.
+    expect(getByText('g r')).toBeInTheDocument();
+  });
+
+  test('Esc closes (via Dialog)', () => {
+    keyboardHelpOpen.value = true;
+    render(<KeyboardHelp />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(keyboardHelpOpen.value).toBe(false);
+  });
+});

--- a/ui/src/chrome/__tests__/NotificationCentre.test.tsx
+++ b/ui/src/chrome/__tests__/NotificationCentre.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for chrome/NotificationCentre.tsx.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+
+import { NotificationCentre } from '../NotificationCentre';
+import {
+  notifications,
+  notificationCentreOpen,
+  pushNotification,
+} from '../../lib/store';
+
+beforeEach(() => {
+  notifications.value = [];
+  notificationCentreOpen.value = false;
+});
+
+afterEach(() => cleanup());
+
+describe('NotificationCentre', () => {
+  test('renders nothing when closed', () => {
+    const { container } = render(<NotificationCentre />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders an empty state when there are no notifications', () => {
+    notificationCentreOpen.value = true;
+    const { getByText } = render(<NotificationCentre />);
+    expect(getByText(/No notifications/)).toBeInTheDocument();
+  });
+
+  test('renders each notification as a list item', () => {
+    pushNotification({
+      id: 'n1',
+      kind: 'run_completed',
+      title: 'Run X completed',
+      timestamp: '2026-06-01T00:00:00Z',
+      read: false,
+    });
+    pushNotification({
+      id: 'n2',
+      kind: 'drift_threshold_breached',
+      title: 'Drift on run Y',
+      body: 'Score 0.85',
+      runId: 'y',
+      timestamp: '2026-06-01T00:01:00Z',
+      read: false,
+    });
+    notificationCentreOpen.value = true;
+    const { container, getByText } = render(<NotificationCentre />);
+    expect(container.querySelectorAll('li').length).toBe(2);
+    expect(getByText('Run X completed')).toBeInTheDocument();
+    expect(getByText('Drift on run Y')).toBeInTheDocument();
+  });
+
+  test('shows the kind + relative timestamp', () => {
+    pushNotification({
+      id: 'n1',
+      kind: 'spec_registered',
+      title: 'New spec',
+      timestamp: '2026-06-01T00:00:00Z',
+      read: false,
+    });
+    notificationCentreOpen.value = true;
+    const { getByText } = render(<NotificationCentre />);
+    expect(getByText('spec_registered')).toBeInTheDocument();
+  });
+
+  test('closing the centre marks all notifications as read', () => {
+    pushNotification({ id: 'n1', kind: 'k', title: 't', timestamp: 't', read: false });
+    pushNotification({ id: 'n2', kind: 'k', title: 't', timestamp: 't', read: false });
+    notificationCentreOpen.value = true;
+    const { getByLabelText } = render(<NotificationCentre />);
+    fireEvent.click(getByLabelText('Close sheet'));
+    expect(notifications.value.every((n) => n.read)).toBe(true);
+  });
+
+  test('per-row "Open run →" link only renders when runId is present', () => {
+    pushNotification({ id: '1', kind: 'x', title: 't', runId: 'abc', timestamp: 't', read: false });
+    pushNotification({ id: '2', kind: 'x', title: 't', timestamp: 't', read: false });
+    notificationCentreOpen.value = true;
+    const { container } = render(<NotificationCentre />);
+    const links = container.querySelectorAll('a[href^="/runs/"]');
+    expect(links.length).toBe(1);
+  });
+});

--- a/ui/src/chrome/__tests__/ThemeApplier.test.tsx
+++ b/ui/src/chrome/__tests__/ThemeApplier.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for chrome/ThemeApplier.tsx.
+ *
+ * Verifies the live mirror of `theme` and `densityMode` signals to
+ * <html> class+attribute. Mocks matchMedia for the 'auto' branch.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/preact';
+
+import { ThemeApplier } from '../ThemeApplier';
+import { densityMode, theme } from '../../lib/store';
+
+let matchMediaListeners: Array<(e: MediaQueryListEvent) => void> = [];
+
+function stubMatchMedia(prefersDark: boolean): void {
+  matchMediaListeners = [];
+  const fakeMql = {
+    matches: prefersDark,
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: (_kind: string, cb: (e: MediaQueryListEvent) => void) => {
+      matchMediaListeners.push(cb);
+    },
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    onchange: null,
+    dispatchEvent: () => true,
+  };
+  vi.stubGlobal('matchMedia', () => fakeMql);
+  window.matchMedia = (() => fakeMql) as never;
+}
+
+beforeEach(() => {
+  document.documentElement.classList.remove('dark');
+  document.documentElement.removeAttribute('data-density');
+  theme.value = 'auto';
+  densityMode.value = 'comfortable';
+  stubMatchMedia(false);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('ThemeApplier', () => {
+  test('applies .dark class when theme=dark', () => {
+    theme.value = 'dark';
+    render(<ThemeApplier />);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  test('removes .dark class when theme=light', () => {
+    document.documentElement.classList.add('dark');
+    theme.value = 'light';
+    render(<ThemeApplier />);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  test('theme=auto follows prefers-color-scheme (dark match)', () => {
+    stubMatchMedia(true);
+    theme.value = 'auto';
+    render(<ThemeApplier />);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  test('theme=auto follows prefers-color-scheme (light match)', () => {
+    stubMatchMedia(false);
+    theme.value = 'auto';
+    render(<ThemeApplier />);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  test('density applied as data-density attribute', () => {
+    densityMode.value = 'compact';
+    render(<ThemeApplier />);
+    expect(document.documentElement.getAttribute('data-density')).toBe('compact');
+  });
+
+  test('renders nothing in the DOM (effect-only)', () => {
+    const { container } = render(<ThemeApplier />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/ui/src/chrome/__tests__/TopBarExtras.test.tsx
+++ b/ui/src/chrome/__tests__/TopBarExtras.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for chrome/TopBarExtras.tsx.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+
+import { TopBarExtras } from '../TopBarExtras';
+import {
+  commandPaletteOpen,
+  commandPaletteSeed,
+  densityMode,
+  keyboardHelpOpen,
+  notifications,
+  notificationCentreOpen,
+  pushNotification,
+  theme,
+} from '../../lib/store';
+
+beforeEach(() => {
+  commandPaletteOpen.value = false;
+  commandPaletteSeed.value = '';
+  keyboardHelpOpen.value = false;
+  notificationCentreOpen.value = false;
+  notifications.value = [];
+  densityMode.value = 'comfortable';
+  theme.value = 'auto';
+});
+
+afterEach(() => cleanup());
+
+describe('TopBarExtras', () => {
+  test('renders all five buttons', () => {
+    const { getByLabelText } = render(<TopBarExtras />);
+    expect(getByLabelText(/Open command palette/)).toBeInTheDocument();
+    expect(getByLabelText(/Density/)).toBeInTheDocument();
+    expect(getByLabelText(/Theme/)).toBeInTheDocument();
+    expect(getByLabelText(/Notifications/)).toBeInTheDocument();
+    expect(getByLabelText(/Keyboard shortcuts/)).toBeInTheDocument();
+  });
+
+  test('Search button opens the palette + clears seed', () => {
+    commandPaletteSeed.value = 'leftover';
+    const { getByLabelText } = render(<TopBarExtras />);
+    fireEvent.click(getByLabelText(/Open command palette/));
+    expect(commandPaletteOpen.value).toBe(true);
+    expect(commandPaletteSeed.value).toBe('');
+  });
+
+  test('Density button cycles compact → comfortable → spacious → compact', () => {
+    densityMode.value = 'comfortable';
+    const { getByLabelText } = render(<TopBarExtras />);
+    fireEvent.click(getByLabelText(/Density/));
+    expect(densityMode.value).toBe('spacious');
+    fireEvent.click(getByLabelText(/Density/));
+    expect(densityMode.value).toBe('compact');
+    fireEvent.click(getByLabelText(/Density/));
+    expect(densityMode.value).toBe('comfortable');
+  });
+
+  test('Theme button cycles auto → light → dark → auto', () => {
+    theme.value = 'auto';
+    const { getByLabelText } = render(<TopBarExtras />);
+    fireEvent.click(getByLabelText(/Theme/));
+    expect(theme.value).toBe('light');
+    fireEvent.click(getByLabelText(/Theme/));
+    expect(theme.value).toBe('dark');
+    fireEvent.click(getByLabelText(/Theme/));
+    expect(theme.value).toBe('auto');
+  });
+
+  test('Notifications button toggles centre open signal', () => {
+    const { getByLabelText } = render(<TopBarExtras />);
+    fireEvent.click(getByLabelText(/Notifications/));
+    expect(notificationCentreOpen.value).toBe(true);
+    fireEvent.click(getByLabelText(/Notifications/));
+    expect(notificationCentreOpen.value).toBe(false);
+  });
+
+  test('Unread badge shows count when >0 (capped at 9+)', () => {
+    pushNotification({ id: '1', kind: 'k', title: 't', timestamp: 't', read: false });
+    pushNotification({ id: '2', kind: 'k', title: 't', timestamp: 't', read: false });
+    const { container } = render(<TopBarExtras />);
+    const badge = container.querySelector('button[aria-label^="Notifications"] span[aria-hidden]');
+    expect(badge?.textContent).toBe('2');
+  });
+
+  test('Unread badge displays 9+ when count exceeds 9', () => {
+    for (let i = 0; i < 15; i++) {
+      pushNotification({ id: String(i), kind: 'k', title: 't', timestamp: 't', read: false });
+    }
+    const { container } = render(<TopBarExtras />);
+    const badge = container.querySelector('button[aria-label^="Notifications"] span[aria-hidden]');
+    expect(badge?.textContent).toBe('9+');
+  });
+
+  test('No badge renders when zero unread', () => {
+    const { container } = render(<TopBarExtras />);
+    const badge = container.querySelector('button[aria-label^="Notifications"] span[aria-hidden]');
+    expect(badge).toBeNull();
+  });
+
+  test('Help button opens the keyboard help', () => {
+    const { getByLabelText } = render(<TopBarExtras />);
+    fireEvent.click(getByLabelText(/Keyboard shortcuts/));
+    expect(keyboardHelpOpen.value).toBe(true);
+  });
+});

--- a/ui/src/lib/__tests__/fuzzy.test.ts
+++ b/ui/src/lib/__tests__/fuzzy.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for lib/fuzzy.ts: scoreOne + rankFuzzy.
+ *
+ * Properties verified:
+ *   - Empty query → score 0, all matches.
+ *   - All-chars-must-appear-in-order rule.
+ *   - Prefix bonus applies only to leading match.
+ *   - Word-boundary bonus on `_`, `-`, ` `, `/`, `.`, `:` predecessors.
+ *   - CamelHump bonus on uppercase matches.
+ *   - Gap penalty: more contiguous = higher score.
+ *   - Length tiebreaker prefers shorter strings.
+ *   - rankFuzzy excludes non-matches + applies weight.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { rankFuzzy, scoreOne } from '../fuzzy';
+
+describe('scoreOne', () => {
+  test('empty query → score 0, empty matches', () => {
+    expect(scoreOne('foo', '')).toEqual({ score: 0, matches: [] });
+  });
+
+  test('returns null when characters do not appear in order', () => {
+    expect(scoreOne('abc', 'cab')).toBeNull();
+    expect(scoreOne('hello', 'world')).toBeNull();
+  });
+
+  test('returns matches when query is a prefix', () => {
+    const r = scoreOne('hello', 'he');
+    expect(r).not.toBeNull();
+    expect(r!.matches).toEqual([0, 1]);
+  });
+
+  test('case-insensitive matching', () => {
+    expect(scoreOne('Hello', 'hl')).not.toBeNull();
+  });
+
+  test('contiguous matches outscore split matches', () => {
+    const contig = scoreOne('abcdef', 'abc')!;
+    const split = scoreOne('axbycz', 'abc')!;
+    expect(contig.score).toBeGreaterThan(split.score);
+  });
+
+  test('prefix match outscores middle match of same length', () => {
+    const prefix = scoreOne('foo', 'fo')!;
+    const middle = scoreOne('xfoo', 'fo')!;
+    expect(prefix.score).toBeGreaterThan(middle.score);
+  });
+
+  test('word-boundary chars boost match', () => {
+    const wb = scoreOne('foo_bar', 'b')!;
+    const inner = scoreOne('foobar', 'b')!;
+    expect(wb.score).toBeGreaterThan(inner.score);
+  });
+
+  test('camelHump boost for uppercase match', () => {
+    const ch = scoreOne('fooBar', 'B')!;
+    const lc = scoreOne('foobar', 'b')!;
+    expect(ch.score).toBeGreaterThan(lc.score);
+  });
+
+  test('shorter strings win tiebreaker', () => {
+    const short = scoreOne('ab', 'ab')!;
+    const long = scoreOne('abc', 'ab')!;
+    expect(short.score).toBeGreaterThan(long.score);
+  });
+
+  test('matches array tracks the matched indices', () => {
+    const r = scoreOne('hello world', 'how')!;
+    expect(r.matches).toEqual([0, 4, 6]);
+  });
+});
+
+describe('rankFuzzy', () => {
+  test('empty query returns all items in original order, score 0', () => {
+    const items = ['c', 'a', 'b'];
+    const hits = rankFuzzy(items, '', { text: (x) => x });
+    expect(hits.map((h) => h.item)).toEqual(['c', 'a', 'b']);
+    expect(hits.every((h) => h.score === 0)).toBe(true);
+  });
+
+  test('excludes non-matches', () => {
+    const items = ['abc', 'def', 'ghi'];
+    const hits = rankFuzzy(items, 'a', { text: (x) => x });
+    expect(hits.length).toBe(1);
+    expect(hits[0].item).toBe('abc');
+  });
+
+  test('ranks by score descending', () => {
+    const items = ['abcdef', 'azbzcz'];
+    const hits = rankFuzzy(items, 'abc', { text: (x) => x });
+    expect(hits[0].item).toBe('abcdef'); // contiguous
+    expect(hits[1].item).toBe('azbzcz');
+  });
+
+  test('weight multiplies the score', () => {
+    const items: { name: string; tier: number }[] = [
+      { name: 'lowprio', tier: 1 },
+      { name: 'lowprio2', tier: 5 }, // higher weight, same query
+    ];
+    const hits = rankFuzzy(items, 'low', {
+      text: (i) => i.name,
+      weight: (i) => i.tier,
+    });
+    expect(hits[0].item.name).toBe('lowprio2');
+  });
+
+  test('respects all query characters appear in order across items', () => {
+    const items = ['runs', 'topology', 'specs'];
+    const hits = rankFuzzy(items, 'topo', { text: (x) => x });
+    expect(hits.map((h) => h.item)).toEqual(['topology']);
+  });
+});

--- a/ui/src/lib/fuzzy.ts
+++ b/ui/src/lib/fuzzy.ts
@@ -1,0 +1,105 @@
+/**
+ * Tiny fzf-style fuzzy scorer for the command palette.
+ *
+ * ~80 LOC, zero deps. Scoring rule (descending priority):
+ *
+ *   1. All query chars must appear in order (case-insensitive). If not,
+ *      the candidate is excluded.
+ *   2. Score = match bonus - gap penalty.
+ *      - Match bonus:  +10 per matched char.
+ *      - Prefix bonus: +20 if the first matched char is at index 0 of
+ *                       the candidate (the query starts the candidate).
+ *      - Word-boundary bonus: +5 for each match whose preceding char is
+ *                              ` `, `_`, `-`, `/`, `.` (i.e. starts a word).
+ *      - Camelhump bonus: +3 for each match where the matched char is
+ *                          uppercase in the original candidate.
+ *      - Gap penalty:  -1 per character between consecutive matches.
+ *   3. Ties: shorter candidates rank higher (-0.01 × candidate.length
+ *      as a tiebreaker).
+ *
+ * Returns a `{score, matches}` for each kept candidate. `matches` is
+ * the array of indices into the original candidate string where the
+ * query chars landed; callers use it to draw <mark> highlights.
+ */
+
+export interface FuzzyHit<T> {
+  item: T;
+  score: number;
+  /** Indices into `text(item)` of the matched query characters. */
+  matches: number[];
+}
+
+export interface FuzzyOptions<T> {
+  /** Extract the searchable text from an item. */
+  text: (item: T) => string;
+  /** Optional weight to multiply the score by (priority bucket). */
+  weight?: (item: T) => number;
+}
+
+const GAP_PENALTY = 1;
+const MATCH_BONUS = 10;
+const PREFIX_BONUS = 20;
+const WORD_BOUNDARY_BONUS = 5;
+const CAMELHUMP_BONUS = 3;
+const LENGTH_TIEBREAKER = 0.01;
+
+const WORD_BOUNDARY_CHARS = new Set([' ', '_', '-', '/', '.', ':']);
+
+/**
+ * Score a single candidate against the query. Returns null if the
+ * query characters cannot all be found in order.
+ */
+export function scoreOne(candidate: string, query: string): { score: number; matches: number[] } | null {
+  if (query.length === 0) return { score: 0, matches: [] };
+  const c = candidate.toLowerCase();
+  const q = query.toLowerCase();
+  const matches: number[] = [];
+  let ci = 0;
+  let qi = 0;
+  let score = 0;
+  let lastMatch = -1;
+  while (qi < q.length && ci < c.length) {
+    if (c[ci] === q[qi]) {
+      matches.push(ci);
+      score += MATCH_BONUS;
+      if (ci === 0 && qi === 0) score += PREFIX_BONUS;
+      if (ci > 0) {
+        const prev = candidate[ci - 1];
+        if (WORD_BOUNDARY_CHARS.has(prev)) score += WORD_BOUNDARY_BONUS;
+      }
+      if (candidate[ci] >= 'A' && candidate[ci] <= 'Z') score += CAMELHUMP_BONUS;
+      if (lastMatch >= 0) score -= GAP_PENALTY * (ci - lastMatch - 1);
+      lastMatch = ci;
+      qi += 1;
+    }
+    ci += 1;
+  }
+  if (qi < q.length) return null;
+  score -= LENGTH_TIEBREAKER * candidate.length;
+  return { score, matches };
+}
+
+/**
+ * Score and rank a list of items against the query. Items that don't
+ * contain the query (in order) are excluded. Returns hits sorted
+ * descending by score.
+ */
+export function rankFuzzy<T>(
+  items: readonly T[],
+  query: string,
+  opts: FuzzyOptions<T>,
+): FuzzyHit<T>[] {
+  if (query.trim().length === 0) {
+    return items.map((item) => ({ item, score: 0, matches: [] }));
+  }
+  const hits: FuzzyHit<T>[] = [];
+  for (const item of items) {
+    const text = opts.text(item);
+    const r = scoreOne(text, query);
+    if (r == null) continue;
+    const weight = opts.weight?.(item) ?? 1;
+    hits.push({ item, score: r.score * weight, matches: r.matches });
+  }
+  hits.sort((a, b) => b.score - a.score);
+  return hits;
+}


### PR DESCRIPTION
The W18 chrome surfaces wired into Shell. See the commit body for per-component detail.

## Verification

- `cd ui && npm test -- --run` → **249/249** (was 196; 53 new tests across 6 files)
- `cd ui && npm run build` → 67 kB gzipped main chunk
- `cd ui && npx tsc -b --noEmit` → clean
- Default + e2e pytest unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)