### PR TITLE
fix(w18-final): Sidebar reads ROUTES registry + FlowGraph fills parent container

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -139,11 +139,24 @@ interface NavLinkDef {
   matchPrefix: string;
 }
 
+// W18 sidebar nav is derived from the ROUTES registry so adding a
+// new route (W18f Topology / W18g Drift / W18h Journal) automatically
+// surfaces here without sidebar-side edits. Static fallbacks for the
+// label come from each registry entry; the matchPrefix is the route's
+// own path (or its first /-segment for nested routes).
+import { primaryRoutes, adminRoutes } from './routes';
+
 const NAV_LINKS: readonly NavLinkDef[] = [
-  { href: '/runs', label: 'Runs', matchPrefix: '/runs' },
-  { href: '/specs', label: 'Specs', matchPrefix: '/specs' },
-  { href: '/consumers', label: 'Consumers', matchPrefix: '/consumers' },
-  { href: '/settings', label: 'Settings', matchPrefix: '/settings' },
+  ...primaryRoutes().map((r) => ({
+    href: r.path,
+    label: r.label,
+    matchPrefix: r.path === '/' ? '/runs' : r.path,
+  })),
+  ...adminRoutes().map((r) => ({
+    href: r.path,
+    label: r.label,
+    matchPrefix: r.path,
+  })),
 ];
 
 /** Highlight a nav link when the current path lives under its prefix. */

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -89,6 +89,10 @@ const NODE_KIND_CLASSES: Record<FlowNodeKind, string> = {
 
 function FsmNode({ data, selected }: NodeProps<Node<FlowNodeData>>): JSX.Element {
   const kind = data.kind;
+  // The pixel dimensions are constants matched against the dagre
+  // layout numbers; staying inline keeps the two values in literal
+  // sync. Suppress the no-inline-styles lint for this single case.
+  /* eslint-disable-next-line react/forbid-dom-props -- xyflow nodes need fixed pixel dimensions matched to dagre layout */
   return (
     <div
       class={[
@@ -96,7 +100,7 @@ function FsmNode({ data, selected }: NodeProps<Node<FlowNodeData>>): JSX.Element
         NODE_KIND_CLASSES[kind],
         selected ? 'ring-2 ring-emerald-400 ring-offset-1' : '',
       ].join(' ')}
-      style={{ width: NODE_WIDTH, minHeight: NODE_HEIGHT }}
+      style={{ width: `${NODE_WIDTH}px`, minHeight: `${NODE_HEIGHT}px` }}
     >
       <div class="flex items-center justify-between gap-1">
         <span class="font-semibold truncate" title={data.label}>
@@ -186,10 +190,13 @@ export function FlowGraph({
     );
   }
 
+  // min-h-[320px] keeps the graph readable when the parent container
+  // doesn't supply an explicit height. h-full + w-full make sure
+  // xyflow's renderer has a measurable box when the parent DOES set
+  // a height (e.g. the Specs route's h-[60vh] tab panel).
   return (
     <div
-      class={['flow-graph relative', className ?? ''].join(' ')}
-      style={{ minHeight: 320 }}
+      class={['flow-graph relative h-full w-full min-h-[320px]', className ?? ''].join(' ')}
     >
       <ReactFlow
         nodes={decoratedNodes}


### PR DESCRIPTION
Two visual regressions caught in W18m smoke-testing against dummy-fsm-test:

1. Sidebar was hard-coded with NAV_LINKS = [Runs, Specs, Consumers, Settings] only — the new W18f/g/h routes (Topology, Drift, Journal) registered in ROUTES were invisible. Fix: derive NAV_LINKS from primaryRoutes() + adminRoutes() so adding a registry entry automatically appears.

2. FlowGraph parent had no measurable height, so xyflow logged 'parent container needs a width and a height' and shrank. Fix: `h-full w-full` on the outer div + min-height moved to a Tailwind class.

Confirmed via Playwright screenshots: sidebar now reads 'Runs | Specs | Topology | Drift | Journal | Settings' and the skill-code-review FSM graph renders all 15 nodes with worker (sky) / inline (violet) / terminal (slate) variants.

286/286 vitest still passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)