### PR TITLE
fix(w22a): 5 inspector polish fixes + relative DB path

### DIFF
--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -67,6 +67,7 @@ from pydantic import BaseModel, Field
 import ctxr.fsm
 from ctxr.fsm.api import _state
 from ctxr.fsm.api._deps import ProjectDep, require_auth
+from ctxr.fsm.api._paths import project_root_and_relative
 from ctxr.fsm.sqlite import Project
 
 __all__ = ["ProjectMetadata", "app", "lifespan_handler"]
@@ -219,7 +220,25 @@ class ProjectMetadata(BaseModel):
 
     fsm_version: str = Field(..., description="The ``ctxr.fsm`` package version.")
     project_open: bool = Field(..., description="Whether the :class:`Project` is bound.")
-    db_path: str = Field(..., description="Filesystem path of the open SQLite database.")
+    db_path: str = Field(..., description="Absolute filesystem path of the open SQLite database.")
+    project_root: str = Field(
+        ...,
+        description=(
+            "Absolute path of the project root that hosts ``.ctxr-fsm/``."
+            " Computed by walking up from the resolved DB path; falls"
+            " back to the DB's parent.parent when no ``.ctxr-fsm/`` is"
+            " found (operator passed a non-canonical ``--db``)."
+        ),
+    )
+    db_path_relative: str = Field(
+        ...,
+        description=(
+            "Path of the open DB relative to ``project_root``. For the"
+            " canonical layout this is ``.ctxr-fsm/fsm.db``. UI surfaces"
+            " prefer this over ``db_path`` so the value stays portable"
+            " across machines + commitable to shared configs."
+        ),
+    )
 
 
 # ── Health endpoints ───────────────────────────────────────────────
@@ -285,10 +304,17 @@ def get_current_project(project: ProjectDep) -> ProjectMetadata:
     # (memory, network) still returns something useful instead of
     # ``None``.
     db_path = project.engine.url.database or str(project.engine.url)
+    # Derive project_root + db_path_relative for portable display
+    # (the UI prefers the relative form for the topbar / Settings
+    # surface — sharing absolute paths across machines is exactly
+    # what this contract avoids).
+    project_root_path, db_relative = project_root_and_relative(db_path)
     return ProjectMetadata(
         fsm_version=ctxr.fsm.__version__,
         project_open=True,
         db_path=db_path,
+        project_root=str(project_root_path),
+        db_path_relative=db_relative,
     )
 
 

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -226,8 +226,9 @@ class ProjectMetadata(BaseModel):
         description=(
             "Absolute path of the project root that hosts ``.ctxr-fsm/``."
             " Computed by walking up from the resolved DB path; falls"
-            " back to the DB's parent.parent when no ``.ctxr-fsm/`` is"
-            " found (operator passed a non-canonical ``--db``)."
+            " back to the DB's parent directory when no ``.ctxr-fsm/``"
+            " ancestor is found (operator passed a non-canonical"
+            " ``--db``)."
         ),
     )
     db_path_relative: str = Field(
@@ -236,7 +237,7 @@ class ProjectMetadata(BaseModel):
             "Path of the open DB relative to ``project_root``. For the"
             " canonical layout this is ``.ctxr-fsm/fsm.db``. UI surfaces"
             " prefer this over ``db_path`` so the value stays portable"
-            " across machines + commitable to shared configs."
+            " across machines and committable to shared configs."
         ),
     )
 

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -315,6 +316,10 @@ def get_current_project(project: ProjectDep) -> ProjectMetadata:
     # rather than emit nonsense (e.g. treating ``sqlite://`` as a
     # filesystem path).
     db_url_database = project.engine.url.database
+    # For non-file backends fall back to the rendered URL so the field
+    # still has SOMETHING useful; for file backends we resolve below
+    # so the doc-promised "absolute filesystem path" actually holds
+    # even when the engine was opened with a relative ``--db`` arg.
     db_path = db_url_database or str(project.engine.url)
     project_root_str: str | None = None
     db_relative: str | None = None
@@ -325,6 +330,12 @@ def get_current_project(project: ProjectDep) -> ProjectMetadata:
     if looks_like_filesystem_db_path(db_url_database):
         project_root_path, db_relative = project_root_and_relative(db_url_database)
         project_root_str = str(project_root_path)
+        # Normalise db_path to absolute too — `project_root_and_relative`
+        # already resolves the path internally, and the doc string says
+        # this field is "absolute". When the engine was opened with a
+        # relative path the raw url.database would be relative too,
+        # contradicting the doc.
+        db_path = str(Path(db_url_database).resolve())
     return ProjectMetadata(
         fsm_version=ctxr.fsm.__version__,
         project_open=True,

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -67,7 +67,7 @@ from pydantic import BaseModel, Field
 import ctxr.fsm
 from ctxr.fsm.api import _state
 from ctxr.fsm.api._deps import ProjectDep, require_auth
-from ctxr.fsm.api._paths import project_root_and_relative
+from ctxr.fsm.api._paths import looks_like_filesystem_db_path, project_root_and_relative
 from ctxr.fsm.sqlite import Project
 
 __all__ = ["ProjectMetadata", "app", "lifespan_handler"]
@@ -318,7 +318,11 @@ def get_current_project(project: ProjectDep) -> ProjectMetadata:
     db_path = db_url_database or str(project.engine.url)
     project_root_str: str | None = None
     db_relative: str | None = None
-    if db_url_database:
+    # `looks_like_filesystem_db_path` filters out :memory:, the URI
+    # in-memory variant, and any other non-file sentinel SQLAlchemy
+    # could expose — a plain `if db_url_database:` truthy check would
+    # treat ':memory:' as a path and resolve it under cwd.
+    if looks_like_filesystem_db_path(db_url_database):
         project_root_path, db_relative = project_root_and_relative(db_url_database)
         project_root_str = str(project_root_path)
     return ProjectMetadata(

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -231,11 +231,14 @@ class ProjectMetadata(BaseModel):
             " filesystem-backed (normalised via :meth:`Path.resolve` so"
             " the value is uniform across hosts regardless of how the"
             " engine was opened). For non-file backends (``:memory:``,"
-            " ``file:``-URI variants, future remote backends) this is"
-            " the rendered SQLAlchemy URL string instead — UI clients"
-            " should treat the value as opaque + paired with the"
-            " ``project_root`` / ``db_path_relative`` nullability to"
-            " tell the two cases apart."
+            " ``file:``-URI variants), this is the raw"
+            " ``engine.url.database`` segment — e.g. ``:memory:`` or"
+            " ``file:test.db`` — so the operator sees exactly what"
+            " SQLAlchemy resolved from the URL. When the URL has no"
+            " ``database`` component at all (``sqlite://``), this"
+            " falls back to the rendered ``str(engine.url)``. Clients"
+            " distinguish a real path from a sentinel by checking"
+            " ``project_root`` / ``db_path_relative`` for ``None``."
         ),
     )
     project_root: str | None = Field(

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -211,11 +211,14 @@ class ReadinessResponse(BaseModel):
 class ProjectMetadata(BaseModel):
     """Metadata payload returned by ``GET /api/v1/projects/current``.
 
-    Intentionally minimal in this bootstrap phase — later waves
-    extend this with project name, root path, registered spec
-    counts, etc. The route exists now so the UI can issue a single
-    discovery call against a running API and know it's talking to a
-    live, project-bound server.
+    W22 added ``project_root`` + ``db_path_relative`` so the UI
+    topbar / Settings surface can render portable, committable
+    project-relative paths instead of absolute filesystem strings.
+    Future waves will extend this further with a project name (slug
+    pulled from ``.ctxr-fsm/``), registered spec + run counts, and
+    workspace metadata; the route already exists so the UI can issue
+    a single discovery call against a running API and know it's
+    talking to a live, project-bound server.
     """
 
     fsm_version: str = Field(..., description="The ``ctxr.fsm`` package version.")

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -224,7 +224,20 @@ class ProjectMetadata(BaseModel):
 
     fsm_version: str = Field(..., description="The ``ctxr.fsm`` package version.")
     project_open: bool = Field(..., description="Whether the :class:`Project` is bound.")
-    db_path: str = Field(..., description="Absolute filesystem path of the open SQLite database.")
+    db_path: str = Field(
+        ...,
+        description=(
+            "Absolute filesystem path of the open SQLite database when"
+            " filesystem-backed (normalised via :meth:`Path.resolve` so"
+            " the value is uniform across hosts regardless of how the"
+            " engine was opened). For non-file backends (``:memory:``,"
+            " ``file:``-URI variants, future remote backends) this is"
+            " the rendered SQLAlchemy URL string instead — UI clients"
+            " should treat the value as opaque + paired with the"
+            " ``project_root`` / ``db_path_relative`` nullability to"
+            " tell the two cases apart."
+        ),
+    )
     project_root: str | None = Field(
         None,
         description=(

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -224,23 +224,27 @@ class ProjectMetadata(BaseModel):
     fsm_version: str = Field(..., description="The ``ctxr.fsm`` package version.")
     project_open: bool = Field(..., description="Whether the :class:`Project` is bound.")
     db_path: str = Field(..., description="Absolute filesystem path of the open SQLite database.")
-    project_root: str = Field(
-        ...,
+    project_root: str | None = Field(
+        None,
         description=(
             "Absolute path of the project root that hosts ``.ctxr-fsm/``."
             " Computed by walking up from the resolved DB path; falls"
             " back to the DB's parent directory when no ``.ctxr-fsm/``"
             " ancestor is found (operator passed a non-canonical"
-            " ``--db``)."
+            " ``--db``). ``None`` when the DB URL has no filesystem"
+            " path (in-memory / non-file backends) — derivation is"
+            " meaningless in that case."
         ),
     )
-    db_path_relative: str = Field(
-        ...,
+    db_path_relative: str | None = Field(
+        None,
         description=(
             "Path of the open DB relative to ``project_root``. For the"
             " canonical layout this is ``.ctxr-fsm/fsm.db``. UI surfaces"
             " prefer this over ``db_path`` so the value stays portable"
             " across machines and committable to shared configs."
+            " ``None`` when ``project_root`` is also ``None`` (paired"
+            " field; see above)."
         ),
     )
 
@@ -306,18 +310,22 @@ def get_current_project(project: ProjectDep) -> ProjectMetadata:
     # attribute is the filesystem path for SQLite URLs. Falls back to
     # the rendered URL string so a future swap to a non-file backend
     # (memory, network) still returns something useful instead of
-    # ``None``.
-    db_path = project.engine.url.database or str(project.engine.url)
-    # Derive project_root + db_path_relative for portable display
-    # (the UI prefers the relative form for the topbar / Settings
-    # surface — sharing absolute paths across machines is exactly
-    # what this contract avoids).
-    project_root_path, db_relative = project_root_and_relative(db_path)
+    # ``None`` — but in that case we cannot meaningfully derive a
+    # project root / relative path, so the paired fields stay ``None``
+    # rather than emit nonsense (e.g. treating ``sqlite://`` as a
+    # filesystem path).
+    db_url_database = project.engine.url.database
+    db_path = db_url_database or str(project.engine.url)
+    project_root_str: str | None = None
+    db_relative: str | None = None
+    if db_url_database:
+        project_root_path, db_relative = project_root_and_relative(db_url_database)
+        project_root_str = str(project_root_path)
     return ProjectMetadata(
         fsm_version=ctxr.fsm.__version__,
         project_open=True,
         db_path=db_path,
-        project_root=str(project_root_path),
+        project_root=project_root_str,
         db_path_relative=db_relative,
     )
 

--- a/ctxr/fsm/api/_paths.py
+++ b/ctxr/fsm/api/_paths.py
@@ -1,0 +1,50 @@
+"""Path-display helpers shared across the API surface.
+
+Lives in its own module so :mod:`ctxr.fsm.api.routes_admin`,
+:mod:`ctxr.fsm.api.__init__` (the ProjectMetadata route), and any
+future surface that wants to render a portable, relative DB path can
+all import without creating a circular dependency. The :class:`Project`
+handle owns the absolute path; this module owns the
+project-root-relative rewrite the UI prefers for display.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def project_root_and_relative(db_path: str) -> tuple[Path, str]:
+    """Return ``(project_root, db_path_relative)`` for the open DB.
+
+    ``project_root`` is the directory that hosts ``.ctxr-fsm/`` — found
+    by walking up from the resolved DB path. ``db_path_relative`` is
+    the DB path rendered relative to ``project_root``; for the
+    canonical ``ctxr-fsm init`` layout this is ``.ctxr-fsm/fsm.db``.
+
+    When the DB lives outside a ``.ctxr-fsm/`` layout (operator passed
+    ``--db /some/random.db``), we fall back to the DB's parent as the
+    root and surface just the filename as the relative path — an
+    honest signal that the layout isn't canonical, without breaking
+    the UI shape.
+
+    The path is ``.resolve()``-d up front so symlinks resolve to their
+    target. The trade-off: when a project sits behind a symlink, the
+    reported ``project_root`` reflects the resolved target, which can
+    differ from where the CLI was invoked. Documented for the API
+    consumers; the UI should treat the value as a stable identifier
+    rather than a navigation target.
+    """
+    abs_db = Path(db_path).resolve()
+    for ancestor in abs_db.parents:
+        if ancestor.name == ".ctxr-fsm":
+            root = ancestor.parent
+            return root, str(abs_db.relative_to(root))
+    # Non-canonical layout: fall back to the DB's parent.
+    fallback_root = abs_db.parent
+    try:
+        return fallback_root, str(abs_db.relative_to(fallback_root))
+    except ValueError:
+        return fallback_root, abs_db.name
+
+
+__all__ = ["project_root_and_relative"]

--- a/ctxr/fsm/api/_paths.py
+++ b/ctxr/fsm/api/_paths.py
@@ -12,6 +12,44 @@ from __future__ import annotations
 
 from pathlib import Path
 
+def looks_like_filesystem_db_path(db_url_database: str | None) -> bool:
+    """Return whether ``db_url_database`` is plausibly a real on-disk path.
+
+    Filters out every non-filesystem sentinel SQLAlchemy's SQLite
+    dialect can emit on ``engine.url.database`` — enumerated by the
+    W22a adversarial-verify workflow (``wbyobu5wr``):
+
+    * :data:`None` — ``sqlite://`` (no database segment).
+    * ``""`` — ``sqlite:///`` (empty database segment; pysqlite
+      internally substitutes ``:memory:`` at connect time).
+    * ``":memory:"`` — canonical SQLite in-memory sentinel
+      (``sqlite:///:memory:``).
+    * Any string starting with ``"file:"`` (case-insensitive) —
+      SQLite's URI-filename scheme. Used for the shared-cache
+      in-memory form ``file::memory:?cache=shared`` AND for any
+      ``mode=ro|rw|rwc|memory`` URI. SQLAlchemy's URL parser
+      strips the query string into ``url.query`` so the bare
+      ``file:test.db`` value lands in ``url.database`` — looking
+      like a relative filename, but it's not: real filesystem
+      paths cannot start with ``file:`` because POSIX / Windows
+      would need a separator before that token. Anything with the
+      prefix needs URI-aware decoding (which is outside the scope
+      of a display helper) so we treat it as non-filesystem.
+
+    Future remote backends (postgresql, mysql, mssql) will populate
+    ``url.database`` with a DSN component, not a path — those would
+    fool a path-derivation function the same way. Adding a guard
+    once a remote backend lands is the right time to extend this
+    function; today it's SQLite-only.
+    """
+    if not db_url_database:
+        return False
+    if db_url_database == ":memory:":
+        return False
+    if db_url_database.lower().startswith("file:"):
+        return False
+    return True
+
 
 def project_root_and_relative(db_path: str) -> tuple[Path, str]:
     """Return ``(project_root, db_path_relative)`` for the open DB.
@@ -47,4 +85,4 @@ def project_root_and_relative(db_path: str) -> tuple[Path, str]:
         return fallback_root, abs_db.name
 
 
-__all__ = ["project_root_and_relative"]
+__all__ = ["looks_like_filesystem_db_path", "project_root_and_relative"]

--- a/ctxr/fsm/api/_paths.py
+++ b/ctxr/fsm/api/_paths.py
@@ -73,14 +73,21 @@ def project_root_and_relative(db_path: str) -> tuple[Path, str]:
     rather than a navigation target.
     """
     abs_db = Path(db_path).resolve()
+    # The returned relative path goes on the wire to the UI + into
+    # committed-to-git configs, so render with POSIX separators
+    # regardless of host OS. ``str(Path('.ctxr-fsm/fsm.db'))`` on
+    # Windows would emit ``.ctxr-fsm\fsm.db``, which the UI's
+    # documented contract expects to be ``.ctxr-fsm/fsm.db`` (the
+    # value an operator commits to a shared config so a teammate on
+    # a different OS still sees the same path).
     for ancestor in abs_db.parents:
         if ancestor.name == ".ctxr-fsm":
             root = ancestor.parent
-            return root, str(abs_db.relative_to(root))
+            return root, abs_db.relative_to(root).as_posix()
     # Non-canonical layout: fall back to the DB's parent.
     fallback_root = abs_db.parent
     try:
-        return fallback_root, str(abs_db.relative_to(fallback_root))
+        return fallback_root, abs_db.relative_to(fallback_root).as_posix()
     except ValueError:
         return fallback_root, abs_db.name
 

--- a/ctxr/fsm/api/_paths.py
+++ b/ctxr/fsm/api/_paths.py
@@ -32,11 +32,16 @@ def looks_like_filesystem_db_path(db_url_database: str | None) -> TypeGuard[str]
       ``mode=ro|rw|rwc|memory`` URI. SQLAlchemy's URL parser
       strips the query string into ``url.query`` so the bare
       ``file:test.db`` value lands in ``url.database`` — looking
-      like a relative filename, but it's not: real filesystem
-      paths cannot start with ``file:`` because POSIX / Windows
-      would need a separator before that token. Anything with the
-      prefix needs URI-aware decoding (which is outside the scope
-      of a display helper) so we treat it as non-filesystem.
+      like a relative filename. We CONSERVATIVELY treat the
+      ``file:`` prefix as the SQLite URI-filename sentinel rather
+      than try to parse the URI here (which would need to honour
+      query args, escape sequences, vfs= overrides, etc.). On
+      POSIX a literal filename ``file:test.db`` IS technically
+      legal (colon is a valid filename character); the very-rare
+      false-positive cost (the operator's ``file:test.db`` on disk
+      doesn't get a portable relative path in the inspector) is
+      acceptable next to the very-common true-positive value (no
+      ``Path(':memory:').resolve()`` on the wire).
 
     Future remote backends (postgresql, mysql, mssql) will populate
     ``url.database`` with a DSN component, not a path — those would

--- a/ctxr/fsm/api/_paths.py
+++ b/ctxr/fsm/api/_paths.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+
 def looks_like_filesystem_db_path(db_url_database: str | None) -> bool:
     """Return whether ``db_url_database`` is plausibly a real on-disk path.
 
@@ -46,9 +47,7 @@ def looks_like_filesystem_db_path(db_url_database: str | None) -> bool:
         return False
     if db_url_database == ":memory:":
         return False
-    if db_url_database.lower().startswith("file:"):
-        return False
-    return True
+    return not db_url_database.lower().startswith("file:")
 
 
 def project_root_and_relative(db_path: str) -> tuple[Path, str]:

--- a/ctxr/fsm/api/_paths.py
+++ b/ctxr/fsm/api/_paths.py
@@ -11,9 +11,10 @@ project-root-relative rewrite the UI prefers for display.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TypeGuard
 
 
-def looks_like_filesystem_db_path(db_url_database: str | None) -> bool:
+def looks_like_filesystem_db_path(db_url_database: str | None) -> TypeGuard[str]:
     """Return whether ``db_url_database`` is plausibly a real on-disk path.
 
     Filters out every non-filesystem sentinel SQLAlchemy's SQLite

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -137,8 +137,11 @@ class DoctorReport(BaseModel):
         ...,
         description=(
             "Absolute path of the project root that hosts ``.ctxr-fsm/``."
-            " UI surfaces use it as the anchor for portable, relative"
-            " display of the DB path."
+            " Computed by walking up from the resolved DB path; falls"
+            " back to the DB's parent directory when no ``.ctxr-fsm/``"
+            " ancestor is found (operator passed a non-canonical"
+            " ``--db``). UI surfaces use this as the anchor for"
+            " portable, relative display of the DB path."
         ),
     )
     db_path_relative: str = Field(

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -43,6 +43,7 @@ Design notes
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -425,6 +426,12 @@ def _build_doctor_report(
     if looks_like_filesystem_db_path(db_url_database):
         project_root_path, db_path_relative = project_root_and_relative(db_url_database)
         project_root_str = str(project_root_path)
+        # Normalise db_path to absolute (matches the field's doc
+        # contract). When the engine was opened with a relative path
+        # the raw url.database would be relative too — `Path.resolve`
+        # plus the canonical layout walk-up keeps the wire shape
+        # uniform across hosts.
+        db_path = str(Path(db_url_database).resolve())
     return DoctorReport(
         db_path=db_path,
         project_root=project_root_str,

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -53,7 +53,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
-from ctxr.fsm.api._paths import project_root_and_relative
+from ctxr.fsm.api._paths import looks_like_filesystem_db_path, project_root_and_relative
 from ctxr.fsm.core.models import JournalStatus
 from ctxr.fsm.sqlite import (
     CommitSignatureRecord,
@@ -419,7 +419,10 @@ def _build_doctor_report(
 
     project_root_str: str | None = None
     db_path_relative: str | None = None
-    if db_url_database:
+    # `looks_like_filesystem_db_path` filters out :memory: and the URI
+    # in-memory variant (and the empty string), so we never derive a
+    # fake project_root for a non-file backend.
+    if looks_like_filesystem_db_path(db_url_database):
         project_root_path, db_path_relative = project_root_and_relative(db_url_database)
         project_root_str = str(project_root_path)
     return DoctorReport(

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -124,10 +124,15 @@ class DriftSignalsResponse(BaseModel):
 class DoctorReport(BaseModel):
     """HTTP shape of the ``ctxr-fsm doctor`` report.
 
-    Mirrors the dict produced by :func:`ctxr.fsm.cli.doctor_cmd.doctor`
-    so an operator can move freely between the CLI and the API without
-    relearning field names. Field-by-field commentary lives on each
-    attribute below.
+    Mostly mirrors the dict produced by
+    :func:`ctxr.fsm.cli.doctor_cmd.doctor`, but the HTTP surface is
+    a strict superset: it additionally carries ``project_root`` +
+    ``db_path_relative`` (W22) so UI consumers can display portable,
+    project-relative paths without re-deriving them. A follow-up
+    will plumb the same fields into the CLI's ``--json`` output so
+    the two surfaces converge; today, an operator reading the CLI
+    JSON will see the absolute ``db_path`` only. Field-by-field
+    commentary lives on each attribute below.
     """
 
     model_config = ConfigDict(strict=True, extra="forbid")

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -53,6 +53,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
+from ctxr.fsm.api._paths import project_root_and_relative
 from ctxr.fsm.core.models import JournalStatus
 from ctxr.fsm.sqlite import (
     CommitSignatureRecord,
@@ -131,7 +132,24 @@ class DoctorReport(BaseModel):
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
-    db_path: str = Field(..., description="Filesystem path of the open DB file.")
+    db_path: str = Field(..., description="Absolute filesystem path of the open DB file.")
+    project_root: str = Field(
+        ...,
+        description=(
+            "Absolute path of the project root that hosts ``.ctxr-fsm/``."
+            " UI surfaces use it as the anchor for portable, relative"
+            " display of the DB path."
+        ),
+    )
+    db_path_relative: str = Field(
+        ...,
+        description=(
+            "DB path rendered relative to ``project_root``. Canonical"
+            " layout: ``.ctxr-fsm/fsm.db``. UI prefers this over"
+            " ``db_path`` so the displayed value stays portable across"
+            " machines and committable to shared configs."
+        ),
+    )
     pragmas: dict[str, Any] = Field(
         default_factory=dict,
         description=(
@@ -381,8 +399,11 @@ def _build_doctor_report(
     journal_breakdown = _journal_status_breakdown(session_factory)
     lock_count = _lock_table_count(session_factory)
 
+    project_root, db_path_relative = project_root_and_relative(db_path)
     return DoctorReport(
         db_path=db_path,
+        project_root=str(project_root),
+        db_path_relative=db_path_relative,
         pragmas=pragmas,
         tables_with_row_counts=row_counts,
         alembic_revision=revision,

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -144,10 +144,13 @@ class DoctorReport(BaseModel):
             "Absolute filesystem path of the open DB file when"
             " filesystem-backed (normalised via :meth:`Path.resolve`)."
             " For non-file backends (``:memory:``, ``file:``-URI"
-            " variants, future remote backends) this is the rendered"
-            " SQLAlchemy URL string instead — clients distinguish the"
-            " two cases by ``project_root`` / ``db_path_relative``"
-            " being ``None``."
+            " variants), this is the raw ``engine.url.database``"
+            " segment — ``:memory:`` or ``file:test.db`` —"
+            " surfacing what SQLAlchemy resolved from the URL. When"
+            " the URL has no ``database`` component (``sqlite://``),"
+            " falls back to the rendered ``str(engine.url)``. Clients"
+            " distinguish a real path from a sentinel by checking"
+            " ``project_root`` / ``db_path_relative`` for ``None``."
         ),
     )
     project_root: str | None = Field(

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -138,7 +138,18 @@ class DoctorReport(BaseModel):
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
-    db_path: str = Field(..., description="Absolute filesystem path of the open DB file.")
+    db_path: str = Field(
+        ...,
+        description=(
+            "Absolute filesystem path of the open DB file when"
+            " filesystem-backed (normalised via :meth:`Path.resolve`)."
+            " For non-file backends (``:memory:``, ``file:``-URI"
+            " variants, future remote backends) this is the rendered"
+            " SQLAlchemy URL string instead — clients distinguish the"
+            " two cases by ``project_root`` / ``db_path_relative``"
+            " being ``None``."
+        ),
+    )
     project_root: str | None = Field(
         None,
         description=(

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -138,24 +138,27 @@ class DoctorReport(BaseModel):
     model_config = ConfigDict(strict=True, extra="forbid")
 
     db_path: str = Field(..., description="Absolute filesystem path of the open DB file.")
-    project_root: str = Field(
-        ...,
+    project_root: str | None = Field(
+        None,
         description=(
             "Absolute path of the project root that hosts ``.ctxr-fsm/``."
             " Computed by walking up from the resolved DB path; falls"
             " back to the DB's parent directory when no ``.ctxr-fsm/``"
             " ancestor is found (operator passed a non-canonical"
             " ``--db``). UI surfaces use this as the anchor for"
-            " portable, relative display of the DB path."
+            " portable, relative display of the DB path. ``None`` when"
+            " the DB URL has no filesystem path (in-memory / non-file"
+            " backends) — derivation is meaningless in that case."
         ),
     )
-    db_path_relative: str = Field(
-        ...,
+    db_path_relative: str | None = Field(
+        None,
         description=(
             "DB path rendered relative to ``project_root``. Canonical"
             " layout: ``.ctxr-fsm/fsm.db``. UI prefers this over"
             " ``db_path`` so the displayed value stays portable across"
-            " machines and committable to shared configs."
+            " machines and committable to shared configs. ``None`` when"
+            " ``project_root`` is also ``None``."
         ),
     )
     pragmas: dict[str, Any] = Field(
@@ -399,7 +402,14 @@ def _build_doctor_report(
     :func:`run_in_threadpool` and the tests can call this directly
     without spinning up FastAPI.
     """
-    db_path = engine.url.database or str(engine.url)
+    # ``engine.url.database`` is the filesystem path for SQLite URLs.
+    # When it's missing (in-memory backend, non-file URL) we still
+    # surface a ``db_path`` derived from the rendered URL for
+    # legibility, but skip the portable-path derivation — calling
+    # project_root_and_relative on ``sqlite://`` would produce
+    # misleading values.
+    db_url_database = engine.url.database
+    db_path = db_url_database or str(engine.url)
     pragmas = detect_journal_state(engine)
     tables = _list_user_tables(engine)
     row_counts = {name: _count_table_rows(engine, name) for name in tables}
@@ -407,10 +417,14 @@ def _build_doctor_report(
     journal_breakdown = _journal_status_breakdown(session_factory)
     lock_count = _lock_table_count(session_factory)
 
-    project_root, db_path_relative = project_root_and_relative(db_path)
+    project_root_str: str | None = None
+    db_path_relative: str | None = None
+    if db_url_database:
+        project_root_path, db_path_relative = project_root_and_relative(db_url_database)
+        project_root_str = str(project_root_path)
     return DoctorReport(
         db_path=db_path,
-        project_root=str(project_root),
+        project_root=project_root_str,
         db_path_relative=db_path_relative,
         pragmas=pragmas,
         tables_with_row_counts=row_counts,

--- a/tests/integration/api/test_api_health.py
+++ b/tests/integration/api/test_api_health.py
@@ -220,6 +220,101 @@ def test_get_current_project_returns_metadata(
     )
 
 
+# ---------------------------------------------------------------------------
+# W22a: project_root + db_path_relative portable-path derivation
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_project_derives_relative_path_for_canonical_layout(
+    tmp_path: Path,
+) -> None:
+    """When ``.ctxr-fsm/fsm.db`` lives under a project root, the route
+    derives ``project_root`` and ``db_path_relative`` correctly.
+
+    Uses a fresh on-disk DB under tmp_path so the standard
+    ``ctxr-fsm init`` layout (``<root>/.ctxr-fsm/fsm.db``) is exercised
+    end to end. The relative path must be exactly ``.ctxr-fsm/fsm.db``
+    on every host — that's what UI surfaces commit to shared configs.
+    """
+    project_dir = tmp_path / "my-project"
+    ctxr_dir = project_dir / ".ctxr-fsm"
+    ctxr_dir.mkdir(parents=True)
+    db_path = ctxr_dir / "fsm.db"
+
+    project = Project.open(db_path, migrate=True)
+    try:
+        _state.set_project(project)
+        with TestClient(app) as client:
+            body = client.get("/api/v1/projects/current").json()
+            assert body["db_path_relative"] == ".ctxr-fsm/fsm.db", (
+                f"canonical layout should produce '.ctxr-fsm/fsm.db'; got "
+                f"{body['db_path_relative']!r}"
+            )
+            assert Path(body["project_root"]).resolve() == project_dir.resolve(), (
+                f"project_root should resolve to {project_dir!s}; got "
+                f"{body['project_root']!r}"
+            )
+    finally:
+        _state.reset_project()
+        project.close()
+
+
+def test_get_current_project_falls_back_for_non_canonical_layout(
+    tmp_path: Path,
+) -> None:
+    """When the DB lives outside a ``.ctxr-fsm/`` ancestor (operator
+    passed an ad-hoc ``--db``), the relative path is just the filename
+    and the project root is the DB's parent. Honest signal, no
+    misleading walk-up to a random ancestor.
+    """
+    rogue_dir = tmp_path / "somewhere"
+    rogue_dir.mkdir()
+    db_path = rogue_dir / "random.db"
+
+    project = Project.open(db_path, migrate=True)
+    try:
+        _state.set_project(project)
+        with TestClient(app) as client:
+            body = client.get("/api/v1/projects/current").json()
+            assert body["db_path_relative"] == "random.db", (
+                f"non-canonical layout should fall back to bare filename; got "
+                f"{body['db_path_relative']!r}"
+            )
+            assert Path(body["project_root"]).resolve() == rogue_dir.resolve()
+    finally:
+        _state.reset_project()
+        project.close()
+
+
+def test_get_current_project_returns_null_for_in_memory_db() -> None:
+    """When the open DB is SQLite ``:memory:``, project_root +
+    db_path_relative must ship as ``null`` — running the walk-up
+    derivation on the ``:memory:`` sentinel would resolve it under
+    the test's cwd and emit a nonsense path. The sentinel guard in
+    :func:`ctxr.fsm.api._paths.looks_like_filesystem_db_path` is the
+    line of defence.
+    """
+    project = Project.open(":memory:", migrate=True)
+    try:
+        _state.set_project(project)
+        with TestClient(app) as client:
+            body = client.get("/api/v1/projects/current").json()
+            assert body["project_root"] is None, (
+                f"in-memory DB should produce project_root=None; got "
+                f"{body['project_root']!r}"
+            )
+            assert body["db_path_relative"] is None, (
+                f"in-memory DB should produce db_path_relative=None; got "
+                f"{body['db_path_relative']!r}"
+            )
+            # db_path itself is still surfaced (the :memory: sentinel)
+            # so the UI knows what it's talking to.
+            assert body["db_path"] == ":memory:"
+    finally:
+        _state.reset_project()
+        project.close()
+
+
 if __name__ == "__main__":  # pragma: no cover - manual debug path
     # Allow ``python tests/integration/api/test_api_health.py`` to
     # run the suite under pytest without remembering the full module

--- a/tests/unit/api/test_paths.py
+++ b/tests/unit/api/test_paths.py
@@ -22,7 +22,6 @@ from ctxr.fsm.api._paths import (
     project_root_and_relative,
 )
 
-
 # ---------------------------------------------------------------------------
 # looks_like_filesystem_db_path — sentinel matrix
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/test_paths.py
+++ b/tests/unit/api/test_paths.py
@@ -1,0 +1,109 @@
+"""Unit coverage for :mod:`ctxr.fsm.api._paths`.
+
+The :func:`looks_like_filesystem_db_path` predicate is the single
+guard the API routes (`get_current_project` + `_build_doctor_report`)
+use to decide whether to derive ``project_root`` / ``db_path_relative``
+from ``engine.url.database``. The matrix below pins the contract
+against every non-filesystem sentinel SQLAlchemy's SQLite dialect
+can emit, enumerated by the W22a adversarial-verify workflow
+``wbyobu5wr``. If a future dialect change widens the sentinel
+surface, this test surfaces the regression before it can land a
+``Path(':memory:').resolve()`` on the wire.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ctxr.fsm.api._paths import (
+    looks_like_filesystem_db_path,
+    project_root_and_relative,
+)
+
+
+# ---------------------------------------------------------------------------
+# looks_like_filesystem_db_path — sentinel matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,  # sqlite://
+        "",  # sqlite:///
+        ":memory:",  # sqlite:///:memory:
+        # SQLite URI-filename family — SQLAlchemy strips the query string
+        # into url.query so the bare 'file:...' lands in url.database.
+        "file::memory:",  # sqlite:///file::memory:?cache=shared&uri=true
+        "file:test.db",  # sqlite:///file:test.db?mode=memory&uri=true
+        "file:foo?mode=memory",  # if SQLAlchemy ever leaves the q in db
+        "file:bar?mode=ro",  # URI-filename in read-only mode
+        "FILE:UPPERCASE",  # case-insensitive prefix
+    ],
+)
+def test_looks_like_filesystem_db_path_rejects_non_file_sentinels(
+    value: str | None,
+) -> None:
+    """Every non-filesystem sentinel must return False so the route
+    skips :func:`project_root_and_relative` derivation."""
+    assert looks_like_filesystem_db_path(value) is False, (
+        f"{value!r} is a non-filesystem sentinel but the guard accepted it; "
+        "derivation would produce a misleading project_root value"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "fsm.db",  # bare filename
+        ".ctxr-fsm/fsm.db",  # canonical layout, relative
+        "/tmp/something/fsm.db",  # POSIX absolute
+        "/Users/dev/work/.ctxr-fsm/fsm.db",  # real path with colon-free segments
+        "C:\\Users\\dev\\fsm.db",  # Windows absolute (defensive)
+        "./relative/path.db",
+        "../sibling.db",
+    ],
+)
+def test_looks_like_filesystem_db_path_accepts_real_paths(value: str) -> None:
+    """Real filesystem paths — POSIX absolute, POSIX relative, Windows
+    absolute, leading-dot relative — must pass the guard so the route
+    can derive a meaningful relative form."""
+    assert looks_like_filesystem_db_path(value) is True, (
+        f"{value!r} is a real filesystem path but the guard rejected it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# project_root_and_relative — canonical and fallback layouts
+# ---------------------------------------------------------------------------
+
+
+def test_project_root_and_relative_canonical_layout(tmp_path: Path) -> None:
+    """When the DB lives under ``<root>/.ctxr-fsm/fsm.db`` the helper
+    returns the root and a ``.ctxr-fsm/fsm.db`` relative path — the
+    portable form UI surfaces commit to shared configs."""
+    project_root = tmp_path / "my-project"
+    ctxr_dir = project_root / ".ctxr-fsm"
+    ctxr_dir.mkdir(parents=True)
+    db = ctxr_dir / "fsm.db"
+    db.touch()
+
+    root, rel = project_root_and_relative(str(db))
+    assert root.resolve() == project_root.resolve()
+    assert rel == ".ctxr-fsm/fsm.db"
+
+
+def test_project_root_and_relative_non_canonical_layout(tmp_path: Path) -> None:
+    """When the DB lives outside a ``.ctxr-fsm/`` ancestor (operator
+    passed ad-hoc ``--db``), the relative path is just the filename
+    and the root is the DB's parent directory — honest, not made up."""
+    rogue_dir = tmp_path / "somewhere"
+    rogue_dir.mkdir()
+    db = rogue_dir / "random.db"
+    db.touch()
+
+    root, rel = project_root_and_relative(str(db))
+    assert root.resolve() == rogue_dir.resolve()
+    assert rel == "random.db"

--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -274,6 +274,13 @@ function applyDagreLayout(
     return {
       ...n,
       position: { x: x - NODE_WIDTH / 2, y: y - NODE_HEIGHT / 2 },
+      // xyflow v12 MiniMap reads node.width / node.height to draw the
+      // thumbnail rectangle. Without these, the mini-map shows only the
+      // viewport indicator + grid, no node dots (W22 user-visible bug).
+      // Stamping the same dimensions we already feed dagre keeps the
+      // mini-map in lockstep with the on-canvas layout.
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
       sourcePosition: direction === 'LR' ? Position.Right : Position.Bottom,
       targetPosition: direction === 'LR' ? Position.Left : Position.Top,
       type: 'fsmNode',
@@ -387,6 +394,12 @@ export function FlowGraph({
       const tp = direction === 'LR' ? Position.Left : Position.Top;
       return nodes.map((n) => ({
         ...n,
+        // W22: stamp width/height so MiniMap renders thumbnails even
+        // for callers that supply manual positions. Only fill in
+        // defaults — callers that explicitly set per-node dimensions
+        // (a future cardinality-aware layout) keep their values.
+        width: n.width ?? NODE_WIDTH,
+        height: n.height ?? NODE_HEIGHT,
         sourcePosition: n.sourcePosition ?? sp,
         targetPosition: n.targetPosition ?? tp,
         type: n.type ?? 'fsmNode',

--- a/ui/src/components/FsmEdge.tsx
+++ b/ui/src/components/FsmEdge.tsx
@@ -128,17 +128,37 @@ export function FsmEdge(props: EdgeProps): JSX.Element {
             }}
             data-edge-id={id}
           >
+            {(() => {
+              // W22: highlight predicate edges — deterministic /
+              // judgement transitions carry meaningful guard text and
+              // should pop visually. always / otherwise bare guards
+              // keep the neutral slate badge so the eye is drawn to
+              // the conditions that actually MATTER for understanding
+              // why the FSM branched.
+              const kind = ed.kind;
+              const isPredicate = kind === 'deterministic' || kind === 'judgement';
+              const badgeClass = isPredicate
+                ? [
+                    'inline-block max-w-[160px] truncate cursor-pointer',
+                    'rounded px-1.5 py-0.5 text-[10px] leading-tight font-semibold font-mono',
+                    'bg-amber-100 dark:bg-amber-900/40',
+                    'border border-amber-400 dark:border-amber-600',
+                    'text-amber-900 dark:text-amber-200',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500',
+                  ].join(' ')
+                : [
+                    'inline-block max-w-[160px] truncate cursor-pointer',
+                    'rounded px-1.5 py-0.5 text-[10px] leading-tight',
+                    'bg-[var(--xy-label-bg,#f8fafc)]/90',
+                    'border border-slate-200 dark:border-slate-700',
+                    'text-slate-700 dark:text-slate-200',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
+                  ].join(' ');
+              return (
             <Tooltip content={fullText} delay={400}>
               <button
                 type="button"
-                class={[
-                  'inline-block max-w-[160px] truncate cursor-pointer',
-                  'rounded px-1.5 py-0.5 text-[10px] leading-tight',
-                  'bg-[var(--xy-label-bg,#f8fafc)]/90',
-                  'border border-slate-200 dark:border-slate-700',
-                  'text-slate-700 dark:text-slate-200',
-                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
-                ].join(' ')}
+                class={badgeClass}
                 // No native title= here: the custom Tooltip already
                 // surfaces fullText with the right delay + ARIA wiring,
                 // and a sibling native title would produce a double
@@ -154,6 +174,8 @@ export function FsmEdge(props: EdgeProps): JSX.Element {
                 {visibleLabel}
               </button>
             </Tooltip>
+              );
+            })()}
           </div>
         </EdgeLabelRenderer>
       ) : null}

--- a/ui/src/lib/__tests__/specGraph.test.ts
+++ b/ui/src/lib/__tests__/specGraph.test.ts
@@ -251,6 +251,46 @@ describe('specToGraph', () => {
     expect(data.fullLabel).toBe('x > 0');
   });
 
+  // -------------------------------------------------------------------------
+  // W22: redundant `inline: <handler_id>` sublabel suppression
+  // -------------------------------------------------------------------------
+
+  test('W22: inline state whose handler_id mirrors state id drops the redundant `inline:` line', () => {
+    const g = specToGraph({
+      states: [{ id: 'synth', inline: { handler_id: 'synth' }, outputs: ['x', 'y'], transitions: [{ to: 'done', when: 'always' }] }, { id: 'done' }],
+    });
+    // Visible row no longer mirrors the label.
+    expect(g.nodes[0].data.sublabel).not.toBe('inline: synth');
+    // ...but the canonical line stays on fullSublabel for the hover
+    // + inspector path.
+    expect(g.nodes[0].data.fullSublabel).toBe('inline: synth');
+    // Structural fallback shows up.
+    expect(g.nodes[0].data.sublabel).toContain('output');
+  });
+
+  test('W22: inline.purpose is preferred over the structural summary when present', () => {
+    const g = specToGraph({
+      states: [{ id: 'judge', inline: { handler_id: 'judge', purpose: 'rank candidates' }, outputs: ['ranked'] }],
+    });
+    expect(g.nodes[0].data.sublabel).toBe('rank candidates');
+  });
+
+  test('W22: structural summary surfaces verifier and post-val counts', () => {
+    const g = specToGraph({
+      states: [{ id: 'check', inline: { handler_id: 'check' }, verifier: {}, post_validations: [1, 2] }],
+    });
+    const sub = g.nodes[0].data.sublabel ?? '';
+    expect(sub).toContain('verifier');
+    expect(sub).toContain('post-val ×2');
+  });
+
+  test('W22: non-mirroring handler_id keeps the canonical line (no false-positive demotion)', () => {
+    const g = specToGraph({
+      states: [{ id: 's', inline: { handler_id: 'aggregate' } }],
+    });
+    expect(g.nodes[0].data.sublabel).toBe('inline: aggregate');
+  });
+
   test('W21: bare predicate-string when is treated as deterministic', () => {
     const g = specToGraph({
       states: [

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -279,9 +279,11 @@ export interface CommitSignatureRecord {
 /** Admin: doctor-report payload (mirrors ``ctxr-fsm doctor``). */
 export interface DoctorReport {
   /** Absolute filesystem path of the open DB file when filesystem-
-   *  backed. For non-file backends (`:memory:`, `file:`-URI variants,
-   *  future remote backends) this is the rendered SQLAlchemy URL
-   *  string instead. Distinguish the two cases by checking whether
+   *  backed. For non-file backends (`:memory:`, `file:`-URI variants)
+   *  this is the raw `engine.url.database` segment (e.g. `:memory:`
+   *  or `file:test.db`). When the URL has no `database` component
+   *  (`sqlite://`), falls back to the rendered `str(engine.url)`.
+   *  Distinguish a real path from a sentinel by checking whether
    *  `project_root` / `db_path_relative` are non-null. */
   db_path: string;
   /** Absolute path of the project root that hosts ``.ctxr-fsm/``.

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -281,12 +281,15 @@ export interface DoctorReport {
   /** Absolute filesystem path of the open DB file. */
   db_path: string;
   /** Absolute path of the project root that hosts ``.ctxr-fsm/``.
-   *  Optional so the UI handles servers older than W22 gracefully. */
-  project_root?: string;
+   *  ``null`` when the DB has no filesystem path (in-memory / non-
+   *  file backends — derivation is meaningless then). ``undefined``
+   *  when talking to a server older than W22. */
+  project_root?: string | null;
   /** DB path rendered relative to ``project_root``. UI surfaces
    *  prefer this so the displayed value stays portable. Canonical
-   *  layout: ``.ctxr-fsm/fsm.db``. */
-  db_path_relative?: string;
+   *  layout: ``.ctxr-fsm/fsm.db``. ``null`` when ``project_root`` is
+   *  also ``null``; ``undefined`` on a pre-W22 server. */
+  db_path_relative?: string | null;
   pragmas: JsonObject;
   tables_with_row_counts: Record<string, number>;
   alembic_revision: string | null;

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -278,7 +278,15 @@ export interface CommitSignatureRecord {
 
 /** Admin: doctor-report payload (mirrors ``ctxr-fsm doctor``). */
 export interface DoctorReport {
+  /** Absolute filesystem path of the open DB file. */
   db_path: string;
+  /** Absolute path of the project root that hosts ``.ctxr-fsm/``.
+   *  Optional so the UI handles servers older than W22 gracefully. */
+  project_root?: string;
+  /** DB path rendered relative to ``project_root``. UI surfaces
+   *  prefer this so the displayed value stays portable. Canonical
+   *  layout: ``.ctxr-fsm/fsm.db``. */
+  db_path_relative?: string;
   pragmas: JsonObject;
   tables_with_row_counts: Record<string, number>;
   alembic_revision: string | null;

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -278,7 +278,11 @@ export interface CommitSignatureRecord {
 
 /** Admin: doctor-report payload (mirrors ``ctxr-fsm doctor``). */
 export interface DoctorReport {
-  /** Absolute filesystem path of the open DB file. */
+  /** Absolute filesystem path of the open DB file when filesystem-
+   *  backed. For non-file backends (`:memory:`, `file:`-URI variants,
+   *  future remote backends) this is the rendered SQLAlchemy URL
+   *  string instead. Distinguish the two cases by checking whether
+   *  `project_root` / `db_path_relative` are non-null. */
   db_path: string;
   /** Absolute path of the project root that hosts ``.ctxr-fsm/``.
    *  ``null`` when the DB has no filesystem path (in-memory / non-

--- a/ui/src/lib/specGraph.ts
+++ b/ui/src/lib/specGraph.ts
@@ -30,10 +30,19 @@ import type { FlowNodeData, FlowNodeKind } from '../components/FlowGraph';
 interface SpecStateShape {
   id: string;
   kind?: string;
+  purpose?: string;
   worker?: { role?: string; prompt_template?: string };
-  loop?: unknown;
-  inline?: { handler_id?: string };
+  loop?: { max_iterations?: number; done_field?: string } | unknown;
+  inline?: {
+    handler_id?: string;
+    purpose?: string;
+    response_schema?: { schema?: { properties?: Record<string, unknown> } };
+    post_validations?: unknown[];
+  };
+  outputs?: unknown[];
+  post_validations?: unknown[];
   transitions?: SpecTransitionShape[];
+  verifier?: unknown;
 }
 
 interface SpecTransitionShape {
@@ -109,6 +118,28 @@ export function transitionKind(t: { when?: unknown }): string | undefined {
   return undefined;
 }
 
+/** Build a short, info-dense sublabel from structural counts on the
+ *  spec state. Used when the canonical `worker: <role>` /
+ *  `inline: <handler_id>` line would mirror the main label (which is
+ *  the state id) and therefore add no information. Returns '' when
+ *  no structural facts are worth showing, so the caller can fall
+ *  through to its next default. */
+function structuralSublabel(s: SpecStateShape): string {
+  const parts: string[] = [];
+  const outs = Array.isArray(s.outputs) ? s.outputs.length : 0;
+  const trans = Array.isArray(s.transitions) ? s.transitions.length : 0;
+  if (outs > 0) parts.push(`${outs} output${outs === 1 ? '' : 's'}`);
+  if (trans > 0) parts.push(`→ ${trans}`);
+  if (s.verifier) parts.push('✓ verifier');
+  const inlinePV = Array.isArray(s.inline?.post_validations)
+    ? s.inline!.post_validations!.length
+    : 0;
+  const statePV = Array.isArray(s.post_validations) ? s.post_validations.length : 0;
+  const pv = inlinePV + statePV;
+  if (pv > 0) parts.push(`post-val ×${pv}`);
+  return parts.join(' · ');
+}
+
 export interface SpecGraph {
   nodes: Node<FlowNodeData>[];
   edges: Edge[];
@@ -130,24 +161,49 @@ export function specToGraph(definition: unknown): SpecGraph {
 
   const nodes: Node<FlowNodeData>[] = states.map((s) => {
     const kind = inferKind(s);
+
+    // Canonical sublabel: `worker: <role>` / `inline: <handler_id>` /
+    // `terminal`. Always kept on `data.fullSublabel` (and surfaced via
+    // hover Tooltip + the inspector Sheet) even when the visible row
+    // gets demoted in favour of a more informative line below.
     let sublabel = '';
     if (s.worker?.role) sublabel = `worker: ${s.worker.role}`;
     else if (s.inline?.handler_id) sublabel = `inline: ${s.inline.handler_id}`;
     else if (kind === 'terminal') sublabel = 'terminal';
+    const canonicalSublabel = sublabel || undefined;
+
+    // W22 redundancy guard: when the canonical line would mirror the
+    // main label (skill-code-review names every handler after its
+    // state, so `inline: synthesize_release_readiness` duplicates the
+    // label one row up), swap the visible row for new information:
+    // prefer `inline.purpose` / `state.purpose` (human-readable),
+    // otherwise fall through to a structural summary built from
+    // counts on the same node (`N outputs · → M · ✓ verifier ·
+    // post-val ×K`). The full canonical line is preserved on
+    // fullSublabel so hover + inspector show it on demand.
+    const mirrorsLabel =
+      (s.inline?.handler_id !== undefined && s.inline.handler_id === s.id) ||
+      (s.worker?.role !== undefined && s.worker.role === s.id);
+    if (mirrorsLabel) {
+      const purpose = (s.inline?.purpose ?? s.purpose ?? '').trim();
+      const structural = structuralSublabel(s);
+      sublabel = purpose || structural || '';
+    }
+
     return {
       id: s.id,
       position: { x: 0, y: 0 }, // dagre fills these in
       // W21: copy the FULL spec state object onto data.state so the
       // click handler can render a State Inspector Sheet without
       // re-walking the spec. fullLabel/fullSublabel mirror the
-      // visible strings; node-label tooltip falls back to label when
-      // these are absent.
+      // visible strings; the Tooltip falls back to label when
+      // fullLabel is absent.
       data: {
         kind,
         label: s.id,
         sublabel,
         fullLabel: s.id,
-        fullSublabel: sublabel || undefined,
+        fullSublabel: canonicalSublabel ?? sublabel ?? undefined,
         state: s as unknown as Record<string, unknown>,
       },
     };

--- a/ui/src/lib/specGraph.ts
+++ b/ui/src/lib/specGraph.ts
@@ -203,14 +203,24 @@ export function specToGraph(definition: unknown): SpecGraph {
       // re-walking the spec. fullLabel/fullSublabel mirror the
       // visible strings; the Tooltip falls back to label when
       // fullLabel is absent.
-      data: {
-        kind,
-        label: s.id,
-        sublabel,
-        fullLabel: s.id,
-        fullSublabel: canonicalSublabel ?? sublabel ?? undefined,
-        state: s as unknown as Record<string, unknown>,
-      },
+      // Compose fullSublabel via `||` (not `??`) so an empty-string
+      // `sublabel` (the initial value when no worker/inline/terminal
+      // applies) falls through to undefined instead of pinning the
+      // tooltip content to '' — which downstream `?? data.sublabel`
+      // wouldn't short-circuit past. Empty-content Tooltip auto-no-
+      // renders, but having `fullSublabel = ''` would suppress the
+      // hover fallback even when `sublabel` IS non-empty.
+      data: (() => {
+        const fs = canonicalSublabel ?? sublabel;
+        return {
+          kind,
+          label: s.id,
+          sublabel,
+          fullLabel: s.id,
+          fullSublabel: fs && fs.length > 0 ? fs : undefined,
+          state: s as unknown as Record<string, unknown>,
+        };
+      })(),
     };
   });
 

--- a/ui/src/lib/specGraph.ts
+++ b/ui/src/lib/specGraph.ts
@@ -32,7 +32,12 @@ interface SpecStateShape {
   kind?: string;
   purpose?: string;
   worker?: { role?: string; prompt_template?: string };
-  loop?: { max_iterations?: number; done_field?: string } | unknown;
+  /** Loop config. We type the structured keys we KNOW about
+   *  (`max_iterations`, `done_field`) and accept extra keys via the
+   *  index signature so the type doesn't collapse to `unknown` (which
+   *  is what `{ ... } | unknown` would have done — a union with
+   *  `unknown` loses all structure). */
+  loop?: { max_iterations?: number; done_field?: string; [k: string]: unknown };
   inline?: {
     handler_id?: string;
     purpose?: string;
@@ -209,17 +214,26 @@ export function specToGraph(definition: unknown): SpecGraph {
     };
   });
 
-  // Mark the entry state visually with a sublabel hint.
+  // Mark the entry state visually with a sublabel hint. The `entry ·`
+  // prefix composes onto whatever sublabel we already chose (canonical
+  // worker:/inline: line OR the structural-summary demotion from the
+  // W22 mirror guard). fullSublabel composes onto the CANONICAL line
+  // (not the demoted visible one) so hover + inspector still see the
+  // un-demoted form — losing it here would defeat the redundancy-
+  // guard's whole point.
   if (def.entry) {
     const entry = nodes.find((n) => n.id === def.entry);
     if (entry) {
-      const newSub = entry.data.sublabel
+      const visibleSub = entry.data.sublabel
         ? `entry · ${entry.data.sublabel}`
         : 'entry';
+      const fullSub = entry.data.fullSublabel
+        ? `entry · ${entry.data.fullSublabel}`
+        : visibleSub;
       entry.data = {
         ...entry.data,
-        sublabel: newSub,
-        fullSublabel: newSub,
+        sublabel: visibleSub,
+        fullSublabel: fullSub,
       };
     }
   }

--- a/ui/src/routes/settings.tsx
+++ b/ui/src/routes/settings.tsx
@@ -89,20 +89,26 @@ export function SettingsRoute(): JSX.Element {
           <dl class="grid grid-cols-1 sm:grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
             {/* W22 Fix 5: display DB path RELATIVE to the project root
                 so the value stays portable across machines and can be
-                committed to shared configs. Falls back to the absolute
-                form when the server is older than W22 (the new field
-                is optional on the wire), and the absolute form is
-                also surfaced below as a small slate-tinted line for
+                committed to shared configs. The absolute db_path is
+                ALSO surfaced as a small slate-tinted line below for
                 operators who genuinely need it (debugging a non-
-                canonical --db location). */}
+                canonical --db location). Falls back to the absolute
+                form alone when the server is older than W22 (the new
+                field is optional on the wire). */}
             <dt class="text-slate-500 dark:text-slate-400">DB path</dt>
             <dd>
               <code class="font-mono text-xs break-all text-emerald-700 dark:text-emerald-300">
                 {report.db_path_relative ?? report.db_path}
               </code>
-              {report.project_root && report.db_path_relative ? (
+              {report.db_path_relative ? (
                 <div class="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5 break-all">
-                  relative to <code class="font-mono">{report.project_root}</code>
+                  absolute: <code class="font-mono">{report.db_path}</code>
+                  {report.project_root ? (
+                    <>
+                      {' · root: '}
+                      <code class="font-mono">{report.project_root}</code>
+                    </>
+                  ) : null}
                 </div>
               ) : null}
             </dd>

--- a/ui/src/routes/settings.tsx
+++ b/ui/src/routes/settings.tsx
@@ -87,8 +87,25 @@ export function SettingsRoute(): JSX.Element {
           <div class="flex items-center justify-center py-6"><Spinner label="Loading project metadata" /></div>
         ) : (
           <dl class="grid grid-cols-1 sm:grid-cols-[10rem_1fr] gap-x-4 gap-y-2 text-sm">
+            {/* W22 Fix 5: display DB path RELATIVE to the project root
+                so the value stays portable across machines and can be
+                committed to shared configs. Falls back to the absolute
+                form when the server is older than W22 (the new field
+                is optional on the wire), and the absolute form is
+                also surfaced below as a small slate-tinted line for
+                operators who genuinely need it (debugging a non-
+                canonical --db location). */}
             <dt class="text-slate-500 dark:text-slate-400">DB path</dt>
-            <dd><code class="font-mono text-xs break-all">{report.db_path}</code></dd>
+            <dd>
+              <code class="font-mono text-xs break-all text-emerald-700 dark:text-emerald-300">
+                {report.db_path_relative ?? report.db_path}
+              </code>
+              {report.project_root && report.db_path_relative ? (
+                <div class="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5 break-all">
+                  relative to <code class="font-mono">{report.project_root}</code>
+                </div>
+              ) : null}
+            </dd>
             <dt class="text-slate-500 dark:text-slate-400">SQLite user_version</dt>
             <dd><code class="font-mono text-xs">{pragma(report, 'user_version')}</code></dd>
             <dt class="text-slate-500 dark:text-slate-400">Alembic revision</dt>

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -169,10 +169,15 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
           <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
             worker.response_schema
           </h4>
+          {/* W22 Fix 2: default to the top two levels of the schema
+              expanded — the operator wants a glance at the shape
+              without scrolling through every nested property. Click
+              the chevrons or the toolbar's Expand button to descend. */}
           <JsonViewer
             value={worker.response_schema}
             rootLabel="response_schema"
-            mode="inline"
+            mode="expanded"
+            defaultExpandDepth={2}
             maxInlineHeight="max-h-64"
           />
         </section>
@@ -214,12 +219,20 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
                     ?? ((t.when as Record<string, unknown>).criteria as string | undefined)
                     ?? '')
                 : '';
+              // W22 Fix 3 site 2: highlight predicates (deterministic /
+              // judgement) so the operator's eye jumps to the
+              // conditions that actually MATTER for understanding why
+              // the FSM branched. always / otherwise stay slate.
+              const isPredicate = tKind === 'deterministic' || tKind === 'judgement';
+              const whenClass = isPredicate
+                ? 'font-mono text-amber-700 dark:text-amber-300 font-semibold truncate flex-1 px-1.5 py-0.5 rounded bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700/50'
+                : 'font-mono text-slate-500 dark:text-slate-400 truncate flex-1';
               return (
                 <li key={`${target}-${idx}`} class="py-1.5 flex items-center gap-2">
                   {tKind ? <Pill variant={transitionKindVariant(tKind)} size="sm">{tKind}</Pill> : null}
                   <code class="font-mono text-slate-700 dark:text-slate-300">{target}</code>
                   {when ? (
-                    <code class="font-mono text-slate-500 dark:text-slate-400 truncate flex-1" title={when}>
+                    <code class={whenClass} title={when}>
                       {when}
                     </code>
                   ) : null}
@@ -268,8 +281,12 @@ function TransitionInspectorBody({
           the FSM library's literal transition-shape paths so the
           operator sees field names, not designer text. */}
       {predicate ? (
-        <section>
-          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+        // W22 Fix 3 site 3: predicate section gets an amber frame +
+        // header colour so it visually pops the moment the inspector
+        // opens. always / otherwise transitions skip this section
+        // entirely (they have no predicate to render).
+        <section class="rounded-md border border-amber-300 dark:border-amber-700/50 bg-amber-50/40 dark:bg-amber-900/10 p-2">
+          <h4 class="text-[11px] font-mono text-amber-700 dark:text-amber-300 mb-1 font-semibold">
             transition.when
           </h4>
           <CodeBlock
@@ -285,10 +302,15 @@ function TransitionInspectorBody({
           <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
             transition (raw)
           </h4>
+          {/* W22 Fix 2: default to the top two levels expanded for
+              the raw transition object — gives the operator a glance
+              at the shape without overwhelming them with every
+              nested predicate node. */}
           <JsonViewer
             value={transition}
             rootLabel="transition"
-            mode="inline"
+            mode="expanded"
+            defaultExpandDepth={2}
             maxInlineHeight="max-h-48"
           />
         </section>

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -224,9 +224,14 @@ function StateInspectorBody({ state, isEntry }: StateInspectorBodyProps): JSX.El
               // conditions that actually MATTER for understanding why
               // the FSM branched. always / otherwise stay slate.
               const isPredicate = tKind === 'deterministic' || tKind === 'judgement';
+              // `min-w-0` is mandatory on a `truncate` flex item: without
+              // it the item's intrinsic min-content width wins and a long
+              // predicate overflows the row instead of truncating with
+              // ellipsis. `flex-1` only gives the item room to grow, not
+              // permission to shrink below its content width.
               const whenClass = isPredicate
-                ? 'font-mono text-amber-700 dark:text-amber-300 font-semibold truncate flex-1 px-1.5 py-0.5 rounded bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700/50'
-                : 'font-mono text-slate-500 dark:text-slate-400 truncate flex-1';
+                ? 'font-mono text-amber-700 dark:text-amber-300 font-semibold truncate flex-1 min-w-0 px-1.5 py-0.5 rounded bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700/50'
+                : 'font-mono text-slate-500 dark:text-slate-400 truncate flex-1 min-w-0';
               return (
                 <li key={`${target}-${idx}`} class="py-1.5 flex items-center gap-2">
                   {tKind ? <Pill variant={transitionKindVariant(tKind)} size="sm">{tKind}</Pill> : null}

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -280,11 +280,11 @@ function TransitionInspectorBody({
       {/* Same convention as StateInspectorBody above: headings are
           the FSM library's literal transition-shape paths so the
           operator sees field names, not designer text. */}
+      {/* W22 Fix 3 site 3: predicate section gets an amber frame +
+          header colour so it visually pops the moment the inspector
+          opens. always / otherwise transitions skip this section
+          entirely (they have no predicate to render). */}
       {predicate ? (
-        // W22 Fix 3 site 3: predicate section gets an amber frame +
-        // header colour so it visually pops the moment the inspector
-        // opens. always / otherwise transitions skip this section
-        // entirely (they have no predicate to render).
         <section class="rounded-md border border-amber-300 dark:border-amber-700/50 bg-amber-50/40 dark:bg-amber-900/10 p-2">
           <h4 class="text-[11px] font-mono text-amber-700 dark:text-amber-300 mb-1 font-semibold">
             transition.when


### PR DESCRIPTION
## Summary

Five user-flagged polish fixes synthesized from workflow `wr6lcyppf`:

| # | Fix | Impact |
|---|---|---|
| 1 | Drop redundant `inline: <handler_id>` sublabel when it mirrors the state id; render `inline.purpose` or a structural summary (`N outputs · → M · ✓ verifier · post-val ×K`) instead. Canonical line preserved on `fullSublabel` for hover/inspector. | Skill-code-review cards no longer waste a row repeating themselves. |
| 2 | `worker.response_schema` + `transition (raw)` JsonViewers default-expand to depth 2 (was: fully collapsed inline / fully expanded sheet). | Operator gets the top of the tree at first paint without scrolling through every nested property. |
| 3 | Highlight `transition.when` predicate text in amber across all three surfaces: FsmEdge label, StateInspectorBody transitions list, TransitionInspectorBody section frame. `always`/`otherwise` stay slate. | Eye jumps to the conditions that actually MATTER for understanding why the FSM branched. |
| 4 | Stamp `width`/`height` on every Node so xyflow's MiniMap actually draws thumbnail rectangles (was empty after the W21 50%-bigger-nodes bump). | Mini-map shows the spec topology overview again. |
| 5 | Add `project_root` + `db_path_relative` to `ProjectMetadata` + `DoctorReport`; Settings displays `.ctxr-fsm/fsm.db` (portable, committable) instead of the absolute path. | Closes the user's `we never use absolute paths` rule. |

## Visual proof (dark mode, skill-code-review spec)

- Mini-map renders sky/violet node thumbnails (was empty)
- Predicate edges glow amber (`tier == 'trivial' AND ...`, `len(activated_leaves) == 0`); `always` badges stay slate
- Inline cards show `2 outputs · → 1 · post-val ×1`, no more redundant `inline: <handler_id>`
- State inspector schema opens at depth 2; transitions list highlights predicate amber
- Transition inspector wraps the predicate section in an amber-tinted frame
- Settings shows `DB path .ctxr-fsm/fsm.db` (emerald)

## Test plan

- [x] `npm test` in `fsm/ui/` — 338/338 pass (was 334; +4 W22 specGraph tests)
- [x] `npm run build` — 165 KB gzipped (under the W18 280 KB budget)
- [x] `uv run pytest` — 674/674 pass, no DoctorReport/ProjectMetadata constructor sites needed updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)