### PR TITLE
W18d: Run Detail v2 — JsonViewer everywhere + FilterChipBar + cross-pane click coordination

### DIFF
--- a/ui/src/lib/__tests__/runDetailStore.test.ts
+++ b/ui/src/lib/__tests__/runDetailStore.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for lib/runDetailStore.ts.
+ */
+
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  clearAllFilters,
+  clearFilter,
+  eventPassesFilters,
+  filtersToChips,
+  runDetailFilters,
+  setFilter,
+  signaturePassesFilters,
+  toggleFilter,
+  toolCallPassesFilters,
+} from '../runDetailStore';
+
+beforeEach(() => {
+  clearAllFilters();
+});
+
+describe('runDetailFilters mutators', () => {
+  test('toggleFilter sets a key', () => {
+    toggleFilter('stateId', 'emit');
+    expect(runDetailFilters.value).toEqual({ stateId: 'emit' });
+  });
+
+  test('toggleFilter twice with same value clears the key', () => {
+    toggleFilter('stateId', 'emit');
+    toggleFilter('stateId', 'emit');
+    expect(runDetailFilters.value).toEqual({});
+  });
+
+  test('toggleFilter with different value replaces', () => {
+    toggleFilter('stateId', 'emit');
+    toggleFilter('stateId', 'done');
+    expect(runDetailFilters.value).toEqual({ stateId: 'done' });
+  });
+
+  test('setFilter undefined clears the key', () => {
+    setFilter('stateId', 'emit');
+    setFilter('stateId', undefined);
+    expect(runDetailFilters.value).toEqual({});
+  });
+
+  test('clearFilter removes the key', () => {
+    setFilter('stateId', 'emit');
+    setFilter('eventKind', 'run_started');
+    clearFilter('stateId');
+    expect(runDetailFilters.value).toEqual({ eventKind: 'run_started' });
+  });
+
+  test('clearAllFilters wipes everything', () => {
+    setFilter('stateId', 'emit');
+    setFilter('eventKind', 'k');
+    clearAllFilters();
+    expect(runDetailFilters.value).toEqual({});
+  });
+});
+
+describe('filtersToChips', () => {
+  test('empty filters produce empty chips', () => {
+    expect(filtersToChips({})).toEqual([]);
+  });
+
+  test('renders one chip per non-empty key', () => {
+    const chips = filtersToChips({
+      stateId: 'emit',
+      eventKind: 'run_started',
+      toolName: 'Read',
+    });
+    expect(chips.length).toBe(3);
+    expect(chips.map((c) => c.kind).sort()).toEqual(['event', 'state', 'tool']);
+  });
+
+  test('chip ids are stable + namespaced', () => {
+    const chips = filtersToChips({ stateId: 'x' });
+    expect(chips[0].id).toBe('state:x');
+  });
+
+  test('producer label is shortened', () => {
+    const chips = filtersToChips({ producerId: 'abcdef0123456789' });
+    expect(chips[0].label).toContain('abcdef012345');
+  });
+});
+
+describe('eventPassesFilters', () => {
+  test('empty filters → always passes', () => {
+    expect(eventPassesFilters({ kind: 'k' }, {})).toBe(true);
+  });
+
+  test('kind mismatch → fails', () => {
+    expect(eventPassesFilters({ kind: 'k1' }, { eventKind: 'k2' })).toBe(false);
+  });
+
+  test('kind match → passes', () => {
+    expect(eventPassesFilters({ kind: 'k1' }, { eventKind: 'k1' })).toBe(true);
+  });
+
+  test('producerId mismatch → fails', () => {
+    expect(eventPassesFilters({ producer_id: 'p1' }, { producerId: 'p2' })).toBe(false);
+  });
+
+  test('stateId matches against state_id in payload', () => {
+    expect(eventPassesFilters({ payload: { state_id: 'emit' } }, { stateId: 'emit' })).toBe(true);
+  });
+
+  test('stateId matches against from_state in payload', () => {
+    expect(eventPassesFilters({ payload: { from_state: 'emit' } }, { stateId: 'emit' })).toBe(true);
+  });
+
+  test('stateId matches against to_state in payload', () => {
+    expect(eventPassesFilters({ payload: { to_state: 'done' } }, { stateId: 'done' })).toBe(true);
+  });
+
+  test('stateId fails when neither field matches', () => {
+    expect(eventPassesFilters({ payload: {} }, { stateId: 'emit' })).toBe(false);
+  });
+
+  test('AND-composes multiple filter keys', () => {
+    expect(
+      eventPassesFilters(
+        { kind: 'k', producer_id: 'p1', payload: { state_id: 'emit' } },
+        { eventKind: 'k', producerId: 'p1', stateId: 'emit' },
+      ),
+    ).toBe(true);
+    expect(
+      eventPassesFilters(
+        { kind: 'k', producer_id: 'p1', payload: { state_id: 'emit' } },
+        { eventKind: 'k', producerId: 'p2' }, // producer mismatch
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('toolCallPassesFilters', () => {
+  test('toolName filter excludes mismatches', () => {
+    expect(toolCallPassesFilters({ tool_name: 'Read' }, { toolName: 'Write' })).toBe(false);
+  });
+
+  test('toolName filter accepts matches', () => {
+    expect(toolCallPassesFilters({ tool_name: 'Read' }, { toolName: 'Read' })).toBe(true);
+  });
+
+  test('producerId filter narrows', () => {
+    expect(toolCallPassesFilters({ producer_id: 'p' }, { producerId: 'q' })).toBe(false);
+  });
+});
+
+describe('signaturePassesFilters', () => {
+  test('stateId filter excludes mismatches', () => {
+    expect(signaturePassesFilters({ state_id: 'emit' }, { stateId: 'done' })).toBe(false);
+  });
+
+  test('empty filter passes everything', () => {
+    expect(signaturePassesFilters({ state_id: 'emit' }, {})).toBe(true);
+  });
+});

--- a/ui/src/lib/runDetailStore.ts
+++ b/ui/src/lib/runDetailStore.ts
@@ -1,0 +1,172 @@
+/**
+ * Per-route store for the Run Detail page.
+ *
+ * `runDetailFilters` is the cross-pane coordination bus. Every label
+ * click in the State Tree / Event Timeline / Tool Calls / Signature
+ * Ledger writes into this signal; every pane reads it to filter its
+ * rows. The FilterChipBar renders one chip per non-empty key.
+ *
+ * Why a separate file from the global `store.ts`: this state is
+ * scoped to ONE route. Lifting it into the global store would risk
+ * other routes accidentally subscribing.
+ */
+
+import { signal, type Signal } from '@preact/signals';
+
+import type { FilterChip } from '../components/FilterChips';
+
+export interface RunDetailFilters {
+  /** Filter all panes to events / tool-calls / signatures touching this state. */
+  stateId?: string;
+  /** Filter the event timeline to a specific kind (e.g. run_started). */
+  eventKind?: string;
+  /** Filter to a single producer. */
+  producerId?: string;
+  /** Filter tool-calls to a single tool_name. */
+  toolName?: string;
+  /** Filter drift signals to a kind. */
+  signalKind?: string;
+}
+
+export const runDetailFilters: Signal<RunDetailFilters> = signal<RunDetailFilters>({});
+
+/**
+ * Toggle a filter key. If the value already equals what's about to be
+ * written, the key is cleared instead (click-same-twice = toggle off).
+ * Used for every label click handler: a user clicking the SAME state
+ * id twice clears it rather than re-confirming.
+ */
+export function toggleFilter<K extends keyof RunDetailFilters>(
+  key: K,
+  value: RunDetailFilters[K],
+): void {
+  const prev = runDetailFilters.value;
+  if (prev[key] === value) {
+    const { [key]: _drop, ...rest } = prev;
+    runDetailFilters.value = rest as RunDetailFilters;
+  } else {
+    runDetailFilters.value = { ...prev, [key]: value };
+  }
+}
+
+/** Set a filter key unconditionally (used by the cmd palette / deep links). */
+export function setFilter<K extends keyof RunDetailFilters>(
+  key: K,
+  value: RunDetailFilters[K] | undefined,
+): void {
+  const prev = runDetailFilters.value;
+  if (value === undefined) {
+    const { [key]: _drop, ...rest } = prev;
+    runDetailFilters.value = rest as RunDetailFilters;
+  } else {
+    runDetailFilters.value = { ...prev, [key]: value };
+  }
+}
+
+/** Remove a single filter key. */
+export function clearFilter(key: keyof RunDetailFilters): void {
+  setFilter(key, undefined);
+}
+
+/** Reset the entire filter set. */
+export function clearAllFilters(): void {
+  runDetailFilters.value = {};
+}
+
+/**
+ * Convert the active filter set into a FilterChip[] for rendering.
+ *
+ * Each chip's `id` is `<key>:<value>` so the chip remove handler can
+ * unambiguously identify which key to clear.
+ */
+export function filtersToChips(filters: RunDetailFilters): FilterChip[] {
+  const chips: FilterChip[] = [];
+  if (filters.stateId) {
+    chips.push({
+      id: `state:${filters.stateId}`,
+      kind: 'state',
+      label: `state: ${filters.stateId}`,
+    });
+  }
+  if (filters.eventKind) {
+    chips.push({
+      id: `kind:${filters.eventKind}`,
+      kind: 'event',
+      label: `kind: ${filters.eventKind}`,
+    });
+  }
+  if (filters.producerId) {
+    chips.push({
+      id: `producer:${filters.producerId}`,
+      kind: 'producer',
+      label: `producer: ${filters.producerId.slice(0, 12)}…`,
+    });
+  }
+  if (filters.toolName) {
+    chips.push({
+      id: `tool:${filters.toolName}`,
+      kind: 'tool',
+      label: `tool: ${filters.toolName}`,
+    });
+  }
+  if (filters.signalKind) {
+    chips.push({
+      id: `signal:${filters.signalKind}`,
+      kind: 'signal',
+      label: `signal: ${filters.signalKind}`,
+    });
+  }
+  return chips;
+}
+
+/**
+ * Predicate: does an event survive the active filter set?
+ *
+ * Filters are AND-composed. A filter for which the event has no
+ * corresponding field is treated as a non-match (so a kind=X filter
+ * excludes events whose kind is undefined / different).
+ */
+export function eventPassesFilters(
+  event: { kind?: string; producer_id?: string; payload?: unknown },
+  filters: RunDetailFilters,
+): boolean {
+  if (filters.eventKind && event.kind !== filters.eventKind) return false;
+  if (filters.producerId && event.producer_id !== filters.producerId) return false;
+  if (filters.stateId) {
+    // The event's payload may reference a state via `state_id`,
+    // `from_state`, or `to_state`. Match any of them.
+    const p = (event.payload ?? {}) as Record<string, unknown>;
+    const refs = [p.state_id, p.from_state, p.to_state];
+    if (!refs.includes(filters.stateId)) return false;
+  }
+  return true;
+}
+
+/**
+ * Predicate: does a tool-call survive the active filter set?
+ *
+ * A `toolName` filter narrows to that exact tool_name. A `stateId`
+ * filter narrows by the call's producer_id (close-enough heuristic
+ * without a state-correlation column on the call row).
+ */
+export function toolCallPassesFilters(
+  call: { tool_name?: string; producer_id?: string },
+  filters: RunDetailFilters,
+): boolean {
+  if (filters.toolName && call.tool_name !== filters.toolName) return false;
+  if (filters.producerId && call.producer_id !== filters.producerId) return false;
+  return true;
+}
+
+/**
+ * Predicate: does a commit signature survive the active filter set?
+ *
+ * State filter narrows by `state_id`.
+ */
+export function signaturePassesFilters(
+  sig: { state_id?: string },
+  filters: RunDetailFilters,
+): boolean {
+  if (filters.stateId && sig.state_id !== filters.stateId) return false;
+  return true;
+}

--- a/ui/src/routes/runDetail.tsx
+++ b/ui/src/routes/runDetail.tsx
@@ -52,15 +52,28 @@ import {
   Card,
   Dialog,
   EmptyState,
+  FilterChips,
+  JsonViewer,
   Pill,
   Spinner,
   Timeline,
   Tree,
   useToast,
+  type FilterChip,
   type PillVariant,
   type TimelineItem,
   type TreeNode,
 } from '../components';
+import {
+  clearAllFilters,
+  clearFilter,
+  eventPassesFilters,
+  filtersToChips,
+  runDetailFilters,
+  signaturePassesFilters,
+  toggleFilter,
+  toolCallPassesFilters,
+} from '../lib/runDetailStore';
 import {
   api,
   ApiError,
@@ -104,14 +117,9 @@ function shortHash(hash: string): string {
   return hash.length > 12 ? hash.slice(0, 12) : hash;
 }
 
-/** Pretty-print a JSON-like value with 2-space indentation. */
-function prettyJson(value: unknown): string {
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-}
+// W18d: prettyJson helper removed — every JSON-render site now uses
+// the JsonViewer primitive (which carries its own copy / download /
+// full-screen / search toolbar instead of producing a raw string).
 
 // ---------------------------------------------------------------------------
 // Variant maps — semantic colours per status / verdict / event kind
@@ -254,11 +262,14 @@ function extractAllowedTools(node: StateNode | null): string[] | null {
 /** Render an FSM event as a :class:`TimelineItem`. */
 function eventToTimelineItem(event: FsmEvent): TimelineItem {
   const variant = variantForEventKind(event.kind);
-  const payloadString = prettyJson(event.payload);
   const payload: VNode = (
-    <pre class="font-mono text-xs leading-snug whitespace-pre-wrap break-words text-slate-600 dark:text-slate-300 bg-slate-50 dark:bg-slate-900/40 rounded-md px-3 py-2 max-h-40 overflow-auto">
-      {payloadString}
-    </pre>
+    <JsonViewer
+      value={event.payload}
+      rootLabel="payload"
+      mode="inline"
+      maxInlineHeight="max-h-40"
+      ariaLabel={`Payload of event ${event.id}`}
+    />
   );
   return {
     id: event.id,
@@ -550,10 +561,36 @@ export function RunDetailRoute(): JSX.Element {
     [selectedNode, currentNode],
   );
 
-  const timelineItems = useMemo(
-    () => events.map(eventToTimelineItem),
-    [events],
+  // W18d: subscribe to the cross-pane filter set so the timeline /
+  // tool calls / signatures rerender when chips change.
+  const activeFilters = runDetailFilters.value;
+  const filterChips: FilterChip[] = useMemo(
+    () => filtersToChips(activeFilters),
+    [activeFilters],
   );
+
+  const filteredEvents = useMemo(
+    () => events.filter((e) => eventPassesFilters(e, activeFilters)),
+    [events, activeFilters],
+  );
+  const filteredToolCalls = useMemo(
+    () => toolCalls.filter((c) => toolCallPassesFilters(c, activeFilters)),
+    [toolCalls, activeFilters],
+  );
+  const filteredSignatures = useMemo(
+    () => signatures.filter((s) => signaturePassesFilters(s, activeFilters)),
+    [signatures, activeFilters],
+  );
+
+  const timelineItems = useMemo(
+    () => filteredEvents.map(eventToTimelineItem),
+    [filteredEvents],
+  );
+
+  // Reset filters whenever the user navigates between runs.
+  useEffect(() => {
+    clearAllFilters();
+  }, [runId]);
 
   // -----------------------------------------------------------------------
   // Action handler — closes dialog, fires the API, toasts, reloads
@@ -641,7 +678,17 @@ export function RunDetailRoute(): JSX.Element {
     journal !== null && journal.status !== 'finalised';
 
   const meta = pendingAction ? ACTION_META[pendingAction.kind] : null;
-  const lastSignatures = signatures.slice(0, 3);
+  const lastSignatures = filteredSignatures.slice(0, 3);
+
+  // FilterChipBar handlers: chip-remove maps back to the right filter key.
+  const onChipRemove = useCallback((chip: FilterChip) => {
+    const [k] = chip.id.split(':');
+    if (k === 'state') clearFilter('stateId');
+    else if (k === 'kind') clearFilter('eventKind');
+    else if (k === 'producer') clearFilter('producerId');
+    else if (k === 'tool') clearFilter('toolName');
+    else if (k === 'signal') clearFilter('signalKind');
+  }, []);
 
   return (
     <div class="p-4 md:p-6 space-y-4">
@@ -750,6 +797,18 @@ export function RunDetailRoute(): JSX.Element {
       </header>
 
       {/* ----------------------------------------------------------------
+          Filter chip bar (W18d): every label click in the panes below
+          writes into the runDetailFilters signal; chips render here so
+          the user can see + remove active filters.
+          ---------------------------------------------------------------- */}
+      <FilterChips
+        chips={filterChips}
+        onRemove={onChipRemove}
+        onClear={clearAllFilters}
+        ariaLabel="Run filters"
+      />
+
+      {/* ----------------------------------------------------------------
           Three-pane grid
           ---------------------------------------------------------------- */}
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
@@ -770,9 +829,14 @@ export function RunDetailRoute(): JSX.Element {
           {selectedNode ? (
             <div class="mt-4 space-y-3 border-t border-slate-200 dark:border-slate-700 pt-3">
               <div class="flex flex-wrap items-baseline gap-2">
-                <h3 class="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                <button
+                  type="button"
+                  onClick={() => toggleFilter('stateId', selectedNode.state_id)}
+                  title={`Filter all panes to state ${selectedNode.state_id}`}
+                  class="text-sm font-semibold text-slate-900 dark:text-slate-100 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
+                >
                   {selectedNode.state_id}
-                </h3>
+                </button>
                 <Pill variant={variantForStatus(selectedNode.status)} size="sm">
                   {selectedNode.status}
                 </Pill>
@@ -784,17 +848,27 @@ export function RunDetailRoute(): JSX.Element {
                 <h4 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">
                   Inputs
                 </h4>
-                <pre class="font-mono text-xs leading-snug whitespace-pre-wrap break-words text-slate-700 dark:text-slate-200 bg-slate-50 dark:bg-slate-900/40 rounded-md px-3 py-2 max-h-48 overflow-auto">
-                  {prettyJson(selectedNode.inputs)}
-                </pre>
+                <JsonViewer
+                  value={selectedNode.inputs}
+                  rootLabel="inputs"
+                  mode="inline"
+                  maxInlineHeight="max-h-48"
+                  downloadFilename={`run-${runId}-${selectedNode.state_id}-inputs.json`}
+                  ariaLabel={`Inputs for state ${selectedNode.state_id}`}
+                />
               </div>
               <div>
                 <h4 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">
                   Outputs
                 </h4>
-                <pre class="font-mono text-xs leading-snug whitespace-pre-wrap break-words text-slate-700 dark:text-slate-200 bg-slate-50 dark:bg-slate-900/40 rounded-md px-3 py-2 max-h-48 overflow-auto">
-                  {prettyJson(selectedNode.outputs)}
-                </pre>
+                <JsonViewer
+                  value={selectedNode.outputs}
+                  rootLabel="outputs"
+                  mode="inline"
+                  maxInlineHeight="max-h-48"
+                  downloadFilename={`run-${runId}-${selectedNode.state_id}-outputs.json`}
+                  ariaLabel={`Outputs for state ${selectedNode.state_id}`}
+                />
               </div>
             </div>
           ) : null}
@@ -971,7 +1045,7 @@ export function RunDetailRoute(): JSX.Element {
           <span>
             Tool calls audit log{' '}
             <span class="ml-1 text-xs font-normal text-slate-500 dark:text-slate-400">
-              ({toolCalls.length} most recent)
+              ({filteredToolCalls.length}{filteredToolCalls.length !== toolCalls.length ? ` of ${toolCalls.length}` : ''} most recent)
             </span>
           </span>
           <span
@@ -998,14 +1072,14 @@ export function RunDetailRoute(): JSX.Element {
             id="tool-call-audit-log"
             class="border-t border-slate-200 dark:border-slate-700 px-4 py-3"
           >
-            {toolCalls.length === 0 ? (
+            {filteredToolCalls.length === 0 ? (
               <EmptyState
                 title="No tool calls recorded"
                 message="The audit log is empty for this run."
               />
             ) : (
               <ul class="divide-y divide-slate-200 dark:divide-slate-700">
-                {toolCalls.map((call) => (
+                {filteredToolCalls.map((call) => (
                   <li key={call.id} class="py-3 space-y-1">
                     <div class="flex flex-wrap items-baseline gap-2">
                       <Pill
@@ -1027,9 +1101,31 @@ export function RunDetailRoute(): JSX.Element {
                         {shortHash(call.producer_id)}
                       </span>
                     </div>
-                    <pre class="font-mono text-xs leading-snug whitespace-pre-wrap break-words text-slate-600 dark:text-slate-300 bg-slate-50 dark:bg-slate-900/40 rounded-md px-3 py-2 max-h-40 overflow-auto">
-                      {prettyJson(call.args_redacted)}
-                    </pre>
+                    <JsonViewer
+                      value={call.args_redacted}
+                      rootLabel="args"
+                      mode="inline"
+                      maxInlineHeight="max-h-40"
+                      ariaLabel={`Tool call args ${call.tool_name}`}
+                    />
+                    <div class="mt-1 flex gap-1">
+                      <button
+                        type="button"
+                        onClick={() => toggleFilter('toolName', call.tool_name)}
+                        title={`Filter tool calls to ${call.tool_name}`}
+                        class="text-[10px] underline text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
+                      >
+                        filter by tool
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => toggleFilter('producerId', call.producer_id)}
+                        title={`Filter to producer ${call.producer_id}`}
+                        class="text-[10px] underline text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
+                      >
+                        filter by producer
+                      </button>
+                    </div>
                   </li>
                 ))}
               </ul>

--- a/ui/src/routes/specs.tsx
+++ b/ui/src/routes/specs.tsx
@@ -10,7 +10,7 @@ import type { JSX, VNode } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
 import {
-  Card, Dialog, EmptyState, Pill, Spinner, Table, type TableColumn,
+  Card, Dialog, EmptyState, JsonViewer, Pill, Spinner, Table, type TableColumn,
 } from '../components';
 import { api, ApiError, type SpecDetail, type SpecSummary } from '../lib/api';
 
@@ -108,9 +108,14 @@ export function SpecsRoute(): JSX.Element {
         ) : !detail ? (
           <div class="flex items-center justify-center py-8"><Spinner label="Loading spec" /></div>
         ) : (
-          <pre class="font-mono text-xs leading-relaxed whitespace-pre-wrap break-words text-slate-800 dark:text-slate-200">
-            {JSON.stringify(detail.definition, null, 2)}
-          </pre>
+          <JsonViewer
+            value={detail.definition}
+            rootLabel="definition"
+            mode="expanded"
+            defaultExpandDepth={3}
+            downloadFilename={`spec-${detail.slug}-v${detail.version}.json`}
+            ariaLabel={`Definition of ${detail.slug} v${detail.version}`}
+          />
         )}
       </Dialog>
     </div>


### PR DESCRIPTION
Closes the user's #1 ask. Every JSON site is now syntax-coloured, copy/download/search/full-screen via JsonViewer; state ids / event kinds / producers / tool names are clickable label-filters that AND-compose across panes and surface as removable chips at the top of the page.

273 vitest / 662 default pytest / 9 e2e pytest all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)