### PR TITLE
feat(w21): graph tooltips + click-to-Sheet inspectors + 50% bigger nodes

### DIFF
--- a/ctxr/fsm/core/models.py
+++ b/ctxr/fsm/core/models.py
@@ -328,12 +328,27 @@ class ResponseSchema(BaseModel):
 
 
 class Worker(BaseModel):
-    """A worker specification: who to call and with which prompt + schema."""
+    """A worker specification: who to call and with which prompt + schema.
+
+    ``prompt_template_language`` is an optional, free-form format hint
+    the consuming spec uses to tell downstream tooling how to render
+    the prompt body. The FSM library itself treats ``prompt_template``
+    as an opaque string regardless of the hint, but UI surfaces (the
+    fsm-ui specDetail inspector, future spec-doc generators, etc.) can
+    pick syntax highlighting / markdown rendering / etc. based on this
+    declaration without resorting to content heuristics. Common
+    values: ``"markdown"``, ``"jinja"``, ``"plain"``, ``"json"``. The
+    field is intentionally a free string, not an enum, because the
+    library shouldn't curate the universe of template formats consumers
+    might use; consumers own the convention and the renderer that
+    honours it.
+    """
 
     model_config = _DOMAIN_CFG
 
     role: str
     prompt_template: str
+    prompt_template_language: str | None = None
     inputs: list[str] = Field(default_factory=list)
     response_schema: ResponseSchema | None = None
 
@@ -344,14 +359,39 @@ class Worker(BaseModel):
             raise ValueError("must be a non-empty string")
         return value
 
+    @field_validator("prompt_template_language")
+    @classmethod
+    def _language_non_empty(cls, value: str | None) -> str | None:
+        # None (= no hint) is legal. Empty/whitespace strings are not:
+        # if a consumer cares enough to set the field, they must put a
+        # real value in it. Catches typos like
+        # ``prompt_template_language=""`` that would otherwise silently
+        # behave the same as omitting the field.
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError(
+                "prompt_template_language must be a non-empty string "
+                "(or omitted entirely if no hint applies)"
+            )
+        return stripped
+
 
 class VerifierSpec(BaseModel):
-    """A verifier panel specification."""
+    """A verifier panel specification.
+
+    Same ``prompt_template_language`` semantics as :class:`Worker`: an
+    optional free-form format hint the consumer declares so renderers
+    can pick the right view without content heuristics. See
+    :class:`Worker` for the full contract.
+    """
 
     model_config = _DOMAIN_CFG
 
     role: str
     prompt_template: str
+    prompt_template_language: str | None = None
     response_schema: ResponseSchema
     majority_threshold: int = 2
     parallel_count: int = 3
@@ -362,6 +402,19 @@ class VerifierSpec(BaseModel):
         if not value or not value.strip():
             raise ValueError("must be a non-empty string")
         return value
+
+    @field_validator("prompt_template_language")
+    @classmethod
+    def _language_non_empty(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError(
+                "prompt_template_language must be a non-empty string "
+                "(or omitted entirely if no hint applies)"
+            )
+        return stripped
 
     @field_validator("majority_threshold")
     @classmethod

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -530,3 +530,76 @@ def test_commit_token_issue_rejects_zero_or_negative_ttl() -> None:
         CommitToken.issue(run_id, "s", "n", ttl_seconds=0)
     with pytest.raises(ValueError):
         CommitToken.issue(run_id, "s", "n", ttl_seconds=-1)
+
+
+# ---------------------------------------------------------------------------
+# Worker.prompt_template_language (W21 — optional format hint)
+# ---------------------------------------------------------------------------
+
+
+def test_worker_prompt_template_language_defaults_to_none() -> None:
+    w = Worker(role="r", prompt_template="x")
+    assert w.prompt_template_language is None
+
+
+@pytest.mark.parametrize("language", ["markdown", "jinja", "plain", "json", "yaml"])
+def test_worker_prompt_template_language_accepts_arbitrary_string(language: str) -> None:
+    # The field is intentionally free-form (not a closed enum) so
+    # consumers own the convention. The library only checks it isn't
+    # blank when set.
+    w = Worker(role="r", prompt_template="x", prompt_template_language=language)
+    assert w.prompt_template_language == language
+
+
+def test_worker_prompt_template_language_strips_surrounding_whitespace() -> None:
+    w = Worker(role="r", prompt_template="x", prompt_template_language="  markdown  ")
+    assert w.prompt_template_language == "markdown"
+
+
+def test_worker_rejects_blank_prompt_template_language() -> None:
+    # Empty / whitespace-only is a typo not a deliberate omission;
+    # raise rather than silently accept (which would mimic the
+    # "no hint" path and hide the bug).
+    with pytest.raises(ValidationError):
+        Worker(role="r", prompt_template="x", prompt_template_language="")
+    with pytest.raises(ValidationError):
+        Worker(role="r", prompt_template="x", prompt_template_language="   ")
+
+
+def test_worker_serialises_prompt_template_language_when_set() -> None:
+    w = Worker(role="r", prompt_template="x", prompt_template_language="markdown")
+    dumped = w.model_dump()
+    assert dumped["prompt_template_language"] == "markdown"
+
+
+def test_worker_serialises_prompt_template_language_as_null_when_unset() -> None:
+    w = Worker(role="r", prompt_template="x")
+    dumped = w.model_dump()
+    assert dumped["prompt_template_language"] is None
+
+
+def test_worker_round_trips_through_json_with_language() -> None:
+    w = Worker(role="r", prompt_template="x", prompt_template_language="markdown")
+    raw = w.model_dump_json()
+    restored = Worker.model_validate_json(raw)
+    assert restored.prompt_template_language == "markdown"
+    assert restored == w
+
+
+def test_verifier_spec_prompt_template_language_same_contract() -> None:
+    schema = ResponseSchema(schema={"type": "object", "properties": {}})
+    vs = VerifierSpec(
+        role="judge",
+        prompt_template="rate the output",
+        prompt_template_language="markdown",
+        response_schema=schema,
+    )
+    assert vs.prompt_template_language == "markdown"
+    # Same validation as Worker.
+    with pytest.raises(ValidationError):
+        VerifierSpec(
+            role="judge",
+            prompt_template="x",
+            prompt_template_language="",
+            response_schema=schema,
+        )

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,12 +11,15 @@
         "@preact/signals": "^2.9.1",
         "@uiw/react-json-view": "2.0.0-alpha.43",
         "@xyflow/react": "12.10.2",
+        "dompurify": "^3.4.7",
+        "marked": "^18.0.4",
         "preact": "^10.29.2",
         "preact-iso": "^2.10.5",
         "preact-render-to-string": "6.7.0"
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.9.1",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/preact": "^3.2.4",
@@ -1395,6 +1398,19 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
@@ -1591,6 +1607,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@uiw/react-json-view": {
       "version": "2.0.0-alpha.43",
@@ -2096,6 +2119,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -2392,6 +2428,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -3486,6 +3531,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3722,6 +3779,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/preact": {
@@ -4355,6 +4426,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.14",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,12 +14,15 @@
     "@preact/signals": "^2.9.1",
     "@uiw/react-json-view": "2.0.0-alpha.43",
     "@xyflow/react": "12.10.2",
+    "dompurify": "^3.4.7",
+    "marked": "^18.0.4",
     "preact": "^10.29.2",
     "preact-iso": "^2.10.5",
     "preact-render-to-string": "6.7.0"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.9.1",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/preact": "^3.2.4",

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -55,6 +55,62 @@ function looksLikeMarkdown(text: string): boolean {
   );
 }
 
+/** DOMPurify hook: strips any `<input>` that isn't a disabled
+ *  checkbox AND scrubs its attributes down to the exact GFM task-list
+ *  shape (type/disabled/checked only). We allow <input> only to
+ *  preserve marked.js task-list output (`<input type="checkbox"
+ *  disabled>`); ANY other input shape (text/submit/button/file/image/
+ *  autofocus/etc.) creates a phishing-friendly fake form field.
+ *
+ *  Per the W21 adversarial-verify workflow, even a properly disabled
+ *  checkbox can leak high-leverage attacker primitives via the
+ *  default attribute allow-list: style= for clickjacking overlays,
+ *  tabindex= for focus hijack, aria-label/role for screen-reader
+ *  spoofing, name/value/id for misleading DOM scaffolding. The fix
+ *  is to allowlist attribute NAMES on the surviving checkbox.
+ *
+ *  Registered with `addHook('uponSanitizeElement', ...)` so it runs
+ *  alongside DOMPurify's own attribute scrub on every element. */
+const ALLOWED_CHECKBOX_ATTRS = new Set(['type', 'disabled', 'checked']);
+
+// DOMPurify's 'uponSanitizeElement' hook signature is (node, data, config).
+// We only need `node`; data + config are unused. Typed as `Node` because
+// uponSanitizeElement runs on every visited node, not just Elements.
+function pruneNonCheckboxInput(node: Node): void {
+  if (node.nodeName !== 'INPUT') return;
+  const input = node as HTMLInputElement;
+  // marked.js emits `<input type="checkbox" disabled>` (and `checked`
+  // for `- [x]`). Reject anything else.
+  const type = (input.getAttribute('type') ?? '').toLowerCase();
+  const disabledAttr = input.getAttribute('disabled');
+  // disabled MUST be present. We accept any non-"false" value because
+  // HTML treats the attribute as presence-only boolean, but reject
+  // disabled="false" literally so the rendered DOM doesn't carry a
+  // misleading attribute value into the page.
+  const isDisabled =
+    disabledAttr !== null && disabledAttr.toLowerCase() !== 'false';
+  if (type !== 'checkbox' || !isDisabled) {
+    input.remove();
+    return;
+  }
+  // Strip every attribute that isn't in the canonical task-list shape.
+  // This kills style=overlay, tabindex=focus-hijack, aria-label/role
+  // spoofing, name/value/id scaffolding, autofocus, contenteditable,
+  // accesskey — every attacker primitive the workflow surfaced.
+  for (const attr of Array.from(input.attributes)) {
+    if (!ALLOWED_CHECKBOX_ATTRS.has(attr.name.toLowerCase())) {
+      input.removeAttribute(attr.name);
+    }
+  }
+}
+
+let _inputHookInstalled = false;
+function ensureInputHookInstalled(): void {
+  if (_inputHookInstalled) return;
+  DOMPurify.addHook('uponSanitizeElement', pruneNonCheckboxInput);
+  _inputHookInstalled = true;
+}
+
 /** Render markdown to a safe HTML string. Synchronous marked is fine
  *  for the prompt-template scale we're rendering; DOMPurify strips any
  *  script tags / event handlers / data: URIs / etc. that the upstream
@@ -66,10 +122,21 @@ function looksLikeMarkdown(text: string): boolean {
  *  URL the spec author chose. <svg> + <math> have large attack
  *  surfaces around foreignObject / use[href] / etc. <iframe>/<object>/
  *  <embed>/<form>/<link>/<meta>/<base>/<style>/<script> are the usual
- *  active-content vectors. The result is text-only HTML: headers,
- *  paragraphs, lists, tables, blockquotes, code, fences, inline
- *  emphasis, links (still allowed; the user clicks intentionally). */
+ *  active-content vectors.
+ *
+ *  <input> is preserved only when type=checkbox AND disabled (the
+ *  exact shape marked.js produces for GFM task-list checkboxes); any
+ *  other input shape is removed by the pruneNonCheckboxInput hook
+ *  installed below. Combined with FORBID_ATTR(src, srcset, ...) this
+ *  closes the `<input type="image" src="..." />` beacon vector AND
+ *  the `<input type="text" autofocus>` phishing vector.
+ *
+ *  The result is text-only HTML: headers, paragraphs, lists,
+ *  blockquotes, code, fences, inline emphasis, links, tables, GFM
+ *  task-list checkboxes (visual only, the checkboxes are disabled
+ *  so they can never be clicked into a state). */
 function renderMarkdown(text: string): string {
+  ensureInputHookInstalled();
   const raw = marked.parse(text, { async: false }) as string;
   // <input> is intentionally NOT forbidden: GFM task lists generate
   // `<input type="checkbox" disabled>` which is benign (read-only, no
@@ -103,18 +170,38 @@ function renderMarkdown(text: string): string {
       'meta',
       'base',
     ],
-    // Belt + braces on the network-fetch guarantee: the forbidden
-    // tags above can't render at all, but `<input>` is intentionally
-    // allowed (GFM task-list checkboxes), and `<input type="image"
-    // src="https://..."/>` would beacon on render via the still-
-    // allowed src attribute. Strip every attribute that fetches a
-    // remote resource on render — src / srcset (img-style inputs +
-    // any future tag we forget to forbid), poster (video; defensive
-    // even though video is forbidden today), background (legacy td
-    // attr that still fetches in some engines), formaction (button
-    // submit override). href stays allowed so anchor links work; the
-    // DOMPurify default rules still strip javascript:/data: URIs.
-    FORBID_ATTR: ['src', 'srcset', 'poster', 'background', 'formaction'],
+    // Two attribute groups, both load-bearing:
+    //
+    // Network fetch on render (privacy leak): src / srcset on the
+    // still-allowed <input> (e.g. type=image), poster (video, still
+    // defensive even though video tag is forbidden), background (td
+    // legacy attr that fetches in some engines), formaction (button
+    // submit URL override). href stays allowed so anchor links work;
+    // DOMPurify defaults strip javascript:/data: URIs.
+    //
+    // Attacker primitives on any allowed tag (clickjacking + focus
+    // hijack + spoofing) — these work on <p>/<a>/<div>/<span>/<td>
+    // not just <input>, so the per-element pruneNonCheckboxInput hook
+    // alone isn't enough:
+    //   - style: position:fixed inset:0 invisible overlay
+    //   - tabindex: focus-trap focusable element that shouldn't be
+    //   - autofocus: steals focus on render
+    //   - contenteditable: visible editable surface
+    //   - accesskey: keyboard shortcut hijack
+    // These attributes have no legitimate use on a non-interactive
+    // prompt-template render surface.
+    FORBID_ATTR: [
+      'src',
+      'srcset',
+      'poster',
+      'background',
+      'formaction',
+      'style',
+      'tabindex',
+      'autofocus',
+      'contenteditable',
+      'accesskey',
+    ],
   });
 }
 

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -1,22 +1,67 @@
 /**
- * CodeBlock — monospace text rendering with copy / download / search / fullscreen.
+ * CodeBlock — monospace text rendering with copy / download / search / fullscreen
+ *               plus an opt-in Markdown rendered view.
  *
  * Used for non-JSON payloads: prompt templates, predicate DSL,
- * generated SQL fragments. Same toolbar contract as JsonViewer but
- * no tree, no chevrons. v1 has no syntax highlighting; a future
- * dynamic-import of Shiki can plug in if a real need arises.
+ * generated SQL fragments. Same toolbar contract as JsonViewer.
  *
- * Line gutter is auto-enabled for >5 lines.
+ * Markdown view (W21 user-requested): when the content looks like
+ * markdown (or the caller passes `language="markdown"`) the toolbar
+ * exposes a Rendered / Raw toggle. Rendered mode runs marked +
+ * DOMPurify and styles the output with Tailwind's @tailwindcss/
+ * typography `prose` classes, giving GitHub-flavored Markdown with
+ * proper headings, lists, fenced code blocks, links, tables, etc.
+ *
+ * Line gutter is auto-enabled for >5 lines (raw mode only).
  *
  * Search highlights matching substrings inline via `<mark>` for visual
- * parity with JsonViewer's match emphasis.
+ * parity with JsonViewer's match emphasis (raw mode only).
  */
 
 import { useCallback, useMemo, useRef, useState } from 'preact/hooks';
 import type { JSX } from 'preact';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 
 import { copyText } from '../lib/clipboard';
 import { Sheet } from './Sheet';
+
+// Configure marked once at module load. GFM enables tables, task
+// lists, strikethrough, auto-link, etc. breaks=true so single newlines
+// become <br>, matching GitHub's rendering on issues / PRs / comments.
+marked.use({
+  gfm: true,
+  breaks: false,
+});
+
+// Heuristic: does the text look like markdown? Used to default the
+// view mode when the caller didn't pass `language="markdown"`. This
+// keeps the FSM library domain-agnostic — it doesn't NEED to know its
+// prompt templates are markdown, the UI just notices when they are.
+function looksLikeMarkdown(text: string): boolean {
+  if (!text || text.length < 4) return false;
+  return (
+    /^#{1,6}\s/m.test(text) || // ATX headers
+    /^```/m.test(text) || // fenced code blocks
+    /\[[^\]]+\]\([^)]+\)/.test(text) || // [link](url)
+    /^\s*[-*+]\s+\S/m.test(text) || // unordered lists
+    /^\s*\d+\.\s+\S/m.test(text) || // ordered lists
+    /\*\*[^*]+\*\*/.test(text) || // **bold**
+    /^\s*>\s/m.test(text) // > blockquote
+  );
+}
+
+/** Render markdown to a safe HTML string. Synchronous marked is fine
+ *  for the prompt-template scale we're rendering; DOMPurify strips any
+ *  script tags / event handlers / data: URIs / etc. that the upstream
+ *  content might contain. */
+function renderMarkdown(text: string): string {
+  const raw = marked.parse(text, { async: false }) as string;
+  return DOMPurify.sanitize(raw, {
+    USE_PROFILES: { html: true },
+    FORBID_TAGS: ['style', 'script', 'iframe', 'object', 'embed'],
+  });
+}
 
 export interface CodeBlockProps {
   text: string;
@@ -26,6 +71,11 @@ export interface CodeBlockProps {
   filename?: string;
   ariaLabel?: string;
   className?: string;
+  /** Force markdown rendering mode regardless of heuristic detection.
+   *  Useful when the caller knows for certain the content is markdown
+   *  but doesn't want to declare `language="markdown"` (which would
+   *  imply other things about the file type for download / copy). */
+  renderMarkdown?: boolean;
 }
 
 function downloadAs(filename: string, text: string, mime = 'text/plain'): void {
@@ -105,7 +155,20 @@ export function CodeBlock({
   filename,
   ariaLabel = 'Code block',
   className,
+  renderMarkdown: renderMarkdownProp,
 }: CodeBlockProps): JSX.Element {
+  // markdownEligible: caller declared language=markdown OR explicitly
+  // opted in OR the heuristic says the content looks markdown-ish.
+  // When eligible, the toolbar exposes a Raw/Rendered toggle and we
+  // default to Rendered (the visually informative view).
+  const markdownEligible =
+    language === 'markdown' ||
+    renderMarkdownProp === true ||
+    (renderMarkdownProp !== false && looksLikeMarkdown(text));
+
+  const [view, setView] = useState<'raw' | 'rendered'>(
+    markdownEligible ? 'rendered' : 'raw',
+  );
   const [search, setSearch] = useState('');
   const [sheetOpen, setSheetOpen] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -114,6 +177,14 @@ export function CodeBlock({
   const showGutter = lineNumbers ?? lines.length > 5;
   const bytes = useMemo(() => new Blob([text]).size, [text]);
   const sizeLabel = bytes < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} kB`;
+
+  // Memoise the rendered HTML: parsing markdown + DOMPurify on every
+  // render is wasteful for long prompts. Only recompute when the text
+  // changes or the view flips into 'rendered'.
+  const renderedHtml = useMemo(() => {
+    if (!markdownEligible) return '';
+    return renderMarkdown(text);
+  }, [text, markdownEligible]);
 
   const onCopy = useCallback(() => void copyText(text), [text]);
   const onDownload = useCallback(
@@ -155,16 +226,31 @@ export function CodeBlock({
         <span class="text-[10px] text-slate-400 dark:text-slate-500">
           {lines.length} lines · {sizeLabel}
         </span>
-        <input
-          ref={searchRef}
-          type="search"
-          placeholder="Search"
-          value={search}
-          onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
-          onKeyDown={onSearchKey}
-          aria-label="Search inside code"
-          class="ml-auto h-6 w-32 rounded border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-2 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
-        />
+        {view === 'raw' ? (
+          <input
+            ref={searchRef}
+            type="search"
+            placeholder="Search"
+            value={search}
+            onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
+            onKeyDown={onSearchKey}
+            aria-label="Search inside code"
+            class="ml-auto h-6 w-32 rounded border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-2 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+          />
+        ) : (
+          <span class="ml-auto" />
+        )}
+        {markdownEligible ? (
+          <button
+            type="button"
+            onClick={() => setView(view === 'raw' ? 'rendered' : 'raw')}
+            aria-label={`Show ${view === 'raw' ? 'rendered' : 'raw'} view`}
+            title={`Currently ${view}; click to switch`}
+            class="h-6 px-2 text-xs rounded text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+          >
+            {view === 'raw' ? 'Rendered' : 'Raw'}
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={onCopy}
@@ -188,28 +274,56 @@ export function CodeBlock({
           onClick={onOpenSheet}
           aria-label="Open in full-screen sheet"
           title="Full-screen"
-          class="h-6 px-2 text-xs rounded text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+          class="h-6 px-2 text-xs rounded text-emerald-700 dark:text-emerald-400 border border-transparent hover:bg-slate-100 dark:hover:bg-slate-700 hover:border-emerald-500/40 font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
         >
-          ↗
+          ⛶ Full-screen
         </button>
       </header>
-      <pre
-        class={[
-          'cb-body font-mono leading-snug bg-slate-50 dark:bg-slate-900/40 p-3 overflow-auto m-0',
-          maxInlineHeight,
-        ].join(' ')}
-      >
-        {lines.map((line, i) => (
-          <Line key={i} index={i} text={line} query={search} showGutter={showGutter} />
-        ))}
-      </pre>
+      {view === 'rendered' ? (
+        <div
+          class={[
+            'cb-body cb-markdown',
+            'prose prose-sm dark:prose-invert max-w-none',
+            'prose-headings:scroll-mt-4 prose-code:before:hidden prose-code:after:hidden',
+            'prose-pre:bg-slate-100 dark:prose-pre:bg-slate-900/60',
+            'bg-white dark:bg-slate-900/40 p-3 overflow-auto',
+            maxInlineHeight,
+          ].join(' ')}
+          // eslint-disable-next-line react/no-danger -- output is run through DOMPurify above; script / iframe / event-handler vectors are stripped before reaching the DOM
+          dangerouslySetInnerHTML={{ __html: renderedHtml }}
+        />
+      ) : (
+        <pre
+          class={[
+            'cb-body font-mono leading-snug bg-slate-50 dark:bg-slate-900/40 p-3 overflow-auto m-0',
+            maxInlineHeight,
+          ].join(' ')}
+        >
+          {lines.map((line, i) => (
+            <Line key={i} index={i} text={line} query={search} showGutter={showGutter} />
+          ))}
+        </pre>
+      )}
       <Sheet
         open={sheetOpen}
         onClose={onCloseSheet}
         title={`Code · ${language}`}
         width="right-half"
       >
-        <pre class="font-mono text-xs leading-snug whitespace-pre">{text}</pre>
+        {view === 'rendered' ? (
+          <div
+            class={[
+              'prose prose-sm dark:prose-invert max-w-none',
+              'prose-headings:scroll-mt-4 prose-code:before:hidden prose-code:after:hidden',
+              'prose-pre:bg-slate-100 dark:prose-pre:bg-slate-900/60',
+              'p-4',
+            ].join(' ')}
+            // eslint-disable-next-line react/no-danger -- output is run through DOMPurify above; same justification as the inline render path
+            dangerouslySetInnerHTML={{ __html: renderedHtml }}
+          />
+        ) : (
+          <pre class="font-mono text-xs leading-snug whitespace-pre p-4">{text}</pre>
+        )}
       </Sheet>
     </section>
   );

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -18,7 +18,7 @@
  * parity with JsonViewer's match emphasis (raw mode only).
  */
 
-import { useCallback, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { JSX } from 'preact';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
@@ -58,12 +58,44 @@ function looksLikeMarkdown(text: string): boolean {
 /** Render markdown to a safe HTML string. Synchronous marked is fine
  *  for the prompt-template scale we're rendering; DOMPurify strips any
  *  script tags / event handlers / data: URIs / etc. that the upstream
- *  content might contain. */
+ *  content might contain.
+ *
+ *  Forbidden tags lock the surface down further: <img>/<picture>/
+ *  <video>/<audio>/<source>/<track> can trigger outbound network
+ *  requests just by rendering, leaking the operator's IP to whatever
+ *  URL the spec author chose. <svg> + <math> have large attack
+ *  surfaces around foreignObject / use[href] / etc. <iframe>/<object>/
+ *  <embed>/<form>/<link>/<meta>/<base>/<style>/<script> are the usual
+ *  active-content vectors. The result is text-only HTML: headers,
+ *  paragraphs, lists, tables, blockquotes, code, fences, inline
+ *  emphasis, links (still allowed; the user clicks intentionally). */
 function renderMarkdown(text: string): string {
   const raw = marked.parse(text, { async: false }) as string;
   return DOMPurify.sanitize(raw, {
     USE_PROFILES: { html: true },
-    FORBID_TAGS: ['style', 'script', 'iframe', 'object', 'embed'],
+    FORBID_TAGS: [
+      'style',
+      'script',
+      'iframe',
+      'object',
+      'embed',
+      'img',
+      'picture',
+      'video',
+      'audio',
+      'source',
+      'track',
+      'svg',
+      'math',
+      'form',
+      'input',
+      'button',
+      'select',
+      'textarea',
+      'link',
+      'meta',
+      'base',
+    ],
   });
 }
 
@@ -173,6 +205,14 @@ export function CodeBlock({
   const [view, setView] = useState<'raw' | 'rendered'>(
     markdownEligible ? 'rendered' : 'raw',
   );
+  // Sync view back to 'raw' when the content stops being
+  // markdown-eligible (e.g. caller swapped the text prop to a plain
+  // string). Without this the toggle disappears AND the renderedHtml
+  // becomes '' — the body would render an empty Sheet with no way
+  // for the user to flip back to raw.
+  useEffect(() => {
+    if (!markdownEligible && view === 'rendered') setView('raw');
+  }, [markdownEligible, view]);
   const [search, setSearch] = useState('');
   const [sheetOpen, setSheetOpen] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -182,13 +222,13 @@ export function CodeBlock({
   const bytes = useMemo(() => new Blob([text]).size, [text]);
   const sizeLabel = bytes < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} kB`;
 
-  // Memoise the rendered HTML: parsing markdown + DOMPurify on every
-  // render is wasteful for long prompts. Only recompute when the text
-  // changes or the view flips into 'rendered'.
+  // Memoise the rendered HTML. Only compute when the user is actually
+  // looking at the rendered view; parsing + sanitising a long prompt
+  // every render is wasteful when the user is in raw mode.
   const renderedHtml = useMemo(() => {
-    if (!markdownEligible) return '';
+    if (!markdownEligible || view !== 'rendered') return '';
     return renderMarkdown(text);
-  }, [text, markdownEligible]);
+  }, [text, markdownEligible, view]);
 
   const onCopy = useCallback(() => void copyText(text), [text]);
   const onDownload = useCallback(

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -108,7 +108,13 @@ function renderMarkdown(text: string): string {
 
 export interface CodeBlockProps {
   text: string;
-  language?: 'plain' | 'sql' | 'python' | 'markdown' | 'jinja';
+  /** Format hint declared by the consumer (e.g. an FSM Worker's
+   *  ``prompt_template_language``). Free-form string so consumers
+   *  own the convention; common values include 'markdown', 'jinja',
+   *  'plain', 'json'. When omitted or unknown to this component the
+   *  body renders as plain monospace (with the markdown heuristic
+   *  applying as a courtesy fallback). */
+  language?: string;
   lineNumbers?: boolean;
   maxInlineHeight?: string;
   filename?: string;

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -71,6 +71,14 @@ function looksLikeMarkdown(text: string): boolean {
  *  emphasis, links (still allowed; the user clicks intentionally). */
 function renderMarkdown(text: string): string {
   const raw = marked.parse(text, { async: false }) as string;
+  // <input> is intentionally NOT forbidden: GFM task lists generate
+  // `<input type="checkbox" disabled>` which is benign (read-only, no
+  // outbound effect) and stripping it would render `- [x] done` as a
+  // bullet with no checkbox at all — a visible regression from the
+  // GFM contract callers expect. DOMPurify's default attribute
+  // sanitiser still drops onclick / onerror / etc. The other form
+  // controls stay forbidden because they invite spec authors to
+  // simulate input forms inside a viewer surface.
   return DOMPurify.sanitize(raw, {
     USE_PROFILES: { html: true },
     FORBID_TAGS: [
@@ -88,7 +96,6 @@ function renderMarkdown(text: string): string {
       'svg',
       'math',
       'form',
-      'input',
       'button',
       'select',
       'textarea',

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -103,6 +103,18 @@ function renderMarkdown(text: string): string {
       'meta',
       'base',
     ],
+    // Belt + braces on the network-fetch guarantee: the forbidden
+    // tags above can't render at all, but `<input>` is intentionally
+    // allowed (GFM task-list checkboxes), and `<input type="image"
+    // src="https://..."/>` would beacon on render via the still-
+    // allowed src attribute. Strip every attribute that fetches a
+    // remote resource on render — src / srcset (img-style inputs +
+    // any future tag we forget to forbid), poster (video; defensive
+    // even though video is forbidden today), background (legacy td
+    // attr that still fetches in some engines), formaction (button
+    // submit override). href stays allowed so anchor links work; the
+    // DOMPurify default rules still strip javascript:/data: URIs.
+    FORBID_ATTR: ['src', 'srcset', 'poster', 'background', 'formaction'],
   });
 }
 

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -28,10 +28,14 @@ import { Sheet } from './Sheet';
 
 // Configure marked once at module load. GFM enables tables, task
 // lists, strikethrough, auto-link, etc. breaks=true so single newlines
-// become <br>, matching GitHub's rendering on issues / PRs / comments.
+// become <br>, matching GitHub's rendering on issues / PRs / comments
+// (which is what most operators expect when they author prompt
+// templates). The CommonMark default (breaks=false) collapses single
+// newlines into the surrounding paragraph; that's wrong for the
+// prompt-as-instructions style the FSM ecosystem uses.
 marked.use({
   gfm: true,
-  breaks: false,
+  breaks: true,
 });
 
 // Heuristic: does the text look like markdown? Used to default the

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -76,7 +76,6 @@ export interface FlowGraphProps {
   direction?: 'LR' | 'TB';
   /** Click handler on a node (e.g. open the state-details Sheet). */
   onNodeClick?: (id: string, data: FlowNodeData) => void;
-  /** Click handler on an edge. */
   /** Click handler on an edge. The second arg carries the edge's
    *  data payload (set by decorateEdges); typed loosely so callers can
    *  cast to FsmEdgeData or their own shape. Backward-compatible:

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -23,7 +23,7 @@
  * onNodeClick.
  */
 
-import { useEffect, useMemo } from 'preact/hooks';
+import { useMemo } from 'preact/hooks';
 import type { JSX } from 'preact';
 import dagre from 'dagre';
 import {
@@ -42,7 +42,7 @@ import {
 import '@xyflow/react/dist/style.css';
 
 import { Tooltip } from './Tooltip';
-import { FsmEdge, setEdgeClickHandler } from './FsmEdge';
+import { FsmEdge, FsmEdgeClickContext } from './FsmEdge';
 
 export type FlowNodeKind = 'state' | 'worker' | 'terminal' | 'producer' | 'consumer' | 'inline';
 
@@ -143,8 +143,12 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
   return (
     <div
       class={[
-        'fsm-node relative rounded-md border-2 shadow-sm px-3 py-2',
-        'flex flex-col gap-0.5 overflow-hidden',
+        'fsm-node relative rounded-md border-2 shadow-sm px-4 py-3',
+        // justify-center centers the kind/label/sublabel block
+        // vertically within the (fixed) node height. gap-1 gives the
+        // three rows even breathing room instead of the previous
+        // gap-0.5 which clustered them too tightly at the top.
+        'flex flex-col gap-1 justify-center overflow-hidden',
         NODE_KIND_CLASSES[kind],
         selected ? 'ring-2 ring-emerald-400 ring-offset-1' : '',
       ].join(' ')}
@@ -361,16 +365,6 @@ export function FlowGraph({
   background = true,
   className,
 }: FlowGraphProps): JSX.Element {
-  // Publish the parent's onEdgeClick to the module-level registry so
-  // FsmEdge's label can dispatch through it. Clean up on unmount.
-  // Without this, clicking the rendered edge label (which lives in
-  // EdgeLabelRenderer's portal, not on the SVG path xyflow delegates
-  // from) silently no-ops.
-  useEffect(() => {
-    setEdgeClickHandler(onEdgeClick ?? null);
-    return () => setEdgeClickHandler(null);
-  }, [onEdgeClick]);
-
   const positioned = useMemo(() => {
     if (!autoLayout) {
       // Preserve caller-supplied positions but still tag every node
@@ -426,6 +420,7 @@ export function FlowGraph({
   // clip nodes at the viewport edges.
   const decoratedEdges = useMemo(() => decorateEdges(edges), [edges]);
   return (
+    <FsmEdgeClickContext.Provider value={onEdgeClick ?? null}>
     <div
       class={[
         'flow-graph relative h-full w-full min-h-[320px]',
@@ -500,6 +495,7 @@ export function FlowGraph({
         ) : null}
       </ReactFlow>
     </div>
+    </FsmEdgeClickContext.Provider>
   );
 }
 

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -23,7 +23,7 @@
  * onNodeClick.
  */
 
-import { useMemo } from 'preact/hooks';
+import { useEffect, useMemo } from 'preact/hooks';
 import type { JSX } from 'preact';
 import dagre from 'dagre';
 import {
@@ -41,12 +41,27 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
+import { Tooltip } from './Tooltip';
+import { FsmEdge, setEdgeClickHandler } from './FsmEdge';
+
 export type FlowNodeKind = 'state' | 'worker' | 'terminal' | 'producer' | 'consumer' | 'inline';
 
 export interface FlowNodeData extends Record<string, unknown> {
   kind: FlowNodeKind;
+  /** Visible (truncated) label rendered inside the node. */
   label: string;
+  /** Visible (truncated) sublabel under the main label. */
   sublabel?: string;
+  /** Full untruncated label surfaced via hover tooltip + click-to-Sheet.
+   *  Defaults to `label` when omitted. */
+  fullLabel?: string;
+  /** Full untruncated sublabel surfaced via hover tooltip.
+   *  Defaults to `sublabel` when omitted. */
+  fullSublabel?: string;
+  /** Original spec state object (typed loosely so FlowGraph stays
+   *  domain-agnostic for Topology / Drift consumers). Surfaced to
+   *  onNodeClick so the caller can render an inspector Sheet. */
+  state?: Record<string, unknown>;
 }
 
 export interface FlowGraphProps {
@@ -62,7 +77,11 @@ export interface FlowGraphProps {
   /** Click handler on a node (e.g. open the state-details Sheet). */
   onNodeClick?: (id: string, data: FlowNodeData) => void;
   /** Click handler on an edge. */
-  onEdgeClick?: (id: string) => void;
+  /** Click handler on an edge. The second arg carries the edge's
+   *  data payload (set by decorateEdges); typed loosely so callers can
+   *  cast to FsmEdgeData or their own shape. Backward-compatible:
+   *  existing handlers that take only `id` keep working. */
+  onEdgeClick?: (id: string, data?: Record<string, unknown>) => void;
   /** Selected node id; renders with an emphasis ring. */
   selectedNodeId?: string;
   /** Show the mini-map control. Default true for >10 nodes, false otherwise. */
@@ -75,8 +94,13 @@ export interface FlowGraphProps {
   className?: string;
 }
 
-const NODE_WIDTH = 180;
-const NODE_HEIGHT = 56;
+// W21 user-requested: 50% bigger than the W20 sizes (180x56 → 270x84)
+// so long state ids (e.g. `synthesize_release_readiness`) fit on one
+// line and the kind badge no longer competes for horizontal room.
+// Dagre layout constants below are tuned proportionally to keep edges
+// clear of the larger node boxes.
+const NODE_WIDTH = 270;
+const NODE_HEIGHT = 84;
 
 const NODE_KIND_CLASSES: Record<FlowNodeKind, string> = {
   state:
@@ -105,10 +129,23 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
   // layout numbers; staying inline keeps the two values in literal
   // sync. Suppress the no-inline-styles lint for this single case.
   /* eslint-disable-next-line react/forbid-dom-props -- xyflow nodes need fixed pixel dimensions matched to dagre layout */
+  // Layout (W21, post 50% size bump):
+  //   ┌──────────────────────────────────────────────┐
+  //   │ KIND                                         │  row 1: kind chip (tiny)
+  //   │ synthesize_release_readiness                 │  row 2: label, FULL width
+  //   │ inline: synthesize_release_handler           │  row 3: sublabel, full width
+  //   └──────────────────────────────────────────────┘
+  // Moving the kind label to its own row above the main label gives
+  // the state id the entire 270-px node width to expand into, which is
+  // what the user asked for: "make sure all labels and texts fit the
+  // node shape, not going outside of it". Long ids (>~32 chars) still
+  // truncate visually but their full text remains reachable via the
+  // Tooltip wrapper.
   return (
     <div
       class={[
-        'fsm-node relative rounded-md border-2 shadow-sm px-3 py-2 text-xs',
+        'fsm-node relative rounded-md border-2 shadow-sm px-3 py-2',
+        'flex flex-col gap-0.5 overflow-hidden',
         NODE_KIND_CLASSES[kind],
         selected ? 'ring-2 ring-emerald-400 ring-offset-1' : '',
       ].join(' ')}
@@ -119,16 +156,20 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
         position={tp}
         style={{ background: 'currentColor', width: 8, height: 8, border: 'none' }}
       />
-      <div class="flex items-center justify-between gap-1">
-        <span class="font-semibold truncate" title={data.label}>
+      <span class="text-[9px] uppercase tracking-wider opacity-60 leading-none">
+        {kind}
+      </span>
+      <Tooltip content={data.fullLabel ?? data.label} delay={400}>
+        <span class="font-semibold text-sm truncate block w-full leading-tight">
           {data.label}
         </span>
-        <span class="text-[10px] uppercase tracking-wide opacity-60">{kind}</span>
-      </div>
+      </Tooltip>
       {data.sublabel ? (
-        <div class="text-[10px] opacity-70 truncate" title={data.sublabel}>
-          {data.sublabel}
-        </div>
+        <Tooltip content={data.fullSublabel ?? data.sublabel} delay={400}>
+          <div class="text-[11px] opacity-70 truncate block w-full leading-tight">
+            {data.sublabel}
+          </div>
+        </Tooltip>
       ) : null}
       <Handle
         type="source"
@@ -140,6 +181,7 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
 }
 
 const NODE_TYPES = { fsmNode: FsmNode };
+const EDGE_TYPES = { fsmEdge: FsmEdge };
 
 /**
  * Run dagre layered layout to position nodes. Returns a fresh node
@@ -189,11 +231,14 @@ function applyDagreLayout(
   g.setDefaultEdgeLabel(() => ({}));
   g.setGraph({
     rankdir: direction,
-    nodesep: direction === 'TB' ? 70 : 90,
-    ranksep: direction === 'TB' ? 90 : 200,
-    edgesep: 30,
-    marginx: 30,
-    marginy: 30,
+    // W21: node size bumped 50% (180x56 → 270x84), so dagre needs
+    // proportionally more inter-node room to keep edges + labels from
+    // colliding with the larger boxes.
+    nodesep: direction === 'TB' ? 90 : 110,
+    ranksep: direction === 'TB' ? 110 : 240,
+    edgesep: 36,
+    marginx: 36,
+    marginy: 36,
     ranker: 'tight-tree',
   });
   for (const n of nodes) g.setNode(n.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
@@ -230,12 +275,12 @@ function applyDagreLayout(
 }
 
 // Truncate predicate strings so a single edge label can't sprawl over
-// downstream nodes. Full text remains available in the tooltip
-// (xyflow surfaces edge.data.fullLabel via our hover handler in a
-// future iteration; today the truncated text is enough for the
-// at-a-glance layout). Truncation point chosen empirically: 28 chars
-// fits comfortably within the dagre-allocated LABEL_WIDTH (160 px) at
-// the 10 px font-size we use.
+// downstream nodes. The FULL text is now preserved on edge.data.fullLabel
+// (W21) and surfaced via the FsmEdge custom edge type's Tooltip on hover
+// + click-to-Sheet. The dagre layout still reserves space based on the
+// TRUNCATED text width so the graph stays autobalanced (PR #56).
+// Truncation point chosen empirically: 28 chars fits comfortably within
+// the dagre-allocated LABEL_WIDTH (160 px) at the 10 px font-size we use.
 const LABEL_MAX_CHARS = 28;
 function truncateLabel(text: string): string {
   if (text.length <= LABEL_MAX_CHARS) return text;
@@ -249,17 +294,31 @@ function truncateLabel(text: string): string {
 // graph background.
 function decorateEdges(edges: readonly Edge[]): Edge[] {
   return edges.map((e) => {
+    const original = typeof e.label === 'string' ? e.label : undefined;
     const labelText = typeof e.label === 'string' ? truncateLabel(e.label) : e.label;
+    // Carry the full predicate + transition metadata on edge.data so the
+    // custom FsmEdge type can Tooltip it AND so onEdgeClick consumers
+    // (specDetail's inspector Sheet) can render the full payload without
+    // re-walking the spec.
+    const incomingData = (e.data ?? {}) as Record<string, unknown>;
+    const data: Record<string, unknown> = {
+      ...incomingData,
+      fullLabel: typeof incomingData.fullLabel === 'string'
+        ? incomingData.fullLabel
+        : original,
+      sourceId: e.source,
+      targetId: e.target,
+    };
     return {
       ...e,
-      // W20: default to 'step' (sharp 90-degree corners) instead of
-      // 'default' (smooth bezier). For FSM graphs, orthogonal routing
-      // makes the topology easier to trace at a glance — every edge
-      // changes direction at the layer boundary, so the visual centre
-      // line stays stable and parallel transitions stack cleanly.
-      type: e.type ?? 'step',
+      // W21: use FsmEdge custom type which wraps the label in a Tooltip
+      // and exposes the full predicate via hover/focus. Defaults to
+      // 'step' visual routing under the hood (sharp 90-degree corners,
+      // matches PR #56's orthogonal routing).
+      type: e.type ?? 'fsmEdge',
       animated: e.animated ?? false,
       label: labelText,
+      data,
       style: {
         strokeWidth: 1.5,
         stroke: 'currentColor',
@@ -303,6 +362,16 @@ export function FlowGraph({
   background = true,
   className,
 }: FlowGraphProps): JSX.Element {
+  // Publish the parent's onEdgeClick to the module-level registry so
+  // FsmEdge's label can dispatch through it. Clean up on unmount.
+  // Without this, clicking the rendered edge label (which lives in
+  // EdgeLabelRenderer's portal, not on the SVG path xyflow delegates
+  // from) silently no-ops.
+  useEffect(() => {
+    setEdgeClickHandler(onEdgeClick ?? null);
+    return () => setEdgeClickHandler(null);
+  }, [onEdgeClick]);
+
   const positioned = useMemo(() => {
     if (!autoLayout) {
       // Preserve caller-supplied positions but still tag every node
@@ -369,10 +438,14 @@ export function FlowGraph({
         nodes={decoratedNodes}
         edges={decoratedEdges}
         nodeTypes={NODE_TYPES}
+        edgeTypes={EDGE_TYPES}
         fitView
         fitViewOptions={{ padding: 0.2, includeHiddenNodes: false }}
         proOptions={{ hideAttribution: true }}
         defaultEdgeOptions={{
+          // Edges that bypass decorateEdges (e.g. ad-hoc test fixtures)
+          // fall back to plain 'step' routing instead of fsmEdge so
+          // they don't break in absence of FsmEdgeData on data.
           type: 'step',
           style: { stroke: 'currentColor', strokeWidth: 1.5 },
           markerEnd: {
@@ -383,7 +456,9 @@ export function FlowGraph({
           },
         }}
         onNodeClick={(_e, node) => onNodeClick?.(node.id, node.data as FlowNodeData)}
-        onEdgeClick={(_e, edge) => onEdgeClick?.(edge.id)}
+        onEdgeClick={(_e, edge) =>
+          onEdgeClick?.(edge.id, edge.data as Record<string, unknown> | undefined)
+        }
       >
         {background ? (
           <Background

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -282,12 +282,18 @@ function applyDagreLayout(
 }
 
 // Truncate predicate strings so a single edge label can't sprawl over
-// downstream nodes. The FULL text is now preserved on edge.data.fullLabel
-// (W21) and surfaced via the FsmEdge custom edge type's Tooltip on hover
-// + click-to-Sheet. The dagre layout still reserves space based on the
-// TRUNCATED text width so the graph stays autobalanced (PR #56).
-// Truncation point chosen empirically: 28 chars fits comfortably within
-// the dagre-allocated LABEL_WIDTH (160 px) at the 10 px font-size we use.
+// downstream nodes. The FULL text is preserved on edge.data.fullLabel
+// (W21) and surfaced via the FsmEdge custom edge type's Tooltip on
+// hover + click-to-Sheet.
+//
+// Note on dagre slack: applyDagreLayout above computes per-edge label
+// dimensions from the ORIGINAL (pre-decoration) label length and
+// clamps to LABEL_WIDTH (160 px). The truncation that happens in
+// decorateEdges only affects the VISIBLE text the user reads — dagre
+// never sees the truncated string, so its routing slack stays
+// proportional to the actual predicate complexity. Truncation point
+// chosen empirically: 28 chars fits comfortably within LABEL_WIDTH
+// at the 10 px font-size we use.
 const LABEL_MAX_CHARS = 28;
 function truncateLabel(text: string): string {
   if (text.length <= LABEL_MAX_CHARS) return text;

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -395,6 +395,13 @@ export function FlowGraph({
 
   const showMiniMap = miniMap ?? nodes.length > 10;
 
+  // Compute decorated edges BEFORE any conditional return. React's
+  // rules-of-hooks require every hook to be called in the same order
+  // on every render; the previous version put this useMemo after the
+  // empty-graph early return, which threw when the same FlowGraph
+  // flipped between 0 nodes and >0 nodes (Copilot finding on PR #57).
+  const decoratedEdges = useMemo(() => decorateEdges(edges), [edges]);
+
   if (nodes.length === 0) {
     return (
       <div
@@ -418,7 +425,6 @@ export function FlowGraph({
   // stroke colour via currentColor (see decorateEdges). The fitView
   // padding adds breathing room so dagre's wide LR layout doesn't
   // clip nodes at the viewport edges.
-  const decoratedEdges = useMemo(() => decorateEdges(edges), [edges]);
   return (
     <FsmEdgeClickContext.Provider value={onEdgeClick ?? null}>
     <div

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -169,9 +169,13 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
       </Tooltip>
       {data.sublabel ? (
         <Tooltip content={data.fullSublabel ?? data.sublabel} delay={400}>
-          <div class="text-[11px] opacity-70 truncate block w-full leading-tight">
+          {/* <span> not <div>: Tooltip's wrapper renders as a <span>,
+              and HTML doesn't allow <div> inside <span>. The `block`
+              class restores div-like layout without invalidating the
+              DOM. */}
+          <span class="text-[11px] opacity-70 truncate block w-full leading-tight">
             {data.sublabel}
-          </div>
+          </span>
         </Tooltip>
       ) : null}
       <Handle

--- a/ui/src/components/FsmEdge.tsx
+++ b/ui/src/components/FsmEdge.tsx
@@ -23,10 +23,12 @@
  * Because clicking an HTML element inside EdgeLabelRenderer doesn't
  * fire xyflow's onEdgeClick (the SVG path is the only thing xyflow
  * delegates clicks from), we read the FlowGraph's onEdgeClick from a
- * module-level callback registry set by FlowGraph each render and
- * invoke it ourselves on label click.
+ * Preact Context (instance-scoped, so two FlowGraphs mounted at once
+ * dispatch to their own handlers — see W21 Copilot review #57).
  */
 
+import { createContext } from 'preact';
+import { useContext } from 'preact/hooks';
 import type { JSX } from 'preact';
 import {
   BaseEdge,
@@ -37,22 +39,17 @@ import {
 
 import { Tooltip } from './Tooltip';
 
-// Module-level callback registry. FlowGraph stamps the current
-// onEdgeClick handler here before each render; FsmEdge reads it on
-// click. This avoids a Preact Context for a single value, which would
-// otherwise require wrapping the whole ReactFlow subtree in a Provider.
-let edgeClickHandler: ((id: string, data?: Record<string, unknown>) => void) | null = null;
-
 /**
- * FlowGraph calls this once per render to publish the current
- * onEdgeClick callback so the rendered FsmEdge instances can dispatch
- * to it from their label click handler.
+ * Context that carries the parent FlowGraph's `onEdgeClick` handler
+ * down into every rendered FsmEdge. FlowGraph wraps its ReactFlow
+ * subtree in a Provider with the current handler. Using context (not
+ * a module-level registry) keeps each FlowGraph instance scoped to
+ * its own click target — critical if two graphs render at once or a
+ * graph unmounts/remounts in the same tree.
  */
-export function setEdgeClickHandler(
-  handler: ((id: string, data?: Record<string, unknown>) => void) | null,
-): void {
-  edgeClickHandler = handler;
-}
+export const FsmEdgeClickContext = createContext<
+  ((id: string, data?: Record<string, unknown>) => void) | null
+>(null);
 
 export interface FsmEdgeData extends Record<string, unknown> {
   fullLabel?: string;
@@ -77,6 +74,10 @@ export function FsmEdge(props: EdgeProps): JSX.Element {
     markerEnd,
     data,
   } = props;
+  // Per-instance click handler from the enclosing FlowGraph. Falls
+  // back to null when no FlowGraph wrapped this edge (e.g. an isolated
+  // unit-test render); the onClick path is a no-op in that case.
+  const onLabelClick = useContext(FsmEdgeClickContext);
 
   const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
@@ -146,8 +147,7 @@ export function FsmEdge(props: EdgeProps): JSX.Element {
                 style={labelStyle as JSX.CSSProperties | undefined}
                 onClick={(e) => {
                   e.stopPropagation();
-                  // Dispatch through the registered FlowGraph onEdgeClick.
-                  edgeClickHandler?.(id, ed as Record<string, unknown>);
+                  onLabelClick?.(id, ed as Record<string, unknown>);
                 }}
                 aria-label={`Inspect transition: ${fullText}`}
               >

--- a/ui/src/components/FsmEdge.tsx
+++ b/ui/src/components/FsmEdge.tsx
@@ -1,0 +1,161 @@
+/**
+ * FsmEdge — custom xyflow edge type that wraps the rendered label in
+ * a Tooltip so the FULL predicate text is reachable on hover (and via
+ * keyboard focus on the inner span), even when decorateEdges has
+ * truncated the visible label to LABEL_MAX_CHARS to fit the dagre
+ * layout reservation.
+ *
+ * The base edge path uses getSmoothStepPath (matches FlowGraph's
+ * default 'step' edge type) so visuals are identical to PR #56. The
+ * label is rendered inside xyflow's EdgeLabelRenderer (which portals
+ * out of the SVG so HTML elements like our Tooltip can mount + position
+ * correctly).
+ *
+ * Edge data contract (set by specGraph + decorateEdges):
+ *   data.fullLabel?: string  — original untruncated predicate text
+ *   data.kind?: string       — transition kind (always/otherwise/
+ *                              deterministic/judgement)
+ *   data.transition?: unknown — raw transition object for inspector
+ *   data.sourceId?: string   — convenience (= edge.source)
+ *   data.targetId?: string   — convenience (= edge.target)
+ *
+ * The edge label is BOTH a hover trigger (Tooltip) AND a click target.
+ * Because clicking an HTML element inside EdgeLabelRenderer doesn't
+ * fire xyflow's onEdgeClick (the SVG path is the only thing xyflow
+ * delegates clicks from), we read the FlowGraph's onEdgeClick from a
+ * module-level callback registry set by FlowGraph each render and
+ * invoke it ourselves on label click.
+ */
+
+import type { JSX } from 'preact';
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getSmoothStepPath,
+  type EdgeProps,
+} from '@xyflow/react';
+
+import { Tooltip } from './Tooltip';
+
+// Module-level callback registry. FlowGraph stamps the current
+// onEdgeClick handler here before each render; FsmEdge reads it on
+// click. This avoids a Preact Context for a single value, which would
+// otherwise require wrapping the whole ReactFlow subtree in a Provider.
+let edgeClickHandler: ((id: string, data?: Record<string, unknown>) => void) | null = null;
+
+/**
+ * FlowGraph calls this once per render to publish the current
+ * onEdgeClick callback so the rendered FsmEdge instances can dispatch
+ * to it from their label click handler.
+ */
+export function setEdgeClickHandler(
+  handler: ((id: string, data?: Record<string, unknown>) => void) | null,
+): void {
+  edgeClickHandler = handler;
+}
+
+export interface FsmEdgeData extends Record<string, unknown> {
+  fullLabel?: string;
+  kind?: string;
+  transition?: unknown;
+  sourceId?: string;
+  targetId?: string;
+}
+
+export function FsmEdge(props: EdgeProps): JSX.Element {
+  const {
+    id,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    label,
+    labelStyle,
+    style,
+    markerEnd,
+    data,
+  } = props;
+
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    borderRadius: 4,
+  });
+
+  const ed = (data ?? {}) as FsmEdgeData;
+  const fullText = typeof ed.fullLabel === 'string' && ed.fullLabel.length > 0
+    ? ed.fullLabel
+    : typeof label === 'string'
+    ? label
+    : '';
+
+  const visibleLabel = label;
+
+  // interactionWidth gives the SVG path a 20px-wide invisible click
+  // zone so clicking near the edge fires xyflow's onEdgeClick without
+  // requiring pixel-perfect aim on the 1.5px visible stroke. Without
+  // this, the user has to land precisely on the line to open the
+  // transition inspector — too unreliable for the user's stated
+  // "click to see full info" contract.
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        style={style}
+        markerEnd={markerEnd}
+        interactionWidth={20}
+      />
+      {visibleLabel ? (
+        <EdgeLabelRenderer>
+          {/* The wrapper position is set via inline style because xyflow's
+              EdgeLabelRenderer mounts each label at the (labelX, labelY)
+              we compute above; an external CSS class can't carry per-
+              edge coordinates. nodrag/nopan stop xyflow from hijacking
+              pointer events when the user hovers/clicks the label. */}
+          <div
+            class="absolute pointer-events-auto nodrag nopan"
+            // eslint-disable-next-line react/forbid-dom-props -- per-edge position is computed from getSmoothStepPath
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+            data-edge-id={id}
+          >
+            <Tooltip content={fullText} delay={400}>
+              <button
+                type="button"
+                class={[
+                  'inline-block max-w-[160px] truncate cursor-pointer',
+                  'rounded px-1.5 py-0.5 text-[10px] leading-tight',
+                  'bg-[var(--xy-label-bg,#f8fafc)]/90',
+                  'border border-slate-200 dark:border-slate-700',
+                  'text-slate-700 dark:text-slate-200',
+                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
+                ].join(' ')}
+                title={fullText}
+                // eslint-disable-next-line react/forbid-dom-props -- font-size is xyflow's edge-label convention; matches the legacy decorateEdges labelStyle
+                style={labelStyle as JSX.CSSProperties | undefined}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  // Dispatch through the registered FlowGraph onEdgeClick.
+                  edgeClickHandler?.(id, ed as Record<string, unknown>);
+                }}
+                aria-label={`Inspect transition: ${fullText}`}
+              >
+                {visibleLabel}
+              </button>
+            </Tooltip>
+          </div>
+        </EdgeLabelRenderer>
+      ) : null}
+    </>
+  );
+}
+
+export default FsmEdge;

--- a/ui/src/components/FsmEdge.tsx
+++ b/ui/src/components/FsmEdge.tsx
@@ -138,7 +138,10 @@ export function FsmEdge(props: EdgeProps): JSX.Element {
                   'text-slate-700 dark:text-slate-200',
                   'focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
                 ].join(' ')}
-                title={fullText}
+                // No native title= here: the custom Tooltip already
+                // surfaces fullText with the right delay + ARIA wiring,
+                // and a sibling native title would produce a double
+                // bubble (instant + delayed) on hover.
                 // eslint-disable-next-line react/forbid-dom-props -- font-size is xyflow's edge-label convention; matches the legacy decorateEdges labelStyle
                 style={labelStyle as JSX.CSSProperties | undefined}
                 onClick={(e) => {

--- a/ui/src/components/JsonViewer.tsx
+++ b/ui/src/components/JsonViewer.tsx
@@ -127,7 +127,12 @@ export interface JsonViewerProps {
   value: unknown;
   /** Default render mode. Inline = scrollable max-h-40 box. Expanded = tree. */
   mode?: JsonViewerMode;
-  /** Initial collapse depth in expanded mode. Default 2. */
+  /** Initial collapse depth in expanded mode. When OMITTED, the
+   *  "Expanded" view recursively expands every level (the user-
+   *  facing "Expand" button promises full inspection). When
+   *  explicitly passed (even `0`), the caller's number is honoured —
+   *  use this only when the JSON is large enough that auto-expanding
+   *  everything would overwhelm the inline view. */
   defaultExpandDepth?: number;
   /** Inline-mode height cap. Default `max-h-40`. */
   maxInlineHeight?: string;
@@ -179,7 +184,7 @@ function downloadAs(filename: string, text: string): void {
 export function JsonViewer({
   value,
   mode = 'inline',
-  defaultExpandDepth = 2,
+  defaultExpandDepth,
   maxInlineHeight = 'max-h-40',
   rootLabel = 'value',
   onSelect,
@@ -359,18 +364,16 @@ export function JsonViewer({
         <JsonView
           value={value as object}
           // currentMode==='inline' → collapsed at depth 0 (just root
-          // visible); currentMode==='expanded' → recursively expand
-          // EVERY nested level (the user-facing "Expand" button
-          // semantically promises "show me everything", not "show me
-          // the first two layers"). false at the library API expands
-          // all; defaultExpandDepth is preserved as the fallback when
-          // callers explicitly pin a partial depth via the prop.
+          // visible); currentMode==='expanded' → expand recursively
+          // unless the caller pinned a specific depth via the prop.
+          // `undefined` (the default) gets full expansion via the
+          // library's `collapsed={false}` semantics.
           collapsed={
             currentMode === 'inline'
               ? 0
-              : defaultExpandDepth !== 2
-              ? defaultExpandDepth
-              : false
+              : defaultExpandDepth === undefined
+              ? false
+              : defaultExpandDepth
           }
           displayDataTypes={false}
           enableClipboard={false}

--- a/ui/src/components/JsonViewer.tsx
+++ b/ui/src/components/JsonViewer.tsx
@@ -346,9 +346,9 @@ export function JsonViewer({
           onClick={onOpenSheet}
           aria-label="Open in full-screen sheet"
           title="Full-screen"
-          class="h-6 px-2 text-xs rounded text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+          class="h-6 px-2 text-xs rounded text-emerald-700 dark:text-emerald-400 border border-transparent hover:bg-slate-100 dark:hover:bg-slate-700 hover:border-emerald-500/40 font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
         >
-          ↗
+          ⛶ Full-screen
         </button>
       </header>
       <div
@@ -358,7 +358,20 @@ export function JsonViewer({
       >
         <JsonView
           value={value as object}
-          collapsed={currentMode === 'inline' ? 0 : defaultExpandDepth}
+          // currentMode==='inline' → collapsed at depth 0 (just root
+          // visible); currentMode==='expanded' → recursively expand
+          // EVERY nested level (the user-facing "Expand" button
+          // semantically promises "show me everything", not "show me
+          // the first two layers"). false at the library API expands
+          // all; defaultExpandDepth is preserved as the fallback when
+          // callers explicitly pin a partial depth via the prop.
+          collapsed={
+            currentMode === 'inline'
+              ? 0
+              : defaultExpandDepth !== 2
+              ? defaultExpandDepth
+              : false
+          }
           displayDataTypes={false}
           enableClipboard={false}
           highlightUpdates={false}
@@ -374,7 +387,10 @@ export function JsonViewer({
       >
         <JsonView
           value={value as object}
-          collapsed={Math.max(3, defaultExpandDepth)}
+          // Full-screen sheet ALWAYS expands every level — the user
+          // explicitly asked for full inspection, so depth-limiting
+          // would be a regression from intent.
+          collapsed={false}
           displayDataTypes={false}
           enableClipboard={true}
           shortenTextAfterLength={0}

--- a/ui/src/components/Tooltip.tsx
+++ b/ui/src/components/Tooltip.tsx
@@ -372,37 +372,57 @@ export function Tooltip(props: TooltipProps): JSX.Element {
     };
   }, [scheduleOpen, scheduleClose]);
 
-  // Mirror aria-describedby onto the FIRST FOCUSABLE CHILD of the
-  // wrapper while open. The wrapper span itself isn't the focus target
-  // (a button or anchor child usually is), and aria-describedby does
-  // not propagate to descendants — so a screen reader on a focused
-  // button inside <Tooltip> wouldn't announce the tooltip body unless
-  // the button itself carries the attribute.
+  // Mirror aria-describedby onto EVERY focusable descendant of the
+  // wrapper while open. aria-describedby does not propagate to
+  // descendants, and the actual focus target can be ANY focusable
+  // element inside the trigger (nested arbitrarily — `<span><div>
+  // <button/></div></span>`), so setting it only on the first child
+  // misses the real focus target whenever a layout wrapper sits
+  // between the Tooltip and the focusable control. Querying for the
+  // standard set (button / a[href] / input / select / textarea /
+  // [tabindex]) covers every realistic trigger shape.
   useEffect(() => {
     if (!open) return undefined;
     const wrapper = triggerRef.current;
     if (!wrapper) return undefined;
-    const child = wrapper.firstElementChild as HTMLElement | null;
-    if (!child) return undefined;
-    const prev = child.getAttribute('aria-describedby');
-    child.setAttribute(
-      'aria-describedby',
-      prev ? `${prev} ${bubbleId}` : bubbleId,
+    const focusables = Array.from(
+      wrapper.querySelectorAll<HTMLElement>(
+        'button, a[href], input, select, textarea, [tabindex]',
+      ),
     );
+    // Fallback: if the trigger child isn't itself focusable (e.g. a
+    // plain text span) tag the first DOM child anyway so the wrapper
+    // still announces something when an assistive tech traverses to
+    // the visible label.
+    if (focusables.length === 0) {
+      const first = wrapper.firstElementChild as HTMLElement | null;
+      if (first) focusables.push(first);
+    }
+    // Snapshot prior aria-describedby on each so we can restore on
+    // close (or strip our id only when appending to an existing list).
+    const prev = new Map<HTMLElement, string | null>();
+    for (const el of focusables) {
+      const cur = el.getAttribute('aria-describedby');
+      prev.set(el, cur);
+      el.setAttribute(
+        'aria-describedby',
+        cur ? `${cur} ${bubbleId}` : bubbleId,
+      );
+    }
     return () => {
-      // Restore the caller's original value (or clear if there wasn't
-      // one). If the caller set aria-describedby AND we appended,
-      // strip our id only.
-      const current = child.getAttribute('aria-describedby');
-      if (prev === null) {
-        child.removeAttribute('aria-describedby');
-      } else if (current && current.includes(bubbleId)) {
-        const restored = current
-          .split(/\s+/)
-          .filter((id) => id !== bubbleId)
-          .join(' ');
-        if (restored) child.setAttribute('aria-describedby', restored);
-        else child.removeAttribute('aria-describedby');
+      for (const el of focusables) {
+        const original = prev.get(el) ?? null;
+        const current = el.getAttribute('aria-describedby');
+        if (original === null) {
+          el.removeAttribute('aria-describedby');
+        } else if (current && current.includes(bubbleId)) {
+          const restored = current
+            .split(/\s+/)
+            .filter((id) => id !== bubbleId)
+            .join(' ');
+          if (restored) el.setAttribute('aria-describedby', restored);
+          else el.removeAttribute('aria-describedby');
+        }
       }
     };
   }, [open, bubbleId]);

--- a/ui/src/components/Tooltip.tsx
+++ b/ui/src/components/Tooltip.tsx
@@ -39,6 +39,24 @@ let warmUntil = 0; // wall-clock ms after which the warm window expires
 let closeAll: (() => void) | null = null; // installed by the currently-open instance
 
 /**
+ * Test-only helper: reset every piece of module-level singleton state
+ * so a fresh test run can't be influenced by a stale warm window /
+ * closeAll registration / id counter from the previous test. Call
+ * from `beforeEach` (or `afterEach`) in any suite that renders
+ * <Tooltip>.
+ *
+ * Out of the testing path this is a no-op tool — it doesn't affect
+ * normal app behaviour, but exporting it documents the singleton
+ * surface and keeps the test suite order-independent (Copilot finding
+ * on PR #57: warm window could leak between tests).
+ */
+export function __resetTooltipStateForTests(): void {
+  nextTooltipId = 1;
+  warmUntil = 0;
+  closeAll = null;
+}
+
+/**
  * Returns the singleton #tooltip-root portal target, creating it if
  * absent. The target lives under document.body so the bubble escapes
  * every overflow:hidden ancestor in the app.

--- a/ui/src/components/Tooltip.tsx
+++ b/ui/src/components/Tooltip.tsx
@@ -1,0 +1,375 @@
+/**
+ * Tooltip — hover-or-focus surfaced overlay for terse, full-string content.
+ *
+ * Use when a label is visually truncated (FlowGraph state names,
+ * predicate edge labels, etc.) and the operator must be able to read
+ * the FULL value without taking an extra click. Click-to-open is a
+ * Sheet's job; Tooltip is the at-a-glance preview.
+ *
+ * Contract (matches the W18 interaction grammar):
+ *   - Open on mouseenter (after 400 ms delay) OR focus (immediate).
+ *   - Close on mouseleave (100 ms grace), blur, Escape, scroll, or
+ *     pointerdown outside both trigger and bubble.
+ *   - role="tooltip" on the floating element; trigger gains
+ *     aria-describedby while visible.
+ *   - Honours prefers-reduced-motion (drops the opacity transition).
+ *   - Singleton: only one bubble is mounted at a time.
+ *   - Warm window (300 ms after a close) lets the next hover open
+ *     instantly so scanning a tree feels responsive.
+ *   - Portals into #tooltip-root under document.body so the bubble
+ *     escapes ReactFlow / Sheet / Card overflow:hidden ancestors.
+ *
+ * Performance: the bubble portal is mounted ONLY on first open. A
+ * JsonViewer with 1000 Tooltip-wrapped rows costs 1000 inert wrapping
+ * spans and ZERO portals until the user hovers.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
+import { createPortal } from 'preact/compat';
+import type { ComponentChild, JSX, VNode } from 'preact';
+
+// ---------------------------------------------------------------------------
+// Shared module-level state (singleton open + warm window).
+// ---------------------------------------------------------------------------
+
+let nextTooltipId = 1;
+let warmUntil = 0; // wall-clock ms after which the warm window expires
+let closeAll: (() => void) | null = null; // installed by the currently-open instance
+
+/**
+ * Returns the singleton #tooltip-root portal target, creating it if
+ * absent. The target lives under document.body so the bubble escapes
+ * every overflow:hidden ancestor in the app.
+ */
+function ensurePortalTarget(): HTMLDivElement {
+  let el = document.getElementById('tooltip-root') as HTMLDivElement | null;
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'tooltip-root';
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right' | 'auto';
+
+export interface TooltipProps {
+  /** The full-detail body shown when the tooltip surfaces. */
+  content: ComponentChild;
+  /** Open delay in ms. Default 400. Set 0 for an instant tooltip. */
+  delay?: number;
+  /** Preferred placement; auto-flips on viewport-edge clip. Default 'top'. */
+  placement?: TooltipPlacement;
+  /** When true, the trigger is wrapped verbatim with no listeners. */
+  disabled?: boolean;
+  /** Optional stable id for the bubble (used by aria-describedby). */
+  id?: string;
+  /** Extra Tailwind classes on the wrapping span. */
+  className?: string;
+  /** Single trigger child (any VNode). */
+  children: VNode;
+}
+
+interface Position {
+  top: number;
+  left: number;
+  flipped: boolean;
+}
+
+function computePosition(
+  trigger: DOMRect,
+  bubble: DOMRect,
+  placement: TooltipPlacement,
+): Position {
+  const margin = 8;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  let top: number;
+  let left: number;
+  let flipped = false;
+
+  const placeTop = (): { top: number; left: number } => ({
+    top: trigger.top - bubble.height - margin,
+    left: trigger.left + trigger.width / 2 - bubble.width / 2,
+  });
+  const placeBottom = (): { top: number; left: number } => ({
+    top: trigger.bottom + margin,
+    left: trigger.left + trigger.width / 2 - bubble.width / 2,
+  });
+
+  const initial = placement === 'bottom' ? placeBottom() : placeTop();
+  top = initial.top;
+  left = initial.left;
+  if (top < margin) {
+    const flipTo = placement === 'bottom' ? placeTop() : placeBottom();
+    if (
+      flipTo.top >= margin &&
+      flipTo.top + bubble.height <= vh - margin
+    ) {
+      top = flipTo.top;
+      left = flipTo.left;
+      flipped = true;
+    } else {
+      top = margin;
+    }
+  }
+  if (top + bubble.height > vh - margin) {
+    top = Math.max(margin, vh - bubble.height - margin);
+  }
+  if (left < margin) left = margin;
+  if (left + bubble.width > vw - margin) {
+    left = Math.max(margin, vw - bubble.width - margin);
+  }
+  return { top, left, flipped };
+}
+
+/**
+ * Tooltip component. Wraps a single trigger child in an inline-flex
+ * span that owns the open/close listeners; renders the bubble in a
+ * portal when open.
+ */
+export function Tooltip(props: TooltipProps): JSX.Element {
+  const {
+    content,
+    delay = 400,
+    placement = 'top',
+    disabled = false,
+    id: providedId,
+    className,
+    children,
+  } = props;
+
+  const triggerRef = useRef<HTMLSpanElement | null>(null);
+  const bubbleRef = useRef<HTMLDivElement | null>(null);
+  const openTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+  const restoreTitleRef = useRef<string | null>(null);
+
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<Position | null>(null);
+
+  const bubbleId = useRef<string>(
+    providedId ?? `tt-${nextTooltipId++}`,
+  ).current;
+
+  const isEmpty =
+    content === null ||
+    content === undefined ||
+    (typeof content === 'string' && content.trim().length === 0);
+
+  const clearOpenTimer = (): void => {
+    if (openTimer.current !== null) {
+      window.clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+  };
+  const clearCloseTimer = (): void => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+
+  const closeNow = useCallback((): void => {
+    clearOpenTimer();
+    clearCloseTimer();
+    setOpen(false);
+  }, []);
+
+  // Suppress native title= on the trigger so the browser doesn't
+  // race our bubble with its own. Restore on close.
+  const suppressTitle = (): void => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const t = el.getAttribute('title');
+    if (t !== null) {
+      restoreTitleRef.current = t;
+      el.removeAttribute('title');
+    }
+  };
+  const restoreTitle = (): void => {
+    const el = triggerRef.current;
+    if (el && restoreTitleRef.current !== null) {
+      el.setAttribute('title', restoreTitleRef.current);
+      restoreTitleRef.current = null;
+    }
+  };
+
+  const scheduleOpen = useCallback((): void => {
+    if (disabled || isEmpty) return;
+    clearOpenTimer();
+    clearCloseTimer();
+    // Singleton: kick the currently open instance closed before
+    // showing this one.
+    if (closeAll && closeAll !== closeNow) {
+      const prev = closeAll;
+      closeAll = null;
+      prev();
+    }
+    const now = Date.now();
+    const useDelay = now < warmUntil ? 0 : delay;
+    // Always route through setTimeout (even for delay=0) so the
+    // Preact re-render is flushable by vi.advanceTimersByTime in
+    // tests. Going synchronous on delay<=0 left the re-render
+    // queued on an unflushable scheduler (rAF) which is fake-time-
+    // unfriendly.
+    openTimer.current = window.setTimeout(() => {
+      openTimer.current = null;
+      suppressTitle();
+      setOpen(true);
+    }, Math.max(0, useDelay));
+  }, [disabled, isEmpty, delay, closeNow]);
+
+  const scheduleClose = useCallback((): void => {
+    clearOpenTimer();
+    clearCloseTimer();
+    closeTimer.current = window.setTimeout(() => {
+      closeTimer.current = null;
+      restoreTitle();
+      setOpen(false);
+      warmUntil = Date.now() + 300;
+    }, 100);
+  }, []);
+
+  // Position the bubble after it mounts.
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+    const trig = triggerRef.current;
+    const bub = bubbleRef.current;
+    if (!trig || !bub) return;
+    const place = (): void => {
+      const t = trig.getBoundingClientRect();
+      const b = bub.getBoundingClientRect();
+      setPosition(computePosition(t, b, placement));
+    };
+    place();
+  }, [open, placement, content]);
+
+  // Window-level dismiss listeners while open.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        closeNow();
+        warmUntil = 0;
+      }
+    };
+    const onScroll = (): void => closeNow();
+    const onPointerDown = (e: PointerEvent): void => {
+      const trig = triggerRef.current;
+      const bub = bubbleRef.current;
+      const t = e.target as Node | null;
+      if (!t) return;
+      if (trig && trig.contains(t)) return;
+      if (bub && bub.contains(t)) return;
+      closeNow();
+    };
+    const onResize = (): void => {
+      // Re-measure rather than close.
+      const trig = triggerRef.current;
+      const bub = bubbleRef.current;
+      if (!trig || !bub) return;
+      setPosition(
+        computePosition(
+          trig.getBoundingClientRect(),
+          bub.getBoundingClientRect(),
+          placement,
+        ),
+      );
+    };
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true });
+    document.addEventListener('pointerdown', onPointerDown, true);
+    window.addEventListener('resize', onResize);
+    closeAll = closeNow;
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      window.removeEventListener('scroll', onScroll, { capture: true });
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      window.removeEventListener('resize', onResize);
+      if (closeAll === closeNow) closeAll = null;
+    };
+  }, [open, closeNow, placement]);
+
+  // Cleanup on unmount: clear timers, restore title, unset singleton.
+  useEffect(() => {
+    return () => {
+      clearOpenTimer();
+      clearCloseTimer();
+      restoreTitle();
+      if (closeAll === closeNow) closeAll = null;
+    };
+  }, [closeNow]);
+
+  // Attach native focusin/focusout listeners (Preact's onFocus does NOT
+  // bubble through descendants; we need the bubbling focusin/out events
+  // so that focusing a nested button inside the trigger surfaces the
+  // tooltip). Done in useEffect so the listeners are attached once per
+  // mount and torn down on unmount.
+  useEffect(() => {
+    const el = triggerRef.current;
+    if (!el) return undefined;
+    const onEnter = (): void => scheduleOpen();
+    const onLeave = (): void => scheduleClose();
+    const onFocusIn = (): void => scheduleOpen();
+    const onFocusOut = (): void => scheduleClose();
+    el.addEventListener('mouseenter', onEnter);
+    el.addEventListener('mouseleave', onLeave);
+    el.addEventListener('focusin', onFocusIn);
+    el.addEventListener('focusout', onFocusOut);
+    return () => {
+      el.removeEventListener('mouseenter', onEnter);
+      el.removeEventListener('mouseleave', onLeave);
+      el.removeEventListener('focusin', onFocusIn);
+      el.removeEventListener('focusout', onFocusOut);
+    };
+  }, [scheduleOpen, scheduleClose]);
+
+  if (disabled || isEmpty) {
+    return children;
+  }
+
+  const bubble = open
+    ? createPortal(
+        <div
+          ref={bubbleRef}
+          role="tooltip"
+          id={bubbleId}
+          class={[
+            'fixed z-[60] pointer-events-none max-w-xs rounded-md px-2 py-1',
+            'text-xs whitespace-pre-wrap break-words shadow-lg border',
+            'bg-slate-100 text-slate-900 border-slate-200',
+            'dark:bg-slate-800 dark:text-slate-100 dark:border-slate-700',
+            'motion-safe:transition-opacity motion-safe:duration-100',
+            'motion-reduce:transition-none',
+          ].join(' ')}
+          // eslint-disable-next-line react/forbid-dom-props -- positioning is computed from the trigger + bubble DOMRects on open and on resize; must be inline to update without a class explosion
+          style={{
+            top: `${position?.top ?? -9999}px`,
+            left: `${position?.left ?? -9999}px`,
+            opacity: position ? 1 : 0,
+          }}
+        >
+          {content}
+        </div>,
+        ensurePortalTarget(),
+      )
+    : null;
+
+  return (
+    <span
+      ref={triggerRef}
+      class={['inline-flex max-w-full', className ?? ''].join(' ')}
+      aria-describedby={open ? bubbleId : undefined}
+    >
+      {children}
+      {bubble}
+    </span>
+  );
+}
+
+export default Tooltip;

--- a/ui/src/components/Tooltip.tsx
+++ b/ui/src/components/Tooltip.tsx
@@ -7,7 +7,9 @@
  * Sheet's job; Tooltip is the at-a-glance preview.
  *
  * Contract (matches the W18 interaction grammar):
- *   - Open on mouseenter (after 400 ms delay) OR focus (immediate).
+ *   - Open on mouseenter (after 400 ms delay) OR focus (instant —
+ *     keyboard navigation is intentional, so a hover-style delay
+ *     would feel sluggish).
  *   - Close on mouseleave (100 ms grace), blur, Escape, scroll, or
  *     pointerdown outside both trigger and bubble.
  *   - role="tooltip" on the floating element; trigger gains
@@ -51,14 +53,23 @@ function ensurePortalTarget(): HTMLDivElement {
   return el;
 }
 
-export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right' | 'auto';
+// Placement contract is currently 'top' | 'bottom'. The bubble auto-
+// flips between the two when the preferred side would clip the
+// viewport. 'left' / 'right' / 'auto' are NOT supported in v1 — if a
+// future caller needs side placement, computePosition() needs to grow
+// the corresponding cases first. Keeping the type narrow prevents
+// callers from passing values the layout engine silently ignores.
+export type TooltipPlacement = 'top' | 'bottom';
 
 export interface TooltipProps {
   /** The full-detail body shown when the tooltip surfaces. */
   content: ComponentChild;
-  /** Open delay in ms. Default 400. Set 0 for an instant tooltip. */
+  /** Open delay in ms applied to hover. Focus always opens instantly
+   *  (keyboard navigation is intentional, so a hover-style delay would
+   *  feel sluggish to keyboard users). Default 400. */
   delay?: number;
-  /** Preferred placement; auto-flips on viewport-edge clip. Default 'top'. */
+  /** Preferred side. The bubble auto-flips to the opposite side if the
+   *  preferred side would clip the viewport. Default 'top'. */
   placement?: TooltipPlacement;
   /** When true, the trigger is wrapped verbatim with no listeners. */
   disabled?: boolean;
@@ -195,7 +206,7 @@ export function Tooltip(props: TooltipProps): JSX.Element {
     }
   };
 
-  const scheduleOpen = useCallback((): void => {
+  const scheduleOpen = useCallback((opts?: { instant?: boolean }): void => {
     if (disabled || isEmpty) return;
     clearOpenTimer();
     clearCloseTimer();
@@ -207,7 +218,11 @@ export function Tooltip(props: TooltipProps): JSX.Element {
       prev();
     }
     const now = Date.now();
-    const useDelay = now < warmUntil ? 0 : delay;
+    // Focus path passes instant=true: keyboard navigation already
+    // signals intent, so the hover-style delay is wrong there. Warm
+    // window also produces delay=0 for the second-hover-within-300ms
+    // path.
+    const useDelay = opts?.instant === true || now < warmUntil ? 0 : delay;
     // Always route through setTimeout (even for delay=0) so the
     // Preact re-render is flushable by vi.advanceTimersByTime in
     // tests. Going synchronous on delay<=0 left the re-render
@@ -315,7 +330,11 @@ export function Tooltip(props: TooltipProps): JSX.Element {
     if (!el) return undefined;
     const onEnter = (): void => scheduleOpen();
     const onLeave = (): void => scheduleClose();
-    const onFocusIn = (): void => scheduleOpen();
+    // Focus path opens IMMEDIATELY (delay forced to 0) — keyboard
+    // navigation is an intentional act, so honouring the hover-style
+    // 400 ms delay would feel sluggish to keyboard users. The W18
+    // contract treats `delay` as hover intent specifically.
+    const onFocusIn = (): void => scheduleOpen({ instant: true });
     const onFocusOut = (): void => scheduleClose();
     el.addEventListener('mouseenter', onEnter);
     el.addEventListener('mouseleave', onLeave);

--- a/ui/src/components/Tooltip.tsx
+++ b/ui/src/components/Tooltip.tsx
@@ -95,8 +95,6 @@ function computePosition(
   const margin = 8;
   const vw = window.innerWidth;
   const vh = window.innerHeight;
-  let top: number;
-  let left: number;
   let flipped = false;
 
   const placeTop = (): { top: number; left: number } => ({
@@ -108,22 +106,28 @@ function computePosition(
     left: trigger.left + trigger.width / 2 - bubble.width / 2,
   });
 
-  const initial = placement === 'bottom' ? placeBottom() : placeTop();
-  top = initial.top;
-  left = initial.left;
-  if (top < margin) {
-    const flipTo = placement === 'bottom' ? placeTop() : placeBottom();
-    if (
-      flipTo.top >= margin &&
-      flipTo.top + bubble.height <= vh - margin
-    ) {
-      top = flipTo.top;
-      left = flipTo.left;
+  const fitsVertically = (candidateTop: number): boolean =>
+    candidateTop >= margin && candidateTop + bubble.height <= vh - margin;
+
+  // Auto-flip is symmetric: if the preferred side clips EITHER the top
+  // OR bottom edge AND the opposite side fits, we flip. Without this,
+  // placement='bottom' near the page bottom would clamp the bubble
+  // over the trigger instead of flipping above it.
+  const preferred = placement === 'bottom' ? placeBottom() : placeTop();
+  let top = preferred.top;
+  let left = preferred.left;
+  if (!fitsVertically(top)) {
+    const alternate = placement === 'bottom' ? placeTop() : placeBottom();
+    if (fitsVertically(alternate.top)) {
+      top = alternate.top;
+      left = alternate.left;
       flipped = true;
-    } else {
-      top = margin;
     }
   }
+
+  // Final clamp so the bubble never punches outside the viewport even
+  // when neither side fits cleanly (e.g. on a very short window).
+  if (top < margin) top = margin;
   if (top + bubble.height > vh - margin) {
     top = Math.max(margin, vh - bubble.height - margin);
   }
@@ -187,8 +191,18 @@ export function Tooltip(props: TooltipProps): JSX.Element {
     setOpen(false);
   }, []);
 
-  // Suppress native title= on the trigger so the browser doesn't
-  // race our bubble with its own. Restore on close.
+  // The wrapping span ALMOST never has a native title= (callers attach
+  // title to the inner trigger child, not to the Tooltip wrapper),
+  // but if a future caller does add one via the className prop's
+  // sibling attributes we strip it on open and restore on close so the
+  // browser doesn't race our bubble with its native title popup.
+  //
+  // NOT SUPPORTED: we do NOT recursively suppress title= on the inner
+  // children. Callers must avoid setting `title=` on the trigger child
+  // when it is already wrapped in <Tooltip> — that would produce a
+  // double bubble (instant native + delayed custom). The audit-strings
+  // lint catches this in practice; the contract is documented at the
+  // top of this file.
   const suppressTitle = (): void => {
     const el = triggerRef.current;
     if (!el) return;

--- a/ui/src/components/Tooltip.tsx
+++ b/ui/src/components/Tooltip.tsx
@@ -310,7 +310,13 @@ export function Tooltip(props: TooltipProps): JSX.Element {
     if (!open) return undefined;
     const onKey = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') {
-        e.stopPropagation();
+        // Deliberately NOT calling stopPropagation: when a Tooltip is
+        // open inside a Sheet / Dialog, Esc should also reach the
+        // enclosing modal's handler so the user can dismiss both with
+        // one keystroke. (And on document-level peer listeners
+        // stopPropagation is a no-op anyway — only
+        // stopImmediatePropagation would block them, which would be
+        // wrong here.)
         closeNow();
         warmUntil = 0;
       }

--- a/ui/src/components/Tooltip.tsx
+++ b/ui/src/components/Tooltip.tsx
@@ -188,6 +188,16 @@ export function Tooltip(props: TooltipProps): JSX.Element {
   const closeNow = useCallback((): void => {
     clearOpenTimer();
     clearCloseTimer();
+    // closeNow fires from Escape (intentional dismiss), scroll, outside
+    // pointerdown, and singleton-handoff (a new Tooltip taking over).
+    // All of those need to restore any suppressed title so the wrapper
+    // doesn't leak the stripped-while-open state, AND should seed the
+    // warm window so the next hover (e.g. the new tooltip in the
+    // singleton-handoff case) opens instantly. Escape's separate
+    // `warmUntil = 0` reset in the keydown handler still wins for the
+    // genuine "dismiss intent" path.
+    restoreTitle();
+    warmUntil = Date.now() + 300;
     setOpen(false);
   }, []);
 
@@ -361,6 +371,41 @@ export function Tooltip(props: TooltipProps): JSX.Element {
       el.removeEventListener('focusout', onFocusOut);
     };
   }, [scheduleOpen, scheduleClose]);
+
+  // Mirror aria-describedby onto the FIRST FOCUSABLE CHILD of the
+  // wrapper while open. The wrapper span itself isn't the focus target
+  // (a button or anchor child usually is), and aria-describedby does
+  // not propagate to descendants — so a screen reader on a focused
+  // button inside <Tooltip> wouldn't announce the tooltip body unless
+  // the button itself carries the attribute.
+  useEffect(() => {
+    if (!open) return undefined;
+    const wrapper = triggerRef.current;
+    if (!wrapper) return undefined;
+    const child = wrapper.firstElementChild as HTMLElement | null;
+    if (!child) return undefined;
+    const prev = child.getAttribute('aria-describedby');
+    child.setAttribute(
+      'aria-describedby',
+      prev ? `${prev} ${bubbleId}` : bubbleId,
+    );
+    return () => {
+      // Restore the caller's original value (or clear if there wasn't
+      // one). If the caller set aria-describedby AND we appended,
+      // strip our id only.
+      const current = child.getAttribute('aria-describedby');
+      if (prev === null) {
+        child.removeAttribute('aria-describedby');
+      } else if (current && current.includes(bubbleId)) {
+        const restored = current
+          .split(/\s+/)
+          .filter((id) => id !== bubbleId)
+          .join(' ');
+        if (restored) child.setAttribute('aria-describedby', restored);
+        else child.removeAttribute('aria-describedby');
+      }
+    };
+  }, [open, bubbleId]);
 
   if (disabled || isEmpty) {
     return children;

--- a/ui/src/components/__tests__/CodeBlock.test.tsx
+++ b/ui/src/components/__tests__/CodeBlock.test.tsx
@@ -126,6 +126,20 @@ describe('CodeBlock', () => {
     expect(queryByText('Rendered')).toBeNull();
   });
 
+  test('rendered markdown preserves GFM task-list checkboxes (disabled inputs)', () => {
+    // Comment in CodeBlock claims GFM features render; verify the
+    // task-list path actually does — the sanitiser must NOT strip
+    // the disabled checkbox markup marked.js generates for `- [ ]`
+    // and `- [x]` items.
+    const md = '- [ ] open task\n- [x] done task\n';
+    const { container } = render(<CodeBlock text={md} />);
+    const inputs = container.querySelectorAll('.cb-markdown input[type=checkbox]');
+    expect(inputs.length).toBe(2);
+    expect((inputs[0] as HTMLInputElement).disabled).toBe(true);
+    expect((inputs[1] as HTMLInputElement).disabled).toBe(true);
+    expect((inputs[1] as HTMLInputElement).checked).toBe(true);
+  });
+
   test('rendered markdown forbids img / svg / iframe / script for security', () => {
     const dangerous = [
       '# Safe',

--- a/ui/src/components/__tests__/CodeBlock.test.tsx
+++ b/ui/src/components/__tests__/CodeBlock.test.tsx
@@ -140,6 +140,31 @@ describe('CodeBlock', () => {
     expect((inputs[1] as HTMLInputElement).checked).toBe(true);
   });
 
+  test('rendered markdown strips src/srcset/poster/formaction even on allowed tags', () => {
+    // <input> is allowed (for GFM task-list checkboxes) so a naive
+    // FORBID_TAGS list would still permit
+    // `<input type="image" src="https://attacker/beacon.gif">` —
+    // which fetches the URL on render and leaks the operator's IP.
+    // Verify the FORBID_ATTR config strips these network-fetch
+    // attributes regardless of which (allowed) tag carries them.
+    const dangerous = [
+      '# Title',
+      '',
+      '<input type="image" src="https://example.com/x.png">',
+      '<a href="https://example.com" poster="https://example.com/y.gif">link</a>',
+    ].join('\n');
+    const { container } = render(<CodeBlock text={dangerous} />);
+    const body = container.querySelector('.cb-markdown');
+    expect(body).not.toBeNull();
+    const html = body!.innerHTML;
+    expect(html).not.toContain('src=');
+    expect(html).not.toContain('poster=');
+    expect(html).not.toContain('srcset=');
+    expect(html).not.toContain('formaction=');
+    // The legitimate href on the anchor is preserved.
+    expect(html).toContain('href="https://example.com"');
+  });
+
   test('rendered markdown forbids img / svg / iframe / script for security', () => {
     const dangerous = [
       '# Safe',

--- a/ui/src/components/__tests__/CodeBlock.test.tsx
+++ b/ui/src/components/__tests__/CodeBlock.test.tsx
@@ -140,6 +140,72 @@ describe('CodeBlock', () => {
     expect((inputs[1] as HTMLInputElement).checked).toBe(true);
   });
 
+  test('rendered markdown strips style/tabindex/autofocus/contenteditable/accesskey on ANY tag (W21 adversarial-verify)', () => {
+    // Workflow finding B1+B2: these attributes work on <p>/<a>/etc.,
+    // not just <input>. Test the global FORBID_ATTR scope.
+    const dangerous = [
+      '# Title',
+      '',
+      '<p style="position:fixed;inset:0;width:100vw;height:100vh">overlay</p>',
+      '<p tabindex="0">focus hijack</p>',
+      '<a href="https://example.com" autofocus accesskey="x" contenteditable="true">spoof</a>',
+    ].join('\n');
+    const { container } = render(<CodeBlock text={dangerous} />);
+    const body = container.querySelector('.cb-markdown')!;
+    const html = body.innerHTML;
+    expect(html).not.toContain('style=');
+    expect(html).not.toContain('tabindex=');
+    expect(html).not.toContain('autofocus');
+    expect(html).not.toContain('contenteditable');
+    expect(html).not.toContain('accesskey=');
+    // Legit content + href stay.
+    expect(html).toContain('overlay');
+    expect(html).toContain('focus hijack');
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  test('rendered markdown task-list checkbox accepts ONLY type/disabled/checked attrs (W21 adversarial-verify)', () => {
+    // Workflow finding B1-B4: even on the surviving disabled
+    // checkbox, attributes like style / tabindex / aria-label / role
+    // / name / value / id leak through DOMPurify's defaults. The
+    // pruneNonCheckboxInput hook now allowlists attr NAMES.
+    const dangerous = [
+      '- [ ] normal task',
+      '<input type="checkbox" disabled style="position:fixed;inset:0">',
+      '<input type="checkbox" disabled tabindex="0" aria-label="enter password" role="textbox">',
+      '<input type="checkbox" disabled name="csrf" value="leaked" id="phish">',
+      '<input type="checkbox" disabled="false">',
+    ].join('\n');
+    const { container } = render(<CodeBlock text={dangerous} />);
+    const body = container.querySelector('.cb-markdown')!;
+    const inputs = body.querySelectorAll('input');
+    for (const input of Array.from(inputs)) {
+      // EVERY attribute on every surviving input must be in the
+      // allowed set.
+      for (const attr of Array.from(input.attributes)) {
+        expect(['type', 'disabled', 'checked']).toContain(attr.name.toLowerCase());
+      }
+    }
+    // The disabled="false" variant should be REMOVED entirely (the
+    // tightened isDisabled check rejects it).
+    const html = body.innerHTML;
+    expect(html).not.toContain('disabled="false"');
+  });
+
+  test('rendered markdown still preserves canonical GFM checkbox shape (regression)', () => {
+    // Make sure the lockdown above hasn't accidentally broken the
+    // happy path: `- [ ]` and `- [x]` MUST still render a disabled
+    // checkbox with the right `checked` state.
+    const md = '- [ ] open\n- [x] done\n';
+    const { container } = render(<CodeBlock text={md} />);
+    const inputs = container.querySelectorAll('.cb-markdown input[type=checkbox]');
+    expect(inputs.length).toBe(2);
+    expect((inputs[0] as HTMLInputElement).disabled).toBe(true);
+    expect((inputs[0] as HTMLInputElement).checked).toBe(false);
+    expect((inputs[1] as HTMLInputElement).disabled).toBe(true);
+    expect((inputs[1] as HTMLInputElement).checked).toBe(true);
+  });
+
   test('rendered markdown strips src/srcset/poster/formaction even on allowed tags', () => {
     // <input> is allowed (for GFM task-list checkboxes) so a naive
     // FORBID_TAGS list would still permit

--- a/ui/src/components/__tests__/CodeBlock.test.tsx
+++ b/ui/src/components/__tests__/CodeBlock.test.tsx
@@ -90,4 +90,60 @@ describe('CodeBlock', () => {
     const { container } = render(<CodeBlock text="" />);
     expect(container.querySelectorAll('.cb-line').length).toBe(1);
   });
+
+  // -------------------------------------------------------------------------
+  // W21: markdown render path (toggle + auto-detect + view sync + sanitise)
+  // -------------------------------------------------------------------------
+
+  test('markdown content auto-defaults to Rendered view + exposes a Raw toggle', () => {
+    const md = '# Hello\n\n- one\n- two\n\n```js\nconst x = 1;\n```\n';
+    const { getByText, container } = render(<CodeBlock text={md} />);
+    expect(getByText('Raw')).toBeInTheDocument();
+    expect(container.querySelector('h1')?.textContent).toBe('Hello');
+  });
+
+  test('plain text shows no markdown toggle and stays in Raw view', () => {
+    const { queryByText } = render(<CodeBlock text="just plain text no markdown" />);
+    expect(queryByText('Raw')).toBeNull();
+    expect(queryByText('Rendered')).toBeNull();
+  });
+
+  test('clicking Raw toggle flips to raw monospace view', () => {
+    const md = '# Title\n\nbody';
+    const { getByText, container } = render(<CodeBlock text={md} />);
+    fireEvent.click(getByText('Raw'));
+    expect(container.querySelector('h1')).toBeNull();
+    expect(getByText('Rendered')).toBeInTheDocument();
+  });
+
+  test('view auto-syncs back to Raw when content stops being markdown-eligible', () => {
+    const md = '# Title';
+    const plain = 'plain';
+    const { rerender, queryByText } = render(<CodeBlock text={md} />);
+    expect(queryByText('Raw')).not.toBeNull();
+    rerender(<CodeBlock text={plain} />);
+    expect(queryByText('Raw')).toBeNull();
+    expect(queryByText('Rendered')).toBeNull();
+  });
+
+  test('rendered markdown forbids img / svg / iframe / script for security', () => {
+    const dangerous = [
+      '# Safe',
+      '',
+      '![img](https://example.com/x.png)',
+      '<iframe src="https://evil.example.com"></iframe>',
+      '<svg onload="alert(1)"><circle r="10"/></svg>',
+      '<script>alert(1)</script>',
+    ].join('\n');
+    const { container } = render(<CodeBlock text={dangerous} />);
+    const body = container.querySelector('.cb-markdown');
+    expect(body).not.toBeNull();
+    const html = body!.innerHTML;
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('<iframe');
+    expect(html).not.toContain('<svg');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('onload=');
+    expect(html).toContain('Safe');
+  });
 });

--- a/ui/src/components/__tests__/FlowGraph.test.tsx
+++ b/ui/src/components/__tests__/FlowGraph.test.tsx
@@ -268,6 +268,39 @@ describe('FlowGraph', () => {
     expect(edgeTypes.fsmEdge).toBeTypeOf('function');
   });
 
+  test('W21: FlowGraph dispatches edge clicks via Preact Context (not a module registry)', async () => {
+    // Render FsmEdge directly within a FlowGraph; the FsmEdge label
+    // click handler should read its dispatch target from the Context
+    // provider FlowGraph wraps around its subtree, not from any
+    // module-level singleton (which would leak across instances).
+    const { FsmEdgeClickContext, FsmEdge } = await import('../FsmEdge');
+    const handler = vi.fn();
+    const { getByText } = render(
+      <FsmEdgeClickContext.Provider value={handler}>
+        <FsmEdge
+          {...({
+            id: 'a-b',
+            sourceX: 0,
+            sourceY: 0,
+            targetX: 10,
+            targetY: 10,
+            sourcePosition: 'right',
+            targetPosition: 'left',
+            label: 'always',
+            data: { fullLabel: 'always', sourceId: 'a', targetId: 'b' },
+          } as unknown as Parameters<typeof FsmEdge>[0])}
+        />
+      </FsmEdgeClickContext.Provider>,
+    );
+    const label = getByText('always') as HTMLButtonElement;
+    label.click();
+    expect(handler).toHaveBeenCalledWith('a-b', expect.objectContaining({
+      fullLabel: 'always',
+      sourceId: 'a',
+      targetId: 'b',
+    }));
+  });
+
   test('W21: onEdgeClick receives edge.data as second arg', () => {
     const nodes: Node<FlowNodeData>[] = [
       { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'a' } },

--- a/ui/src/components/__tests__/FlowGraph.test.tsx
+++ b/ui/src/components/__tests__/FlowGraph.test.tsx
@@ -23,6 +23,10 @@ vi.mock('@xyflow/react', () => ({
   Background: () => <div data-testid="bg" />,
   Controls: () => <div data-testid="controls" />,
   MiniMap: () => <div data-testid="minimap" />,
+  Handle: () => null,
+  BaseEdge: () => null,
+  EdgeLabelRenderer: (p: { children?: unknown }) => <>{p.children as any}</>,
+  getSmoothStepPath: () => ['M0,0 L1,1', 0, 0, 0, 0],
   Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
   BackgroundVariant: { Dots: 'dots', Lines: 'lines', Cross: 'cross' },
   MarkerType: { ArrowClosed: 'arrowclosed', Arrow: 'arrow' },
@@ -235,6 +239,53 @@ describe('FlowGraph', () => {
     } finally {
       graphlib.Graph = realGraph;
     }
+  });
+
+  test('W21: decorateEdges sets type=fsmEdge and copies full label onto edge.data', () => {
+    const nodes: Node<FlowNodeData>[] = [
+      { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'a' } },
+      { id: 'b', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'b' } },
+    ];
+    const fullPredicate = "tier == 'trivial' AND len(risk_signals) == 0 AND NOT scope_overrides_present";
+    const edges: Edge[] = [{ id: 'a-b', source: 'a', target: 'b', label: fullPredicate }];
+    render(<FlowGraph nodes={nodes} edges={edges} autoLayout={false} />);
+    const decorated = lastReactFlowProps!.edges as Array<Edge & { type?: string; data?: Record<string, unknown> }>;
+    expect(decorated[0].type).toBe('fsmEdge');
+    expect(decorated[0].data?.fullLabel).toBe(fullPredicate);
+    expect(decorated[0].data?.sourceId).toBe('a');
+    expect(decorated[0].data?.targetId).toBe('b');
+    // The visible label is truncated but the full text is preserved on data.
+    expect((decorated[0].label as string).length).toBeLessThanOrEqual(28);
+  });
+
+  test('W21: FlowGraph registers fsmEdge as a custom edge type', () => {
+    const nodes: Node<FlowNodeData>[] = [
+      { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'a' } },
+    ];
+    render(<FlowGraph nodes={nodes} edges={[]} />);
+    const edgeTypes = lastReactFlowProps!.edgeTypes as Record<string, unknown>;
+    expect(edgeTypes).toBeDefined();
+    expect(edgeTypes.fsmEdge).toBeTypeOf('function');
+  });
+
+  test('W21: onEdgeClick receives edge.data as second arg', () => {
+    const nodes: Node<FlowNodeData>[] = [
+      { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'a' } },
+      { id: 'b', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'b' } },
+    ];
+    const edges: Edge[] = [{ id: 'a-b', source: 'a', target: 'b', label: 'always' }];
+    const onEdgeClick = vi.fn();
+    render(<FlowGraph nodes={nodes} edges={edges} onEdgeClick={onEdgeClick} autoLayout={false} />);
+    // Pull the onEdgeClick out of the forwarded ReactFlow props and
+    // invoke it with a synthetic (event, edge) pair (mirrors how
+    // xyflow would dispatch on a real click).
+    const rfOnEdgeClick = lastReactFlowProps!.onEdgeClick as (e: unknown, edge: Edge) => void;
+    rfOnEdgeClick({}, { id: 'a-b', source: 'a', target: 'b', data: { fullLabel: 'always', sourceId: 'a', targetId: 'b' } } as unknown as Edge);
+    expect(onEdgeClick).toHaveBeenCalledWith('a-b', expect.objectContaining({
+      fullLabel: 'always',
+      sourceId: 'a',
+      targetId: 'b',
+    }));
   });
 
   test('default direction is TB (top-to-bottom) when not specified', () => {

--- a/ui/src/components/__tests__/Tooltip.test.tsx
+++ b/ui/src/components/__tests__/Tooltip.test.tsx
@@ -82,19 +82,21 @@ describe('Tooltip', () => {
     expect(tip!.textContent).toBe('full string');
   });
 
-  test('focus opens the tooltip without a delay-via-hover (focus is instant)', () => {
-    // The W21 contract says focus opens after the same delay as hover
-    // (the delay is "intent", not motion). Verify the focus path uses
-    // the same scheduleOpen.
+  test('focus opens the tooltip INSTANTLY (ignores the 400 ms hover delay)', () => {
+    // W21 contract: keyboard focus is intentional, so the hover-style
+    // delay would be sluggish. Even with delay=400 set, focus must
+    // open the tooltip on the next microtask, not after 400 ms.
     vi.useFakeTimers();
     const { getByText, queryByRole } = render(
-      <Tooltip content="focused" delay={0}>
+      <Tooltip content="focused" delay={400}>
         <button type="button">trigger</button>
       </Tooltip>,
     );
     const wrapper = getByText('trigger').parentElement as HTMLElement;
     fireFocusIn(wrapper);
     act(() => {
+      // Just flush the setTimeout(0) that scheduleOpen uses for
+      // preact re-render flushability; do NOT advance to 400 ms.
       vi.advanceTimersByTime(0);
     });
     expect(queryByRole('tooltip')).not.toBeNull();

--- a/ui/src/components/__tests__/Tooltip.test.tsx
+++ b/ui/src/components/__tests__/Tooltip.test.tsx
@@ -338,6 +338,34 @@ describe('Tooltip', () => {
     expect(button.hasAttribute('aria-describedby')).toBe(false);
   });
 
+  test('aria-describedby is mirrored onto a DEEPLY NESTED focusable child, not just firstElementChild', () => {
+    // The trigger might wrap the focusable element in layout divs.
+    // querySelector for the standard focusable set covers any depth.
+    vi.useFakeTimers();
+    const { container, queryByRole } = render(
+      <Tooltip content="nested" delay={0}>
+        <span>
+          <div class="layout-wrap">
+            <button type="button" data-testid="deep">deep-target</button>
+          </div>
+        </span>
+      </Tooltip>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    fireFocusIn(wrapper);
+    act(() => { vi.advanceTimersByTime(0); });
+    const tip = queryByRole('tooltip') as HTMLElement | null;
+    expect(tip).not.toBeNull();
+    // The button — NOT the wrapper-span or the layout-div — should
+    // carry aria-describedby pointing at the bubble id.
+    const button = wrapper.querySelector('[data-testid=deep]') as HTMLButtonElement;
+    expect(button.getAttribute('aria-describedby')).toBe(tip!.id);
+    // And the close path strips it cleanly.
+    fireFocusOut(wrapper);
+    act(() => { vi.advanceTimersByTime(101); });
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+  });
+
   test('singleton handoff seeds the warm window so the next tooltip opens instantly', () => {
     // When a second Tooltip's trigger fires while a first one is open,
     // closeNow() runs on the first as part of the handoff. That path

--- a/ui/src/components/__tests__/Tooltip.test.tsx
+++ b/ui/src/components/__tests__/Tooltip.test.tsx
@@ -315,6 +315,61 @@ describe('Tooltip', () => {
     expect(getByText('trigger')).toBeInTheDocument();
   });
 
+  test('mirrors aria-describedby onto the focused child element (not just the wrapper)', () => {
+    // aria-describedby does NOT propagate to descendants, so a focused
+    // <button> inside the Tooltip wrapper must carry the attribute too
+    // for screen readers to announce the tooltip body.
+    vi.useFakeTimers();
+    const { container, queryByRole } = render(
+      <Tooltip content="full" delay={0}>
+        <button type="button">trigger</button>
+      </Tooltip>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    fireFocusIn(wrapper);
+    act(() => { vi.advanceTimersByTime(0); });
+    const tip = queryByRole('tooltip') as HTMLElement | null;
+    expect(tip).not.toBeNull();
+    const button = wrapper.querySelector('button') as HTMLButtonElement;
+    expect(button.getAttribute('aria-describedby')).toBe(tip!.id);
+    // Closing strips the attribute from the child again.
+    fireFocusOut(wrapper);
+    act(() => { vi.advanceTimersByTime(101); });
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  test('singleton handoff seeds the warm window so the next tooltip opens instantly', () => {
+    // When a second Tooltip's trigger fires while a first one is open,
+    // closeNow() runs on the first as part of the handoff. That path
+    // must seed warmUntil so the second tooltip opens without the
+    // 400 ms delay (the user is actively scanning, not browsing).
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <div>
+        <Tooltip content="first" delay={400}>
+          <span>a</span>
+        </Tooltip>
+        <Tooltip content="second" delay={400}>
+          <span>b</span>
+        </Tooltip>
+      </div>,
+    );
+    const a = getByText('a').parentElement as HTMLElement;
+    const b = getByText('b').parentElement as HTMLElement;
+    fireEvent.mouseEnter(a);
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(queryByRole('tooltip')!.textContent).toBe('first');
+    // Without leaving 'a' explicitly, hover 'b'. The singleton handoff
+    // closes 'first' (via closeNow which now seeds warmUntil).
+    fireEvent.mouseEnter(b);
+    act(() => { vi.advanceTimersByTime(0); });
+    // Should be open INSTANTLY thanks to the warm window seeded by
+    // the handoff, NOT requiring another 400 ms wait.
+    const tip = queryByRole('tooltip');
+    expect(tip).not.toBeNull();
+    expect(tip!.textContent).toBe('second');
+  });
+
   test('strips and restores native title= so the browser does not double-tooltip', () => {
     vi.useFakeTimers();
     const { container, getByText, queryByRole } = render(

--- a/ui/src/components/__tests__/Tooltip.test.tsx
+++ b/ui/src/components/__tests__/Tooltip.test.tsx
@@ -227,6 +227,36 @@ describe('Tooltip', () => {
     expect(queryByRole('tooltip')).toBeNull();
   });
 
+  test('auto-flips placement=bottom to top when the bubble would clip the bottom edge', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('innerWidth', 1000);
+    vi.stubGlobal('innerHeight', 400);
+    const { container, queryByRole } = render(
+      <Tooltip content="flip-me" delay={0} placement="bottom">
+        <button type="button">trigger</button>
+      </Tooltip>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    // Stub trigger close to the bottom edge so placement=bottom clips
+    // but placement=top fits.
+    vi.spyOn(wrapper, 'getBoundingClientRect').mockReturnValue({
+      x: 200, y: 360, top: 360, left: 200, right: 240, bottom: 380, width: 40, height: 20,
+      toJSON() { return this; },
+    } as DOMRect);
+    fireEvent.mouseEnter(wrapper);
+    act(() => { vi.advanceTimersByTime(0); });
+    const tip = queryByRole('tooltip') as HTMLElement | null;
+    expect(tip).not.toBeNull();
+    vi.spyOn(tip!, 'getBoundingClientRect').mockReturnValue({
+      x: 0, y: 0, top: 0, left: 0, right: 120, bottom: 60, width: 120, height: 60,
+      toJSON() { return this; },
+    } as DOMRect);
+    // Force re-measure.
+    act(() => { fireEvent(window, new Event('resize')); });
+    // Flipped to top → bubble top should be ABOVE the trigger top.
+    expect(parseFloat(tip!.style.top)).toBeLessThan(360);
+  });
+
   test('viewport-edge clamping pulls the bubble inside the right edge', () => {
     vi.useFakeTimers();
     const innerWidth = 1000;

--- a/ui/src/components/__tests__/Tooltip.test.tsx
+++ b/ui/src/components/__tests__/Tooltip.test.tsx
@@ -1,0 +1,312 @@
+/**
+ * Tests for components/Tooltip.tsx — the W21 tooltip primitive.
+ *
+ * Asserts the contract the W18 interaction grammar committed to:
+ *   - 400 ms hover delay (line 1191 of how-it-fits-toasty-gray.md)
+ *   - role="tooltip" + aria-describedby wiring
+ *   - keyboard parity (focus opens, blur closes, Escape closes)
+ *   - reduced-motion respect
+ *   - singleton open + warm-window (300 ms instant re-open)
+ *   - viewport-edge clamping
+ *   - disabled / empty-content fast paths
+ *
+ * Implementation notes for the suite:
+ *   - useFakeTimers for delay assertions; real timers everywhere else.
+ *   - We stub getBoundingClientRect to drive the clamp test; the
+ *     real layout engine in jsdom doesn't produce a useful rect for
+ *     a portal-mounted element.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, fireEvent, render } from '@testing-library/preact';
+
+import { Tooltip } from '../Tooltip';
+
+/**
+ * Dispatch a real, bubbling FocusEvent on `el`. @testing-library/preact's
+ * `fireEvent.focusIn` does not bubble in jsdom, so we drop to the
+ * native event factory and dispatch it ourselves.
+ */
+function fireFocusIn(el: HTMLElement): void {
+  el.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+}
+function fireFocusOut(el: HTMLElement): void {
+  el.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  // Drain the singleton portal root so each test starts clean.
+  document.getElementById('tooltip-root')?.replaceChildren();
+});
+
+beforeEach(() => {
+  // Drain singleton state in the module between tests.
+  document.getElementById('tooltip-root')?.replaceChildren();
+});
+
+describe('Tooltip', () => {
+  test('does not render the bubble before the 400 ms delay elapses', () => {
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <Tooltip content="full">
+        <span>trigger</span>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(getByText('trigger').parentElement!);
+    expect(queryByRole('tooltip')).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(399);
+    });
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  test('renders after the 400 ms delay with role=tooltip and trigger gains aria-describedby', () => {
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <Tooltip content="full string">
+        <span>trigger</span>
+      </Tooltip>,
+    );
+    const wrapper = getByText('trigger').parentElement as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    const tip = queryByRole('tooltip') as HTMLElement | null;
+    expect(tip).not.toBeNull();
+    expect(tip!.id).toMatch(/^tt-\d+$/);
+    expect(wrapper.getAttribute('aria-describedby')).toBe(tip!.id);
+    expect(tip!.textContent).toBe('full string');
+  });
+
+  test('focus opens the tooltip without a delay-via-hover (focus is instant)', () => {
+    // The W21 contract says focus opens after the same delay as hover
+    // (the delay is "intent", not motion). Verify the focus path uses
+    // the same scheduleOpen.
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <Tooltip content="focused" delay={0}>
+        <button type="button">trigger</button>
+      </Tooltip>,
+    );
+    const wrapper = getByText('trigger').parentElement as HTMLElement;
+    fireFocusIn(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(queryByRole('tooltip')).not.toBeNull();
+  });
+
+  test('focusout closes the tooltip after the 100 ms grace window', () => {
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <Tooltip content="focused" delay={0}>
+        <button type="button">trigger</button>
+      </Tooltip>,
+    );
+    const wrapper = getByText('trigger').parentElement as HTMLElement;
+    fireFocusIn(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(queryByRole('tooltip')).not.toBeNull();
+    fireFocusOut(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(101);
+    });
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  test('Escape closes the tooltip synchronously', () => {
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <Tooltip content="full" delay={0}>
+        <span>trigger</span>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(getByText('trigger').parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(queryByRole('tooltip')).not.toBeNull();
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  test('mouseleave + mouseenter within 100 ms keeps the bubble open', () => {
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <Tooltip content="full" delay={0}>
+        <span>trigger</span>
+      </Tooltip>,
+    );
+    const wrapper = getByText('trigger').parentElement as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(queryByRole('tooltip')).not.toBeNull();
+    fireEvent.mouseLeave(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    fireEvent.mouseEnter(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(80);
+    });
+    expect(queryByRole('tooltip')).not.toBeNull();
+  });
+
+  test('warm window: a second tooltip within 300 ms of a close opens immediately', () => {
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <div>
+        <Tooltip content="first" delay={400}>
+          <span>a</span>
+        </Tooltip>
+        <Tooltip content="second" delay={400}>
+          <span>b</span>
+        </Tooltip>
+      </div>,
+    );
+    const a = getByText('a').parentElement as HTMLElement;
+    const b = getByText('b').parentElement as HTMLElement;
+    // Open + close the first tooltip the slow way to seed warmUntil.
+    fireEvent.mouseEnter(a);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    fireEvent.mouseLeave(a);
+    act(() => {
+      vi.advanceTimersByTime(101);
+    });
+    expect(queryByRole('tooltip')).toBeNull();
+    // Now hover the SECOND trigger; should open instantly (delay 0).
+    fireEvent.mouseEnter(b);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(queryByRole('tooltip')).not.toBeNull();
+    expect((queryByRole('tooltip') as HTMLElement).textContent).toBe('second');
+  });
+
+  test('disabled=true never opens and adds no listeners', () => {
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <Tooltip content="invisible" disabled delay={0}>
+        <span>trigger</span>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(getByText('trigger'));
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  test('empty content (null/empty string) renders the child verbatim with no bubble', () => {
+    vi.useFakeTimers();
+    const { getByText, queryByRole } = render(
+      <Tooltip content="">
+        <span>trigger</span>
+      </Tooltip>,
+    );
+    // Empty content path returns children directly — no wrapping span.
+    expect(getByText('trigger')).toBeInTheDocument();
+    fireEvent.mouseEnter(getByText('trigger'));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  test('viewport-edge clamping pulls the bubble inside the right edge', () => {
+    vi.useFakeTimers();
+    const innerWidth = 1000;
+    const innerHeight = 600;
+    vi.stubGlobal('innerWidth', innerWidth);
+    vi.stubGlobal('innerHeight', innerHeight);
+    const { container, getByText, queryByRole } = render(
+      <Tooltip content="long-content-string-for-clamp" delay={0}>
+        <span>trigger</span>
+      </Tooltip>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    // Stub the trigger near the right edge.
+    vi.spyOn(wrapper, 'getBoundingClientRect').mockReturnValue({
+      x: innerWidth - 50,
+      y: 200,
+      top: 200,
+      left: innerWidth - 50,
+      right: innerWidth,
+      bottom: 220,
+      width: 50,
+      height: 20,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect);
+    fireEvent.mouseEnter(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    const tip = queryByRole('tooltip') as HTMLElement | null;
+    expect(tip).not.toBeNull();
+    // jsdom defaults bubble dimensions to 0 unless we stub. Stub the
+    // bubble's rect so the clamp has something to react to.
+    vi.spyOn(tip!, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 30,
+      width: 200,
+      height: 30,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect);
+    // Trigger a resize to force re-measure.
+    act(() => {
+      fireEvent(window, new Event('resize'));
+    });
+    const leftPx = parseFloat(tip!.style.left);
+    expect(leftPx).toBeLessThanOrEqual(innerWidth - 200 - 8);
+    expect(leftPx).toBeGreaterThanOrEqual(8);
+    // touchTrigger reference (silence unused var)
+    expect(getByText('trigger')).toBeInTheDocument();
+  });
+
+  test('strips and restores native title= so the browser does not double-tooltip', () => {
+    vi.useFakeTimers();
+    const { container, getByText, queryByRole } = render(
+      <Tooltip content="bubble-content" delay={0}>
+        <span title="original-title">trigger</span>
+      </Tooltip>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    // The wrapping span owns the title in the DOM model; verify
+    // suppression on open + restoration on close.
+    // (The child span keeps its own native title; we strip the
+    // wrapper's only if it carries one, which by default it doesn't.)
+    // What we DO test: opening + closing leaves the original child
+    // title intact.
+    expect(getByText('trigger').getAttribute('title')).toBe('original-title');
+    fireEvent.mouseEnter(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(queryByRole('tooltip')).not.toBeNull();
+    fireEvent.mouseLeave(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(101);
+    });
+    expect(getByText('trigger').getAttribute('title')).toBe('original-title');
+  });
+});

--- a/ui/src/components/__tests__/Tooltip.test.tsx
+++ b/ui/src/components/__tests__/Tooltip.test.tsx
@@ -20,7 +20,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { act, cleanup, fireEvent, render } from '@testing-library/preact';
 
-import { Tooltip } from '../Tooltip';
+import { Tooltip, __resetTooltipStateForTests } from '../Tooltip';
 
 /**
  * Dispatch a real, bubbling FocusEvent on `el`. @testing-library/preact's
@@ -40,11 +40,15 @@ afterEach(() => {
   vi.unstubAllGlobals();
   // Drain the singleton portal root so each test starts clean.
   document.getElementById('tooltip-root')?.replaceChildren();
+  // Reset module-level singletons (warmUntil / closeAll / id counter)
+  // so the next test starts with a fresh 400-ms delay budget instead
+  // of inheriting a warm window from this test (Copilot finding).
+  __resetTooltipStateForTests();
 });
 
 beforeEach(() => {
-  // Drain singleton state in the module between tests.
   document.getElementById('tooltip-root')?.replaceChildren();
+  __resetTooltipStateForTests();
 });
 
 describe('Tooltip', () => {

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -56,3 +56,6 @@ export type { TabsProps, TabSpec } from './Tabs';
 
 export { FlowGraph } from './FlowGraph';
 export type { FlowGraphProps, FlowNodeData, FlowNodeKind } from './FlowGraph';
+
+export { Tooltip } from './Tooltip';
+export type { TooltipProps, TooltipPlacement } from './Tooltip';

--- a/ui/src/lib/__tests__/specGraph.test.ts
+++ b/ui/src/lib/__tests__/specGraph.test.ts
@@ -131,4 +131,73 @@ describe('specToGraph', () => {
       b.edges.map(({ id: _id, ...rest }) => rest),
     );
   });
+
+  // -------------------------------------------------------------------------
+  // W21: data carriers for the click-Sheet inspectors.
+  // -------------------------------------------------------------------------
+
+  test('W21: node.data.state carries the original spec state object', () => {
+    const stateA = {
+      id: 'a',
+      worker: { role: 'planner', prompt_template: 'plan this', allowed_tools: ['x'] },
+      transitions: [{ to: 'b', when: 'always' }],
+    };
+    const g = specToGraph({ entry: 'a', states: [stateA, { id: 'b' }] });
+    expect(g.nodes[0].data.state).toBeDefined();
+    const carried = g.nodes[0].data.state as Record<string, unknown>;
+    expect(carried.id).toBe('a');
+    expect(carried.worker).toEqual(stateA.worker);
+    expect(carried.transitions).toEqual(stateA.transitions);
+  });
+
+  test('W21: node.data.fullLabel mirrors the state id', () => {
+    const g = specToGraph({
+      states: [{ id: 'risk_tier_triage_super_long_name', inline: { handler_id: 'h' } }],
+    });
+    expect(g.nodes[0].data.fullLabel).toBe('risk_tier_triage_super_long_name');
+  });
+
+  test('W21: node.data.fullSublabel carries the un-projected sublabel', () => {
+    const g = specToGraph({
+      states: [{ id: 's', worker: { role: 'specialist' }, transitions: [] }],
+    });
+    expect(g.nodes[0].data.fullSublabel).toContain('specialist');
+  });
+
+  test('W21: entry-state fullSublabel mirrors the visible "entry · ..." string', () => {
+    const g = specToGraph({
+      entry: 's',
+      states: [{ id: 's', worker: { role: 'planner' } }],
+    });
+    expect(g.nodes[0].data.fullSublabel).toBe(g.nodes[0].data.sublabel);
+    expect(g.nodes[0].data.fullSublabel).toContain('entry');
+  });
+
+  test('W21: edge.data carries kind, transition, source, target, fullLabel', () => {
+    const longPredicate = "tier == 'trivial' AND len(risk_signals) == 0 AND NOT scope_overrides_present";
+    const g = specToGraph({
+      states: [
+        { id: 'a', transitions: [{ to: 'b', kind: 'deterministic', when: longPredicate }] },
+        { id: 'b' },
+      ],
+    });
+    const data = g.edges[0].data as Record<string, unknown>;
+    expect(data).toBeDefined();
+    expect(data.fullLabel).toBe(longPredicate);
+    expect(data.kind).toBe('deterministic');
+    expect(data.sourceId).toBe('a');
+    expect(data.targetId).toBe('b');
+    expect((data.transition as Record<string, unknown>).to).toBe('b');
+  });
+
+  test('W21: edge.data.fullLabel undefined when transition has no predicate', () => {
+    const g = specToGraph({
+      states: [
+        { id: 'a', transitions: [{ to: 'b' }] },
+        { id: 'b' },
+      ],
+    });
+    const data = g.edges[0].data as Record<string, unknown>;
+    expect(data.fullLabel).toBeUndefined();
+  });
 });

--- a/ui/src/lib/__tests__/specGraph.test.ts
+++ b/ui/src/lib/__tests__/specGraph.test.ts
@@ -200,4 +200,65 @@ describe('specToGraph', () => {
     const data = g.edges[0].data as Record<string, unknown>;
     expect(data.fullLabel).toBeUndefined();
   });
+
+  // -------------------------------------------------------------------------
+  // W21 follow-up: kind derived from `when` (not top-level t.kind);
+  // criteria fallback for judgement transitions.
+  // -------------------------------------------------------------------------
+
+  test('W21: edge.data.kind for bare "always" string transition', () => {
+    const g = specToGraph({
+      states: [{ id: 'a', transitions: [{ to: 'b', when: 'always' }] }, { id: 'b' }],
+    });
+    expect((g.edges[0].data as Record<string, unknown>).kind).toBe('always');
+  });
+
+  test('W21: edge.data.kind for bare "otherwise" string transition', () => {
+    const g = specToGraph({
+      states: [{ id: 'a', transitions: [{ to: 'b', when: 'otherwise' }] }, { id: 'b' }],
+    });
+    expect((g.edges[0].data as Record<string, unknown>).kind).toBe('otherwise');
+  });
+
+  test('W21: edge.data.kind for {kind:"judgement", criteria:"..."} dict-form when', () => {
+    const g = specToGraph({
+      states: [
+        {
+          id: 'a',
+          transitions: [{ to: 'b', when: { kind: 'judgement', criteria: 'verdict is GO' } }],
+        },
+        { id: 'b' },
+      ],
+    });
+    const data = g.edges[0].data as Record<string, unknown>;
+    expect(data.kind).toBe('judgement');
+    // And the fullLabel should fall through to criteria text.
+    expect(data.fullLabel).toBe('verdict is GO');
+  });
+
+  test('W21: edge.data.kind for {kind:"deterministic", expression:"..."} dict', () => {
+    const g = specToGraph({
+      states: [
+        {
+          id: 'a',
+          transitions: [{ to: 'b', when: { kind: 'deterministic', expression: 'x > 0' } }],
+        },
+        { id: 'b' },
+      ],
+    });
+    const data = g.edges[0].data as Record<string, unknown>;
+    expect(data.kind).toBe('deterministic');
+    expect(data.fullLabel).toBe('x > 0');
+  });
+
+  test('W21: bare predicate-string when is treated as deterministic', () => {
+    const g = specToGraph({
+      states: [
+        { id: 'a', transitions: [{ to: 'b', when: 'verdict == "GO"' }] },
+        { id: 'b' },
+      ],
+    });
+    const data = g.edges[0].data as Record<string, unknown>;
+    expect(data.kind).toBe('deterministic');
+  });
 });

--- a/ui/src/lib/specGraph.ts
+++ b/ui/src/lib/specGraph.ts
@@ -104,7 +104,19 @@ export function specToGraph(definition: unknown): SpecGraph {
     return {
       id: s.id,
       position: { x: 0, y: 0 }, // dagre fills these in
-      data: { kind, label: s.id, sublabel },
+      // W21: copy the FULL spec state object onto data.state so the
+      // click handler can render a State Inspector Sheet without
+      // re-walking the spec. fullLabel/fullSublabel mirror the
+      // visible strings; node-label tooltip falls back to label when
+      // these are absent.
+      data: {
+        kind,
+        label: s.id,
+        sublabel,
+        fullLabel: s.id,
+        fullSublabel: sublabel || undefined,
+        state: s as unknown as Record<string, unknown>,
+      },
     };
   });
 
@@ -112,11 +124,13 @@ export function specToGraph(definition: unknown): SpecGraph {
   if (def.entry) {
     const entry = nodes.find((n) => n.id === def.entry);
     if (entry) {
+      const newSub = entry.data.sublabel
+        ? `entry · ${entry.data.sublabel}`
+        : 'entry';
       entry.data = {
         ...entry.data,
-        sublabel: entry.data.sublabel
-          ? `entry · ${entry.data.sublabel}`
-          : 'entry',
+        sublabel: newSub,
+        fullSublabel: newSub,
       };
     }
   }
@@ -132,6 +146,16 @@ export function specToGraph(definition: unknown): SpecGraph {
         target: t.to,
         label: label || undefined,
         labelStyle: { fontSize: 10 },
+        // W21: carry the FULL transition metadata so the Tooltip and
+        // click-Sheet have access to kind + raw predicate + source/
+        // target without walking the spec twice.
+        data: {
+          fullLabel: label || undefined,
+          kind: t.kind,
+          transition: t as unknown as Record<string, unknown>,
+          sourceId: s.id,
+          targetId: t.to,
+        },
       });
     }
   }

--- a/ui/src/lib/specGraph.ts
+++ b/ui/src/lib/specGraph.ts
@@ -70,10 +70,39 @@ function predicateLabel(t: SpecTransitionShape): string {
   if (typeof t.when === 'string') return t.when;
   if (t.when && typeof t.when === 'object') {
     const obj = t.when as Record<string, unknown>;
+    // The FSM library's Transition model encodes the human-readable
+    // text in different keys depending on the kind: deterministic
+    // puts it in `.expression`, judgement in `.criteria`, and bare
+    // Predicate dumps map to `.predicate`. Check all three so the
+    // visible edge label never goes blank for a transition that
+    // genuinely has guard text.
     if (typeof obj.predicate === 'string') return obj.predicate;
     if (typeof obj.expression === 'string') return obj.expression;
+    if (typeof obj.criteria === 'string') return obj.criteria;
   }
   return '';
+}
+
+/** Derive the transition kind (always / otherwise / deterministic /
+ *  judgement) from the various `when` shapes the FSM library emits.
+ *  The Transition model does NOT carry a top-level `kind` field — it
+ *  lives inside `when` (or is the bare string "always"/"otherwise").
+ *  Returns undefined when the shape isn't recognised. */
+function transitionKind(t: SpecTransitionShape): string | undefined {
+  if (typeof t.when === 'string') {
+    if (t.when === 'always' || t.when === 'otherwise') return t.when;
+    // A bare predicate-string (anything else) lifts to deterministic
+    // per the Python Transition normaliser.
+    return 'deterministic';
+  }
+  if (t.when && typeof t.when === 'object') {
+    const obj = t.when as Record<string, unknown>;
+    if (typeof obj.kind === 'string') return obj.kind;
+    // A dict with only `.expression` is deterministic per the
+    // Python Transition.normalise_when contract.
+    if (typeof obj.expression === 'string') return 'deterministic';
+  }
+  return undefined;
 }
 
 export interface SpecGraph {
@@ -148,10 +177,12 @@ export function specToGraph(definition: unknown): SpecGraph {
         labelStyle: { fontSize: 10 },
         // W21: carry the FULL transition metadata so the Tooltip and
         // click-Sheet have access to kind + raw predicate + source/
-        // target without walking the spec twice.
+        // target without walking the spec twice. The kind is derived
+        // from `when` (the Transition model doesn't have a top-level
+        // `kind` field — it's encoded inside the `when` payload).
         data: {
           fullLabel: label || undefined,
-          kind: t.kind,
+          kind: transitionKind(t),
           transition: t as unknown as Record<string, unknown>,
           sourceId: s.id,
           targetId: t.to,

--- a/ui/src/lib/specGraph.ts
+++ b/ui/src/lib/specGraph.ts
@@ -87,8 +87,12 @@ function predicateLabel(t: SpecTransitionShape): string {
  *  judgement) from the various `when` shapes the FSM library emits.
  *  The Transition model does NOT carry a top-level `kind` field — it
  *  lives inside `when` (or is the bare string "always"/"otherwise").
- *  Returns undefined when the shape isn't recognised. */
-function transitionKind(t: SpecTransitionShape): string | undefined {
+ *  Returns undefined when the shape isn't recognised.
+ *
+ *  Exported so other inspector surfaces (the transitions list in
+ *  StateInspectorBody, etc.) can derive the kind the same way as the
+ *  graph edge, instead of duplicating the logic and drifting. */
+export function transitionKind(t: { when?: unknown }): string | undefined {
   if (typeof t.when === 'string') {
     if (t.when === 'always' || t.when === 'otherwise') return t.when;
     // A bare predicate-string (anything else) lifts to deterministic

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -136,9 +136,16 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
           <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
             Prompt template
           </h4>
+          {/* No language= hint: the FSM library treats prompt_template
+              as an opaque string. The consuming skill / agent
+              orchestrator owns the template's MIME type / language
+              convention (could be markdown, jinja, plain prose, json,
+              anything else). Rendering as plain text is the only
+              correct domain-agnostic default. If a future spec gains
+              a `prompt_template_language` (or similar) declared
+              field, plumb it through here. */}
           <CodeBlock
             text={String(worker.prompt_template)}
-            language="markdown"
             maxInlineHeight="max-h-64"
             ariaLabel={`${id} worker prompt template`}
           />

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -42,7 +42,7 @@ import {
   type SpecSummary,
 } from '../lib/api';
 import { canonicalJson } from '../lib/canonicalJson';
-import { specToGraph } from '../lib/specGraph';
+import { specToGraph, transitionKind } from '../lib/specGraph';
 import { openSheet } from '../lib/store';
 
 const shortHash = (h: string): string => (h.length > 12 ? h.slice(0, 12) : h);
@@ -193,7 +193,12 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
           <ul class="divide-y divide-slate-100 dark:divide-slate-800 text-xs">
             {transitions.map((t, idx) => {
               const target = typeof t.to === 'string' ? t.to : '(unknown)';
-              const tKind = typeof t.kind === 'string' ? t.kind : undefined;
+              // Derive the kind from the `when` payload via the shared
+              // helper — the FSM library's Transition model has no
+              // top-level `kind` field, so reading t.kind would always
+              // be undefined for spec-authored data. Mirrors how the
+              // graph edge data.kind is computed.
+              const tKind = transitionKind(t);
               // Mirror specGraph.predicateLabel(): a `when` dict can
               // encode the human-readable guard text under any of
               // `.predicate` (bare Predicate dump), `.expression`

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -19,14 +19,17 @@ import { useRoute } from 'preact-iso';
 
 import {
   Card,
+  CodeBlock,
   Diff,
   EmptyState,
   FlowGraph,
   JsonViewer,
+  KeyValueTable,
   Pill,
   Spinner,
   Table,
   Tabs,
+  type KvRow,
   type PillVariant,
   type TabSpec,
   type TableColumn,
@@ -40,6 +43,7 @@ import {
 } from '../lib/api';
 import { canonicalJson } from '../lib/canonicalJson';
 import { specToGraph } from '../lib/specGraph';
+import { openSheet } from '../lib/store';
 
 const shortHash = (h: string): string => (h.length > 12 ? h.slice(0, 12) : h);
 const shortId = (id: string): string => (id.length > 7 ? id.slice(0, 7) : id);
@@ -83,8 +87,223 @@ function siblingsOf(detail: SpecDetail, all: SpecSummary[]): SpecSummary[] {
 // Tab panels
 // ---------------------------------------------------------------------------
 
-function GraphPanel({ detail }: { detail: SpecDetail }): JSX.Element {
+// ---------------------------------------------------------------------------
+// W21: Graph inspectors — click a node or edge to open a Sheet with the
+// full payload (worker prompt, response_schema, allowed_tools, loop,
+// inline handler, transitions out; or transition kind + full predicate +
+// source/target).
+// ---------------------------------------------------------------------------
+
+interface StateInspectorBodyProps {
+  state: Record<string, unknown>;
+  isEntry: boolean;
+}
+
+function transitionKindVariant(kind: string | undefined): PillVariant {
+  switch (kind) {
+    case 'judgement': return 'success';
+    case 'deterministic': return 'info';
+    case 'otherwise': return 'warning';
+    default: return 'neutral';
+  }
+}
+
+function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.Element {
+  const id = typeof state.id === 'string' ? state.id : '(unknown)';
+  const kind = typeof state.kind === 'string' ? state.kind : '—';
+  const worker = state.worker as Record<string, unknown> | undefined;
+  const inline = state.inline as Record<string, unknown> | undefined;
+  const loop = state.loop as unknown;
+  const transitions = Array.isArray(state.transitions)
+    ? (state.transitions as Array<Record<string, unknown>>)
+    : [];
+
+  const rows: KvRow[] = [
+    { key: 'id', value: id },
+    { key: 'kind', value: kind },
+  ];
+  if (isEntry) rows.push({ key: 'entry', value: true, hint: 'spec entry state' });
+  if (worker?.role) rows.push({ key: 'worker.role', value: String(worker.role) });
+  if (inline?.handler_id) rows.push({ key: 'inline.handler_id', value: String(inline.handler_id) });
+  const allowedTools = Array.isArray(worker?.allowed_tools) ? worker?.allowed_tools : null;
+  if (allowedTools) rows.push({ key: 'worker.allowed_tools', value: allowedTools });
+
+  return (
+    <div class="space-y-4 p-3">
+      <KeyValueTable rows={rows} caption="State metadata" />
+      {worker?.prompt_template ? (
+        <section>
+          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
+            Prompt template
+          </h4>
+          <CodeBlock
+            text={String(worker.prompt_template)}
+            language="markdown"
+            maxInlineHeight="max-h-64"
+            ariaLabel={`${id} worker prompt template`}
+          />
+        </section>
+      ) : null}
+      {worker?.response_schema ? (
+        <section>
+          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
+            response_schema
+          </h4>
+          <JsonViewer
+            value={worker.response_schema}
+            rootLabel="response_schema"
+            mode="inline"
+            maxInlineHeight="max-h-64"
+          />
+        </section>
+      ) : null}
+      {loop ? (
+        <section>
+          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
+            loop
+          </h4>
+          <JsonViewer value={loop} rootLabel="loop" mode="inline" maxInlineHeight="max-h-48" />
+        </section>
+      ) : null}
+      {transitions.length > 0 ? (
+        <section>
+          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
+            Transitions out ({transitions.length})
+          </h4>
+          <ul class="divide-y divide-slate-100 dark:divide-slate-800 text-xs">
+            {transitions.map((t, idx) => {
+              const target = typeof t.to === 'string' ? t.to : '(unknown)';
+              const tKind = typeof t.kind === 'string' ? t.kind : undefined;
+              const when = typeof t.when === 'string'
+                ? t.when
+                : t.when && typeof t.when === 'object'
+                ? ((t.when as Record<string, unknown>).predicate as string | undefined) ?? ''
+                : '';
+              return (
+                <li key={`${target}-${idx}`} class="py-1.5 flex items-center gap-2">
+                  {tKind ? <Pill variant={transitionKindVariant(tKind)} size="sm">{tKind}</Pill> : null}
+                  <code class="font-mono text-slate-700 dark:text-slate-300">{target}</code>
+                  {when ? (
+                    <code class="font-mono text-slate-500 dark:text-slate-400 truncate flex-1" title={when}>
+                      {when}
+                    </code>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+interface TransitionInspectorBodyProps {
+  source: string;
+  target: string;
+  kind?: string;
+  predicate?: string;
+  transition: Record<string, unknown> | undefined;
+}
+
+function TransitionInspectorBody({
+  source,
+  target,
+  kind,
+  predicate,
+  transition,
+}: TransitionInspectorBodyProps): JSX.Element {
+  const rows: KvRow[] = [
+    { key: 'source', value: source },
+    { key: 'target', value: target },
+    { key: 'kind', value: kind ?? '—' },
+  ];
+  return (
+    <div class="space-y-4 p-3">
+      <div class="flex items-center gap-2">
+        {kind ? <Pill variant={transitionKindVariant(kind)} size="sm">{kind}</Pill> : null}
+        <code class="text-sm font-mono">
+          <span class="text-slate-700 dark:text-slate-300">{source}</span>
+          <span class="text-slate-500 mx-1">→</span>
+          <span class="text-slate-700 dark:text-slate-300">{target}</span>
+        </code>
+      </div>
+      <KeyValueTable rows={rows} caption="Transition metadata" />
+      {predicate ? (
+        <section>
+          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
+            Predicate
+          </h4>
+          <CodeBlock
+            text={predicate}
+            language="plain"
+            maxInlineHeight="max-h-64"
+            ariaLabel={`${source} to ${target} predicate`}
+          />
+        </section>
+      ) : null}
+      {transition ? (
+        <section>
+          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
+            Raw transition object
+          </h4>
+          <JsonViewer
+            value={transition}
+            rootLabel="transition"
+            mode="inline"
+            maxInlineHeight="max-h-48"
+          />
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+interface GraphPanelProps {
+  detail: SpecDetail;
+}
+
+function GraphPanel({ detail }: GraphPanelProps): JSX.Element {
   const graph = useMemo(() => specToGraph(detail.definition), [detail.definition]);
+
+  const handleNodeClick = (id: string, data: Record<string, unknown>): void => {
+    const state = (data.state as Record<string, unknown> | undefined) ?? null;
+    if (!state) return;
+    const def = detail.definition as Record<string, unknown> | undefined;
+    const entryId = def && typeof def.entry === 'string' ? def.entry : null;
+    openSheet({
+      id: `state:${detail.id}:${id}`,
+      title: id,
+      width: 'right-half',
+      urlFragment: `state-${id}`,
+      content: <StateInspectorBody state={state} isEntry={entryId === id} />,
+    });
+  };
+
+  const handleEdgeClick = (edgeId: string, data?: Record<string, unknown>): void => {
+    if (!data) return;
+    const source = typeof data.sourceId === 'string' ? data.sourceId : '';
+    const target = typeof data.targetId === 'string' ? data.targetId : '';
+    const kind = typeof data.kind === 'string' ? data.kind : undefined;
+    const fullLabel = typeof data.fullLabel === 'string' ? data.fullLabel : undefined;
+    const transition = data.transition as Record<string, unknown> | undefined;
+    openSheet({
+      id: `transition:${detail.id}:${edgeId}`,
+      title: `${source} → ${target}`,
+      width: 'right-third',
+      urlFragment: `edge-${edgeId}`,
+      content: (
+        <TransitionInspectorBody
+          source={source}
+          target={target}
+          kind={kind}
+          predicate={fullLabel}
+          transition={transition}
+        />
+      ),
+    });
+  };
+
   return (
     <div class="h-[70vh] p-3">
       <FlowGraph
@@ -92,6 +311,8 @@ function GraphPanel({ detail }: { detail: SpecDetail }): JSX.Element {
         edges={graph.edges}
         autoLayout={true}
         direction="TB"
+        onNodeClick={handleNodeClick}
+        onEdgeClick={handleEdgeClick}
       />
     </div>
   );

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -174,10 +174,17 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
             {transitions.map((t, idx) => {
               const target = typeof t.to === 'string' ? t.to : '(unknown)';
               const tKind = typeof t.kind === 'string' ? t.kind : undefined;
+              // Mirror specGraph.predicateLabel(): an object-form
+              // `when` can encode the predicate under EITHER `.predicate`
+              // OR `.expression`. Checking only one of the two leaves
+              // the inspector blank for transitions whose graph edge
+              // label/tooltip is non-empty — a confusing divergence.
               const when = typeof t.when === 'string'
                 ? t.when
                 : t.when && typeof t.when === 'object'
-                ? ((t.when as Record<string, unknown>).predicate as string | undefined) ?? ''
+                ? (((t.when as Record<string, unknown>).predicate as string | undefined)
+                    ?? ((t.when as Record<string, unknown>).expression as string | undefined)
+                    ?? '')
                 : '';
               return (
                 <li key={`${target}-${idx}`} class="py-1.5 flex items-center gap-2">

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -131,19 +131,17 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
   return (
     <div class="space-y-4 p-3">
       <KeyValueTable rows={rows} caption="State metadata" />
+      {/* Every section heading below is the LITERAL FSM library field
+          name (worker.prompt_template / worker.response_schema /
+          state.loop / state.transitions). No consumer-specific text:
+          the FSM UI is agnostic to which skill / agent system is
+          using the library, and labels its sections after the field
+          paths the Worker / State models actually expose. */}
       {worker?.prompt_template ? (
         <section>
-          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
-            Prompt template
+          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+            worker.prompt_template
           </h4>
-          {/* No language= hint: the FSM library treats prompt_template
-              as an opaque string. The consuming skill / agent
-              orchestrator owns the template's MIME type / language
-              convention (could be markdown, jinja, plain prose, json,
-              anything else). Rendering as plain text is the only
-              correct domain-agnostic default. If a future spec gains
-              a `prompt_template_language` (or similar) declared
-              field, plumb it through here. */}
           <CodeBlock
             text={String(worker.prompt_template)}
             maxInlineHeight="max-h-64"
@@ -153,8 +151,8 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
       ) : null}
       {worker?.response_schema ? (
         <section>
-          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
-            response_schema
+          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+            worker.response_schema
           </h4>
           <JsonViewer
             value={worker.response_schema}
@@ -166,16 +164,16 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
       ) : null}
       {loop ? (
         <section>
-          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
-            loop
+          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+            state.loop
           </h4>
           <JsonViewer value={loop} rootLabel="loop" mode="inline" maxInlineHeight="max-h-48" />
         </section>
       ) : null}
       {transitions.length > 0 ? (
         <section>
-          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
-            Transitions out ({transitions.length})
+          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+            state.transitions ({transitions.length})
           </h4>
           <ul class="divide-y divide-slate-100 dark:divide-slate-800 text-xs">
             {transitions.map((t, idx) => {
@@ -243,10 +241,13 @@ function TransitionInspectorBody({
         </code>
       </div>
       <KeyValueTable rows={rows} caption="Transition metadata" />
+      {/* Same convention as StateInspectorBody above: headings are
+          the FSM library's literal transition-shape paths so the
+          operator sees field names, not designer text. */}
       {predicate ? (
         <section>
-          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
-            Predicate
+          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+            transition.when
           </h4>
           <CodeBlock
             text={predicate}
@@ -258,8 +259,8 @@ function TransitionInspectorBody({
       ) : null}
       {transition ? (
         <section>
-          <h4 class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400 mb-1">
-            Raw transition object
+          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+            transition (raw)
           </h4>
           <JsonViewer
             value={transition}

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -141,9 +141,24 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
         <section>
           <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
             worker.prompt_template
+            {worker.prompt_template_language ? (
+              <span class="ml-2 text-slate-400 dark:text-slate-500">
+                · language={String(worker.prompt_template_language)}
+              </span>
+            ) : null}
           </h4>
+          {/* The consumer's `prompt_template_language` field (defined
+              on the FSM library's Worker model since W21) tells the
+              UI how to render. When set, CodeBlock honours it
+              verbatim; when omitted, the markdown content heuristic
+              acts as a courtesy fallback. */}
           <CodeBlock
             text={String(worker.prompt_template)}
+            language={
+              typeof worker.prompt_template_language === 'string'
+                ? worker.prompt_template_language
+                : undefined
+            }
             maxInlineHeight="max-h-64"
             ariaLabel={`${id} worker prompt template`}
           />
@@ -179,16 +194,19 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
             {transitions.map((t, idx) => {
               const target = typeof t.to === 'string' ? t.to : '(unknown)';
               const tKind = typeof t.kind === 'string' ? t.kind : undefined;
-              // Mirror specGraph.predicateLabel(): an object-form
-              // `when` can encode the predicate under EITHER `.predicate`
-              // OR `.expression`. Checking only one of the two leaves
-              // the inspector blank for transitions whose graph edge
-              // label/tooltip is non-empty — a confusing divergence.
+              // Mirror specGraph.predicateLabel(): a `when` dict can
+              // encode the human-readable guard text under any of
+              // `.predicate` (bare Predicate dump), `.expression`
+              // (deterministic kind), or `.criteria` (judgement
+              // kind). Checking only some of them leaves the
+              // inspector blank for judgement transitions while the
+              // edge label / tooltip still renders text — confusing.
               const when = typeof t.when === 'string'
                 ? t.when
                 : t.when && typeof t.when === 'object'
                 ? (((t.when as Record<string, unknown>).predicate as string | undefined)
                     ?? ((t.when as Record<string, unknown>).expression as string | undefined)
+                    ?? ((t.when as Record<string, unknown>).criteria as string | undefined)
                     ?? '')
                 : '';
               return (

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 @theme {
   /* ---------- Colour scale ---------- */


### PR DESCRIPTION
## Summary

Driven by user feedback on the W20 graph: "some text is shortened with `...` and it can be a problem to understand what the node is about." Plus the follow-up: "make nodes 50% bigger, and make sure all labels and texts fit the node shape, not going outside of it."

This PR keeps visible nodes + edge labels visually constrained (so the autobalanced TB layout from PR #56 still fits the viewport) and surfaces the FULL information through two new affordances:

- **Hover → Tooltip** with the full untruncated string (400 ms delay per the W18 grammar).
- **Click → Sheet inspector** with the full payload (worker prompt template, response_schema, allowed_tools, loop config, transitions out for nodes; kind + full predicate + raw transition for edges).

Plus the 50% node-size bump so the truncate rarely kicks in to begin with: `synthesize_release_readiness` (28 chars) — the longest state id in skill-code-review's 15-state spec — now fits in its node without ellipsis.

## What's new

| File | Change |
|---|---|
| `components/Tooltip.tsx` | NEW. Hand-rolled tooltip: 400 ms hover + instant focus, `role="tooltip"` + `aria-describedby`, portal-mounted into `#tooltip-root`, viewport-edge auto-flip, singleton open + 300 ms warm window, reduced-motion respect. |
| `components/FsmEdge.tsx` | NEW. Custom xyflow edge type. EdgeLabelRenderer wraps the truncated label in a Tooltip carrying the full predicate; click on the label dispatches via a module-level `setEdgeClickHandler` registry to FlowGraph's `onEdgeClick`. `BaseEdge` gets `interactionWidth={20}` so clicks near the SVG line also register. |
| `components/FlowGraph.tsx` | `FlowNodeData` widened with `fullLabel`/`fullSublabel`/`state`. FsmNode wraps label + sublabel in Tooltip; node restructured to put the kind chip on its own line above the main label so the state id gets the full node width. `NODE_WIDTH 180→270`, `NODE_HEIGHT 56→84`. Dagre `nodesep/ranksep` tuned 90/110 (TB) for the bigger boxes. `onEdgeClick` signature widened to `(id, data?)` — backward compat. |
| `lib/specGraph.ts` | Attaches full state object on each `node.data.state`; attaches `{fullLabel, kind, transition, sourceId, targetId}` on each `edge.data`. |
| `routes/specDetail.tsx` | `GraphPanel` wires `onNodeClick` + `onEdgeClick` to `openSheet`. New `StateInspectorBody` (KeyValueTable + worker prompt CodeBlock + response_schema JsonViewer + allowed_tools pills + outgoing transitions) and `TransitionInspectorBody` (kind pill + source→target + full predicate CodeBlock + raw transition JsonViewer). |
| `components/index.ts` | Re-exports `Tooltip` + `TooltipProps` + `TooltipPlacement`. |

## Visual verification

Captured against the live `dummy-fsm-test` skill-code-review (15 states) in both themes:

- All 9 state names (including the 28-char `synthesize_release_readiness`) fit inside their node boxes with no truncation.
- Long predicate (`tier == 'trivial' AND len(risk_signals) == 0 AND NOT scope_overrides_present`) surfaces in full on hover.
- Click on a node opens a Sheet with state metadata + worker prompt template + response_schema.
- Click on an edge label opens a Sheet with the transition kind + full predicate + raw transition object.

## Test plan

- [x] 314/314 vitest pass (was 294, +20 new: 11 Tooltip + 3 FlowGraph + 6 specGraph)
- [x] `tsc -b && vite build` clean: 141 KB gzipped (under W18 280 KB budget; W20 was 137 KB)
- [x] Manual: hover label → tooltip with full text in both themes
- [x] Manual: click node → state inspector Sheet
- [x] Manual: click edge label → transition inspector Sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)