### PR TITLE
docs(w22b1): deterministic bootstrap detect-then-install-once + ensure --check terminator

### DIFF
--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -8,16 +8,26 @@
 **Decision tree (no improvising):**
 
 ```bash
-# Detect. Clear PACKAGE_MISSING first so a pre-set env var from the
-# parent shell can't force-install. Probe via `uv run` (without
-# --no-project so a project-installed ctxr-fsm IS picked up; the bare
-# `uv run` will fall back to a UV_PROJECT_ENVIRONMENT cache if no
-# workdir pyproject.toml exists). The `command -v` fallback catches
-# pipx / pip --user installs that don't live in a uv environment.
-unset PACKAGE_MISSING
-uv run --quiet ctxr-fsm --version 2>/dev/null \
-  || command -v ctxr-fsm >/dev/null \
-  || PACKAGE_MISSING=1
+# Detect. Clear PACKAGE_MISSING and FSM_CMD first so pre-set env vars
+# from the parent shell can't force-install or wedge the runner. Try
+# `uv run` first (project-installed ctxr-fsm wins; `uv run` honours
+# the workdir pyproject.toml when present and falls back to the
+# UV_PROJECT_ENVIRONMENT cache otherwise). On miss, fall through to
+# `command -v` (catches pipx / pip --user installs that don't live
+# in a uv environment).
+#
+# FSM_CMD captures the runner that succeeded so Step 2 invokes the
+# same one — otherwise `uv run ctxr-fsm ensure` would fail for a
+# pipx-installed package and send the caller back to Step 1
+# (risking duplicate installs, which this doc is trying to prevent).
+unset PACKAGE_MISSING FSM_CMD
+if uv run --quiet ctxr-fsm --version >/dev/null 2>&1; then
+  FSM_CMD="uv run ctxr-fsm"
+elif command -v ctxr-fsm >/dev/null 2>&1; then
+  FSM_CMD="ctxr-fsm"
+else
+  PACKAGE_MISSING=1
+fi
 ```
 
 If `PACKAGE_MISSING` is set, follow this rule **exactly once**, in this order:
@@ -41,10 +51,10 @@ If the install fails for any reason (permission, network, version pin), return `
 
 ## Step 2 — bootstrap the project (`ctxr-fsm ensure`)
 
-**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file:
+**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file. Use `$FSM_CMD` carried forward from Step 1 so a pipx-installed package isn't re-probed via `uv run` (which would fail and falsely report missing):
 
 ```bash
-uv run ctxr-fsm ensure --check --json
+$FSM_CMD ensure --check --json
 ```
 
 Routing rule (no improvising):
@@ -56,10 +66,10 @@ Routing rule (no improvising):
 | `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
 | Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
 
-When you need to apply changes (anything other than `ready`):
+When the status is `missing_*` (and ONLY then), apply the changes by re-invoking with the same runner:
 
 ```bash
-uv run ctxr-fsm ensure --json
+$FSM_CMD ensure --json
 ```
 
 This is idempotent. On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client config(s), boots the supervisor (MCP + FastAPI + UI). On a warm project it returns in <500ms confirming everything is up.
@@ -104,7 +114,7 @@ This is the path skills should default to when invoked from a Bash-driven shell 
 Skills that ship an FsmSpec must register it before `start_run`:
 
 ```bash
-uv run ctxr-fsm spec register <your.module.path:fsm>
+$FSM_CMD spec register <your.module.path:fsm>
 ```
 
 Idempotent — re-registering the same spec at the same version is a no-op. If the spec's body changed, fsm bumps `fsm_specs.version` automatically.

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -35,7 +35,7 @@ After the install command completes, re-run the version check from the top of th
 - **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
 - **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
 - **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
-- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure), using `mkdir` so the directory-create acts as the atomic lock acquisition. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir -p .ctxr-fsm/` followed by `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure). The first `mkdir -p` is idempotent and just ensures the parent directory exists (cold projects have no `.ctxr-fsm/` until `ctxr-fsm ensure` creates it); the second is the atomic lock acquisition that fails fast when another caller holds the lock. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
 
 If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 
@@ -53,7 +53,7 @@ Routing rule (no improvising):
 |---|---|
 | `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
 | `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
-| `degraded` / `failed` | Run the full `ensure` command; if it still doesn't reach `ready`, return `MissingRequirement` to the caller. |
+| `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
 | Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
 
 When you need to apply changes (anything other than `ready`):

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -64,7 +64,8 @@ Routing rule (no improvising):
 | `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
 | `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
 | `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
-| Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
+| Exit non-zero AND no JSON, AND `FSM_CMD` was just set in Step 1 (i.e. the runner responded to `--version` seconds ago) | This is a **broken install** crashing before it can emit JSON (import error, Python version mismatch, corrupt venv). Capture stderr, return `MissingRequirement` with the captured output, and STOP. Do NOT loop back to Step 1 — reinstalling will not fix a runtime crash, and on a shared workdir it will trample whatever the operator was debugging. |
+| Exit non-zero AND no JSON, AND Step 1 left `PACKAGE_MISSING=1` (the runner check itself failed) | The package isn't installed in this workdir — go back to Step 1's install table. This branch only fires when you got here in error (Step 2 should not have been attempted with `PACKAGE_MISSING` set). |
 
 When the status is `missing_*` (and ONLY then), apply the changes by re-invoking with the same runner:
 

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -3,23 +3,60 @@
 
 **Before any work in a skill that depends on `ctxr-fsm`, run this once per session.** It is idempotent and fast (<500ms) when the project is already initialised and the supervisor is running.
 
-## Step 1 — confirm the package is installed
+## Step 1 — detect the package, then install ONCE if missing
+
+**Decision tree (no improvising):**
 
 ```bash
-uv run ctxr-fsm --version  # or: pipx run ctxr-fsm --version
+# Detect. Clear PACKAGE_MISSING first so a pre-set env var from the
+# parent shell can't force-install. Probe via `uv run` (without
+# --no-project so a project-installed ctxr-fsm IS picked up; the bare
+# `uv run` will fall back to a UV_PROJECT_ENVIRONMENT cache if no
+# workdir pyproject.toml exists). The `command -v` fallback catches
+# pipx / pip --user installs that don't live in a uv environment.
+unset PACKAGE_MISSING
+uv run --quiet ctxr-fsm --version 2>/dev/null \
+  || command -v ctxr-fsm >/dev/null \
+  || PACKAGE_MISSING=1
 ```
 
-If this prints a version, skip to Step 2. If it errors with "command not found":
+If `PACKAGE_MISSING` is set, follow this rule **exactly once**, in this order:
 
-```bash
-uv add ctxr-fsm                              # in a uv project
-pipx install ctxr-fsm                        # globally, isolated
-pip install --user ctxr-fsm                  # last resort
-```
+| Workdir state | Run THIS command (and only this command) |
+|---|---|
+| `pyproject.toml` exists at workdir root | `uv add 'ctxr-fsm[all]'` |
+| No `pyproject.toml`, `pipx` on `PATH` | `pipx install 'ctxr-fsm[all]'` |
+| Neither | Return `MissingRequirement` and ASK the user (Principle 1). Do not pick a third path on your own. |
 
-Then retry the version check. If it still fails, return `MissingRequirement` and STOP — do NOT improvise.
+After the install command completes, re-run the version check from the top of this step to confirm.
+
+**Hard rules to prevent the common LLM failure modes:**
+
+- **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
+- **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
+- **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure), using `mkdir` so the directory-create acts as the atomic lock acquisition. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+
+If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 
 ## Step 2 — bootstrap the project (`ctxr-fsm ensure`)
+
+**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file:
+
+```bash
+uv run ctxr-fsm ensure --check --json
+```
+
+Routing rule (no improvising):
+
+| `--check` JSON `status` | Action |
+|---|---|
+| `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
+| `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
+| `degraded` / `failed` | Run the full `ensure` command; if it still doesn't reach `ready`, return `MissingRequirement` to the caller. |
+| Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
+
+When you need to apply changes (anything other than `ready`):
 
 ```bash
 uv run ctxr-fsm ensure --json

--- a/ctxr/fsm/memory/bootstrap.md
+++ b/ctxr/fsm/memory/bootstrap.md
@@ -7,8 +7,14 @@
 **Decision tree (no improvising):**
 
 ```bash
-# Detect. STDERR-silent so command-not-found doesn't pollute logs.
-uv run --quiet --no-project ctxr-fsm --version 2>/dev/null \
+# Detect. Clear PACKAGE_MISSING first so a pre-set env var from the
+# parent shell can't force-install. Probe via `uv run` (without
+# --no-project so a project-installed ctxr-fsm IS picked up; the bare
+# `uv run` will fall back to a UV_PROJECT_ENVIRONMENT cache if no
+# workdir pyproject.toml exists). The `command -v` fallback catches
+# pipx / pip --user installs that don't live in a uv environment.
+unset PACKAGE_MISSING
+uv run --quiet ctxr-fsm --version 2>/dev/null \
   || command -v ctxr-fsm >/dev/null \
   || PACKAGE_MISSING=1
 ```
@@ -28,7 +34,7 @@ After the install command completes, re-run the version check from the top of th
 - **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
 - **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
 - **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
-- **Concurrency:** if `.ctxr-fsm/install.lock/` exists (mkdir-based lock), another session is mid-install. Wait or back off; do not run the install command. The lock is acquired by the installer (`mkdir .ctxr-fsm/install.lock` before, `rmdir` after); on a crash the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure), using `mkdir` so the directory-create acts as the atomic lock acquisition. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
 
 If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 

--- a/ctxr/fsm/memory/bootstrap.md
+++ b/ctxr/fsm/memory/bootstrap.md
@@ -63,7 +63,8 @@ Routing rule (no improvising):
 | `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
 | `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
 | `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
-| Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
+| Exit non-zero AND no JSON, AND `FSM_CMD` was just set in Step 1 (i.e. the runner responded to `--version` seconds ago) | This is a **broken install** crashing before it can emit JSON (import error, Python version mismatch, corrupt venv). Capture stderr, return `MissingRequirement` with the captured output, and STOP. Do NOT loop back to Step 1 — reinstalling will not fix a runtime crash, and on a shared workdir it will trample whatever the operator was debugging. |
+| Exit non-zero AND no JSON, AND Step 1 left `PACKAGE_MISSING=1` (the runner check itself failed) | The package isn't installed in this workdir — go back to Step 1's install table. This branch only fires when you got here in error (Step 2 should not have been attempted with `PACKAGE_MISSING` set). |
 
 When the status is `missing_*` (and ONLY then), apply the changes by re-invoking with the same runner:
 

--- a/ctxr/fsm/memory/bootstrap.md
+++ b/ctxr/fsm/memory/bootstrap.md
@@ -34,7 +34,7 @@ After the install command completes, re-run the version check from the top of th
 - **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
 - **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
 - **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
-- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure), using `mkdir` so the directory-create acts as the atomic lock acquisition. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir -p .ctxr-fsm/` followed by `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure). The first `mkdir -p` is idempotent and just ensures the parent directory exists (cold projects have no `.ctxr-fsm/` until `ctxr-fsm ensure` creates it); the second is the atomic lock acquisition that fails fast when another caller holds the lock. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
 
 If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 
@@ -52,7 +52,7 @@ Routing rule (no improvising):
 |---|---|
 | `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
 | `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
-| `degraded` / `failed` | Run the full `ensure` command; if it still doesn't reach `ready`, return `MissingRequirement` to the caller. |
+| `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
 | Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
 
 When you need to apply changes (anything other than `ready`):

--- a/ctxr/fsm/memory/bootstrap.md
+++ b/ctxr/fsm/memory/bootstrap.md
@@ -2,23 +2,54 @@
 
 **Before any work in a skill that depends on `ctxr-fsm`, run this once per session.** It is idempotent and fast (<500ms) when the project is already initialised and the supervisor is running.
 
-## Step 1 — confirm the package is installed
+## Step 1 — detect the package, then install ONCE if missing
+
+**Decision tree (no improvising):**
 
 ```bash
-uv run ctxr-fsm --version  # or: pipx run ctxr-fsm --version
+# Detect. STDERR-silent so command-not-found doesn't pollute logs.
+uv run --quiet --no-project ctxr-fsm --version 2>/dev/null \
+  || command -v ctxr-fsm >/dev/null \
+  || PACKAGE_MISSING=1
 ```
 
-If this prints a version, skip to Step 2. If it errors with "command not found":
+If `PACKAGE_MISSING` is set, follow this rule **exactly once**, in this order:
 
-```bash
-uv add ctxr-fsm                              # in a uv project
-pipx install ctxr-fsm                        # globally, isolated
-pip install --user ctxr-fsm                  # last resort
-```
+| Workdir state | Run THIS command (and only this command) |
+|---|---|
+| `pyproject.toml` exists at workdir root | `uv add 'ctxr-fsm[all]'` |
+| No `pyproject.toml`, `pipx` on `PATH` | `pipx install 'ctxr-fsm[all]'` |
+| Neither | Return `MissingRequirement` and ASK the user (Principle 1). Do not pick a third path on your own. |
 
-Then retry the version check. If it still fails, return `MissingRequirement` and STOP — do NOT improvise.
+After the install command completes, re-run the version check from the top of this step to confirm.
+
+**Hard rules to prevent the common LLM failure modes:**
+
+- **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
+- **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
+- **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists (mkdir-based lock), another session is mid-install. Wait or back off; do not run the install command. The lock is acquired by the installer (`mkdir .ctxr-fsm/install.lock` before, `rmdir` after); on a crash the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+
+If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 
 ## Step 2 — bootstrap the project (`ctxr-fsm ensure`)
+
+**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file:
+
+```bash
+uv run ctxr-fsm ensure --check --json
+```
+
+Routing rule (no improvising):
+
+| `--check` JSON `status` | Action |
+|---|---|
+| `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
+| `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
+| `degraded` / `failed` | Run the full `ensure` command; if it still doesn't reach `ready`, return `MissingRequirement` to the caller. |
+| Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
+
+When you need to apply changes (anything other than `ready`):
 
 ```bash
 uv run ctxr-fsm ensure --json

--- a/ctxr/fsm/memory/bootstrap.md
+++ b/ctxr/fsm/memory/bootstrap.md
@@ -7,16 +7,26 @@
 **Decision tree (no improvising):**
 
 ```bash
-# Detect. Clear PACKAGE_MISSING first so a pre-set env var from the
-# parent shell can't force-install. Probe via `uv run` (without
-# --no-project so a project-installed ctxr-fsm IS picked up; the bare
-# `uv run` will fall back to a UV_PROJECT_ENVIRONMENT cache if no
-# workdir pyproject.toml exists). The `command -v` fallback catches
-# pipx / pip --user installs that don't live in a uv environment.
-unset PACKAGE_MISSING
-uv run --quiet ctxr-fsm --version 2>/dev/null \
-  || command -v ctxr-fsm >/dev/null \
-  || PACKAGE_MISSING=1
+# Detect. Clear PACKAGE_MISSING and FSM_CMD first so pre-set env vars
+# from the parent shell can't force-install or wedge the runner. Try
+# `uv run` first (project-installed ctxr-fsm wins; `uv run` honours
+# the workdir pyproject.toml when present and falls back to the
+# UV_PROJECT_ENVIRONMENT cache otherwise). On miss, fall through to
+# `command -v` (catches pipx / pip --user installs that don't live
+# in a uv environment).
+#
+# FSM_CMD captures the runner that succeeded so Step 2 invokes the
+# same one — otherwise `uv run ctxr-fsm ensure` would fail for a
+# pipx-installed package and send the caller back to Step 1
+# (risking duplicate installs, which this doc is trying to prevent).
+unset PACKAGE_MISSING FSM_CMD
+if uv run --quiet ctxr-fsm --version >/dev/null 2>&1; then
+  FSM_CMD="uv run ctxr-fsm"
+elif command -v ctxr-fsm >/dev/null 2>&1; then
+  FSM_CMD="ctxr-fsm"
+else
+  PACKAGE_MISSING=1
+fi
 ```
 
 If `PACKAGE_MISSING` is set, follow this rule **exactly once**, in this order:
@@ -40,10 +50,10 @@ If the install fails for any reason (permission, network, version pin), return `
 
 ## Step 2 — bootstrap the project (`ctxr-fsm ensure`)
 
-**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file:
+**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file. Use `$FSM_CMD` carried forward from Step 1 so a pipx-installed package isn't re-probed via `uv run` (which would fail and falsely report missing):
 
 ```bash
-uv run ctxr-fsm ensure --check --json
+$FSM_CMD ensure --check --json
 ```
 
 Routing rule (no improvising):
@@ -55,10 +65,10 @@ Routing rule (no improvising):
 | `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
 | Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
 
-When you need to apply changes (anything other than `ready`):
+When the status is `missing_*` (and ONLY then), apply the changes by re-invoking with the same runner:
 
 ```bash
-uv run ctxr-fsm ensure --json
+$FSM_CMD ensure --json
 ```
 
 This is idempotent. On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client config(s), boots the supervisor (MCP + FastAPI + UI). On a warm project it returns in <500ms confirming everything is up.
@@ -103,7 +113,7 @@ This is the path skills should default to when invoked from a Bash-driven shell 
 Skills that ship an FsmSpec must register it before `start_run`:
 
 ```bash
-uv run ctxr-fsm spec register <your.module.path:fsm>
+$FSM_CMD spec register <your.module.path:fsm>
 ```
 
 Idempotent — re-registering the same spec at the same version is a no-op. If the spec's body changed, fsm bumps `fsm_specs.version` automatically.

--- a/ctxr/fsm/memory/principles.codex.md
+++ b/ctxr/fsm/memory/principles.codex.md
@@ -52,7 +52,7 @@ After the install command completes, re-run the version check from the top of th
 - **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
 - **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
 - **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
-- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure), using `mkdir` so the directory-create acts as the atomic lock acquisition. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir -p .ctxr-fsm/` followed by `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure). The first `mkdir -p` is idempotent and just ensures the parent directory exists (cold projects have no `.ctxr-fsm/` until `ctxr-fsm ensure` creates it); the second is the atomic lock acquisition that fails fast when another caller holds the lock. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
 
 If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 
@@ -70,7 +70,7 @@ Routing rule (no improvising):
 |---|---|
 | `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
 | `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
-| `degraded` / `failed` | Run the full `ensure` command; if it still doesn't reach `ready`, return `MissingRequirement` to the caller. |
+| `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
 | Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
 
 When you need to apply changes (anything other than `ready`):

--- a/ctxr/fsm/memory/principles.codex.md
+++ b/ctxr/fsm/memory/principles.codex.md
@@ -25,16 +25,26 @@ Before any FSM-using skill or agent does ANYTHING else, follow the bootstrap pro
 **Decision tree (no improvising):**
 
 ```bash
-### Detect. Clear PACKAGE_MISSING first so a pre-set env var from the
-### parent shell can't force-install. Probe via `uv run` (without
-### --no-project so a project-installed ctxr-fsm IS picked up; the bare
-### `uv run` will fall back to a UV_PROJECT_ENVIRONMENT cache if no
-### workdir pyproject.toml exists). The `command -v` fallback catches
-### pipx / pip --user installs that don't live in a uv environment.
-unset PACKAGE_MISSING
-uv run --quiet ctxr-fsm --version 2>/dev/null \
-  || command -v ctxr-fsm >/dev/null \
-  || PACKAGE_MISSING=1
+### Detect. Clear PACKAGE_MISSING and FSM_CMD first so pre-set env vars
+### from the parent shell can't force-install or wedge the runner. Try
+### `uv run` first (project-installed ctxr-fsm wins; `uv run` honours
+### the workdir pyproject.toml when present and falls back to the
+### UV_PROJECT_ENVIRONMENT cache otherwise). On miss, fall through to
+### `command -v` (catches pipx / pip --user installs that don't live
+### in a uv environment).
+#
+### FSM_CMD captures the runner that succeeded so Step 2 invokes the
+### same one — otherwise `uv run ctxr-fsm ensure` would fail for a
+### pipx-installed package and send the caller back to Step 1
+### (risking duplicate installs, which this doc is trying to prevent).
+unset PACKAGE_MISSING FSM_CMD
+if uv run --quiet ctxr-fsm --version >/dev/null 2>&1; then
+  FSM_CMD="uv run ctxr-fsm"
+elif command -v ctxr-fsm >/dev/null 2>&1; then
+  FSM_CMD="ctxr-fsm"
+else
+  PACKAGE_MISSING=1
+fi
 ```
 
 If `PACKAGE_MISSING` is set, follow this rule **exactly once**, in this order:
@@ -58,10 +68,10 @@ If the install fails for any reason (permission, network, version pin), return `
 
 #### Step 2 — bootstrap the project (`ctxr-fsm ensure`)
 
-**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file:
+**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file. Use `$FSM_CMD` carried forward from Step 1 so a pipx-installed package isn't re-probed via `uv run` (which would fail and falsely report missing):
 
 ```bash
-uv run ctxr-fsm ensure --check --json
+$FSM_CMD ensure --check --json
 ```
 
 Routing rule (no improvising):
@@ -73,10 +83,10 @@ Routing rule (no improvising):
 | `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
 | Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
 
-When you need to apply changes (anything other than `ready`):
+When the status is `missing_*` (and ONLY then), apply the changes by re-invoking with the same runner:
 
 ```bash
-uv run ctxr-fsm ensure --json
+$FSM_CMD ensure --json
 ```
 
 This is idempotent. On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client config(s), boots the supervisor (MCP + FastAPI + UI). On a warm project it returns in <500ms confirming everything is up.
@@ -121,7 +131,7 @@ This is the path skills should default to when invoked from a Bash-driven shell 
 Skills that ship an FsmSpec must register it before `start_run`:
 
 ```bash
-uv run ctxr-fsm spec register <your.module.path:fsm>
+$FSM_CMD spec register <your.module.path:fsm>
 ```
 
 Idempotent — re-registering the same spec at the same version is a no-op. If the spec's body changed, fsm bumps `fsm_specs.version` automatically.

--- a/ctxr/fsm/memory/principles.codex.md
+++ b/ctxr/fsm/memory/principles.codex.md
@@ -20,23 +20,60 @@ Before any FSM-using skill or agent does ANYTHING else, follow the bootstrap pro
 
 **Before any work in a skill that depends on `ctxr-fsm`, run this once per session.** It is idempotent and fast (<500ms) when the project is already initialised and the supervisor is running.
 
-#### Step 1 — confirm the package is installed
+#### Step 1 — detect the package, then install ONCE if missing
+
+**Decision tree (no improvising):**
 
 ```bash
-uv run ctxr-fsm --version  # or: pipx run ctxr-fsm --version
+### Detect. Clear PACKAGE_MISSING first so a pre-set env var from the
+### parent shell can't force-install. Probe via `uv run` (without
+### --no-project so a project-installed ctxr-fsm IS picked up; the bare
+### `uv run` will fall back to a UV_PROJECT_ENVIRONMENT cache if no
+### workdir pyproject.toml exists). The `command -v` fallback catches
+### pipx / pip --user installs that don't live in a uv environment.
+unset PACKAGE_MISSING
+uv run --quiet ctxr-fsm --version 2>/dev/null \
+  || command -v ctxr-fsm >/dev/null \
+  || PACKAGE_MISSING=1
 ```
 
-If this prints a version, skip to Step 2. If it errors with "command not found":
+If `PACKAGE_MISSING` is set, follow this rule **exactly once**, in this order:
 
-```bash
-uv add ctxr-fsm                              # in a uv project
-pipx install ctxr-fsm                        # globally, isolated
-pip install --user ctxr-fsm                  # last resort
-```
+| Workdir state | Run THIS command (and only this command) |
+|---|---|
+| `pyproject.toml` exists at workdir root | `uv add 'ctxr-fsm[all]'` |
+| No `pyproject.toml`, `pipx` on `PATH` | `pipx install 'ctxr-fsm[all]'` |
+| Neither | Return `MissingRequirement` and ASK the user (Principle 1). Do not pick a third path on your own. |
 
-Then retry the version check. If it still fails, return `MissingRequirement` and STOP — do NOT improvise.
+After the install command completes, re-run the version check from the top of this step to confirm.
+
+**Hard rules to prevent the common LLM failure modes:**
+
+- **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
+- **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
+- **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure), using `mkdir` so the directory-create acts as the atomic lock acquisition. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+
+If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 
 #### Step 2 — bootstrap the project (`ctxr-fsm ensure`)
+
+**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file:
+
+```bash
+uv run ctxr-fsm ensure --check --json
+```
+
+Routing rule (no improvising):
+
+| `--check` JSON `status` | Action |
+|---|---|
+| `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
+| `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
+| `degraded` / `failed` | Run the full `ensure` command; if it still doesn't reach `ready`, return `MissingRequirement` to the caller. |
+| Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
+
+When you need to apply changes (anything other than `ready`):
 
 ```bash
 uv run ctxr-fsm ensure --json

--- a/ctxr/fsm/memory/principles.codex.md
+++ b/ctxr/fsm/memory/principles.codex.md
@@ -81,7 +81,8 @@ Routing rule (no improvising):
 | `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
 | `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
 | `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
-| Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
+| Exit non-zero AND no JSON, AND `FSM_CMD` was just set in Step 1 (i.e. the runner responded to `--version` seconds ago) | This is a **broken install** crashing before it can emit JSON (import error, Python version mismatch, corrupt venv). Capture stderr, return `MissingRequirement` with the captured output, and STOP. Do NOT loop back to Step 1 — reinstalling will not fix a runtime crash, and on a shared workdir it will trample whatever the operator was debugging. |
+| Exit non-zero AND no JSON, AND Step 1 left `PACKAGE_MISSING=1` (the runner check itself failed) | The package isn't installed in this workdir — go back to Step 1's install table. This branch only fires when you got here in error (Step 2 should not have been attempted with `PACKAGE_MISSING` set). |
 
 When the status is `missing_*` (and ONLY then), apply the changes by re-invoking with the same runner:
 

--- a/ctxr/fsm/memory/principles.cursor.md
+++ b/ctxr/fsm/memory/principles.cursor.md
@@ -25,23 +25,60 @@ Before any FSM-using skill or agent does ANYTHING else, follow the bootstrap pro
 
 **Before any work in a skill that depends on `ctxr-fsm`, run this once per session.** It is idempotent and fast (<500ms) when the project is already initialised and the supervisor is running.
 
-#### Step 1 — confirm the package is installed
+#### Step 1 — detect the package, then install ONCE if missing
+
+**Decision tree (no improvising):**
 
 ```bash
-uv run ctxr-fsm --version  # or: pipx run ctxr-fsm --version
+### Detect. Clear PACKAGE_MISSING first so a pre-set env var from the
+### parent shell can't force-install. Probe via `uv run` (without
+### --no-project so a project-installed ctxr-fsm IS picked up; the bare
+### `uv run` will fall back to a UV_PROJECT_ENVIRONMENT cache if no
+### workdir pyproject.toml exists). The `command -v` fallback catches
+### pipx / pip --user installs that don't live in a uv environment.
+unset PACKAGE_MISSING
+uv run --quiet ctxr-fsm --version 2>/dev/null \
+  || command -v ctxr-fsm >/dev/null \
+  || PACKAGE_MISSING=1
 ```
 
-If this prints a version, skip to Step 2. If it errors with "command not found":
+If `PACKAGE_MISSING` is set, follow this rule **exactly once**, in this order:
 
-```bash
-uv add ctxr-fsm                              # in a uv project
-pipx install ctxr-fsm                        # globally, isolated
-pip install --user ctxr-fsm                  # last resort
-```
+| Workdir state | Run THIS command (and only this command) |
+|---|---|
+| `pyproject.toml` exists at workdir root | `uv add 'ctxr-fsm[all]'` |
+| No `pyproject.toml`, `pipx` on `PATH` | `pipx install 'ctxr-fsm[all]'` |
+| Neither | Return `MissingRequirement` and ASK the user (Principle 1). Do not pick a third path on your own. |
 
-Then retry the version check. If it still fails, return `MissingRequirement` and STOP — do NOT improvise.
+After the install command completes, re-run the version check from the top of this step to confirm.
+
+**Hard rules to prevent the common LLM failure modes:**
+
+- **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
+- **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
+- **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure), using `mkdir` so the directory-create acts as the atomic lock acquisition. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+
+If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 
 #### Step 2 — bootstrap the project (`ctxr-fsm ensure`)
+
+**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file:
+
+```bash
+uv run ctxr-fsm ensure --check --json
+```
+
+Routing rule (no improvising):
+
+| `--check` JSON `status` | Action |
+|---|---|
+| `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
+| `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
+| `degraded` / `failed` | Run the full `ensure` command; if it still doesn't reach `ready`, return `MissingRequirement` to the caller. |
+| Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
+
+When you need to apply changes (anything other than `ready`):
 
 ```bash
 uv run ctxr-fsm ensure --json

--- a/ctxr/fsm/memory/principles.cursor.md
+++ b/ctxr/fsm/memory/principles.cursor.md
@@ -86,7 +86,8 @@ Routing rule (no improvising):
 | `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
 | `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
 | `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
-| Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
+| Exit non-zero AND no JSON, AND `FSM_CMD` was just set in Step 1 (i.e. the runner responded to `--version` seconds ago) | This is a **broken install** crashing before it can emit JSON (import error, Python version mismatch, corrupt venv). Capture stderr, return `MissingRequirement` with the captured output, and STOP. Do NOT loop back to Step 1 — reinstalling will not fix a runtime crash, and on a shared workdir it will trample whatever the operator was debugging. |
+| Exit non-zero AND no JSON, AND Step 1 left `PACKAGE_MISSING=1` (the runner check itself failed) | The package isn't installed in this workdir — go back to Step 1's install table. This branch only fires when you got here in error (Step 2 should not have been attempted with `PACKAGE_MISSING` set). |
 
 When the status is `missing_*` (and ONLY then), apply the changes by re-invoking with the same runner:
 

--- a/ctxr/fsm/memory/principles.cursor.md
+++ b/ctxr/fsm/memory/principles.cursor.md
@@ -57,7 +57,7 @@ After the install command completes, re-run the version check from the top of th
 - **Resolve "this workdir" BEFORE installing.** Walk up from `cwd` looking for `pyproject.toml`; if none, treat `cwd` as the workdir. Run the install command from that directory and nowhere else. An install in the wrong directory lands in the wrong project venv and the next session sees a "missing" package again.
 - **Do not run a second installer in a different directory.** One per workdir, ever. If the first command fails, surface the error to the user, do not silently try the next row.
 - **Do not try the three installers in sequence "just in case".** Each one targets a different install scope (project venv vs user-isolated vs system); chaining them creates multiple installs that drift and confuse the next session.
-- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure), using `mkdir` so the directory-create acts as the atomic lock acquisition. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
+- **Concurrency:** if `.ctxr-fsm/install.lock/` exists, another session is mid-install. Wait or back off; do not run the install command. **The CALLER (you, the skill or agent following this doc) wraps the install in the lock — `uv add` / `pipx install` do NOT manage it themselves.** The contract is `mkdir -p .ctxr-fsm/` followed by `mkdir .ctxr-fsm/install.lock` BEFORE the install command, `rmdir .ctxr-fsm/install.lock` AFTER (success or failure). The first `mkdir -p` is idempotent and just ensures the parent directory exists (cold projects have no `.ctxr-fsm/` until `ctxr-fsm ensure` creates it); the second is the atomic lock acquisition that fails fast when another caller holds the lock. On a crash that leaves the lock dangling, the operator unwedges with `rmdir .ctxr-fsm/install.lock`.
 
 If the install fails for any reason (permission, network, version pin), return `MissingRequirement` to the caller with the captured stderr and STOP. Do not improvise.
 
@@ -75,7 +75,7 @@ Routing rule (no improvising):
 |---|---|
 | `ready` | **DONE. Skip every other step in this file** and proceed to your skill's actual work. The project is fully bootstrapped. |
 | `missing_init` / `missing_supervisor` / `missing_mcp_config` / `missing_memory` | Run the full `ensure` command below to apply the missing axis. |
-| `degraded` / `failed` | Run the full `ensure` command; if it still doesn't reach `ready`, return `MissingRequirement` to the caller. |
+| `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
 | Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
 
 When you need to apply changes (anything other than `ready`):

--- a/ctxr/fsm/memory/principles.cursor.md
+++ b/ctxr/fsm/memory/principles.cursor.md
@@ -30,16 +30,26 @@ Before any FSM-using skill or agent does ANYTHING else, follow the bootstrap pro
 **Decision tree (no improvising):**
 
 ```bash
-### Detect. Clear PACKAGE_MISSING first so a pre-set env var from the
-### parent shell can't force-install. Probe via `uv run` (without
-### --no-project so a project-installed ctxr-fsm IS picked up; the bare
-### `uv run` will fall back to a UV_PROJECT_ENVIRONMENT cache if no
-### workdir pyproject.toml exists). The `command -v` fallback catches
-### pipx / pip --user installs that don't live in a uv environment.
-unset PACKAGE_MISSING
-uv run --quiet ctxr-fsm --version 2>/dev/null \
-  || command -v ctxr-fsm >/dev/null \
-  || PACKAGE_MISSING=1
+### Detect. Clear PACKAGE_MISSING and FSM_CMD first so pre-set env vars
+### from the parent shell can't force-install or wedge the runner. Try
+### `uv run` first (project-installed ctxr-fsm wins; `uv run` honours
+### the workdir pyproject.toml when present and falls back to the
+### UV_PROJECT_ENVIRONMENT cache otherwise). On miss, fall through to
+### `command -v` (catches pipx / pip --user installs that don't live
+### in a uv environment).
+#
+### FSM_CMD captures the runner that succeeded so Step 2 invokes the
+### same one — otherwise `uv run ctxr-fsm ensure` would fail for a
+### pipx-installed package and send the caller back to Step 1
+### (risking duplicate installs, which this doc is trying to prevent).
+unset PACKAGE_MISSING FSM_CMD
+if uv run --quiet ctxr-fsm --version >/dev/null 2>&1; then
+  FSM_CMD="uv run ctxr-fsm"
+elif command -v ctxr-fsm >/dev/null 2>&1; then
+  FSM_CMD="ctxr-fsm"
+else
+  PACKAGE_MISSING=1
+fi
 ```
 
 If `PACKAGE_MISSING` is set, follow this rule **exactly once**, in this order:
@@ -63,10 +73,10 @@ If the install fails for any reason (permission, network, version pin), return `
 
 #### Step 2 — bootstrap the project (`ctxr-fsm ensure`)
 
-**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file:
+**Probe first to short-circuit on a warm project.** `ensure --check` is the read-only probe; if it reports `ready`, you are done and MUST skip the rest of this file. Use `$FSM_CMD` carried forward from Step 1 so a pipx-installed package isn't re-probed via `uv run` (which would fail and falsely report missing):
 
 ```bash
-uv run ctxr-fsm ensure --check --json
+$FSM_CMD ensure --check --json
 ```
 
 Routing rule (no improvising):
@@ -78,10 +88,10 @@ Routing rule (no improvising):
 | `failed` | The check itself succeeded but the project is in an unrecoverable state (e.g. corrupt DB). Return `MissingRequirement` to the caller with the JSON envelope and STOP — do not re-run `ensure --json` blindly. |
 | Exit non-zero AND no JSON on stdout | The package itself isn't installed in this workdir — go back to Step 1. |
 
-When you need to apply changes (anything other than `ready`):
+When the status is `missing_*` (and ONLY then), apply the changes by re-invoking with the same runner:
 
 ```bash
-uv run ctxr-fsm ensure --json
+$FSM_CMD ensure --json
 ```
 
 This is idempotent. On a cold project it: creates `.ctxr-fsm/fsm.db`, runs migrations, installs principles into CLAUDE.md/AGENTS.md/.cursor/rules, registers `ctxr-fsm` as an MCP server in the active client config(s), boots the supervisor (MCP + FastAPI + UI). On a warm project it returns in <500ms confirming everything is up.
@@ -126,7 +136,7 @@ This is the path skills should default to when invoked from a Bash-driven shell 
 Skills that ship an FsmSpec must register it before `start_run`:
 
 ```bash
-uv run ctxr-fsm spec register <your.module.path:fsm>
+$FSM_CMD spec register <your.module.path:fsm>
 ```
 
 Idempotent — re-registering the same spec at the same version is a no-op. If the spec's body changed, fsm bumps `fsm_specs.version` automatically.

--- a/tests/integration/memory/test_install_memory_stages_bootstrap.py
+++ b/tests/integration/memory/test_install_memory_stages_bootstrap.py
@@ -53,7 +53,7 @@ _INLINE_END = "<!-- bootstrap-content-end -->"
 # demotion (the heading text itself is unchanged; only the leading
 # ``#`` count grows). Used to verify the bootstrap BODY (not just
 # the markers) landed inside the inlined block.
-_BOOTSTRAP_SUBSTRING = "Step 1 — confirm the package is installed"
+_BOOTSTRAP_SUBSTRING = "Step 1 — detect the package, then install ONCE if missing"
 
 
 @pytest.fixture

--- a/tests/unit/memory/test_adapter_inlining.py
+++ b/tests/unit/memory/test_adapter_inlining.py
@@ -170,7 +170,7 @@ def test_non_claude_adapter_inlines_bootstrap_body(
     begin_pos = rendered.index(begin_marker)
     end_pos = rendered.index(end_marker)
     inlined_block = rendered[begin_pos:end_pos]
-    assert "Step 1 — confirm the package is installed" in inlined_block, (
+    assert "Step 1 — detect the package, then install ONCE if missing" in inlined_block, (
         inlined_block
     )
 
@@ -232,7 +232,7 @@ def test_codex_adapter_demotes_step_headings_to_h4(gen_mod: object) -> None:
     """``## Step 1`` in bootstrap.md becomes ``#### Step 1`` in the codex adapter."""
 
     rendered = _render_all(gen_mod)["principles.codex.md"]
-    assert "#### Step 1 — confirm the package is installed" in rendered, rendered
+    assert "#### Step 1 — detect the package, then install ONCE if missing" in rendered, rendered
     # The original H2 form must not appear as a line-start heading.
     # We grep line-by-line rather than substring-matching because
     # ``## Step 1`` is a substring of ``#### Step 1`` and would
@@ -240,7 +240,7 @@ def test_codex_adapter_demotes_step_headings_to_h4(gen_mod: object) -> None:
     h2_step_lines = [
         line
         for line in rendered.splitlines()
-        if line.startswith("## Step 1 — confirm the package is installed")
+        if line.startswith("## Step 1 — detect the package, then install ONCE if missing")
     ]
     assert h2_step_lines == [], h2_step_lines
 


### PR DESCRIPTION
## Summary

Workflow `wj910jlf0` Phase 1 (smallest, no blockers): collapse the
LLM's bootstrap decision tree to a single deterministic path so the
common failure modes (re-installing in the wrong directory, chaining
three installers, running a full \`ensure\` on a warm project) stop
happening.

Two coordinated changes, one per repo:

| Repo | Change |
|---|---|
| **fsm** (this PR) | \`bootstrap.md\` Step 1 rewritten as a decision table + hard rules + concurrency lock; Step 2 gains an \`ensure --check\` terminator at the top. |
| **skill-code-review** (companion PR) | \`SKILL.md\` enforces the precondition gate before deferring to \`bootstrap.md\` for detail. |

## What the LLM does now

```bash
uv run ctxr-fsm ensure --check --json
```

| JSON \`status\` | Action |
|---|---|
| \`ready\` | DONE. Skip every other step in bootstrap.md. |
| \`missing_*\` | Run \`ensure --json\` once to repair. |
| \`failed\` | Return \`MissingRequirement\` to caller. |
| exit ≠ 0, no JSON | Package not on PATH → Step 1's decision table. |

Step 1's decision table is now:

| Workdir state | Run THIS (and only this) |
|---|---|
| \`pyproject.toml\` at workdir root | \`uv add 'ctxr-fsm[all]'\` |
| no \`pyproject.toml\`, \`pipx\` on PATH | \`pipx install 'ctxr-fsm[all]'\` |
| neither | \`MissingRequirement\` + ASK the user |

Plus hard rules to prevent the obvious failure modes: resolve workdir
via pyproject.toml walk-up **before** installing; install in that
directory only; never chain installers; mkdir-based
\`.ctxr-fsm/install.lock\` so two concurrent skills can't race
\`uv add\`.

## Test plan

- [x] \`bootstrap.md\` content reviewed against the workflow's design
- [x] \`SKILL.md\` companion change committed locally; will push as a
      sibling PR after this one lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)