### PR TITLE
W19: spec-first IA + visual polish across both themes

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -139,25 +139,18 @@ interface NavLinkDef {
   matchPrefix: string;
 }
 
-// W18 sidebar nav is derived from the ROUTES registry so adding a
-// new route (W18f Topology / W18g Drift / W18h Journal) automatically
-// surfaces here without sidebar-side edits. Static fallbacks for the
-// label come from each registry entry; the matchPrefix is the route's
-// own path (or its first /-segment for nested routes).
+// W19 sidebar splits into two groups: PRIMARY (spec-first workflow:
+// just Specs) and ADMIN (cross-spec views). The split makes the
+// spec-first IA visually obvious — users see Specs at the top, and
+// the cross-spec admin tools sit below a divider as secondary.
 import { primaryRoutes, adminRoutes } from './routes';
 
-const NAV_LINKS: readonly NavLinkDef[] = [
-  ...primaryRoutes().map((r) => ({
-    href: r.path,
-    label: r.label,
-    matchPrefix: r.path === '/' ? '/runs' : r.path,
-  })),
-  ...adminRoutes().map((r) => ({
-    href: r.path,
-    label: r.label,
-    matchPrefix: r.path,
-  })),
-];
+function toNavLink(r: { path: string; label: string }): NavLinkDef {
+  return { href: r.path, label: r.label, matchPrefix: r.path };
+}
+
+const PRIMARY_NAV: readonly NavLinkDef[] = primaryRoutes().map(toNavLink);
+const ADMIN_NAV: readonly NavLinkDef[] = adminRoutes().map(toNavLink);
 
 /** Highlight a nav link when the current path lives under its prefix. */
 function isActive(currentPath: string, prefix: string): boolean {
@@ -173,15 +166,36 @@ function isActive(currentPath: string, prefix: string): boolean {
  * ``<a>`` so :class:`LocationProvider`'s click interceptor catches them
  * (it only intercepts left-clicks on anchors with matching origin).
  */
+function NavLink({ link, active }: { link: NavLinkDef; active: boolean }): JSX.Element {
+  return (
+    <li>
+      <a
+        href={link.href}
+        aria-current={active ? 'page' : undefined}
+        class={[
+          'block rounded-md px-3 py-2 text-sm font-medium',
+          'transition-colors duration-(--duration-fast) ease-(--ease-default)',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
+          active
+            ? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100'
+            : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-700',
+        ].join(' ')}
+      >
+        {link.label}
+      </a>
+    </li>
+  );
+}
+
 function Sidebar(): JSX.Element {
   const { path } = useLocation();
   return (
     <nav
       aria-label="Primary"
-      class="flex h-full w-56 shrink-0 flex-col gap-6 border-r border-slate-200 bg-white px-4 py-6 dark:border-slate-700 dark:bg-slate-800"
+      class="flex h-full w-56 shrink-0 flex-col gap-4 border-r border-slate-200 bg-white px-4 py-6 dark:border-slate-700 dark:bg-slate-800"
     >
       <a
-        href="/runs"
+        href="/specs"
         class="flex items-center gap-2 text-lg font-semibold text-slate-900 dark:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
       >
         <span
@@ -191,28 +205,24 @@ function Sidebar(): JSX.Element {
         <span>ctxr-fsm</span>
       </a>
       <ul class="flex flex-col gap-1">
-        {NAV_LINKS.map((link) => {
-          const active = isActive(path, link.matchPrefix);
-          return (
-            <li key={link.href}>
-              <a
-                href={link.href}
-                aria-current={active ? 'page' : undefined}
-                class={[
-                  'block rounded-md px-3 py-2 text-sm font-medium',
-                  'transition-colors duration-(--duration-fast) ease-(--ease-default)',
-                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
-                  active
-                    ? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100'
-                    : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-700',
-                ].join(' ')}
-              >
-                {link.label}
-              </a>
-            </li>
-          );
-        })}
+        {PRIMARY_NAV.map((link) => (
+          <NavLink key={link.href} link={link} active={isActive(path, link.matchPrefix)} />
+        ))}
       </ul>
+      {ADMIN_NAV.length > 0 ? (
+        <>
+          <div class="pt-3 border-t border-slate-200 dark:border-slate-700">
+            <h3 class="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400 px-3 py-1">
+              Admin
+            </h3>
+          </div>
+          <ul class="flex flex-col gap-1">
+            {ADMIN_NAV.map((link) => (
+              <NavLink key={link.href} link={link} active={isActive(path, link.matchPrefix)} />
+            ))}
+          </ul>
+        </>
+      ) : null}
     </nav>
   );
 }

--- a/ui/src/chrome/__tests__/CommandPalette.test.tsx
+++ b/ui/src/chrome/__tests__/CommandPalette.test.tsx
@@ -66,11 +66,14 @@ describe('CommandPalette', () => {
     expect(commandPaletteOpen.value).toBe(false);
   });
 
-  test('default results include the route entries (e.g. "Runs")', () => {
+  test('default results include the route entries (e.g. "Specs", "All runs")', () => {
     commandPaletteOpen.value = true;
     const { getByText } = render(<CommandPalette />);
-    expect(getByText('Runs')).toBeInTheDocument();
+    // W19 sidebar shows "Specs" (primary) and "All runs" (admin
+    // section). Both must appear in the palette so users can jump
+    // anywhere with Cmd+K.
     expect(getByText('Specs')).toBeInTheDocument();
+    expect(getByText('All runs')).toBeInTheDocument();
   });
 
   test('typing filters the result list', async () => {

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -27,9 +27,12 @@ import { useMemo } from 'preact/hooks';
 import type { JSX } from 'preact';
 import dagre from 'dagre';
 import {
+  BackgroundVariant,
   ReactFlow,
   Background,
   Controls,
+  Handle,
+  MarkerType,
   MiniMap,
   Position,
   type Edge,
@@ -87,8 +90,14 @@ const NODE_KIND_CLASSES: Record<FlowNodeKind, string> = {
     'border-cyan-500 bg-cyan-50 dark:bg-cyan-900/30 text-cyan-900 dark:text-cyan-100',
 };
 
-function FsmNode({ data, selected }: NodeProps<Node<FlowNodeData>>): JSX.Element {
+function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<Node<FlowNodeData>>): JSX.Element {
   const kind = data.kind;
+  // Handles are the connection anchors xyflow draws edges into.
+  // Without these, no edge has anywhere to land and the connection
+  // lines render zero-length / invisible. Position defaults match
+  // the dagre layout's direction (LR: source=right, target=left).
+  const sp = sourcePosition ?? Position.Right;
+  const tp = targetPosition ?? Position.Left;
   // The pixel dimensions are constants matched against the dagre
   // layout numbers; staying inline keeps the two values in literal
   // sync. Suppress the no-inline-styles lint for this single case.
@@ -96,12 +105,17 @@ function FsmNode({ data, selected }: NodeProps<Node<FlowNodeData>>): JSX.Element
   return (
     <div
       class={[
-        'fsm-node rounded-md border-2 shadow-sm px-3 py-2 text-xs',
+        'fsm-node relative rounded-md border-2 shadow-sm px-3 py-2 text-xs',
         NODE_KIND_CLASSES[kind],
         selected ? 'ring-2 ring-emerald-400 ring-offset-1' : '',
       ].join(' ')}
       style={{ width: `${NODE_WIDTH}px`, minHeight: `${NODE_HEIGHT}px` }}
     >
+      <Handle
+        type="target"
+        position={tp}
+        style={{ background: 'currentColor', width: 8, height: 8, border: 'none' }}
+      />
       <div class="flex items-center justify-between gap-1">
         <span class="font-semibold truncate" title={data.label}>
           {data.label}
@@ -113,6 +127,11 @@ function FsmNode({ data, selected }: NodeProps<Node<FlowNodeData>>): JSX.Element
           {data.sublabel}
         </div>
       ) : null}
+      <Handle
+        type="source"
+        position={sp}
+        style={{ background: 'currentColor', width: 8, height: 8, border: 'none' }}
+      />
     </div>
   );
 }
@@ -146,6 +165,33 @@ function applyDagreLayout(
       type: 'fsmNode',
     };
   });
+}
+
+// Decorate edges so they render visibly in both themes: stroke via
+// currentColor (the outer container sets text-color per theme), arrow
+// markers so direction is unambiguous, labels with a themed fill.
+function decorateEdges(edges: readonly Edge[]): Edge[] {
+  return edges.map((e) => ({
+    ...e,
+    type: e.type ?? 'default',
+    animated: e.animated ?? false,
+    style: {
+      strokeWidth: 1.5,
+      stroke: 'currentColor',
+      ...(e.style ?? {}),
+    },
+    markerEnd: e.markerEnd ?? {
+      type: MarkerType.ArrowClosed,
+      width: 18,
+      height: 18,
+      color: 'currentColor',
+    },
+    labelStyle: {
+      fontSize: 10,
+      fill: 'currentColor',
+      ...(e.labelStyle ?? {}),
+    },
+  }));
 }
 
 export function FlowGraph({
@@ -194,22 +240,78 @@ export function FlowGraph({
   // doesn't supply an explicit height. h-full + w-full make sure
   // xyflow's renderer has a measurable box when the parent DOES set
   // a height (e.g. the Specs route's h-[60vh] tab panel).
+  //
+  // The wrapper's `text-slate-400 dark:text-slate-600` drives edge
+  // stroke colour via currentColor (see decorateEdges). The fitView
+  // padding adds breathing room so dagre's wide LR layout doesn't
+  // clip nodes at the viewport edges.
+  const decoratedEdges = useMemo(() => decorateEdges(edges), [edges]);
   return (
     <div
-      class={['flow-graph relative h-full w-full min-h-[320px]', className ?? ''].join(' ')}
+      class={[
+        'flow-graph relative h-full w-full min-h-[320px]',
+        'text-slate-400 dark:text-slate-500',
+        className ?? '',
+      ].join(' ')}
     >
       <ReactFlow
         nodes={decoratedNodes}
-        edges={[...edges]}
+        edges={decoratedEdges}
         nodeTypes={NODE_TYPES}
         fitView
+        fitViewOptions={{ padding: 0.2, includeHiddenNodes: false }}
         proOptions={{ hideAttribution: true }}
+        defaultEdgeOptions={{
+          style: { stroke: 'currentColor', strokeWidth: 1.5 },
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            width: 18,
+            height: 18,
+            color: 'currentColor',
+          },
+        }}
         onNodeClick={(_e, node) => onNodeClick?.(node.id, node.data as FlowNodeData)}
         onEdgeClick={(_e, edge) => onEdgeClick?.(edge.id)}
       >
-        {background ? <Background gap={16} /> : null}
-        {controls ? <Controls position="bottom-right" showInteractive={false} /> : null}
-        {showMiniMap ? <MiniMap pannable zoomable position="top-right" /> : null}
+        {background ? (
+          <Background
+            gap={16}
+            // Subtle dot pattern; the CSS sets dot colour based on
+            // current text colour so both themes render visibly.
+            color="currentColor"
+            variant={BackgroundVariant.Dots}
+          />
+        ) : null}
+        {controls ? (
+          <Controls
+            position="bottom-right"
+            showInteractive={false}
+            // Override default white background; let xyflow inherit
+            // surface colours from theme tokens via Tailwind.
+            className="!bg-white dark:!bg-slate-800 !border !border-slate-200 dark:!border-slate-700 !rounded-md !overflow-hidden [&_button]:!bg-white [&_button]:dark:!bg-slate-800 [&_button]:!text-slate-700 [&_button]:dark:!text-slate-200 [&_button]:!border-slate-200 [&_button]:dark:!border-slate-700 [&_button:hover]:!bg-slate-100 [&_button:hover]:dark:!bg-slate-700"
+          />
+        ) : null}
+        {showMiniMap ? (
+          <MiniMap
+            pannable
+            zoomable
+            position="top-right"
+            // Theme-aware mini-map: dim background, themed node colour.
+            maskColor="rgba(15, 23, 42, 0.05)"
+            nodeColor={(n) => {
+              const k = (n.data as FlowNodeData | undefined)?.kind;
+              switch (k) {
+                case 'worker': return '#0ea5e9';
+                case 'inline': return '#8b5cf6';
+                case 'terminal': return '#64748b';
+                case 'producer': return '#f59e0b';
+                case 'consumer': return '#06b6d4';
+                default: return '#10b981';
+              }
+            }}
+            className="!bg-white/80 dark:!bg-slate-800/80 !border !border-slate-200 dark:!border-slate-700 !rounded-md"
+          />
+        ) : null}
       </ReactFlow>
     </div>
   );

--- a/ui/src/components/Tabs.tsx
+++ b/ui/src/components/Tabs.tsx
@@ -104,7 +104,7 @@ export function Tabs({
               type="button"
               role="tab"
               id={`${baseId}-tab-${tab.id}`}
-              aria-selected={isActive}
+              aria-selected={isActive ? 'true' : 'false'}
               aria-controls={`${baseId}-panel-${tab.id}`}
               tabIndex={isActive ? 0 : -1}
               disabled={tab.disabled}
@@ -114,7 +114,7 @@ export function Tabs({
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm',
                 isActive
                   ? 'border-emerald-500 text-slate-900 dark:text-slate-100 font-medium'
-                  : 'border-transparent text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200',
+                  : 'border-transparent text-slate-700 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100',
                 tab.disabled ? 'opacity-40 cursor-not-allowed' : '',
               ].join(' ')}
             >

--- a/ui/src/components/__tests__/FlowGraph.test.tsx
+++ b/ui/src/components/__tests__/FlowGraph.test.tsx
@@ -24,6 +24,8 @@ vi.mock('@xyflow/react', () => ({
   Controls: () => <div data-testid="controls" />,
   MiniMap: () => <div data-testid="minimap" />,
   Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+  BackgroundVariant: { Dots: 'dots', Lines: 'lines', Cross: 'cross' },
+  MarkerType: { ArrowClosed: 'arrowclosed', Arrow: 'arrow' },
 }));
 vi.mock('@xyflow/react/dist/style.css', () => ({}));
 

--- a/ui/src/routes/index.ts
+++ b/ui/src/routes/index.ts
@@ -15,6 +15,14 @@
  * routes like `/runs/:id` and `/runs/:id/compare/:otherId` (the user
  * doesn't navigate to them via a link; they get there by clicking a
  * row or by deep link).
+ *
+ * **W19 IA shift**: `/specs` is the landing page (`/` redirects to
+ * it). `/specs/:specId` is the per-spec dashboard with tabs for
+ * Graph / Runs / Schemas / Definition / Versions; this is where the
+ * user spends most of their time. The global `/runs`, `/topology`,
+ * `/drift`, `/journal` routes still exist as cross-spec admin views
+ * but live in a secondary nav group so the spec-first model stays
+ * the primary mental model.
  */
 
 import type { ComponentType } from 'preact';
@@ -23,6 +31,7 @@ import { Runs } from './runs';
 import { RunDetailRoute } from './runDetail';
 import { RunCompareRoute } from './runCompare';
 import { SpecsRoute } from './specs';
+import { SpecDetailRoute } from './specDetail';
 import { TopologyRoute } from './topology';
 import { DriftRoute } from './drift';
 import { JournalRoute } from './journal';
@@ -48,22 +57,35 @@ export interface RouteDef {
  * Registry, in display order.
  *
  * Order in this array IS the sidebar order. Edit deliberately.
+ *
+ * W19 ordering: Specs first (the spec catalog is the entry point;
+ * `/` redirects here). Per-spec view is /specs/:specId. The
+ * cross-spec admin views (Runs / Topology / Drift / Journal) live in
+ * the 'admin' group so the sidebar stays uncluttered for the
+ * spec-first user workflow.
  */
 export const ROUTES: readonly RouteDef[] = [
   {
     path: '/',
-    component: Runs,
-    label: 'Runs',
-    navGroup: null, // alias for /runs; surfaced via /runs below
-    description: 'Live and historical FSM runs.',
+    component: SpecsRoute,
+    label: 'Specs',
+    navGroup: null, // alias of /specs
+    description: 'Spec catalog landing page.',
   },
   {
-    path: '/runs',
-    component: Runs,
-    label: 'Runs',
+    path: '/specs',
+    component: SpecsRoute,
+    label: 'Specs',
     navGroup: 'primary',
-    shortcut: 'g r',
-    description: 'Live and historical FSM runs.',
+    shortcut: 'g s',
+    description: 'Spec catalog — entry point. Pick a spec to drill in.',
+  },
+  {
+    path: '/specs/:specId',
+    component: SpecDetailRoute,
+    label: 'Spec detail',
+    navGroup: null,
+    description: 'Per-spec dashboard: graph, runs, schemas, versions.',
   },
   {
     path: '/runs/:id',
@@ -79,37 +101,28 @@ export const ROUTES: readonly RouteDef[] = [
     navGroup: null,
     description: 'Side-by-side comparison of two runs.',
   },
+  // ---- Admin (cross-spec) views -----------------------------------------
   {
-    path: '/specs',
-    component: SpecsRoute,
-    label: 'Specs',
-    navGroup: 'primary',
-    shortcut: 'g s',
-    description: 'Registered FSM specs and version lineage.',
+    path: '/runs',
+    component: Runs,
+    label: 'All runs',
+    navGroup: 'admin',
+    shortcut: 'g r',
+    description: 'Every run across every spec.',
   },
   {
     path: '/topology',
     component: TopologyRoute,
     label: 'Topology',
-    navGroup: 'primary',
+    navGroup: 'admin',
     shortcut: 'g t',
     description: 'Event-bus producers, consumers, and SSE health.',
-  },
-  // /consumers is the pre-W18f path; kept registered as a non-nav
-  // entry so any bookmarks still resolve to the same list-view
-  // component until users naturally migrate to /topology.
-  {
-    path: '/consumers',
-    component: ConsumersRoute,
-    label: 'Consumers (legacy)',
-    navGroup: null,
-    description: 'Deprecated; see /topology.',
   },
   {
     path: '/drift',
     component: DriftRoute,
     label: 'Drift',
-    navGroup: 'primary',
+    navGroup: 'admin',
     shortcut: 'g d',
     description: 'Runs ranked by accumulated drift score.',
   },
@@ -120,6 +133,16 @@ export const ROUTES: readonly RouteDef[] = [
     navGroup: 'admin',
     shortcut: 'g j',
     description: 'Recover pending journal transactions across runs.',
+  },
+  // /consumers is the pre-W18f path; kept registered as a non-nav
+  // entry so any bookmarks still resolve to the same list-view
+  // component until users naturally migrate to /topology.
+  {
+    path: '/consumers',
+    component: ConsumersRoute,
+    label: 'Consumers (legacy)',
+    navGroup: null,
+    description: 'Deprecated; see /topology.',
   },
   {
     path: '/settings',

--- a/ui/src/routes/runs.tsx
+++ b/ui/src/routes/runs.tsx
@@ -123,16 +123,16 @@ function formatTimestamp(value: string | null): string {
 }
 
 /**
- * Compose the ``spec`` column cell — ``slug:version`` if both are
- * derivable, otherwise the raw ``fsm_spec_id``.
- *
- * The API currently exposes only ``fsm_spec_id`` on :class:`RunSummary`
- * (no embedded slug). We display the id directly; a future server-side
- * enrichment will swap this for a real slug:version pair without
- * touching the callsite.
+ * Map a run's `fsm_spec_id` to a human-readable label using the
+ * resolver populated by a one-shot `api.listSpecs()` call. Falls
+ * back to the raw UUID when the spec isn't in the cache (a race or
+ * a stale resolver after the run was created from a freshly
+ * registered spec).
  */
-function specCell(run: RunSummary): string {
-  return run.fsm_spec_id;
+function specCell(run: RunSummary, resolver: Map<string, { slug: string; version: number }>): string {
+  const entry = resolver.get(run.fsm_spec_id);
+  if (entry) return `${entry.slug} v${entry.version}`;
+  return run.fsm_spec_id.slice(0, 12) + '…';
 }
 
 /**
@@ -402,6 +402,29 @@ export function Runs(): JSX.Element {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [cursor, setCursor] = useState<number>(0);
+  const [specResolver, setSpecResolver] = useState<Map<string, { slug: string; version: number }>>(
+    new Map(),
+  );
+
+  // Fetch the spec list once on mount + build a resolver map so the
+  // Spec column on each row can render slug + version instead of a
+  // raw UUID. Best-effort: a failure leaves the resolver empty so the
+  // fallback ("12-char prefix...") still works.
+  useEffect(() => {
+    let cancelled = false;
+    api.listSpecs()
+      .then((specs) => {
+        if (cancelled) return;
+        const m = new Map<string, { slug: string; version: number }>();
+        for (const s of specs) m.set(s.id, { slug: s.slug, version: s.version });
+        setSpecResolver(m);
+      })
+      .catch(() => {
+        // Silent — the resolver stays empty and rows render with the
+        // UUID-prefix fallback.
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   // Track which event we've already reacted to so the SSE refetch
   // fires once per new event, not on every signal subscriber tick.
@@ -549,9 +572,14 @@ export function Runs(): JSX.Element {
         key: 'spec',
         label: 'Spec',
         render: (r) => (
-          <span class="text-sm text-slate-800 dark:text-slate-200">
-            {specCell(r)}
-          </span>
+          <a
+            href={`/specs/${encodeURIComponent(r.fsm_spec_id)}`}
+            class="text-sm text-slate-800 dark:text-slate-200 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
+            title="Open spec"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {specCell(r, specResolver)}
+          </a>
         ),
       },
       {
@@ -585,7 +613,10 @@ export function Runs(): JSX.Element {
         ),
       },
     ],
-    [],
+    // W19: re-create columns when the spec resolver populates so the
+    // Spec column re-renders from `019e80be-ebe…` → `code-reviewer v1`.
+    // Without `specResolver` here the empty initial Map is captured.
+    [specResolver],
   );
 
   // --- Body content ---------------------------------------------------------

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -1,0 +1,439 @@
+/**
+ * /specs/:specId — per-spec dashboard.
+ *
+ * This is the post-W19 spec-first IA: the user lands on /specs,
+ * picks a spec, lands here. From this page they see EVERYTHING
+ * scoped to that spec — graph, runs of this spec, schemas,
+ * definition, version timeline.
+ *
+ * Tabs: Graph · Runs · Schemas · Definition · Versions.
+ *
+ * "Runs" is the spec-scoped equivalent of the global /runs list,
+ * filtered to runs whose `fsm_spec_id` matches this spec (or any
+ * sibling version of the same slug).
+ */
+
+import type { JSX } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useRoute } from 'preact-iso';
+
+import {
+  Card,
+  Diff,
+  EmptyState,
+  FlowGraph,
+  JsonViewer,
+  Pill,
+  Spinner,
+  Table,
+  Tabs,
+  type PillVariant,
+  type TabSpec,
+  type TableColumn,
+} from '../components';
+import {
+  api,
+  ApiError,
+  type RunSummary,
+  type SpecDetail,
+  type SpecSummary,
+} from '../lib/api';
+import { canonicalJson } from '../lib/canonicalJson';
+import { specToGraph } from '../lib/specGraph';
+
+const shortHash = (h: string): string => (h.length > 12 ? h.slice(0, 12) : h);
+const shortId = (id: string): string => (id.length > 7 ? id.slice(0, 7) : id);
+
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+function statusVariant(status: string): PillVariant {
+  switch (status) {
+    case 'completed': return 'success';
+    case 'in_progress': return 'info';
+    case 'paused': return 'warning';
+    case 'faulted':
+    case 'aborted':
+    case 'drift_paused': return 'danger';
+    default: return 'neutral';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface SpecSiblings {
+  /** The selected spec (full detail). */
+  detail: SpecDetail;
+  /** All registered specs (used to find sibling versions of this slug). */
+  all: SpecSummary[];
+}
+
+function siblingsOf(detail: SpecDetail, all: SpecSummary[]): SpecSummary[] {
+  return all
+    .filter((s) => s.slug === detail.slug)
+    .sort((a, b) => b.version - a.version);
+}
+
+// ---------------------------------------------------------------------------
+// Tab panels
+// ---------------------------------------------------------------------------
+
+function GraphPanel({ detail }: { detail: SpecDetail }): JSX.Element {
+  const graph = useMemo(() => specToGraph(detail.definition), [detail.definition]);
+  return (
+    <div class="h-[60vh] p-3">
+      <FlowGraph
+        nodes={graph.nodes}
+        edges={graph.edges}
+        autoLayout={true}
+        direction="LR"
+      />
+    </div>
+  );
+}
+
+interface RunsPanelProps {
+  spec: SpecSiblings;
+  navigate: (path: string) => void;
+}
+
+function RunsPanel({ spec, navigate }: RunsPanelProps): JSX.Element {
+  const [runs, setRuns] = useState<RunSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Match against ALL sibling versions so the user sees every run
+  // of the slug, not just the currently-selected version.
+  const matchIds = useMemo(
+    () => new Set(spec.all.filter((s) => s.slug === spec.detail.slug).map((s) => s.id)),
+    [spec],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    api.listRuns({ limit: 500 })
+      .then((all) => {
+        if (cancelled) return;
+        setRuns(all.filter((r) => matchIds.has(r.fsm_spec_id)));
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof ApiError ? err.message : String(err));
+      });
+    return () => { cancelled = true; };
+  }, [matchIds]);
+
+  if (error) return <EmptyState title="Failed to load runs" message={error} />;
+  if (runs === null) {
+    return (
+      <div class="flex items-center justify-center py-12">
+        <Spinner label="Loading runs" />
+      </div>
+    );
+  }
+  if (runs.length === 0) {
+    return (
+      <EmptyState
+        title="No runs for this spec yet"
+        message={`Start a run of ${spec.detail.slug} via the CLI or MCP server to see it here.`}
+      />
+    );
+  }
+
+  const versionLabel = (id: string): string => {
+    const v = spec.all.find((s) => s.id === id);
+    return v ? `v${v.version}` : id.slice(0, 7);
+  };
+
+  const cols: TableColumn<RunSummary>[] = [
+    {
+      key: 'id', label: 'ID',
+      render: (r) => (
+        <code class="font-mono text-xs text-slate-700 dark:text-slate-300">{shortId(r.id)}</code>
+      ),
+    },
+    {
+      key: 'fsm_spec_id', label: 'Version', width: '5rem',
+      render: (r) => <Pill variant="info" size="sm">{versionLabel(r.fsm_spec_id)}</Pill>,
+    },
+    {
+      key: 'status', label: 'Status', width: '8rem',
+      render: (r) => <Pill variant={statusVariant(r.status)} size="sm">{r.status}</Pill>,
+    },
+    {
+      key: 'current_state', label: 'Current state',
+      render: (r) => <code class="text-xs text-slate-700 dark:text-slate-300">{r.current_state ?? '—'}</code>,
+    },
+    {
+      key: 'started_at', label: 'Started', width: '12rem',
+      render: (r) => <span class="text-xs text-slate-600 dark:text-slate-400">{formatTimestamp(r.started_at)}</span>,
+    },
+    {
+      key: 'last_update_at', label: 'Last update', width: '12rem',
+      render: (r) => <span class="text-xs text-slate-600 dark:text-slate-400">{formatTimestamp(r.last_update_at)}</span>,
+    },
+  ];
+
+  return (
+    <Table<RunSummary>
+      columns={cols}
+      rows={runs.sort((a, b) => (b.last_update_at ?? '').localeCompare(a.last_update_at ?? ''))}
+      rowKey={(r) => r.id}
+      onRowClick={(r) => navigate(`/runs/${encodeURIComponent(r.id)}`)}
+      caption={`Runs of ${spec.detail.slug}`}
+    />
+  );
+}
+
+function SchemasPanel({ detail }: { detail: SpecDetail }): JSX.Element {
+  const def = (detail.definition as Record<string, unknown>) ?? {};
+  const states = Array.isArray(def.states) ? def.states : [];
+  const withSchemas = (states as Record<string, unknown>[]).filter((s) => {
+    const w = s.worker as Record<string, unknown> | undefined;
+    return w && w.response_schema;
+  });
+  if (withSchemas.length === 0) {
+    return <EmptyState title="No worker schemas" message="This spec has no worker response schemas declared." />;
+  }
+  return (
+    <div class="space-y-4">
+      {withSchemas.map((s) => {
+        const sid = String(s.id);
+        const worker = s.worker as Record<string, unknown>;
+        return (
+          <div key={sid}>
+            <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
+              {sid}
+            </h4>
+            <JsonViewer
+              value={worker.response_schema}
+              rootLabel="response_schema"
+              mode="inline"
+              maxInlineHeight="max-h-48"
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function DefinitionPanel({ detail }: { detail: SpecDetail }): JSX.Element {
+  return (
+    <JsonViewer
+      value={detail.definition}
+      rootLabel="definition"
+      mode="expanded"
+      defaultExpandDepth={3}
+      downloadFilename={`spec-${detail.slug}-v${detail.version}.json`}
+    />
+  );
+}
+
+interface VersionsPanelProps {
+  spec: SpecSiblings;
+  navigate: (path: string) => void;
+}
+
+function VersionsPanel({ spec, navigate }: VersionsPanelProps): JSX.Element {
+  const [compareWith, setCompareWith] = useState<string | null>(null);
+  const [compareDetail, setCompareDetail] = useState<SpecDetail | null>(null);
+  const siblings = useMemo(() => siblingsOf(spec.detail, spec.all), [spec]);
+
+  useEffect(() => {
+    setCompareWith(null);
+    setCompareDetail(null);
+  }, [spec.detail.id]);
+
+  useEffect(() => {
+    if (!compareWith) return;
+    let cancelled = false;
+    api.getSpec(compareWith)
+      .then((d) => { if (!cancelled) setCompareDetail(d); })
+      .catch(() => { if (!cancelled) setCompareDetail(null); });
+    return () => { cancelled = true; };
+  }, [compareWith]);
+
+  if (siblings.length <= 1) {
+    return (
+      <p class="text-sm text-slate-600 dark:text-slate-400 py-2">
+        Only one version registered for this slug.
+      </p>
+    );
+  }
+
+  return (
+    <div class="space-y-3">
+      <div class="text-xs text-slate-600 dark:text-slate-400">
+        {siblings.length} versions of <code class="font-mono">{spec.detail.slug}</code>. Click a row to switch; pick another from the dropdown to diff against the current selection.
+      </div>
+      <ul class="divide-y divide-slate-100 dark:divide-slate-800 text-xs font-mono">
+        {siblings.map((s) => (
+          <li key={s.id} class="py-1.5 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => navigate(`/specs/${encodeURIComponent(s.id)}`)}
+              class={[
+                'text-left flex-1 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm',
+                s.id === spec.detail.id ? 'text-emerald-700 dark:text-emerald-400 font-semibold' : '',
+              ].join(' ')}
+            >
+              v{s.version}
+            </button>
+            <code class="text-slate-500 dark:text-slate-400">{shortHash(s.hash)}</code>
+            <span class="text-slate-500 dark:text-slate-400">{formatTimestamp(s.created_at)}</span>
+          </li>
+        ))}
+      </ul>
+      <div class="flex items-center gap-2 text-sm pt-2 border-t border-slate-200 dark:border-slate-700">
+        <label for="spec-diff-target">Diff against:</label>
+        <select
+          id="spec-diff-target"
+          aria-label="Pick a version to diff against"
+          value={compareWith ?? ''}
+          onChange={(e) => setCompareWith((e.target as HTMLSelectElement).value || null)}
+          class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-100 rounded-md px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+        >
+          <option value="">— pick a version —</option>
+          {siblings.filter((s) => s.id !== spec.detail.id).map((s) => (
+            <option value={s.id} key={s.id}>v{s.version} ({shortHash(s.hash)})</option>
+          ))}
+        </select>
+      </div>
+      {compareDetail ? (
+        <Diff
+          before={canonicalJson(compareDetail.definition)}
+          after={canonicalJson(spec.detail.definition)}
+          label={`v${compareDetail.version} → v${spec.detail.version}`}
+        />
+      ) : compareWith ? (
+        <div class="flex items-center gap-2 text-xs text-slate-500"><Spinner size="sm" /> Loading...</div>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function SpecDetailRoute(): JSX.Element {
+  const { params } = useRoute();
+  const specId = params.specId ?? '';
+  const [activeTab, setActiveTab] = useState<string>('graph');
+  const [detail, setDetail] = useState<SpecDetail | null>(null);
+  const [allSpecs, setAllSpecs] = useState<SpecSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [runCount, setRunCount] = useState<number | null>(null);
+
+  const navigate = (path: string): void => {
+    if (typeof window === 'undefined') return;
+    window.history.pushState(null, '', path);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    setDetail(null);
+    setError(null);
+    api.getSpec(specId)
+      .then((d) => { if (!cancelled) setDetail(d); })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof ApiError ? err.message : String(err));
+      });
+    return () => { cancelled = true; };
+  }, [specId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.listSpecs()
+      .then((all) => { if (!cancelled) setAllSpecs(all); })
+      .catch(() => { if (!cancelled) setAllSpecs([]); });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    // Compute run count across all sibling versions for the header badge.
+    if (!detail || !allSpecs) return;
+    let cancelled = false;
+    const matchIds = new Set(allSpecs.filter((s) => s.slug === detail.slug).map((s) => s.id));
+    api.listRuns({ limit: 500 })
+      .then((rs) => { if (!cancelled) setRunCount(rs.filter((r) => matchIds.has(r.fsm_spec_id)).length); })
+      .catch(() => { if (!cancelled) setRunCount(null); });
+    return () => { cancelled = true; };
+  }, [detail, allSpecs]);
+
+  if (error) {
+    return (
+      <div class="p-4 md:p-6">
+        <Card>
+          <EmptyState title="Failed to load spec" message={error} />
+        </Card>
+      </div>
+    );
+  }
+  if (!detail || allSpecs === null) {
+    return (
+      <div class="p-4 md:p-6">
+        <Card>
+          <div class="flex items-center justify-center py-12"><Spinner label="Loading spec" /></div>
+        </Card>
+      </div>
+    );
+  }
+
+  const spec: SpecSiblings = { detail, all: allSpecs };
+  const siblings = siblingsOf(detail, allSpecs);
+
+  const tabs: TabSpec[] = [
+    { id: 'graph', label: 'Graph' },
+    { id: 'runs', label: 'Runs', badge: runCount !== null ? <Pill variant="neutral" size="sm">{runCount}</Pill> : undefined },
+    { id: 'schemas', label: 'Schemas' },
+    { id: 'definition', label: 'Definition' },
+    { id: 'versions', label: 'Versions', badge: <Pill variant="neutral" size="sm">{siblings.length}</Pill> },
+  ];
+
+  return (
+    <div class="p-4 md:p-6 space-y-4 flex flex-col h-full min-h-0">
+      <header class="space-y-2">
+        <div class="flex items-center gap-2 text-xs">
+          <a
+            href="/specs"
+            class="text-slate-500 dark:text-slate-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
+          >
+            ← All specs
+          </a>
+        </div>
+        <div class="flex flex-wrap items-baseline gap-2">
+          <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{detail.slug}</h1>
+          <Pill variant="info">v{detail.version}</Pill>
+          <code class="text-xs font-mono text-slate-600 dark:text-slate-400" title={detail.hash}>
+            {shortHash(detail.hash)}
+          </code>
+          <span class="ml-auto text-xs text-slate-600 dark:text-slate-400">
+            Registered {formatTimestamp(detail.registered_at)}
+          </span>
+        </div>
+      </header>
+      <Card className="flex-1 min-h-0 p-0">
+        <Tabs
+          tabs={tabs}
+          activeTab={activeTab}
+          onChange={setActiveTab}
+          panels={{
+            graph: <GraphPanel detail={detail} />,
+            runs: <div class="p-3"><RunsPanel spec={spec} navigate={navigate} /></div>,
+            schemas: <div class="p-3"><SchemasPanel detail={detail} /></div>,
+            definition: <div class="p-3"><DefinitionPanel detail={detail} /></div>,
+            versions: <div class="p-3"><VersionsPanel spec={spec} navigate={navigate} /></div>,
+          }}
+        />
+      </Card>
+    </div>
+  );
+}
+
+export default SpecDetailRoute;

--- a/ui/src/routes/specs.tsx
+++ b/ui/src/routes/specs.tsx
@@ -1,12 +1,22 @@
 /**
- * /specs v2 — master / detail with FSM graph + version timeline.
+ * /specs — spec catalog (W19 spec-first IA landing page).
  *
- * Layout: 40/60 split (stacks on mobile). Master = master list of
- * specs grouped by slug; detail = selected spec rendered as a
- * tabbed view (Graph / Schemas / Definition / Versions). The graph
- * uses the W18b FlowGraph primitive to render the state diagram
- * (n8n/Dify-style nodes + edges with predicate labels) so a non-
- * trivial spec is comprehensible at a glance.
+ * Lists every registered spec, GROUPED BY SLUG, ordered by most-
+ * recently-active first (last_update_at of any run of that slug). Each
+ * row surfaces:
+ *
+ *   - slug + latest version pill
+ *   - total runs across all versions
+ *   - newest run's status pill + when it last updated
+ *   - number of registered versions
+ *
+ * Clicking a row navigates to /specs/:specId (the W19 spec-scoped
+ * dashboard with Graph / Runs / Schemas / Definition / Versions
+ * tabs). This page replaces the previous master/detail split — the
+ * detail view is now its own URL.
+ *
+ * If no specs are registered, the empty state hints at the CLI
+ * command users typically run to register one.
  */
 
 import type { JSX } from 'preact';
@@ -14,401 +24,218 @@ import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import {
   Card,
-  Diff,
   EmptyState,
-  FlowGraph,
-  JsonViewer,
   Pill,
   Spinner,
-  Tabs,
-  type TabSpec,
+  Table,
+  type PillVariant,
+  type TableColumn,
 } from '../components';
-import { api, ApiError, type SpecDetail, type SpecSummary } from '../lib/api';
-import { canonicalJson } from '../lib/canonicalJson';
-import { specToGraph } from '../lib/specGraph';
+import {
+  api,
+  ApiError,
+  type RunSummary,
+  type SpecSummary,
+} from '../lib/api';
 
 const shortHash = (h: string): string => (h.length > 12 ? h.slice(0, 12) : h);
 
-function formatTimestamp(iso: string): string {
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
   const d = new Date(iso);
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
 }
 
-// ---------------------------------------------------------------------------
-// Master list grouped by slug
-// ---------------------------------------------------------------------------
-
-interface SpecGroup {
-  slug: string;
-  rows: SpecSummary[]; // sorted by version desc
+function statusVariant(status: string): PillVariant {
+  switch (status) {
+    case 'completed': return 'success';
+    case 'in_progress': return 'info';
+    case 'paused': return 'warning';
+    case 'faulted':
+    case 'aborted':
+    case 'drift_paused': return 'danger';
+    default: return 'neutral';
+  }
 }
 
-function groupBySlug(specs: readonly SpecSummary[]): SpecGroup[] {
-  const map = new Map<string, SpecSummary[]>();
+interface SpecGroupRow {
+  /** The latest registered SpecSummary for this slug (used for the navigation target). */
+  latest: SpecSummary;
+  /** Number of registered versions of this slug. */
+  versionCount: number;
+  /** Number of runs across all versions of this slug. */
+  runCount: number;
+  /** Newest run for this slug (any version), or null if none. */
+  newestRun: RunSummary | null;
+}
+
+/**
+ * Build the per-slug rows: group specs by slug, take the latest
+ * version as the navigation target, count runs across all versions,
+ * and pick the most-recently-updated run for the status pill.
+ */
+function buildRows(specs: readonly SpecSummary[], runs: readonly RunSummary[]): SpecGroupRow[] {
+  // Map slug -> sorted-desc-by-version list of SpecSummary.
+  const bySlug = new Map<string, SpecSummary[]>();
   for (const s of specs) {
-    if (!map.has(s.slug)) map.set(s.slug, []);
-    map.get(s.slug)!.push(s);
+    if (!bySlug.has(s.slug)) bySlug.set(s.slug, []);
+    bySlug.get(s.slug)!.push(s);
   }
-  const groups: SpecGroup[] = [];
-  for (const [slug, rows] of map.entries()) {
-    rows.sort((a, b) => b.version - a.version);
-    groups.push({ slug, rows });
+  for (const list of bySlug.values()) list.sort((a, b) => b.version - a.version);
+
+  // Map fsm_spec_id -> slug (so we can attribute each run to its slug).
+  const idToSlug = new Map<string, string>();
+  for (const s of specs) idToSlug.set(s.id, s.slug);
+
+  // Map slug -> { runs[] }; pick newest by last_update_at descending.
+  const slugRuns = new Map<string, RunSummary[]>();
+  for (const r of runs) {
+    const slug = idToSlug.get(r.fsm_spec_id);
+    if (!slug) continue;
+    if (!slugRuns.has(slug)) slugRuns.set(slug, []);
+    slugRuns.get(slug)!.push(r);
   }
-  groups.sort((a, b) => a.slug.localeCompare(b.slug));
-  return groups;
-}
 
-interface MasterListProps {
-  groups: readonly SpecGroup[];
-  selectedId: string | null;
-  onSelect: (id: string) => void;
-}
-
-function MasterList({ groups, selectedId, onSelect }: MasterListProps): JSX.Element {
-  const [expandedSlugs, setExpandedSlugs] = useState<Set<string>>(new Set());
-  const toggle = (slug: string) =>
-    setExpandedSlugs((prev) => {
-      const next = new Set(prev);
-      if (next.has(slug)) next.delete(slug);
-      else next.add(slug);
-      return next;
+  const rows: SpecGroupRow[] = [];
+  for (const [slug, vList] of bySlug.entries()) {
+    const runsForSlug = slugRuns.get(slug) ?? [];
+    runsForSlug.sort((a, b) => (b.last_update_at ?? '').localeCompare(a.last_update_at ?? ''));
+    rows.push({
+      latest: vList[0],
+      versionCount: vList.length,
+      runCount: runsForSlug.length,
+      newestRun: runsForSlug[0] ?? null,
     });
-
-  if (groups.length === 0) {
-    return (
-      <EmptyState
-        title="No specs registered"
-        message="Register an FSM spec via POST /api/v1/specs."
-      />
-    );
   }
-  return (
-    <ul class="divide-y divide-slate-200 dark:divide-slate-700" aria-label="Registered FSM specs">
-      {groups.map((g) => {
-        const latest = g.rows[0];
-        const expanded = expandedSlugs.has(g.slug);
-        return (
-          <li key={g.slug}>
-            <div class="flex items-center gap-1 py-2 px-3">
-              <button
-                type="button"
-                onClick={() => toggle(g.slug)}
-                aria-label={expanded ? `Collapse ${g.slug}` : `Expand ${g.slug}`}
-                aria-expanded={expanded}
-                class="inline-flex w-4 h-4 items-center justify-center text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
-              >
-                <svg
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  class={['w-3 h-3 transition-transform', expanded ? 'rotate-90' : ''].join(' ')}
-                  aria-hidden="true"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-              </button>
-              <button
-                type="button"
-                onClick={() => onSelect(latest.id)}
-                class={[
-                  'flex-1 text-left flex items-center gap-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm',
-                  selectedId === latest.id
-                    ? 'font-semibold text-slate-900 dark:text-slate-100'
-                    : 'text-slate-700 dark:text-slate-300',
-                ].join(' ')}
-              >
-                <span class="truncate">{g.slug}</span>
-                <Pill variant="info" size="sm">v{latest.version}</Pill>
-                <span class="text-[10px] text-slate-500 ml-auto">
-                  {g.rows.length} version{g.rows.length === 1 ? '' : 's'}
-                </span>
-              </button>
-            </div>
-            {expanded ? (
-              <ul class="ml-7 mb-2 space-y-0.5">
-                {g.rows.map((r) => (
-                  <li key={r.id}>
-                    <button
-                      type="button"
-                      onClick={() => onSelect(r.id)}
-                      class={[
-                        'block w-full text-left text-xs py-1 px-2 rounded-sm font-mono',
-                        selectedId === r.id
-                          ? 'bg-emerald-50 dark:bg-emerald-900/30 text-slate-900 dark:text-slate-100'
-                          : 'text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800/50',
-                      ].join(' ')}
-                    >
-                      v{r.version} · {shortHash(r.hash)} · {formatTimestamp(r.created_at)}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-          </li>
-        );
-      })}
-    </ul>
-  );
+  // Most-recently-active first: order by newest run's last_update_at
+  // descending, with specs that have never been run falling to the
+  // bottom but still sorted by latest-version registered_at.
+  rows.sort((a, b) => {
+    const aT = a.newestRun?.last_update_at ?? '';
+    const bT = b.newestRun?.last_update_at ?? '';
+    if (aT && !bT) return -1;
+    if (bT && !aT) return 1;
+    if (aT && bT) return bT.localeCompare(aT);
+    return (b.latest.created_at ?? '').localeCompare(a.latest.created_at ?? '');
+  });
+  return rows;
 }
 
-// ---------------------------------------------------------------------------
-// Detail pane (tabs: Graph / Schemas / Definition / Versions)
-// ---------------------------------------------------------------------------
-
-interface DetailPaneProps {
-  detail: SpecDetail | null;
-  detailError: string | null;
-  /** All versions of the selected slug (for the Versions tab). */
-  siblings: SpecSummary[];
+function navigateTo(path: string): void {
+  if (typeof window === 'undefined') return;
+  window.history.pushState(null, '', path);
+  window.dispatchEvent(new PopStateEvent('popstate'));
 }
-
-function DetailPane({ detail, detailError, siblings }: DetailPaneProps): JSX.Element {
-  const [activeTab, setActiveTab] = useState('graph');
-  const [compareWith, setCompareWith] = useState<string | null>(null);
-  const [compareDetail, setCompareDetail] = useState<SpecDetail | null>(null);
-
-  // Reset the diff target when the detail itself changes.
-  useEffect(() => {
-    setCompareWith(null);
-    setCompareDetail(null);
-  }, [detail?.id]);
-
-  useEffect(() => {
-    if (!compareWith) return;
-    let cancelled = false;
-    api.getSpec(compareWith)
-      .then((d) => { if (!cancelled) setCompareDetail(d); })
-      .catch(() => { if (!cancelled) setCompareDetail(null); });
-    return () => { cancelled = true; };
-  }, [compareWith]);
-
-  if (detailError) {
-    return <EmptyState title="Failed to load spec" message={detailError} />;
-  }
-  if (!detail) {
-    return (
-      <div class="flex items-center justify-center py-16">
-        <Spinner label="Pick a spec on the left" />
-      </div>
-    );
-  }
-
-  const graph = specToGraph(detail.definition);
-
-  const schemasPanel = (() => {
-    const def = (detail.definition as Record<string, unknown>) ?? {};
-    const states = Array.isArray(def.states) ? def.states : [];
-    const withSchemas = (states as Record<string, unknown>[]).filter((s) => {
-      const w = s.worker as Record<string, unknown> | undefined;
-      return w && w.response_schema;
-    });
-    if (withSchemas.length === 0) {
-      return <EmptyState title="No worker schemas" message="This spec has no worker response schemas declared." />;
-    }
-    return (
-      <div class="space-y-4">
-        {withSchemas.map((s) => {
-          const sid = String(s.id);
-          const worker = s.worker as Record<string, unknown>;
-          return (
-            <div key={sid}>
-              <h4 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">
-                {sid}
-              </h4>
-              <JsonViewer
-                value={worker.response_schema}
-                rootLabel="response_schema"
-                mode="inline"
-                maxInlineHeight="max-h-48"
-              />
-            </div>
-          );
-        })}
-      </div>
-    );
-  })();
-
-  const versionsPanel = (() => {
-    if (siblings.length <= 1) {
-      return (
-        <p class="text-sm text-slate-500 py-2">
-          Only one version registered for this slug.
-        </p>
-      );
-    }
-    return (
-      <div class="space-y-3">
-        <div class="text-xs text-slate-500">
-          Compare definitions between any two versions of this slug.
-        </div>
-        <div class="flex items-center gap-2 text-sm">
-          <label for="spec-diff-target">Diff against:</label>
-          <select
-            id="spec-diff-target"
-            aria-label="Pick a version to diff against"
-            value={compareWith ?? ''}
-            onChange={(e) => setCompareWith((e.target as HTMLSelectElement).value || null)}
-            class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
-          >
-            <option value="">— pick a version —</option>
-            {siblings.filter((s) => s.id !== detail.id).map((s) => (
-              <option value={s.id} key={s.id}>v{s.version} ({shortHash(s.hash)})</option>
-            ))}
-          </select>
-        </div>
-        {compareDetail ? (
-          <Diff
-            before={canonicalJson(compareDetail.definition)}
-            after={canonicalJson(detail.definition)}
-            label={`v${compareDetail.version} → v${detail.version}`}
-          />
-        ) : compareWith ? (
-          <div class="flex items-center gap-2 text-xs text-slate-500">
-            <Spinner size="sm" /> Loading...
-          </div>
-        ) : null}
-      </div>
-    );
-  })();
-
-  const definitionPanel = (
-    <JsonViewer
-      value={detail.definition}
-      rootLabel="definition"
-      mode="expanded"
-      defaultExpandDepth={3}
-      downloadFilename={`spec-${detail.slug}-v${detail.version}.json`}
-    />
-  );
-
-  const tabs: TabSpec[] = [
-    { id: 'graph', label: 'Graph', badge: <Pill variant="neutral" size="sm">{graph.nodes.length}</Pill> },
-    { id: 'schemas', label: 'Schemas' },
-    { id: 'definition', label: 'Definition' },
-    { id: 'versions', label: 'Versions', badge: <Pill variant="neutral" size="sm">{siblings.length}</Pill> },
-  ];
-
-  return (
-    <div class="flex flex-col h-full min-h-0">
-      <header class="px-3 pt-3 pb-2 border-b border-slate-200 dark:border-slate-700">
-        <div class="flex items-baseline gap-2">
-          <h2 class="text-base font-semibold">{detail.slug}</h2>
-          <Pill variant="info">v{detail.version}</Pill>
-          <code class="text-xs font-mono text-slate-500" title={detail.hash}>
-            {shortHash(detail.hash)}
-          </code>
-          <span class="ml-auto text-xs text-slate-500">
-            Registered {formatTimestamp(detail.registered_at)}
-          </span>
-        </div>
-      </header>
-      <div class="flex-1 min-h-0">
-        <Tabs
-          tabs={tabs}
-          activeTab={activeTab}
-          onChange={setActiveTab}
-          panels={{
-            graph: (
-              <div class="h-[60vh] p-3">
-                <FlowGraph
-                  nodes={graph.nodes}
-                  edges={graph.edges}
-                  autoLayout={true}
-                  direction="LR"
-                />
-              </div>
-            ),
-            schemas: <div class="p-3">{schemasPanel}</div>,
-            definition: <div class="p-3">{definitionPanel}</div>,
-            versions: <div class="p-3">{versionsPanel}</div>,
-          }}
-        />
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
 
 export function SpecsRoute(): JSX.Element {
   const [specs, setSpecs] = useState<SpecSummary[] | null>(null);
+  const [runs, setRuns] = useState<RunSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [detail, setDetail] = useState<SpecDetail | null>(null);
-  const [detailError, setDetailError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    api.listSpecs()
-      .then((rows) => {
-        if (!cancelled) {
-          setSpecs(rows);
-          // Auto-select the latest version of the first slug for a
-          // populated initial paint instead of an empty right pane.
-          if (rows.length > 0 && selectedId == null) {
-            const first = groupBySlug(rows)[0];
-            if (first) setSelectedId(first.rows[0].id);
-          }
-        }
+    Promise.all([api.listSpecs(), api.listRuns({ limit: 500 })])
+      .then(([s, r]) => {
+        if (cancelled) return;
+        setSpecs(s);
+        setRuns(r);
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(err instanceof ApiError ? err.message : String(err));
       });
     return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    if (!selectedId) { setDetail(null); setDetailError(null); return; }
-    let cancelled = false;
-    setDetail(null); setDetailError(null);
-    api.getSpec(selectedId)
-      .then((d) => { if (!cancelled) setDetail(d); })
-      .catch((err: unknown) => {
-        if (!cancelled) setDetailError(err instanceof ApiError ? err.message : String(err));
-      });
-    return () => { cancelled = true; };
-  }, [selectedId]);
+  const rows = useMemo(() => {
+    if (!specs || !runs) return null;
+    return buildRows(specs, runs);
+  }, [specs, runs]);
 
-  const groups = useMemo(() => (specs ? groupBySlug(specs) : []), [specs]);
+  const cols: TableColumn<SpecGroupRow>[] = [
+    {
+      key: 'slug', label: 'Spec',
+      render: (r) => (
+        <div class="flex items-baseline gap-2">
+          <span class="text-sm font-medium text-slate-900 dark:text-slate-100">{r.latest.slug}</span>
+          <Pill variant="info" size="sm">v{r.latest.version}</Pill>
+          {r.versionCount > 1 ? (
+            <span class="text-[10px] text-slate-500 dark:text-slate-400">
+              · {r.versionCount} versions
+            </span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: 'runs', label: 'Runs', align: 'right' as const, width: '5rem',
+      render: (r) => (
+        <span class="font-mono text-xs text-slate-700 dark:text-slate-300">{r.runCount}</span>
+      ),
+    },
+    {
+      key: 'status', label: 'Last run', width: '9rem',
+      render: (r) => r.newestRun ? (
+        <Pill variant={statusVariant(r.newestRun.status)} size="sm">{r.newestRun.status}</Pill>
+      ) : (
+        <span class="text-[10px] text-slate-500 dark:text-slate-400">no runs yet</span>
+      ),
+    },
+    {
+      key: 'lastUpdate', label: 'Last activity', width: '14rem',
+      render: (r) => (
+        <span class="text-xs text-slate-600 dark:text-slate-400">
+          {formatTimestamp(r.newestRun?.last_update_at ?? r.latest.created_at)}
+        </span>
+      ),
+    },
+    {
+      key: 'hash', label: 'Hash', width: '12rem',
+      render: (r) => (
+        <code class="font-mono text-xs text-slate-600 dark:text-slate-400" title={r.latest.hash}>
+          {shortHash(r.latest.hash)}
+        </code>
+      ),
+    },
+  ];
 
-  // Siblings = all versions of the currently-selected slug.
-  const siblings = useMemo(() => {
-    if (!detail || !specs) return [];
-    return specs.filter((s) => s.slug === detail.slug).sort((a, b) => b.version - a.version);
-  }, [detail, specs]);
+  let body: JSX.Element;
+  if (error) {
+    body = <EmptyState title="Failed to load specs" message={error} />;
+  } else if (rows === null) {
+    body = (
+      <div class="flex items-center justify-center py-12">
+        <Spinner label="Loading specs and runs" />
+      </div>
+    );
+  } else if (rows.length === 0) {
+    body = (
+      <EmptyState
+        title="No specs registered"
+        message="Register a spec via `ctxr-fsm spec register <module:attr>` then refresh."
+      />
+    );
+  } else {
+    body = (
+      <Table<SpecGroupRow>
+        columns={cols}
+        rows={rows}
+        rowKey={(r) => r.latest.slug}
+        onRowClick={(r) => navigateTo(`/specs/${encodeURIComponent(r.latest.id)}`)}
+        caption="Registered FSM specs, ordered by most recent activity"
+      />
+    );
+  }
 
   return (
-    <div class="p-4 md:p-6 space-y-4 flex flex-col h-full min-h-0">
+    <div class="p-4 md:p-6 space-y-4">
       <header>
-        <h1 class="text-2xl font-semibold">Specs</h1>
+        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Specs</h1>
         <p class="text-sm text-slate-600 dark:text-slate-400">
-          Registered FSM definitions. Pick a spec to view its graph, schemas, full definition, and version diffs.
+          The spec catalog is the entry point. Pick one to see its graph, runs, schemas, and version history.
+          Ordered by most-recently-active first.
         </p>
       </header>
-      {error ? (
-        <Card>
-          <EmptyState title="Failed to load specs" message={error} />
-        </Card>
-      ) : specs == null ? (
-        <Card>
-          <div class="flex items-center justify-center py-12"><Spinner label="Loading specs" /></div>
-        </Card>
-      ) : (
-        <div class="grid gap-4 lg:grid-cols-[24rem_1fr] flex-1 min-h-0">
-          <Card className="p-0 overflow-auto">
-            <MasterList groups={groups} selectedId={selectedId} onSelect={setSelectedId} />
-          </Card>
-          <Card className="p-0">
-            <DetailPane detail={detail} detailError={detailError} siblings={siblings} />
-          </Card>
-        </div>
-      )}
+      <Card className="p-0">{body}</Card>
     </div>
   );
 }


### PR DESCRIPTION
Closes both user complaints from the last review:

1. **"UI is not polished enough — text/graph elements invisible in dark theme"**
2. **"Runs, topology, etc - should be per spec. for now it's a big black hole with everything unstructured and easy to be lost in"**

## Spec-first IA

- `/` redirects to `/specs`. The spec catalog is the landing page and the spine of the IA.
- `/specs` shows each spec as a row with runs count, last-run status pill, last activity timestamp, hash. Ordered by **most-recently-active first** so the spec you just worked on is at the top.
- `/specs/:specId` is a new per-spec dashboard with tabs: **Graph** (FSM state diagram for THIS version) · **Runs** (runs of THIS slug, any sibling version) · **Schemas** · **Definition** · **Versions** (sibling list + Diff between any two).
- Sidebar now splits into PRIMARY (just **Specs**) and ADMIN (**All runs**, Topology, Drift, Journal, Settings) so the spec-first model is visually obvious. The logo links to /specs.

## Visual polish

- **FlowGraph edges**: custom nodes now ship `<Handle>` anchors so edges actually attach and render visible connection lines + arrow markers + predicate labels.
- **FlowGraph dark theme**: edges via `currentColor` (themed); mini-map themed (`bg-white/80 dark:bg-slate-800/80`, per-kind node colours, no longer a blinding white block); controls themed (button backgrounds + borders + hover state); background dots themed.
- **Tabs**: inactive tab text bumped to `slate-700 / dark:slate-300` (was `slate-600 / dark:slate-400` — barely visible in dark mode). `aria-selected` uses explicit `'true' / 'false'` strings.
- **Runs Spec column**: resolves `fsm_spec_id` to `code-reviewer v1` via a one-shot specs cache. Falls back to a 12-char UUID prefix. Cell links to `/specs/:specId`.

## Verification

- 286/286 vitest passing
- 136 kB gzipped main chunk (under 280 kB target)
- Screenshot battery (light + dark for every page) captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)