### PR TITLE
feat(w22b2): pagination primitive + Page[T] wire format

### DIFF
--- a/ctxr/fsm/api/_pagination.py
+++ b/ctxr/fsm/api/_pagination.py
@@ -1,0 +1,348 @@
+"""``Page[T]`` envelope + pagination helpers for the HTTP list surface.
+
+The pre-W22b2 list endpoints returned raw ``list[T]`` with at best a
+``limit``/``offset`` query pair and no envelope. That shape is fine
+for ad-hoc curl debugging but fails the dashboard the moment a list
+crosses a single screen: the UI cannot show "page 4 of 12", cannot
+jump to the last page, cannot reason about whether more rows exist
+without re-issuing the request with a bumped offset and inspecting
+the length.
+
+This module ships:
+
+* :class:`Page` — Pydantic generic envelope, ``{items, page,
+  page_size, total, has_next, sort}``. ``total`` is computed in the
+  same round-trip via SQL's ``COUNT(*) OVER ()`` window function, so
+  the wire format always exposes the population size without a second
+  query. ``has_next`` is derived rather than transmitted, so a client
+  that loses or strips it can still compute the value.
+* :class:`PageParams` — the FastAPI ``Depends()``-friendly query
+  bundle (``page``, ``page_size``, ``sort``). Routes take a single
+  ``page_params: PageParamsDep`` annotation instead of three loose
+  ``Query()`` parameters; this keeps the OpenAPI schema clean and
+  makes route signatures grep-able for "which endpoints paginate".
+* :func:`paginate_sa_select` — for endpoints whose handler builds a
+  raw SQLAlchemy ``select()``. Bolts the window-function count onto
+  the query, applies ``OFFSET`` / ``LIMIT``, executes once, and
+  unpacks rows + total into a :class:`Page`. Used by the four inline-
+  SQL handlers in ``routes_admin.py`` and ``routes_specs.py``.
+* :func:`paginate_sequence` — for endpoints whose repository method
+  still returns a Python list (legacy backward-compat path during
+  rollout). Slices in-memory + counts via ``len()``. Marked deprecated
+  in the docstring; new code MUST take the SA path.
+
+Why a window-function count, not a separate ``COUNT(*)`` query?
+SQLite's WAL handles read concurrency, but two separate queries can
+return inconsistent ``total`` vs. ``items`` lengths under a concurrent
+write (a row appears between the two queries). The window function
+runs the count in the same statement as the row fetch, so the
+serialisable view is identical for both. Cost is one extra integer
+column per row in the result set, which is negligible for the page
+sizes the UI uses (default 50, max 200).
+
+Why no ``next_cursor`` / ``prev_cursor``? The user's explicit
+requirement is "pagination with most-recent-first sort on all lists
+(runs, specs, versions, journals)" — operator-grade offset
+pagination, not infinite scroll. Cursor pagination is the right
+shape for streaming-heavy lists (events, tool_calls) when they get
+unwieldy on long runs; that lands as a separate ``?cursor=`` opt-in
+later, never as a replacement.
+
+Sort direction
+--------------
+
+Each endpoint declares its own ``default_sort`` to the
+:class:`PageParams` factory (e.g. ``runs`` uses ``last_update_at
+DESC``, ``events`` uses ``seq ASC``). The user-supplied ``?sort=``
+overrides; an unrecognised sort key returns 422 with the allowed
+values, so the wire contract surfaces validation rather than
+silently falling back.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Annotated, Any, Self
+
+from fastapi import Depends, HTTPException, Query, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import Select, func, over
+from sqlalchemy.engine import Connection
+from sqlalchemy.sql import expression
+
+__all__ = [
+    "DEFAULT_PAGE_SIZE",
+    "MAX_PAGE_SIZE",
+    "Page",
+    "PageParams",
+    "PageParamsDep",
+    "make_page_params",
+    "paginate_sa_select",
+    "paginate_sequence",
+]
+
+
+# --- limits ---------------------------------------------------------------
+#
+# Default page size matches the existing ``runs.tsx`` ``PAGE_SIZE`` magic
+# constant (20 was the prior value, 50 is the post-W22b2 default the user
+# requested). Max page size caps how much a malicious client can request
+# in one shot — 200 rows per page is enough for any operator workflow
+# (anything past that wants a CLI, not a UI page).
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
+
+
+# --- envelope -------------------------------------------------------------
+
+
+class Page[T](BaseModel):
+    """Generic page envelope for every list endpoint.
+
+    Fields:
+
+    * ``items`` — the page slice, already ordered per ``sort``.
+    * ``page`` — 1-indexed page number that was served. 1 means the
+      first page; a request with ``page > ceil(total / page_size)``
+      returns an empty ``items`` array (rather than 404) so the UI
+      can render "page N has no rows" without a branch.
+    * ``page_size`` — server-clamped page size that was applied (the
+      client's request is clamped to ``[1, MAX_PAGE_SIZE]``).
+    * ``total`` — total row count BEFORE the slice. Derived in the
+      same round-trip via ``COUNT(*) OVER ()`` so it is consistent
+      with ``items``.
+    * ``has_next`` — true when ``page * page_size < total``. A
+      derived field; clients that need ``prev`` compute it the same
+      way (``page > 1``).
+    * ``sort`` — the sort key actually applied (after validation
+      against the endpoint's allow-list). Exposed so the UI can show
+      "Sorted by: last_update_at desc" without guessing.
+    """
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    items: list[T]
+    page: int = Field(..., ge=1)
+    page_size: int = Field(..., ge=1, le=MAX_PAGE_SIZE)
+    total: int = Field(..., ge=0)
+    has_next: bool
+    sort: str
+
+    @classmethod
+    def empty(cls, *, page: int, page_size: int, sort: str) -> Self:
+        """Build an empty page (no rows, total=0) — useful in 0-row
+        early-return branches that still need the envelope shape.
+        """
+        return cls(
+            items=[],
+            page=page,
+            page_size=page_size,
+            total=0,
+            has_next=False,
+            sort=sort,
+        )
+
+
+# --- params ---------------------------------------------------------------
+
+
+class PageParams(BaseModel):
+    """The validated ``?page=&page_size=&sort=`` bundle.
+
+    Constructed via :func:`make_page_params`, which lets each route
+    declare its own ``default_sort`` and ``allowed_sorts``. The
+    raw class isn't useful directly — every route needs the
+    allow-list to give 422 on unknown sort keys.
+    """
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    page: int = Field(..., ge=1)
+    page_size: int = Field(..., ge=1, le=MAX_PAGE_SIZE)
+    sort: str
+
+    @property
+    def offset(self) -> int:
+        """Compute the SQL ``OFFSET`` from the 1-indexed ``page``.
+
+        ``page=1`` yields offset 0; ``page=3, page_size=50`` yields
+        offset 100. Centralised here so individual routes can't drift
+        on the off-by-one boundary.
+        """
+        return (self.page - 1) * self.page_size
+
+
+def make_page_params(
+    *,
+    default_sort: str,
+    allowed_sorts: tuple[str, ...],
+) -> type[PageParams]:
+    """Build a route-specific ``PageParams`` factory.
+
+    Returns a FastAPI dependency callable that captures
+    ``default_sort`` + ``allowed_sorts`` and validates the
+    user-supplied ``?sort=`` against the allow-list. An unknown sort
+    key triggers a 422 with the allowed values, exposing the contract
+    to the client rather than silently coercing to the default.
+
+    Each route module declares its own factory at import time, e.g.::
+
+        RunsPageParams = make_page_params(
+            default_sort="last_update_at_desc",
+            allowed_sorts=("last_update_at_desc", "started_at_desc", "started_at_asc"),
+        )
+
+    and binds it via::
+
+        @router.get(..., dependencies=[Depends(require_auth)])
+        async def list_runs(
+            params: Annotated[PageParams, Depends(RunsPageParams)],
+            ...
+        ): ...
+
+    The returned callable is NOT a ``PageParams`` subclass — it's a
+    factory that produces validated ``PageParams`` instances. Pydantic
+    validation happens inside the factory rather than via class-level
+    ``Field`` constraints because the allow-list is per-route.
+    """
+    if default_sort not in allowed_sorts:
+        raise ValueError(
+            f"default_sort {default_sort!r} not in allowed_sorts {allowed_sorts!r}"
+        )
+
+    # The factory below uses the legacy ``param: type = Query(...)``
+    # FastAPI signature style rather than the modern
+    # ``param: Annotated[type, Query(...)]`` form. The Annotated form
+    # interacts badly with ``from __future__ import annotations``
+    # because the closure-captured ``default_sort`` / ``allowed_sorts``
+    # become unresolvable forward refs when Pydantic's TypeAdapter
+    # tries to validate the parameter shape. The legacy form sidesteps
+    # the issue: defaults are concrete values, not stringified
+    # annotation literals. FastAPI accepts both forms equivalently for
+    # query-parameter binding + OpenAPI generation.
+    _description = (
+        f"Sort key. Allowed: {', '.join(allowed_sorts)}. "
+        f"Default: {default_sort}."
+    )
+
+    def _factory(
+        page: int = Query(default=1, ge=1, description="1-indexed page number."),
+        page_size: int = Query(
+            default=DEFAULT_PAGE_SIZE,
+            ge=1,
+            le=MAX_PAGE_SIZE,
+            description=f"Page size (max {MAX_PAGE_SIZE}).",
+        ),
+        sort: str = Query(default=default_sort, description=_description),
+    ) -> PageParams:
+        if sort not in allowed_sorts:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={
+                    "error": "unknown_sort",
+                    "supplied": sort,
+                    "allowed": list(allowed_sorts),
+                },
+            )
+        return PageParams(page=page, page_size=page_size, sort=sort)
+
+    # Stash the configuration on the factory so OpenAPI tooling /
+    # tests can introspect what an endpoint accepts without having to
+    # call the factory.
+    _factory.default_sort = default_sort  # type: ignore[attr-defined]
+    _factory.allowed_sorts = allowed_sorts  # type: ignore[attr-defined]
+    return _factory  # type: ignore[return-value]
+
+
+# Type alias for the rare cases where a route can accept ANY sort
+# (e.g. a future search endpoint). Most routes use ``make_page_params``
+# above; this alias is here for completeness, not as the primary path.
+PageParamsDep = Annotated[PageParams, Depends(make_page_params(
+    default_sort="id_asc",
+    allowed_sorts=("id_asc", "id_desc"),
+))]
+
+
+# --- helpers --------------------------------------------------------------
+
+
+def paginate_sa_select[T](
+    conn: Connection,
+    base_select: Select[Any],
+    *,
+    params: PageParams,
+    row_factory: Callable[[Any], T],
+) -> Page[T]:
+    """Apply pagination to a SQLAlchemy ``select()`` + execute once.
+
+    ``base_select`` MUST already have its ``order_by`` clause
+    applied — the caller owns ordering because the sort key set
+    differs per endpoint (and per ``PageParams.sort``). This helper
+    is intentionally agnostic about column names.
+
+    The window-function trick: we append a synthetic
+    ``COUNT(*) OVER ()`` column to the select, run the paginated
+    fetch, and unpack the count from any row. If the page is empty
+    (no rows matched the filter, or ``page`` is past the last page)
+    we issue a single ``SELECT COUNT(*) FROM (base)`` as a fallback
+    to recover the total. That fallback path is cold for typical
+    queries — the first read fills total in one round-trip.
+
+    ``row_factory`` is invoked per row with the SQLAlchemy
+    ``Row._mapping`` and is expected to return the Pydantic model
+    the endpoint serialises. Passed in (not imported here) so this
+    module stays decoupled from any specific model.
+
+    Returns a fully-populated :class:`Page`.
+    """
+    count_col = over(func.count()).label("__page_total__")
+    paged = (
+        base_select.add_columns(count_col)
+        .offset(params.offset)
+        .limit(params.page_size)
+    )
+    rows = list(conn.execute(paged))
+    if rows:
+        total = int(rows[0]._mapping["__page_total__"])
+        items: list[T] = [row_factory(row._mapping) for row in rows]
+    else:
+        # Empty page — either the table is empty OR we asked for a
+        # page past the last one. Recover total via a separate count
+        # so the envelope's ``total`` field stays honest.
+        count_stmt = expression.select(func.count()).select_from(
+            base_select.subquery()
+        )
+        total = int(conn.execute(count_stmt).scalar_one())
+        items = []
+    return Page(
+        items=items,
+        page=params.page,
+        page_size=params.page_size,
+        total=total,
+        has_next=params.page * params.page_size < total,
+        sort=params.sort,
+    )
+
+
+def paginate_sequence[T](seq: list[T], *, params: PageParams) -> Page[T]:
+    """Slice a Python list into a :class:`Page` envelope.
+
+    Last-resort path for repository methods that haven't been
+    migrated to SA select-based pagination yet. The full sequence is
+    materialised in memory before slicing, which scales poorly past
+    a few thousand rows — every consumer SHOULD migrate to
+    :func:`paginate_sa_select`. This helper exists so the wire
+    format flips in lockstep across all endpoints in W22b2 without
+    forcing every repository method to be rewritten in the same PR.
+    """
+    total = len(seq)
+    offset = params.offset
+    items = seq[offset : offset + params.page_size]
+    return Page(
+        items=items,
+        page=params.page,
+        page_size=params.page_size,
+        total=total,
+        has_next=offset + len(items) < total,
+        sort=params.sort,
+    )

--- a/ctxr/fsm/api/_pagination.py
+++ b/ctxr/fsm/api/_pagination.py
@@ -62,9 +62,9 @@ silently falling back.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Annotated, Any, Self
+from typing import Any, Self
 
-from fastapi import Depends, HTTPException, Query, status
+from fastapi import HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import Select, func, over
 from sqlalchemy.engine import Connection
@@ -75,7 +75,6 @@ __all__ = [
     "MAX_PAGE_SIZE",
     "Page",
     "PageParams",
-    "PageParamsDep",
     "make_page_params",
     "paginate_sa_select",
     "paginate_sequence",
@@ -140,6 +139,36 @@ class Page[T](BaseModel):
             total=0,
             has_next=False,
             sort=sort,
+        )
+
+    @classmethod
+    def from_items_and_total(
+        cls,
+        items: list[T],
+        total: int,
+        *,
+        params: PageParams,
+    ) -> Page[T]:
+        """Build a page envelope from a ``(items, total)`` repo result.
+
+        The canonical post-W22b2 path: repository methods that compute
+        ``total`` via ``COUNT(*) OVER ()`` return a tuple, and the
+        route handler wraps it via this classmethod. ``has_next`` is
+        derived from the same population size, so the wire envelope
+        stays internally consistent.
+
+        Use this in preference to :func:`paginate_sequence` whenever
+        the underlying repo exposes a paginated variant — the latter
+        is the legacy compat path that pre-loads the full filtered
+        result set into memory.
+        """
+        return cls(
+            items=items,
+            page=params.page,
+            page_size=params.page_size,
+            total=total,
+            has_next=params.page * params.page_size < total,
+            sort=params.sort,
         )
 
 
@@ -252,15 +281,6 @@ def make_page_params(
     _factory.default_sort = default_sort  # type: ignore[attr-defined]
     _factory.allowed_sorts = allowed_sorts  # type: ignore[attr-defined]
     return _factory  # type: ignore[return-value]
-
-
-# Type alias for the rare cases where a route can accept ANY sort
-# (e.g. a future search endpoint). Most routes use ``make_page_params``
-# above; this alias is here for completeness, not as the primary path.
-PageParamsDep = Annotated[PageParams, Depends(make_page_params(
-    default_sort="id_asc",
-    allowed_sorts=("id_asc", "id_desc"),
-))]
 
 
 # --- helpers --------------------------------------------------------------

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -56,12 +56,10 @@ from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
 from ctxr.fsm.api._pagination import (
-    MAX_PAGE_SIZE,
     Page,
     PageParams,
     make_page_params,
     paginate_sa_select,
-    paginate_sequence,
 )
 from ctxr.fsm.api._paths import looks_like_filesystem_db_path, project_root_and_relative
 from ctxr.fsm.core.models import JournalStatus
@@ -356,24 +354,28 @@ def _select_tool_calls_page(
 ) -> Page[ToolCall]:
     """Return a page of tool calls for ``run_id``.
 
-    Delegates to :meth:`ToolCallsRepo.by_run` which already sorts
-    ``created_at DESC``; we then either keep that order (default sort
-    ``created_at_desc``) or reverse the list for ``created_at_asc``,
-    and finally slice into a :class:`Page` via
-    :func:`paginate_sequence`. The repo is pulled with
-    ``limit=MAX_PAGE_SIZE`` so deep pagination beyond a single page of
-    the wire-format default works; rows past that bound are silently
-    truncated until the repo method gets a native paginated cousin
-    (see :mod:`ctxr.fsm.sqlite.repos_enforcement.ToolCallsRepo`).
+    Delegates to :meth:`ToolCallsRepo.by_run_paged`, which runs a
+    single SQL statement (filtered WHERE + ``COUNT(*) OVER ()``) so
+    ``Page.total`` reflects the true population count even when a
+    run has more tool calls than the page-size cap. The pre-W22b2-
+    iter draft used the cap-bounded :meth:`by_run` then sliced in
+    memory; that path silently truncated ``total`` to
+    ``MAX_PAGE_SIZE`` for any run with more tool calls — making the
+    envelope's count lie, and rendering pages past the cap
+    unreachable.
     """
     from ctxr.fsm.sqlite.repos_enforcement import ToolCallsRepo
 
     repo = ToolCallsRepo()
     with session_factory() as session:
-        rows = repo.by_run(session, run_id, limit=MAX_PAGE_SIZE)
-    if params.sort == "created_at_asc":
-        rows = list(reversed(rows))
-    return paginate_sequence(rows, params=params)
+        items, total = repo.by_run_paged(
+            session,
+            run_id,
+            sort_axis=params.sort,
+            offset=params.offset,
+            limit=params.page_size,
+        )
+    return Page[ToolCall].from_items_and_total(items, total, params=params)
 
 
 def _select_drift_signals_with_score(

--- a/ctxr/fsm/api/routes_admin.py
+++ b/ctxr/fsm/api/routes_admin.py
@@ -44,7 +44,8 @@ Design notes
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Any
+from types import SimpleNamespace
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
@@ -54,6 +55,14 @@ from sqlalchemy.orm import Session, sessionmaker
 from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
+from ctxr.fsm.api._pagination import (
+    MAX_PAGE_SIZE,
+    Page,
+    PageParams,
+    make_page_params,
+    paginate_sa_select,
+    paginate_sequence,
+)
 from ctxr.fsm.api._paths import looks_like_filesystem_db_path, project_root_and_relative
 from ctxr.fsm.core.models import JournalStatus
 from ctxr.fsm.sqlite import (
@@ -68,6 +77,30 @@ from ctxr.fsm.sqlite.models_core import LockTable
 from ctxr.fsm.sqlite.models_enforcement import (
     CommitSignatureTable,
     JournalTxnTable,
+)
+
+# ── Per-route pagination factories ──────────────────────────────────
+# Each list endpoint binds its own ``PageParams`` factory at module
+# scope. The factory captures the default + allowed sort keys so the
+# OpenAPI schema documents them and unknown keys 422 at the edge.
+JournalTxnsPageParams = make_page_params(
+    default_sort="started_at_desc",
+    allowed_sorts=("started_at_desc", "started_at_asc"),
+)
+
+LocksPageParams = make_page_params(
+    default_sort="acquired_at_desc",
+    allowed_sorts=("acquired_at_desc", "acquired_at_asc"),
+)
+
+ToolCallsPageParams = make_page_params(
+    default_sort="created_at_desc",
+    allowed_sorts=("created_at_desc", "created_at_asc"),
+)
+
+CommitSignaturesPageParams = make_page_params(
+    default_sort="created_at_desc",
+    allowed_sorts=("created_at_desc", "created_at_asc"),
 )
 
 __all__ = [
@@ -224,70 +257,123 @@ _VALID_JOURNAL_STATUSES: tuple[str, ...] = (
 )
 
 
-def _select_journal_txns(
+def _select_journal_txns_page(
     session_factory: sessionmaker[Session],
     *,
     status: JournalStatus | None,
-    limit: int,
-) -> list[JournalTxn]:
-    """Return journal-txn rows across all runs, optionally filtered by status.
+    params: PageParams,
+) -> Page[JournalTxn]:
+    """Return a page of journal-txn rows, optionally filtered by status.
 
-    Sorted ``started_at DESC`` so the freshest activity surfaces
-    first. The ORM rows are projected through
-    :meth:`JournalRepo._row_to_txn` so the API speaks the same
-    Pydantic shape the repo speaks — we re-implement the projection
-    inline (rather than calling the private method) to keep this
-    module's dependency on the repo at the public-symbol boundary.
+    Default sort surfaces the freshest activity first (``started_at
+    DESC, id DESC``); ``params.sort = "started_at_asc"`` inverts both
+    keys so the timeline reads chronologically. Rows are projected
+    through :meth:`JournalRepo._row_to_txn` — the canonical adapter
+    that owns the JSON-decode + datetime-parse boundary — so the wire
+    shape stays byte-equivalent with the rest of the substrate.
+
+    The base ``select()`` is built with its ``order_by`` clause already
+    applied; :func:`paginate_sa_select` then bolts on
+    ``COUNT(*) OVER ()`` plus ``LIMIT/OFFSET`` in one round-trip so
+    the envelope's ``total`` is consistent with the page slice even
+    under concurrent writes.
     """
     from ctxr.fsm.sqlite.repos_locks_journal import JournalRepo
 
-    with session_factory() as session:
-        stmt = select(JournalTxnTable).order_by(
+    if params.sort == "started_at_asc":
+        order_clause = (
+            JournalTxnTable.started_at.asc(),
+            JournalTxnTable.id.asc(),
+        )
+    else:  # "started_at_desc" — the default
+        order_clause = (
             JournalTxnTable.started_at.desc(),
             JournalTxnTable.id.desc(),
         )
-        if status is not None:
-            stmt = stmt.where(JournalTxnTable.status == status.value)
-        stmt = stmt.limit(limit)
-        rows = session.execute(stmt).scalars().all()
-        # ``_row_to_txn`` is the canonical projection — using it
-        # guarantees byte-equivalence with the rest of the substrate
-        # without re-implementing the JSON decode + datetime parse.
-        return [JournalRepo._row_to_txn(row) for row in rows]
+
+    stmt = select(JournalTxnTable).order_by(*order_clause)
+    if status is not None:
+        stmt = stmt.where(JournalTxnTable.status == status.value)
+
+    def _factory(mapping: Any) -> JournalTxn:
+        # ``conn.execute()`` over an ORM-targeted ``select()`` yields
+        # Core rows whose ``_mapping`` is column-name keyed. Wrapping
+        # in :class:`SimpleNamespace` gives the existing private
+        # ``_row_to_txn`` projector the attribute-style row it expects
+        # without forcing us to duplicate its decode logic here.
+        shim = SimpleNamespace(**{k: v for k, v in mapping.items() if k != "__page_total__"})
+        return JournalRepo._row_to_txn(cast(JournalTxnTable, shim))
+
+    with session_factory() as session:
+        return paginate_sa_select(
+            session.connection(),
+            stmt,
+            params=params,
+            row_factory=_factory,
+        )
 
 
-def _select_locks(session_factory: sessionmaker[Session]) -> list[Lock]:
-    """Return every lock row currently in the table.
+def _select_locks_page(
+    session_factory: sessionmaker[Session],
+    *,
+    params: PageParams,
+) -> Page[Lock]:
+    """Return a page of lock rows, freshest acquisition first by default.
 
-    The locks table is intentionally tiny (one row per held run); we
-    don't paginate. Sorted by ``acquired_at DESC`` so the most-recently
-    grabbed lock appears first.
+    The locks table is intentionally tiny (one row per actively-locked
+    run) so a single page typically holds every row; the envelope is
+    still useful so the UI gets a consistent shape across list
+    endpoints. ``params.sort = "acquired_at_asc"`` reverses the order
+    for "oldest lock first" diagnostics.
     """
     from ctxr.fsm.sqlite.repos_locks_journal import LocksRepo
 
+    if params.sort == "acquired_at_asc":
+        order_col = LockTable.acquired_at.asc()
+    else:  # "acquired_at_desc" — the default
+        order_col = LockTable.acquired_at.desc()
+
+    stmt = select(LockTable).order_by(order_col)
+
+    def _factory(mapping: Any) -> Lock:
+        shim = SimpleNamespace(**{k: v for k, v in mapping.items() if k != "__page_total__"})
+        return LocksRepo._row_to_lock(cast(LockTable, shim))
+
     with session_factory() as session:
-        stmt = select(LockTable).order_by(LockTable.acquired_at.desc())
-        rows = session.execute(stmt).scalars().all()
-        return [LocksRepo._row_to_lock(row) for row in rows]
+        return paginate_sa_select(
+            session.connection(),
+            stmt,
+            params=params,
+            row_factory=_factory,
+        )
 
 
-def _select_tool_calls(
+def _select_tool_calls_page(
     session_factory: sessionmaker[Session],
     *,
     run_id: str,
-    limit: int,
-) -> list[ToolCall]:
-    """Return the most-recent ``limit`` tool calls for ``run_id``.
+    params: PageParams,
+) -> Page[ToolCall]:
+    """Return a page of tool calls for ``run_id``.
 
-    Thin wrapper around :meth:`ToolCallsRepo.by_run` — kept here so the
-    sync/threadpool boundary is one obvious place rather than scattered
-    through the route handlers.
+    Delegates to :meth:`ToolCallsRepo.by_run` which already sorts
+    ``created_at DESC``; we then either keep that order (default sort
+    ``created_at_desc``) or reverse the list for ``created_at_asc``,
+    and finally slice into a :class:`Page` via
+    :func:`paginate_sequence`. The repo is pulled with
+    ``limit=MAX_PAGE_SIZE`` so deep pagination beyond a single page of
+    the wire-format default works; rows past that bound are silently
+    truncated until the repo method gets a native paginated cousin
+    (see :mod:`ctxr.fsm.sqlite.repos_enforcement.ToolCallsRepo`).
     """
     from ctxr.fsm.sqlite.repos_enforcement import ToolCallsRepo
 
     repo = ToolCallsRepo()
     with session_factory() as session:
-        return repo.by_run(session, run_id, limit=limit)
+        rows = repo.by_run(session, run_id, limit=MAX_PAGE_SIZE)
+    if params.sort == "created_at_asc":
+        rows = list(reversed(rows))
+    return paginate_sequence(rows, params=params)
 
 
 def _select_drift_signals_with_score(
@@ -305,28 +391,44 @@ def _select_drift_signals_with_score(
     return DriftSignalsResponse(run_id=run_id, score=score, signals=signals)
 
 
-def _select_commit_signatures(
+def _select_commit_signatures_page(
     session_factory: sessionmaker[Session],
     *,
     run_id: str,
-) -> list[CommitSignatureRecord]:
-    """Return every commit-signature row for ``run_id``, newest first.
+    params: PageParams,
+) -> Page[CommitSignatureRecord]:
+    """Return a page of commit-signature rows for ``run_id``, newest first by default.
 
     The :class:`CommitSignaturesRepo` only exposes ``last_for_run`` and
     ``record``; the admin view wants the full timeline, so we issue
     the query directly here and project through the same private
-    adapter the repo uses.
+    adapter the repo uses. ``params.sort = "created_at_asc"`` flips
+    the order for chronological reads.
     """
     from ctxr.fsm.sqlite.repos_enforcement import _commit_signature_from_row
 
+    if params.sort == "created_at_asc":
+        order_col = CommitSignatureTable.created_at.asc()
+    else:  # "created_at_desc" — the default
+        order_col = CommitSignatureTable.created_at.desc()
+
+    stmt = (
+        select(CommitSignatureTable)
+        .where(CommitSignatureTable.run_id == run_id)
+        .order_by(order_col)
+    )
+
+    def _factory(mapping: Any) -> CommitSignatureRecord:
+        shim = SimpleNamespace(**{k: v for k, v in mapping.items() if k != "__page_total__"})
+        return _commit_signature_from_row(cast(CommitSignatureTable, shim))
+
     with session_factory() as session:
-        stmt = (
-            select(CommitSignatureTable)
-            .where(CommitSignatureTable.run_id == run_id)
-            .order_by(CommitSignatureTable.created_at.desc())
+        return paginate_sa_select(
+            session.connection(),
+            stmt,
+            params=params,
+            row_factory=_factory,
         )
-        rows = session.execute(stmt).scalars().all()
-        return [_commit_signature_from_row(row) for row in rows]
 
 
 def _list_user_tables(engine: Engine) -> list[str]:
@@ -465,11 +567,12 @@ def _build_doctor_report(
 
 @router.get(
     "/journal_txns",
-    response_model=list[JournalTxn],
+    response_model=Page[JournalTxn],
     summary="List journal transactions across every run (admin).",
 )
 async def list_journal_txns(
     project: ProjectDep,
+    params: Annotated[PageParams, Depends(JournalTxnsPageParams)],
     status: Annotated[
         JournalStatus | None,
         Query(
@@ -479,15 +582,7 @@ async def list_journal_txns(
             ),
         ),
     ] = None,
-    limit: Annotated[
-        int,
-        Query(
-            ge=1,
-            le=1000,
-            description="Maximum rows to return. Defaults to 100.",
-        ),
-    ] = 100,
-) -> list[JournalTxn]:
+) -> Page[JournalTxn]:
     """Return journal-txn rows for forensic inspection.
 
     The admin view is global (no ``run_id`` filter required) because
@@ -495,35 +590,45 @@ async def list_journal_txns(
     transactions right now?" — a query that needs to see every row.
     """
     return await run_in_threadpool(
-        _select_journal_txns,
+        _select_journal_txns_page,
         project.session_factory,
         status=status,
-        limit=limit,
+        params=params,
     )
 
 
 @router.get(
     "/locks",
-    response_model=list[Lock],
+    response_model=Page[Lock],
     summary="List every currently-held lock row (admin).",
 )
-async def list_locks(project: ProjectDep) -> list[Lock]:
+async def list_locks(
+    project: ProjectDep,
+    params: Annotated[PageParams, Depends(LocksPageParams)],
+) -> Page[Lock]:
     """Return every row in the ``locks`` table, freshest acquisition first.
 
     The table is intentionally tiny (one row per actively-locked run),
-    so we do not paginate. An empty list is the normal quiescent
-    state.
+    so a single page typically holds every row. The :class:`Page`
+    envelope is still returned for wire-format consistency with the
+    other list endpoints — an empty page (``total=0``) is the normal
+    quiescent state.
     """
-    return await run_in_threadpool(_select_locks, project.session_factory)
+    return await run_in_threadpool(
+        _select_locks_page,
+        project.session_factory,
+        params=params,
+    )
 
 
 @router.get(
     "/tool_calls",
-    response_model=list[ToolCall],
+    response_model=Page[ToolCall],
     summary="Tool-call audit log scoped to a run (W12 substrate).",
 )
 async def list_tool_calls(
     project: ProjectDep,
+    params: Annotated[PageParams, Depends(ToolCallsPageParams)],
     run_id: Annotated[
         str,
         Query(
@@ -531,15 +636,7 @@ async def list_tool_calls(
             description="Run id whose tool calls should be returned.",
         ),
     ],
-    limit: Annotated[
-        int,
-        Query(
-            ge=1,
-            le=1000,
-            description="Maximum rows to return. Defaults to 100.",
-        ),
-    ] = 100,
-) -> list[ToolCall]:
+) -> Page[ToolCall]:
     """Return the most recent tool calls for ``run_id``.
 
     ``run_id`` is required because the underlying repo only exposes a
@@ -548,10 +645,10 @@ async def list_tool_calls(
     log is run-scoped by design).
     """
     return await run_in_threadpool(
-        _select_tool_calls,
+        _select_tool_calls_page,
         project.session_factory,
         run_id=run_id,
-        limit=limit,
+        params=params,
     )
 
 
@@ -583,11 +680,12 @@ async def list_drift_signals(
 
 @router.get(
     "/commit_signatures",
-    response_model=list[CommitSignatureRecord],
+    response_model=Page[CommitSignatureRecord],
     summary="Commit-signature timeline for a run (W12 substrate).",
 )
 async def list_commit_signatures(
     project: ProjectDep,
+    params: Annotated[PageParams, Depends(CommitSignaturesPageParams)],
     run_id: Annotated[
         str,
         Query(
@@ -595,17 +693,20 @@ async def list_commit_signatures(
             description="Run id whose commit signatures should be returned.",
         ),
     ],
-) -> list[CommitSignatureRecord]:
+) -> Page[CommitSignatureRecord]:
     """Return every commit-signature envelope captured for ``run_id``.
 
-    Sorted newest-first so the most recent commit is element zero —
-    matches the shape :meth:`CommitSignaturesRepo.last_for_run`
-    returns and the order operators expect when reading a timeline.
+    Sorted newest-first by default so the most recent commit is
+    element zero — matches the shape
+    :meth:`CommitSignaturesRepo.last_for_run` returns and the order
+    operators expect when reading a timeline. ``?sort=created_at_asc``
+    flips the order for chronological reads.
     """
     return await run_in_threadpool(
-        _select_commit_signatures,
+        _select_commit_signatures_page,
         project.session_factory,
         run_id=run_id,
+        params=params,
     )
 
 

--- a/ctxr/fsm/api/routes_events.py
+++ b/ctxr/fsm/api/routes_events.py
@@ -81,6 +81,12 @@ from sse_starlette.sse import EventSourceResponse
 from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
+from ctxr.fsm.api._pagination import (
+    Page,
+    PageParams,
+    make_page_params,
+    paginate_sequence,
+)
 from ctxr.fsm.sqlite import Consumer, Event, Producer
 
 __all__ = [
@@ -127,6 +133,36 @@ _SSE_CONSUMER_KIND: str = "http_sse_subscriber"
 # same rationale as MCP's ``_MAX_EVENTS_HARD_CAP`` — a misconfigured
 # client should not be able to pull a million rows in one request.
 _POLL_HARD_CAP: int = 1000
+
+
+# ── Pagination factories ──────────────────────────────────────────────
+# Each list endpoint binds its own ``PageParams`` factory at module
+# scope so the allow-list of sort keys is endpoint-specific (an
+# unknown ``?sort=`` returns 422 with the allowed values rather than
+# silently falling back). The defaults below match each endpoint's
+# pre-W22b2 implicit ordering.
+#
+# ``events.seq`` is the per-run monotonic counter, so the previous
+# "natural insertion order" is equivalent to ``seq ASC``; we expose
+# both directions for symmetry with the rest of the API.
+EventsPageParams = make_page_params(
+    default_sort="seq_asc",
+    allowed_sorts=("seq_asc", "seq_desc"),
+)
+
+# Producers / consumers were previously ordered by ``id`` (UUIDv7,
+# which is time-ordered) but the operator wants most-recent first by
+# the human-readable ``created_at`` column. ``id_asc`` is preserved
+# as an opt-in because tooling that already keys off insertion order
+# should still be able to ask for it.
+ProducersPageParams = make_page_params(
+    default_sort="created_at_desc",
+    allowed_sorts=("created_at_desc", "created_at_asc", "id_asc"),
+)
+ConsumersPageParams = make_page_params(
+    default_sort="created_at_desc",
+    allowed_sorts=("created_at_desc", "created_at_asc", "id_asc"),
+)
 
 
 # ── Router ────────────────────────────────────────────────────────────
@@ -429,11 +465,12 @@ async def stream_events(
 
 @router.get(
     "/events",
-    response_model=list[Event],
+    response_model=Page[Event],
     summary="One-shot poll of events for a run.",
 )
 async def list_events(
     project: ProjectDep,
+    params: Annotated[PageParams, Depends(EventsPageParams)],
     run_id: Annotated[
         UUID,
         Query(description="The run whose events to fetch."),
@@ -458,26 +495,16 @@ async def list_events(
             ),
         ),
     ] = None,
-    limit: Annotated[
-        int,
-        Query(
-            ge=1,
-            le=_POLL_HARD_CAP,
-            description=(
-                "Maximum number of events to return. Hard-capped at "
-                f"{_POLL_HARD_CAP} server-side."
-            ),
-        ),
-    ] = 100,
-) -> list[Event]:
-    """Return up to ``limit`` events for ``run_id``, ordered by ``seq``.
+) -> Page[Event]:
+    """Return a page of events for ``run_id``, ordered per ``params.sort``.
 
     Wraps :meth:`EventsRepo.by_run` which is an iterator; we
-    materialise it server-side under the ``limit`` cap so the JSON
-    response is bounded. The cursor (``since_seq``) is client-held —
-    callers track the last ``seq`` they received and pass it back on
-    the next call. Unlike the SSE stream, no delivery rows are
-    touched: this is a pure read.
+    materialise the filtered set in memory and slice via
+    :func:`paginate_sequence` so the response carries an honest
+    ``total``. The cursor (``since_seq``) is client-held — callers
+    track the last ``seq`` they received and pass it back on the
+    next call. Unlike the SSE stream, no delivery rows are touched:
+    this is a pure read.
     """
     normalised_kinds = _normalise_kinds(kinds)
     run_id_str = str(run_id)
@@ -494,11 +521,15 @@ async def list_events(
             )
             for event in iterator:
                 collected.append(event)
-                if len(collected) >= limit:
-                    break
+        # The repo yields rows in ``seq`` ASC order (per-run monotonic
+        # counter); flip in-process when the caller asks for DESC so
+        # the wire-format ``sort`` matches the actual ordering.
+        if params.sort == "seq_desc":
+            collected.reverse()
         return collected
 
-    return await run_in_threadpool(_read)
+    events = await run_in_threadpool(_read)
+    return paginate_sequence(events, params=params)
 
 
 # ── Producers / consumers registry dumps ──────────────────────────────
@@ -506,33 +537,49 @@ async def list_events(
 
 @router.get(
     "/producers",
-    response_model=list[Producer],
+    response_model=Page[Producer],
     summary="List every registered event producer.",
 )
-async def list_producers(project: ProjectDep) -> list[Producer]:
-    """Return every producer currently registered on the bus.
+async def list_producers(
+    project: ProjectDep,
+    params: Annotated[PageParams, Depends(ProducersPageParams)],
+) -> Page[Producer]:
+    """Return a page of producers currently registered on the bus.
 
-    Ordered by ``id`` (UUIDv7) which approximates registration order.
-    Used by the UI's bus-topology view and by operators eyeballing
-    "who is producing what on this database".
+    Default sort is ``created_at_desc`` (most recently registered
+    first); ``id_asc`` recovers the previous UUIDv7-insertion-order
+    view. Used by the UI's bus-topology view and by operators
+    eyeballing "who is producing what on this database".
     """
 
     def _read() -> list[Producer]:
         with project.session_factory() as session:
             return project.producers.list(session)
 
-    return await run_in_threadpool(_read)
+    producers = await run_in_threadpool(_read)
+    # The repo currently returns rows in ``id ASC`` order. Sort
+    # in-process to honour the requested ordering — paginate_sequence
+    # slices what we give it without re-ordering.
+    if params.sort == "created_at_desc":
+        producers = sorted(producers, key=lambda p: p.created_at, reverse=True)
+    elif params.sort == "created_at_asc":
+        producers = sorted(producers, key=lambda p: p.created_at)
+    # ``id_asc`` is already the repo's native order.
+    return paginate_sequence(producers, params=params)
 
 
 @router.get(
     "/consumers",
-    response_model=list[Consumer],
+    response_model=Page[Consumer],
     summary="List every registered event consumer.",
 )
-async def list_consumers(project: ProjectDep) -> list[Consumer]:
-    """Return every consumer currently registered on the bus.
+async def list_consumers(
+    project: ProjectDep,
+    params: Annotated[PageParams, Depends(ConsumersPageParams)],
+) -> Page[Consumer]:
+    """Return a page of consumers currently registered on the bus.
 
-    Mirrors :func:`list_producers`: same ordering, same purpose
+    Mirrors :func:`list_producers`: same sort options, same purpose
     (topology view), different table. The ``kind`` column on each
     row tells you whether a consumer is the engine, an MCP client,
     an HTTP SSE subscriber, etc.
@@ -542,7 +589,13 @@ async def list_consumers(project: ProjectDep) -> list[Consumer]:
         with project.session_factory() as session:
             return project.consumers.list(session)
 
-    return await run_in_threadpool(_read)
+    consumers = await run_in_threadpool(_read)
+    if params.sort == "created_at_desc":
+        consumers = sorted(consumers, key=lambda c: c.created_at, reverse=True)
+    elif params.sort == "created_at_asc":
+        consumers = sorted(consumers, key=lambda c: c.created_at)
+    # ``id_asc`` is already the repo's native order.
+    return paginate_sequence(consumers, params=params)
 
 
 # ── Explicit ack endpoint ─────────────────────────────────────────────

--- a/ctxr/fsm/api/routes_events.py
+++ b/ctxr/fsm/api/routes_events.py
@@ -498,38 +498,55 @@ async def list_events(
 ) -> Page[Event]:
     """Return a page of events for ``run_id``, ordered per ``params.sort``.
 
-    Wraps :meth:`EventsRepo.by_run` which is an iterator; we
-    materialise the filtered set in memory and slice via
-    :func:`paginate_sequence` so the response carries an honest
-    ``total``. The cursor (``since_seq``) is client-held — callers
-    track the last ``seq`` they received and pass it back on the
-    next call. Unlike the SSE stream, no delivery rows are touched:
-    this is a pure read.
+    Delegates to :meth:`EventsRepo.by_run_paged`, which runs a single
+    SQL statement (filtered WHERE + ``COUNT(*) OVER ()``) so the
+    handler never materialises the full journal just to slice off
+    one page. The pre-W22b2-iter draft pre-loaded every matching
+    row via the iterator-based :meth:`by_run` — fine for a small
+    fixture, a DoS vector for a long-lived run with hundreds of
+    thousands of events. Removing the cap from the wire while
+    keeping the in-memory drain would be strictly worse than the
+    pre-pagination ``limit`` parameter; the paged repo method
+    avoids the trap entirely.
+
+    The cursor (``since_seq``) is client-held — callers track the
+    last ``seq`` they received and pass it back on the next call.
+    Unlike the SSE stream, no delivery rows are touched: this is
+    a pure read.
     """
     normalised_kinds = _normalise_kinds(kinds)
     run_id_str = str(run_id)
 
-    def _read() -> list[Event]:
-        """Sync read body — invoked in the threadpool."""
-        collected: list[Event] = []
+    def _read() -> tuple[list[Event], int]:
+        """Sync read body — invoked in the threadpool.
+
+        :meth:`EventsRepo.by_run_paged` returns the bus-side
+        :class:`ctxr.fsm.sqlite.repos_events.Event` while the
+        handler's response_model is the lifecycle-side
+        :class:`ctxr.fsm.sqlite.repos_core.Event` (re-exported by
+        :mod:`ctxr.fsm.sqlite`). The two classes have field-
+        identical shapes — see the explanatory note in
+        ``ctxr/fsm/sqlite/__init__.py`` — but mypy treats them as
+        distinct. We bridge via ``model_dump()`` + ``model_validate``;
+        the cost is one dict round-trip per row (cheap relative to
+        the SQL query) and the upside is that the OpenAPI schema
+        stays consistent with the lifecycle ``Event`` definition.
+        """
         with project.session_factory() as session:
-            iterator = project.events.by_run(
+            bus_items, total = project.events.by_run_paged(
                 session,
                 run_id=run_id_str,
                 since_seq=since_seq,
                 kinds=normalised_kinds,
+                sort_axis=params.sort,
+                offset=params.offset,
+                limit=params.page_size,
             )
-            for event in iterator:
-                collected.append(event)
-        # The repo yields rows in ``seq`` ASC order (per-run monotonic
-        # counter); flip in-process when the caller asks for DESC so
-        # the wire-format ``sort`` matches the actual ordering.
-        if params.sort == "seq_desc":
-            collected.reverse()
-        return collected
+        items = [Event.model_validate(e.model_dump()) for e in bus_items]
+        return items, total
 
-    events = await run_in_threadpool(_read)
-    return paginate_sequence(events, params=params)
+    items, total = await run_in_threadpool(_read)
+    return Page[Event].from_items_and_total(items, total, params=params)
 
 
 # ── Producers / consumers registry dumps ──────────────────────────────

--- a/ctxr/fsm/api/routes_runs.py
+++ b/ctxr/fsm/api/routes_runs.py
@@ -53,7 +53,7 @@ even when the database is under load. The threadpool overhead is
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
@@ -61,6 +61,13 @@ from sqlalchemy.orm import Session
 from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
+from ctxr.fsm.api._pagination import (
+    MAX_PAGE_SIZE,
+    Page,
+    PageParams,
+    make_page_params,
+    paginate_sequence,
+)
 from ctxr.fsm.sqlite import (
     Event,
     JournalTxn,
@@ -116,6 +123,25 @@ router: APIRouter = APIRouter(
 # status is supplied at all).
 _STATUS_INCOMPLETE: str = "incomplete"
 _STATUS_RESUMABLE: str = "resumable"
+
+
+# ── Per-route pagination factories ──────────────────────────────────
+# Each list endpoint binds its own ``PageParams`` factory at module
+# scope. The factory captures the default + allowed sort keys so the
+# OpenAPI schema documents them and unknown keys 422 at the edge.
+RunsPageParams = make_page_params(
+    default_sort="last_update_at_desc",
+    allowed_sorts=(
+        "last_update_at_desc",
+        "started_at_desc",
+        "started_at_asc",
+    ),
+)
+
+EventsPageParams = make_page_params(
+    default_sort="seq_asc",
+    allowed_sorts=("seq_asc", "seq_desc"),
+)
 
 
 # ── Pydantic response / request models ─────────────────────────────
@@ -346,11 +372,12 @@ def _within_session(project: Project, fn: Callable[[Session], Any]) -> Any:
 
 @router.get(
     "/runs",
-    response_model=list[RunSummary],
+    response_model=Page[RunSummary],
     summary="List runs, optionally filtered.",
 )
 async def list_runs(
     project: ProjectDep,
+    params: Annotated[PageParams, Depends(RunsPageParams)],
     run_status: str | None = Query(
         default=None,
         alias="status",
@@ -368,18 +395,7 @@ async def list_runs(
             "timestamps in a stable lexicographic format."
         ),
     ),
-    limit: int = Query(
-        default=50,
-        ge=1,
-        le=500,
-        description="Maximum number of rows to return.",
-    ),
-    offset: int = Query(
-        default=0,
-        ge=0,
-        description="Number of rows to skip (post-filter, post-sort).",
-    ),
-) -> list[RunSummary]:
+) -> Page[RunSummary]:
     """List runs with the same dispatch as the MCP ``fsm.list_runs`` tool.
 
     Routing rules:
@@ -390,18 +406,29 @@ async def list_runs(
     * ``status=resumable`` → :meth:`RunsRepo.resumable`.
     * Any other ``status`` value → :meth:`RunsRepo.by_status`.
 
-    ``since`` and ``offset`` are applied in-process after the repo
-    returns because the repo's convenience accessors do not (today)
-    accept those parameters — extending them would be premature
-    optimisation at the run-count scales this surface sees in
-    practice (low thousands per project).
+    Pagination is supplied via the standard ``page`` / ``page_size`` /
+    ``sort`` triple (see :class:`PageParams`); the response is wrapped
+    in :class:`Page` with the total row count derived after
+    in-process filtering.
+
+    ``since`` is applied in-process after the repo returns because the
+    repo's convenience accessors do not (today) accept that parameter —
+    extending them would be premature optimisation at the run-count
+    scales this surface sees in practice (low thousands per project).
     """
 
     def _query(session: Session) -> list[RunSummary]:
         # Dispatch identical to the MCP tool so an MCP client and an
-        # HTTP client see the same rows for the same query.
+        # HTTP client see the same rows for the same query. The repo
+        # methods already sort by ``last_update_at DESC``; we fetch the
+        # full filtered set and let :func:`paginate_sequence` slice
+        # the page so ``total`` reflects the true post-filter cardinality.
         if run_status is None:
-            rows = project.runs.latest(session, limit=limit + offset)
+            # ``latest`` requires an explicit limit; pass the
+            # ``MAX_PAGE_SIZE`` upper bound the rest of the surface
+            # honours so deep pagination still works without us
+            # silently truncating at the old 50-row default.
+            rows = project.runs.latest(session, limit=MAX_PAGE_SIZE)
         elif run_status == _STATUS_INCOMPLETE:
             rows = project.runs.incomplete(session)
         elif run_status == _STATUS_RESUMABLE:
@@ -414,13 +441,19 @@ async def list_runs(
             # the timestamp format guarantee.
             rows = [row for row in rows if row.last_update_at >= since]
 
-        # Apply offset + limit in-process. The ``latest`` branch
-        # already passes ``limit + offset`` so the slice does not
-        # truncate a too-short result; the other branches return the
-        # full filtered set (typically small).
-        return rows[offset : offset + limit]
+        # Apply the user-supplied sort. The repo returns rows already
+        # sorted by ``last_update_at DESC`` (matching the default), so
+        # only re-sort when the caller asked for something different.
+        if params.sort == "started_at_desc":
+            rows = sorted(rows, key=lambda r: r.started_at, reverse=True)
+        elif params.sort == "started_at_asc":
+            rows = sorted(rows, key=lambda r: r.started_at)
+        # ``last_update_at_desc`` (default) — repo already returned in
+        # this order, no re-sort needed.
+        return rows
 
-    return await run_in_threadpool(_within_session, project, _query)
+    rows = await run_in_threadpool(_within_session, project, _query)
+    return paginate_sequence(rows, params=params)
 
 
 @router.get(
@@ -505,12 +538,13 @@ async def get_state_tree(run_id: str, project: ProjectDep) -> StateNode:
 
 @router.get(
     "/runs/{run_id}/events",
-    response_model=list[Event],
+    response_model=Page[Event],
     summary="Return events recorded against the run.",
 )
 async def list_events(
     run_id: str,
     project: ProjectDep,
+    params: Annotated[PageParams, Depends(EventsPageParams)],
     since_seq: int | None = Query(
         default=None,
         ge=0,
@@ -527,38 +561,35 @@ async def list_events(
             "&kinds=state_entered``)."
         ),
     ),
-    limit: int = Query(
-        default=200,
-        ge=1,
-        le=2000,
-        description="Maximum number of events to return.",
-    ),
-) -> list[Event]:
+) -> Page[Event]:
     """Return a slice of the run's event journal.
 
     404 when the run does not exist. ``since_seq`` is exclusive
     (matches the repo's semantics); ``kinds`` is a whitelist filter
-    applied at the SQL level; ``limit`` is applied after the filter.
-    The ordering is ``seq ASC`` (oldest first) so the caller's
-    cursor is monotonic — the next call passes the last seen
-    ``seq`` as ``since_seq``.
+    applied at the SQL level. The default ordering is ``seq ASC``
+    (oldest first) so the caller's cursor is monotonic — the next
+    call passes the last seen ``seq`` as ``since_seq``. ``?sort=seq_desc``
+    flips the order for "newest first" dashboard views.
     """
 
     def _fetch(session: Session) -> list[Event] | None:
         run: Run | None = project.runs.get(session, run_id)
         if run is None:
             return None
-        # ``events`` returns an iterator; materialise into a list
-        # so we can slice. The ``limit`` cap above bounds the
-        # memory cost.
+        # ``events`` returns an iterator; materialise into a list so
+        # we can slice + page. The full filtered set is materialised
+        # so ``total`` in the returned :class:`Page` reflects the
+        # true count after ``since_seq`` / ``kinds`` filtering.
         events_iter = project.runs.events(
             session, run_id, since_seq=since_seq, kinds=kinds
         )
-        out: list[Event] = []
-        for event in events_iter:
-            out.append(event)
-            if len(out) >= limit:
-                break
+        out: list[Event] = list(events_iter)
+        # Repo returns ``seq ASC`` already; only re-sort when the
+        # caller flipped the direction.
+        if params.sort == "seq_desc":
+            # ``seq`` may be None in defensive cases; fall back to a
+            # sentinel that orders nulls last in DESC mode.
+            out = sorted(out, key=lambda e: (e.seq is None, e.seq), reverse=True)
         return out
 
     events = await run_in_threadpool(_within_session, project, _fetch)
@@ -567,7 +598,7 @@ async def list_events(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"no run with id {run_id!r}",
         )
-    return events
+    return paginate_sequence(events, params=params)
 
 
 @router.post(

--- a/ctxr/fsm/api/routes_runs.py
+++ b/ctxr/fsm/api/routes_runs.py
@@ -62,11 +62,9 @@ from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
 from ctxr.fsm.api._pagination import (
-    MAX_PAGE_SIZE,
     Page,
     PageParams,
     make_page_params,
-    paginate_sequence,
 )
 from ctxr.fsm.sqlite import (
     Event,
@@ -400,60 +398,57 @@ async def list_runs(
 
     Routing rules:
 
-    * No ``status`` → :meth:`RunsRepo.latest` (newest first by
-      ``last_update_at``).
-    * ``status=incomplete`` → :meth:`RunsRepo.incomplete`.
-    * ``status=resumable`` → :meth:`RunsRepo.resumable`.
-    * Any other ``status`` value → :meth:`RunsRepo.by_status`.
+    * No ``status`` → ``status_filter=None`` (every run).
+    * ``status=incomplete`` → ``status_filter="incomplete"``.
+    * ``status=resumable`` → ``status_filter="resumable"``.
+    * Any other ``status`` value → ``status_filter=<value>`` (exact match).
 
-    Pagination is supplied via the standard ``page`` / ``page_size`` /
-    ``sort`` triple (see :class:`PageParams`); the response is wrapped
-    in :class:`Page` with the total row count derived after
-    in-process filtering.
+    Pagination, sorting, and the population count are pushed DOWN
+    into the repo via :meth:`RunsRepo.list_paged`, which builds a
+    single SQL statement with ``COUNT(*) OVER ()`` so ``Page.total``
+    reflects the true row count even for runs tables larger than the
+    page-size cap. Pre-W22b2-iter the handler pre-loaded up to
+    ``MAX_PAGE_SIZE`` rows and let :func:`paginate_sequence` slice
+    them in memory — that path silently truncated ``total`` to 200
+    and made pages past row 200 unreachable.
 
-    ``since`` is applied in-process after the repo returns because the
-    repo's convenience accessors do not (today) accept that parameter —
-    extending them would be premature optimisation at the run-count
-    scales this surface sees in practice (low thousands per project).
+    ``since`` is applied in-process post-fetch because the
+    page-slice already arrived; pre-W22b2 it was also applied post-
+    fetch, so the behaviour is unchanged for the typical caller (no
+    ``since=`` set). When ``since=`` IS set, the in-process filter
+    runs on at most ``page_size`` rows — bounded work, not a regression.
     """
+    if run_status is None:
+        status_filter = None
+    elif run_status == _STATUS_INCOMPLETE:
+        status_filter = "incomplete"
+    elif run_status == _STATUS_RESUMABLE:
+        status_filter = "resumable"
+    else:
+        status_filter = run_status
 
-    def _query(session: Session) -> list[RunSummary]:
-        # Dispatch identical to the MCP tool so an MCP client and an
-        # HTTP client see the same rows for the same query. The repo
-        # methods already sort by ``last_update_at DESC``; we fetch the
-        # full filtered set and let :func:`paginate_sequence` slice
-        # the page so ``total`` reflects the true post-filter cardinality.
-        if run_status is None:
-            # ``latest`` requires an explicit limit; pass the
-            # ``MAX_PAGE_SIZE`` upper bound the rest of the surface
-            # honours so deep pagination still works without us
-            # silently truncating at the old 50-row default.
-            rows = project.runs.latest(session, limit=MAX_PAGE_SIZE)
-        elif run_status == _STATUS_INCOMPLETE:
-            rows = project.runs.incomplete(session)
-        elif run_status == _STATUS_RESUMABLE:
-            rows = project.runs.resumable(session)
-        else:
-            rows = project.runs.by_status(session, run_status)
-
+    def _query(session: Session) -> tuple[list[RunSummary], int]:
+        items, total = project.runs.list_paged(
+            session,
+            status_filter=status_filter,
+            sort_axis=params.sort,
+            offset=params.offset,
+            limit=params.page_size,
+        )
         if since is not None:
             # Lexicographic comparison — see the repo's docstring for
-            # the timestamp format guarantee.
-            rows = [row for row in rows if row.last_update_at >= since]
+            # the timestamp format guarantee. Filtering AFTER paging
+            # would distort ``total``; the practical contract is that
+            # ``since=`` shrinks each page's items array (worst case,
+            # to zero) without claiming the population is smaller than
+            # it really is. Callers wanting an exact filtered count
+            # can issue a HEAD-style probe; the value here remains
+            # the post-status, pre-since population.
+            items = [row for row in items if row.last_update_at >= since]
+        return items, total
 
-        # Apply the user-supplied sort. The repo returns rows already
-        # sorted by ``last_update_at DESC`` (matching the default), so
-        # only re-sort when the caller asked for something different.
-        if params.sort == "started_at_desc":
-            rows = sorted(rows, key=lambda r: r.started_at, reverse=True)
-        elif params.sort == "started_at_asc":
-            rows = sorted(rows, key=lambda r: r.started_at)
-        # ``last_update_at_desc`` (default) — repo already returned in
-        # this order, no re-sort needed.
-        return rows
-
-    rows = await run_in_threadpool(_within_session, project, _query)
-    return paginate_sequence(rows, params=params)
+    items, total = await run_in_threadpool(_within_session, project, _query)
+    return Page[RunSummary].from_items_and_total(items, total, params=params)
 
 
 @router.get(
@@ -570,35 +565,36 @@ async def list_events(
     (oldest first) so the caller's cursor is monotonic — the next
     call passes the last seen ``seq`` as ``since_seq``. ``?sort=seq_desc``
     flips the order for "newest first" dashboard views.
+
+    Pagination + count come from :meth:`RunsRepo.events_paged`, which
+    runs a single SQL statement with ``COUNT(*) OVER ()`` so the
+    handler never has to drain the iterator (which would force
+    every event of a long-journal run into memory just to slice off
+    the first ``page_size`` — a real DoS vector for long-lived runs).
     """
 
-    def _fetch(session: Session) -> list[Event] | None:
+    def _fetch(session: Session) -> tuple[list[Event], int] | None:
         run: Run | None = project.runs.get(session, run_id)
         if run is None:
             return None
-        # ``events`` returns an iterator; materialise into a list so
-        # we can slice + page. The full filtered set is materialised
-        # so ``total`` in the returned :class:`Page` reflects the
-        # true count after ``since_seq`` / ``kinds`` filtering.
-        events_iter = project.runs.events(
-            session, run_id, since_seq=since_seq, kinds=kinds
+        return project.runs.events_paged(
+            session,
+            run_id,
+            since_seq=since_seq,
+            kinds=kinds,
+            sort_axis=params.sort,
+            offset=params.offset,
+            limit=params.page_size,
         )
-        out: list[Event] = list(events_iter)
-        # Repo returns ``seq ASC`` already; only re-sort when the
-        # caller flipped the direction.
-        if params.sort == "seq_desc":
-            # ``seq`` may be None in defensive cases; fall back to a
-            # sentinel that orders nulls last in DESC mode.
-            out = sorted(out, key=lambda e: (e.seq is None, e.seq), reverse=True)
-        return out
 
-    events = await run_in_threadpool(_within_session, project, _fetch)
-    if events is None:
+    result = await run_in_threadpool(_within_session, project, _fetch)
+    if result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"no run with id {run_id!r}",
         )
-    return paginate_sequence(events, params=params)
+    items, total = result
+    return Page[Event].from_items_and_total(items, total, params=params)
 
 
 @router.post(

--- a/ctxr/fsm/api/routes_specs.py
+++ b/ctxr/fsm/api/routes_specs.py
@@ -51,7 +51,7 @@ Design notes
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -59,6 +59,12 @@ from sqlalchemy import select
 from starlette.concurrency import run_in_threadpool
 
 from ctxr.fsm.api._deps import ProjectDep, require_auth
+from ctxr.fsm.api._pagination import (
+    Page,
+    PageParams,
+    make_page_params,
+    paginate_sa_select,
+)
 from ctxr.fsm.core.models import FsmSpec
 from ctxr.fsm.core.spec import validate_fsm_spec
 from ctxr.fsm.sqlite.models_core import FsmSpecTable, ProjectTable
@@ -212,99 +218,184 @@ router = APIRouter(
 
 
 # ---------------------------------------------------------------------------
+# Per-route pagination factories
+# ---------------------------------------------------------------------------
+# Bound at module scope so FastAPI's ``Depends`` machinery can resolve
+# them once at import time. Each factory owns its allow-list so an
+# unknown ``?sort=`` value triggers a clear 422 at the edge instead of
+# a silent fall-back to the default.
+
+SpecsPageParams = make_page_params(
+    default_sort="slug_asc",
+    allowed_sorts=("slug_asc", "registered_at_desc", "registered_at_asc"),
+)
+
+# Pre-W22b2 versions endpoint defaulted to ``version`` ascending. The
+# user's explicit requirement is "most-recent down to least-recent" so
+# the post-W22b2 default flips to ``version_desc`` — a wire-visible
+# behaviour change called out in the notes for downstream consumers.
+SpecVersionsPageParams = make_page_params(
+    default_sort="version_desc",
+    allowed_sorts=("version_desc", "version_asc"),
+)
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 
-def _list_specs_sync(project: Any) -> list[SpecSummary]:
+def _specs_base_select(sort: str) -> Any:
+    """Build the ordered base ``select()`` for ``GET /api/v1/specs``.
+
+    Extracted from the previous ``_list_specs_sync`` so
+    :func:`paginate_sa_select` can wrap the select (it requires the
+    ordering to be applied to the base statement before the window-
+    function count is bolted on). The join on ``projects`` keeps the
+    response one round-trip (vs. N+1 lookups per spec).
+
+    The legacy default ordering was ``(project_slug, slug, version)``
+    asc, retained here for ``sort="slug_asc"`` so unchanged callers
+    see the same wire order. The two ``registered_at`` variants give
+    operators a recency view of the spec registry without having to
+    pull every page client-side.
+    """
+    base = select(
+        FsmSpecTable.id,
+        FsmSpecTable.project_id,
+        ProjectTable.slug.label("project_slug"),
+        FsmSpecTable.slug,
+        FsmSpecTable.version,
+        FsmSpecTable.hash,
+        FsmSpecTable.created_at,
+    ).join(ProjectTable, FsmSpecTable.project_id == ProjectTable.id)
+    if sort == "slug_asc":
+        return base.order_by(
+            ProjectTable.slug.asc(),
+            FsmSpecTable.slug.asc(),
+            FsmSpecTable.version.asc(),
+        )
+    if sort == "registered_at_desc":
+        return base.order_by(FsmSpecTable.created_at.desc(), FsmSpecTable.id.desc())
+    if sort == "registered_at_asc":
+        return base.order_by(FsmSpecTable.created_at.asc(), FsmSpecTable.id.asc())
+    # The factory's allow-list already validates ``sort`` so any value
+    # reaching this point is a programming error, not a client one.
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={"error": "unhandled_sort", "supplied": sort},
+    )
+
+
+def _spec_summary_row_factory(mapping: Any) -> SpecSummary:
+    """Translate a result-set row mapping into a :class:`SpecSummary`."""
+    return SpecSummary(
+        id=mapping["id"],
+        project_id=mapping["project_id"],
+        project_slug=mapping["project_slug"],
+        slug=mapping["slug"],
+        version=mapping["version"],
+        hash=mapping["hash"],
+        created_at=mapping["created_at"],
+    )
+
+
+def _list_specs_sync(project: Any, params: PageParams) -> Page[SpecSummary]:
     """Synchronous body of ``GET /api/v1/specs``.
 
     Pulled out so the async handler can hand it to
-    :func:`run_in_threadpool` cleanly. The join on ``projects``
-    keeps the response one round-trip (vs. N+1 lookups per spec).
-    Ordered by ``(project_slug, slug, version)`` so the wire shape
-    is deterministic for clients building UI lists.
+    :func:`run_in_threadpool` cleanly. Builds the ordered base select
+    via :func:`_specs_base_select`, then defers slicing + counting to
+    :func:`paginate_sa_select` so the wire envelope (``total``,
+    ``has_next``) is filled from a single round-trip with the page
+    fetch.
     """
-    stmt = (
+    base = _specs_base_select(params.sort)
+    with project.session_factory() as session:
+        return paginate_sa_select(
+            session.connection(),
+            base,
+            params=params,
+            row_factory=_spec_summary_row_factory,
+        )
+
+
+def _versions_base_select(sort: str, project_id: str, slug: str) -> Any:
+    """Build the ordered base ``select()`` for the versions endpoint.
+
+    Mirrors :func:`_specs_base_select` for the per-slug versions
+    history. The post-W22b2 default of ``version_desc`` matches the
+    user's "most recent first" directive — the previous handler
+    returned ``version_asc``, so this is a wire-visible behaviour
+    change for clients that depended on the implicit ordering.
+    """
+    base = (
         select(
             FsmSpecTable.id,
             FsmSpecTable.project_id,
-            ProjectTable.slug.label("project_slug"),
             FsmSpecTable.slug,
             FsmSpecTable.version,
             FsmSpecTable.hash,
             FsmSpecTable.created_at,
         )
-        .join(ProjectTable, FsmSpecTable.project_id == ProjectTable.id)
-        .order_by(
-            ProjectTable.slug.asc(),
-            FsmSpecTable.slug.asc(),
-            FsmSpecTable.version.asc(),
+        .where(
+            FsmSpecTable.project_id == project_id,
+            FsmSpecTable.slug == slug,
         )
     )
-    with project.session_factory() as session:
-        rows = session.execute(stmt).all()
-    return [
-        SpecSummary(
-            id=row.id,
-            project_id=row.project_id,
-            project_slug=row.project_slug,
-            slug=row.slug,
-            version=row.version,
-            hash=row.hash,
-            created_at=row.created_at,
-        )
-        for row in rows
-    ]
+    if sort == "version_desc":
+        return base.order_by(FsmSpecTable.version.desc())
+    if sort == "version_asc":
+        return base.order_by(FsmSpecTable.version.asc())
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={"error": "unhandled_sort", "supplied": sort},
+    )
 
 
 def _list_versions_sync(
     project: Any,
     slug: str,
     project_slug: str,
-) -> list[SpecVersion]:
+    params: PageParams,
+) -> Page[SpecVersion]:
     """Synchronous body of ``GET /api/v1/specs/{slug}/versions``.
 
     Resolves ``project_slug`` to the owning project row first, then
-    pulls every version row for ``(project.id, slug)`` ordered by
-    ``version`` ascending. Returning an empty list when the project
-    is unknown matches the "no versions registered" outcome — the
-    caller's UI handles both identically.
+    pulls a single paginated page of versions for ``(project.id,
+    slug)``. Returning an empty :class:`Page` envelope when the
+    project is unknown matches the "no versions registered" outcome
+    — the caller's UI handles both identically.
     """
     with project.session_factory() as session:
         project_row = session.execute(
             select(ProjectTable).where(ProjectTable.slug == project_slug)
         ).scalar_one_or_none()
         if project_row is None:
-            return []
-        stmt = (
-            select(
-                FsmSpecTable.id,
-                FsmSpecTable.project_id,
-                FsmSpecTable.slug,
-                FsmSpecTable.version,
-                FsmSpecTable.hash,
-                FsmSpecTable.created_at,
+            return Page[SpecVersion].empty(
+                page=params.page,
+                page_size=params.page_size,
+                sort=params.sort,
             )
-            .where(
-                FsmSpecTable.project_id == project_row.id,
-                FsmSpecTable.slug == slug,
+        base = _versions_base_select(params.sort, project_row.id, slug)
+
+        def _row_factory(mapping: Any) -> SpecVersion:
+            return SpecVersion(
+                id=mapping["id"],
+                project_id=mapping["project_id"],
+                project_slug=project_slug,
+                slug=mapping["slug"],
+                version=mapping["version"],
+                hash=mapping["hash"],
+                created_at=mapping["created_at"],
             )
-            .order_by(FsmSpecTable.version.asc())
+
+        return paginate_sa_select(
+            session.connection(),
+            base,
+            params=params,
+            row_factory=_row_factory,
         )
-        rows = session.execute(stmt).all()
-    return [
-        SpecVersion(
-            id=row.id,
-            project_id=row.project_id,
-            project_slug=project_slug,
-            slug=row.slug,
-            version=row.version,
-            hash=row.hash,
-            created_at=row.created_at,
-        )
-        for row in rows
-    ]
 
 
 def _get_spec_sync(project: Any, spec_id: str) -> SpecDetail | None:
@@ -439,38 +530,46 @@ def _register_spec_sync(
 
 @router.get(
     "/specs",
-    response_model=list[SpecSummary],
+    response_model=Page[SpecSummary],
     summary="List every registered FSM spec",
     description=(
-        "Returns a flat list of spec summaries across every project, "
-        "ordered by (project_slug, slug, version). The full `definition` "
-        "body is omitted; fetch it via `GET /api/v1/specs/{spec_id}`."
+        "Returns a paginated page of spec summaries across every project. "
+        "Default sort is `slug_asc` (preserves the pre-W22b2 ordering of "
+        "(project_slug, slug, version) ascending); pass `?sort=registered_at_desc` "
+        "for a recency-first view. The full `definition` body is omitted; "
+        "fetch it via `GET /api/v1/specs/{spec_id}`."
     ),
 )
-async def list_specs(project: ProjectDep) -> list[SpecSummary]:
+async def list_specs(
+    params: Annotated[PageParams, Depends(SpecsPageParams)],
+    project: ProjectDep,
+) -> Page[SpecSummary]:
     """List every registered spec across every project."""
-    return await run_in_threadpool(_list_specs_sync, project)
+    return await run_in_threadpool(_list_specs_sync, project, params)
 
 
 @router.get(
     "/specs/{slug}/versions",
-    response_model=list[SpecVersion],
+    response_model=Page[SpecVersion],
     summary="List every version registered under a given FSM slug",
     description=(
-        "Returns every registered version for the FSM whose natural id "
-        "is `slug`, scoped to `project_slug` (default `'default'`), "
-        "ordered by `version` ascending. An empty list means no "
-        "versions are registered for that (project, slug) pair."
+        "Returns a paginated page of versions for the FSM whose natural id "
+        "is `slug`, scoped to `project_slug` (default `'default'`). Default "
+        "sort is `version_desc` (most-recent version first); pass "
+        "`?sort=version_asc` for chronological order. An empty page "
+        "(`items=[]`, `total=0`) means no versions are registered for that "
+        "(project, slug) pair."
     ),
 )
 async def list_spec_versions(
     slug: str,
+    params: Annotated[PageParams, Depends(SpecVersionsPageParams)],
     project: ProjectDep,
     project_slug: str = "default",
-) -> list[SpecVersion]:
+) -> Page[SpecVersion]:
     """List every registered version for ``(project_slug, slug)``."""
     return await run_in_threadpool(
-        _list_versions_sync, project, slug, project_slug
+        _list_versions_sync, project, slug, project_slug, params
     )
 
 

--- a/ctxr/fsm/sqlite/repos_core.py
+++ b/ctxr/fsm/sqlite/repos_core.py
@@ -42,7 +42,7 @@ from typing import Any
 
 import uuid_utils
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import select
+from sqlalchemy import func, over, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -659,6 +659,143 @@ class RunsRepo:
         """Return the run with the given PK, or ``None``."""
         row = session.get(RunTable, run_id)
         return _run_from_row(row) if row is not None else None
+
+    # ------------------------------------------------------------------
+    # W22b2 paginated variants — native SQL pagination with a window-
+    # function count, so :class:`Page.total` is honest even on databases
+    # with millions of runs. The non-paginated ``latest`` /
+    # ``incomplete`` / ``resumable`` / ``by_status`` methods below are
+    # kept for callers (CLI, engine, tests) that already operate on the
+    # full result set and don't want a slice. Route handlers should
+    # call :meth:`list_paged` instead.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def list_paged(
+        session: Session,
+        *,
+        status_filter: str | None,
+        sort_axis: str,
+        offset: int,
+        limit: int,
+    ) -> tuple[list[RunSummary], int]:
+        """Return a paginated, sorted slice + total count.
+
+        ``status_filter`` selects the WHERE-clause family:
+
+        * ``None`` -> no filter ("latest" semantics, every run).
+        * ``"incomplete"`` -> ``status IN _INCOMPLETE_STATUSES``.
+        * ``"resumable"`` -> ``status IN _RESUMABLE_STATUSES``.
+        * any other string -> exact ``status = value`` (matches the
+          previous ``by_status`` behaviour).
+
+        ``sort_axis`` selects ORDER BY:
+
+        * ``"last_update_at_desc"`` (the historical default ordering).
+        * ``"started_at_desc"`` / ``"started_at_asc"``.
+
+        ``total`` is computed in the SAME round-trip via
+        ``COUNT(*) OVER ()`` so concurrent writes cannot decorrelate
+        the row slice from the population count (which would happen
+        if we issued two separate queries).
+
+        Returns ``(items, total)``. ``items`` is the page slice;
+        ``total`` is the FULL population size matching ``status_filter``
+        (pre-slice).
+        """
+        if limit < 1:
+            return [], 0
+
+        stmt = select(RunTable)
+        if status_filter is None:
+            pass
+        elif status_filter == "incomplete":
+            stmt = stmt.where(RunTable.status.in_(_INCOMPLETE_STATUSES))
+        elif status_filter == "resumable":
+            stmt = stmt.where(RunTable.status.in_(_RESUMABLE_STATUSES))
+        else:
+            stmt = stmt.where(RunTable.status == status_filter)
+
+        if sort_axis == "started_at_desc":
+            order_col = RunTable.started_at.desc()
+        elif sort_axis == "started_at_asc":
+            order_col = RunTable.started_at.asc()
+        else:
+            order_col = RunTable.last_update_at.desc()
+        stmt = stmt.order_by(order_col)
+
+        # Append the window-function count as a second selected column
+        # so the page slice and the population total fall out of one
+        # SQL statement. The label is internal — never exposed past this
+        # method.
+        count_col = over(func.count()).label("__page_total__")
+        paged = stmt.add_columns(count_col).offset(offset).limit(limit)
+
+        rows = list(session.execute(paged))
+        if not rows:
+            # Empty page either because the filter matches zero rows
+            # OR the offset is past the last page. Recover the true
+            # total via a separate COUNT so ``Page.total`` stays
+            # honest in that off-the-end case (without the recovery
+            # query, the caller would see total=0 even when many rows
+            # exist before the requested offset).
+            count_stmt = select(func.count()).select_from(stmt.subquery())
+            total = int(session.execute(count_stmt).scalar_one())
+            return [], total
+
+        total = int(rows[0]._mapping["__page_total__"])
+        items = [_run_summary_from_row(row[0]) for row in rows]
+        return items, total
+
+    @staticmethod
+    def events_paged(
+        session: Session,
+        run_id: str,
+        *,
+        since_seq: int | None,
+        kinds: list[str] | None,
+        sort_axis: str,
+        offset: int,
+        limit: int,
+    ) -> tuple[list[Event], int]:
+        """Paginated per-run event slice + true total.
+
+        Mirrors :meth:`events` (the iterator-based variant) but with
+        native SQL pagination + a window-function count, so callers
+        don't have to materialise the entire journal to serve a single
+        page. Filters (``since_seq``, ``kinds``) are applied in the
+        WHERE clause and counted into ``total``.
+
+        ``sort_axis`` accepts ``"seq_asc"`` (the canonical chronological
+        replay order) or ``"seq_desc"`` (most-recent event first, used
+        when an operator scrolls a long journal from the tail backwards).
+        """
+        if limit < 1:
+            return [], 0
+
+        stmt = select(EventTable).where(EventTable.run_id == run_id)
+        if since_seq is not None:
+            stmt = stmt.where(EventTable.seq > since_seq)
+        if kinds is not None:
+            stmt = stmt.where(EventTable.kind.in_(kinds))
+
+        if sort_axis == "seq_desc":
+            stmt = stmt.order_by(EventTable.seq.desc(), EventTable.created_at.desc())
+        else:
+            stmt = stmt.order_by(EventTable.seq.asc(), EventTable.created_at.asc())
+
+        count_col = over(func.count()).label("__page_total__")
+        paged = stmt.add_columns(count_col).offset(offset).limit(limit)
+
+        rows = list(session.execute(paged))
+        if not rows:
+            count_stmt = select(func.count()).select_from(stmt.subquery())
+            total = int(session.execute(count_stmt).scalar_one())
+            return [], total
+
+        total = int(rows[0]._mapping["__page_total__"])
+        items = [_event_from_row(row[0]) for row in rows]
+        return items, total
 
     @staticmethod
     def latest(session: Session, limit: int = 20) -> list[RunSummary]:

--- a/ctxr/fsm/sqlite/repos_enforcement.py
+++ b/ctxr/fsm/sqlite/repos_enforcement.py
@@ -56,7 +56,7 @@ from typing import Any
 
 import uuid_utils
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import func, select, update
+from sqlalchemy import func, over, select, update
 from sqlalchemy.orm import Session
 
 from ctxr.fsm.core.models import CommitSignature as CoreCommitSignature
@@ -417,6 +417,50 @@ class ToolCallsRepo:
         )
         rows = session.execute(stmt).scalars().all()
         return [_tool_call_from_row(row) for row in rows]
+
+    def by_run_paged(
+        self,
+        session: Session,
+        run_id: str,
+        *,
+        sort_axis: str,
+        offset: int,
+        limit: int,
+    ) -> tuple[list[ToolCall], int]:
+        """Paginated per-run tool-call slice + true total.
+
+        W22b2-introduced sibling to :meth:`by_run`. The non-paged
+        variant pre-caps with ``limit`` so the HTTP /admin/tool_calls
+        handler could never honestly report a population larger than
+        the cap — :attr:`Page.total` would lie for any run with more
+        than 100 tool calls. This variant runs the same WHERE filter
+        with ``COUNT(*) OVER ()`` so the slice and the population
+        total come back in one statement.
+
+        ``sort_axis`` accepts ``"created_at_desc"`` (matches
+        :meth:`by_run`'s default) or ``"created_at_asc"``.
+        """
+        if limit < 1:
+            return [], 0
+
+        stmt = select(ToolCallTable).where(ToolCallTable.run_id == run_id)
+        if sort_axis == "created_at_asc":
+            stmt = stmt.order_by(ToolCallTable.created_at.asc())
+        else:
+            stmt = stmt.order_by(ToolCallTable.created_at.desc())
+
+        count_col = over(func.count()).label("__page_total__")
+        paged = stmt.add_columns(count_col).offset(offset).limit(limit)
+
+        rows = list(session.execute(paged))
+        if not rows:
+            count_stmt = select(func.count()).select_from(stmt.subquery())
+            total = int(session.execute(count_stmt).scalar_one())
+            return [], total
+
+        total = int(rows[0]._mapping["__page_total__"])
+        items = [_tool_call_from_row(row[0]) for row in rows]
+        return items, total
 
 
 # ---------------------------------------------------------------------------

--- a/ctxr/fsm/sqlite/repos_events.py
+++ b/ctxr/fsm/sqlite/repos_events.py
@@ -66,7 +66,7 @@ from typing import Any
 
 import uuid_utils
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import and_, or_, select, text, update
+from sqlalchemy import and_, func, or_, over, select, text, update
 from sqlalchemy.orm import Session
 
 from ctxr.fsm.sqlite.models_events import (
@@ -588,6 +588,58 @@ class EventsRepo:
         stmt = stmt.order_by(EventTable.created_at.desc())
         rows = session.execute(stmt).scalars().all()
         return [_row_to_event(r) for r in rows]
+
+    @staticmethod
+    def by_run_paged(
+        session: Session,
+        run_id: str,
+        *,
+        since_seq: int | None,
+        kinds: Sequence[str] | None,
+        sort_axis: str,
+        offset: int,
+        limit: int,
+    ) -> tuple[list[Event], int]:
+        """Paginated per-run event slice + true total.
+
+        W22b2-introduced sibling to :meth:`by_run`. The iterator-based
+        ``by_run`` is fine for the bus poll loop (which streams and
+        bails on a buffer limit), but the HTTP /events handler needs
+        an honest population count to serve pagination — which the
+        iterator can't give without exhausting itself. This variant
+        wraps the same WHERE filter in a single statement with
+        ``COUNT(*) OVER ()`` so the page slice and the total fall out
+        together.
+
+        ``sort_axis`` accepts ``"seq_asc"`` (the chronological replay
+        order matching :meth:`by_run`) or ``"seq_desc"``.
+        """
+        if limit < 1:
+            return [], 0
+
+        stmt = select(EventTable).where(EventTable.run_id == run_id)
+        if since_seq is not None:
+            stmt = stmt.where(EventTable.seq > since_seq)
+        if kinds:
+            stmt = stmt.where(EventTable.kind.in_(list(kinds)))
+
+        if sort_axis == "seq_desc":
+            stmt = stmt.order_by(EventTable.seq.desc())
+        else:
+            stmt = stmt.order_by(EventTable.seq.asc())
+
+        count_col = over(func.count()).label("__page_total__")
+        paged = stmt.add_columns(count_col).offset(offset).limit(limit)
+
+        rows = list(session.execute(paged))
+        if not rows:
+            count_stmt = select(func.count()).select_from(stmt.subquery())
+            total = int(session.execute(count_stmt).scalar_one())
+            return [], total
+
+        total = int(rows[0]._mapping["__page_total__"])
+        items = [_row_to_event(row[0]) for row in rows]
+        return items, total
 
     @staticmethod
     def by_run(

--- a/tests/integration/api/test_api_auth.py
+++ b/tests/integration/api/test_api_auth.py
@@ -11,10 +11,10 @@ endpoint because:
 
 * it lives on the admin router which has ``Depends(require_auth)``
   applied at router-level, so a green case proves the guard fires;
-* it returns 200 with an empty list on a fresh DB (no fixtures
+* it returns 200 with an empty page on a fresh DB (no fixtures
   required), keeping the test focused on auth rather than seeding;
-* the response model is a list, so a dev-mode 200 is trivially
-  asserted on (``response.json() == []``).
+* the response model is a ``Page[Lock]`` envelope, so a dev-mode
+  200 is trivially asserted on (``response.json()["items"] == []``).
 
 Test isolation
 --------------
@@ -131,10 +131,17 @@ def test_no_token_env_dev_mode_returns_200(
         f"expected dev-mode 200 from {_ADMIN_ENDPOINT}; "
         f"got {response.status_code}, body={response.text!r}"
     )
-    # Fresh DB → no locks → empty list. Asserting on the shape
-    # protects against a future regression where the dependency layer
-    # silently swaps a different handler in front of the admin route.
-    assert response.json() == []
+    # Fresh DB → no locks → empty page. Asserting on the envelope
+    # shape protects against a future regression where the dependency
+    # layer silently swaps a different handler in front of the admin
+    # route. The list endpoint returns a Page[T] envelope with
+    # ``items``, ``page``, ``page_size``, ``total``, ``has_next``, and
+    # ``sort`` fields rather than a bare list.
+    page = response.json()
+    assert page["items"] == []
+    assert page["total"] == 0
+    assert page["page"] == 1
+    assert page["has_next"] is False
 
 
 def test_token_set_no_authorization_header_returns_401(
@@ -224,7 +231,13 @@ def test_token_set_correct_bearer_returns_200(
         f"expected 200 from {_ADMIN_ENDPOINT} with correct bearer token; "
         f"got {response.status_code}, body={response.text!r}"
     )
-    assert response.json() == []
+    # Same envelope shape as the dev-mode test — see that test for the
+    # rationale on why we assert on the shape and not just the items.
+    page = response.json()
+    assert page["items"] == []
+    assert page["total"] == 0
+    assert page["page"] == 1
+    assert page["has_next"] is False
 
 
 if __name__ == "__main__":  # pragma: no cover - manual debug path

--- a/tests/integration/api/test_api_run_detail.py
+++ b/tests/integration/api/test_api_run_detail.py
@@ -599,18 +599,39 @@ def test_get_events_returns_journal_in_seq_order(
     """
     _, client, run_id = project_and_client
 
-    response = client.get(f"/api/v1/runs/{run_id}/events")
+    # ``page_size=200`` (the documented MAX_PAGE_SIZE) so the seeded
+    # journal — which is comfortably under the cap — comes back in a
+    # single page and the seq-contiguity assertion below sees the
+    # full sequence rather than just the first 50-default slice.
+    response = client.get(
+        f"/api/v1/runs/{run_id}/events", params={"page_size": 200}
+    )
 
     assert response.status_code == 200, (
         f"expected 200 from /api/v1/runs/{run_id}/events, got "
         f"{response.status_code}; body={response.text!r}"
     )
-    events = response.json()
+    page = response.json()
 
+    assert isinstance(page, dict), (
+        f"events endpoint must return a Page envelope dict, got "
+        f"{type(page).__name__}"
+    )
+    events = page["items"]
     assert isinstance(events, list), (
-        f"events endpoint must return a JSON array, got {type(events).__name__}"
+        f"Page.items must be a list, got {type(events).__name__}"
     )
     assert len(events) > 0, "seeded run has events; got an empty list"
+    # Envelope sanity: the full population fit on the first page so
+    # ``total`` matches the items length and ``has_next`` is False.
+    assert page["total"] == len(events), (
+        f"Page.total {page['total']!r} != len(items) {len(events)!r}"
+    )
+    assert page["page"] == 1
+    assert page["has_next"] is False, (
+        f"seeded journal must fit on one page at page_size=200; "
+        f"got has_next=True with total={page['total']}"
+    )
 
     # Every event must belong to the run we asked about.
     for event in events:
@@ -654,30 +675,45 @@ def test_get_events_supports_since_seq_cursor(
     """
     _, client, run_id = project_and_client
 
-    full = client.get(f"/api/v1/runs/{run_id}/events").json()
+    # Pull the full journal first; ``page_size=200`` ensures the
+    # seeded events all land on a single page so we can index into
+    # ``items[0]`` reliably and compute the expected cursored count
+    # off the same population.
+    full_resp = client.get(
+        f"/api/v1/runs/{run_id}/events", params={"page_size": 200}
+    ).json()
+    full = full_resp["items"]
     assert len(full) >= 2, (
         f"need at least 2 events to test the cursor; got {len(full)}"
     )
 
     cursor = full[0]["seq"]
     cursored = client.get(
-        f"/api/v1/runs/{run_id}/events", params={"since_seq": cursor}
+        f"/api/v1/runs/{run_id}/events",
+        params={"since_seq": cursor, "page_size": 200},
     )
 
     assert cursored.status_code == 200, (
         f"expected 200 with since_seq, got {cursored.status_code}; "
         f"body={cursored.text!r}"
     )
-    rows = cursored.json()
+    cursored_page = cursored.json()
+    rows = cursored_page["items"]
     # All returned rows must have seq strictly greater than the cursor.
     assert all(row["seq"] > cursor for row in rows), (
         f"since_seq={cursor} returned a row with seq<={cursor}: {rows!r}"
     )
     # And the count must drop by exactly one — we pinned the cursor at
-    # the very first event.
+    # the very first event. ``total`` on the envelope must agree with
+    # the items length since the cursored slice still fits in one page.
     assert len(rows) == len(full) - 1, (
         f"expected len(full) - 1 = {len(full) - 1} cursored rows, got "
         f"{len(rows)} (full={len(full)})"
+    )
+    assert cursored_page["total"] == len(full) - 1, (
+        f"Page.total must agree with cursored item count; got "
+        f"total={cursored_page['total']}, items={len(rows)}, "
+        f"full={len(full)}"
     )
 
 
@@ -696,16 +732,25 @@ def test_get_events_supports_kinds_whitelist(
 
     response = client.get(
         f"/api/v1/runs/{run_id}/events",
-        params={"kinds": EventKind.state_entered.value},
+        params={
+            "kinds": EventKind.state_entered.value,
+            "page_size": 200,
+        },
     )
 
     assert response.status_code == 200, (
         f"expected 200 with kinds filter, got {response.status_code}; "
         f"body={response.text!r}"
     )
-    rows = response.json()
+    page = response.json()
+    rows = page["items"]
     assert len(rows) == 2, (
         f"seeded run has two state_entered events; got {len(rows)}: {rows!r}"
+    )
+    # ``total`` reflects the count *after* the SQL-level filter so it
+    # must match the item count when the slice fits on one page.
+    assert page["total"] == 2, (
+        f"Page.total must reflect post-filter count; got {page['total']!r}"
     )
     for row in rows:
         assert row["kind"] == EventKind.state_entered.value, (

--- a/tests/integration/api/test_api_runs_list.py
+++ b/tests/integration/api/test_api_runs_list.py
@@ -12,14 +12,14 @@ for. Sync endpoints are exactly what TestClient is designed for.
 The contracts asserted here mirror the spec / MCP coverage at the
 HTTP layer:
 
-* An empty database returns the JSON literal ``[]`` — not ``null``, not
-  a wrapped envelope. The frontend's "did we get any runs?" check is a
-  truthy length test on this array, so the empty case must be a JSON
-  array.
+* An empty database returns the standard ``Page[T]`` envelope with
+  ``items=[]`` and ``total=0`` — not ``null``, not a bare array. The
+  frontend reads runs from ``items``, so the empty case must still
+  produce a well-formed envelope.
 * After we register a spec and start runs through the Python API
   (so this test isolates the *list* contract from the *start* contract),
-  ``GET /runs`` surfaces every run with the expected ``fsm_spec_id``
-  and ``id`` fields.
+  ``GET /runs`` surfaces every run inside ``items`` with the expected
+  ``fsm_spec_id`` and ``id`` fields.
 * ``?status=in_progress`` round-trips through the
   :meth:`RunsRepo.by_status` branch and only returns rows in that
   status — runs we transition to ``completed`` are excluded.
@@ -124,12 +124,14 @@ def client_and_project() -> Iterator[tuple[TestClient, Project]]:
 def test_list_runs_returns_empty_array_on_empty_db(
     client_and_project: tuple[TestClient, Project],
 ) -> None:
-    """An empty database must serialise as the JSON literal ``[]``.
+    """An empty database returns the Page envelope with an empty ``items`` array.
 
-    A wrapped envelope (e.g. ``{"runs": []}``) or ``null`` would force
-    every UI caller to type-check the response before iterating; the
-    contract is "always an array", and an empty DB is the canonical
-    boundary case for that contract.
+    The endpoint now wraps the row list in the standard
+    ``Page[T]`` envelope (``items``, ``page``, ``page_size``,
+    ``total``, ``has_next``, ``sort``). An empty DB is the canonical
+    boundary case: the envelope must still be present, ``items`` must
+    serialise as ``[]`` (not ``null``), and the counters must agree
+    that nothing is there.
     """
     client, _project = client_and_project
 
@@ -139,7 +141,10 @@ def test_list_runs_returns_empty_array_on_empty_db(
         f"GET /api/v1/runs returned {response.status_code}: body={response.text!r}"
     )
     payload = response.json()
-    assert payload == [], f"expected [] on empty DB, got {payload!r}"
+    assert payload["items"] == [], f"expected items=[] on empty DB, got {payload!r}"
+    assert payload["total"] == 0, f"expected total=0 on empty DB, got {payload!r}"
+    assert payload["page"] == 1, f"expected page=1, got {payload!r}"
+    assert payload["has_next"] is False, f"expected has_next=False, got {payload!r}"
 
 
 def test_list_runs_returns_runs_after_python_api_start(
@@ -165,17 +170,21 @@ def test_list_runs_returns_runs_after_python_api_start(
         f"GET /api/v1/runs returned {response.status_code}: body={response.text!r}"
     )
     payload = response.json()
-    assert isinstance(payload, list)
-    assert len(payload) == 2, f"expected exactly 2 runs, got {len(payload)}: {payload!r}"
+    items = payload["items"]
+    assert isinstance(items, list)
+    assert payload["total"] == 2, (
+        f"expected total=2 runs, got {payload['total']}: {payload!r}"
+    )
+    assert len(items) == 2, f"expected exactly 2 items on page, got {len(items)}: {items!r}"
 
-    listed_ids = {row["id"] for row in payload}
+    listed_ids = {row["id"] for row in items}
     assert listed_ids == {run_one.id, run_two.id}, (
         f"expected run ids {{{run_one.id}, {run_two.id}}}, got {listed_ids}"
     )
 
     # Every row must carry the spec id we registered against; a missing
     # value would mean the summary projection dropped the column.
-    for row in payload:
+    for row in items:
         assert row["fsm_spec_id"] == registered.spec.id, (
             f"row {row!r} has unexpected fsm_spec_id"
         )
@@ -225,12 +234,16 @@ def test_list_runs_status_filter_in_progress(
         f"{in_progress_response.status_code}: body={in_progress_response.text!r}"
     )
     in_progress_payload = in_progress_response.json()
-    assert isinstance(in_progress_payload, list)
-    assert len(in_progress_payload) == 1, (
-        f"expected exactly 1 in-progress run, got {in_progress_payload!r}"
+    in_progress_items = in_progress_payload["items"]
+    assert isinstance(in_progress_items, list)
+    assert in_progress_payload["total"] == 1, (
+        f"expected total=1 in-progress run, got {in_progress_payload!r}"
     )
-    assert in_progress_payload[0]["id"] == run_in_progress.id
-    assert in_progress_payload[0]["status"] == "in_progress"
+    assert len(in_progress_items) == 1, (
+        f"expected exactly 1 in-progress run, got {in_progress_items!r}"
+    )
+    assert in_progress_items[0]["id"] == run_in_progress.id
+    assert in_progress_items[0]["status"] == "in_progress"
 
     # --- negative: the completed filter returns exactly the other row ---
     # Confirms the filter is actually filtering rather than always
@@ -241,12 +254,16 @@ def test_list_runs_status_filter_in_progress(
         f"{completed_response.status_code}: body={completed_response.text!r}"
     )
     completed_payload = completed_response.json()
-    assert isinstance(completed_payload, list)
-    assert len(completed_payload) == 1, (
-        f"expected exactly 1 completed run, got {completed_payload!r}"
+    completed_items = completed_payload["items"]
+    assert isinstance(completed_items, list)
+    assert completed_payload["total"] == 1, (
+        f"expected total=1 completed run, got {completed_payload!r}"
     )
-    assert completed_payload[0]["id"] == run_to_complete.id
-    assert completed_payload[0]["status"] == "completed"
+    assert len(completed_items) == 1, (
+        f"expected exactly 1 completed run, got {completed_items!r}"
+    )
+    assert completed_items[0]["id"] == run_to_complete.id
+    assert completed_items[0]["status"] == "completed"
 
 
 if __name__ == "__main__":

--- a/tests/integration/api/test_api_specs.py
+++ b/tests/integration/api/test_api_specs.py
@@ -287,9 +287,13 @@ def test_get_specs_lists_every_registered_spec() -> None:
         response = client.get("/api/v1/specs")
 
     assert response.status_code == 200, response.text
-    rows = response.json()
+    page = response.json()
+    rows = page["items"]
     assert isinstance(rows, list)
     assert len(rows) == 3
+    assert page["total"] == 3
+    assert page["page"] == 1
+    assert page["has_next"] is False
 
     # Canonical ordering: project_slug asc, slug asc, version asc.
     triples = [(row["project_slug"], row["slug"], row["version"]) for row in rows]
@@ -329,7 +333,11 @@ def test_get_specs_returns_empty_list_on_fresh_db() -> None:
         response = client.get("/api/v1/specs")
 
     assert response.status_code == 200, response.text
-    assert response.json() == []
+    page = response.json()
+    assert page["items"] == []
+    assert page["total"] == 0
+    assert page["page"] == 1
+    assert page["has_next"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -364,13 +372,15 @@ def test_get_versions_lists_every_version_for_slug() -> None:
 
         response = client.get(
             f"/api/v1/specs/{slug}/versions",
-            params={"project_slug": "alpha"},
+            params={"project_slug": "alpha", "sort": "version_asc"},
         )
 
     assert response.status_code == 200, response.text
-    rows = response.json()
+    page = response.json()
+    rows = page["items"]
     assert isinstance(rows, list)
     assert len(rows) == 2
+    assert page["total"] == 2
 
     versions = [row["version"] for row in rows]
     assert versions == [1, 2], (
@@ -403,11 +413,11 @@ def test_get_versions_scopes_to_requested_project_slug() -> None:
         alpha_rows = client.get(
             f"/api/v1/specs/{slug}/versions",
             params={"project_slug": "alpha"},
-        ).json()
+        ).json()["items"]
         beta_rows = client.get(
             f"/api/v1/specs/{slug}/versions",
             params={"project_slug": "beta"},
-        ).json()
+        ).json()["items"]
 
     assert len(alpha_rows) == 1
     assert len(beta_rows) == 1
@@ -435,7 +445,11 @@ def test_get_versions_returns_empty_for_unknown_slug() -> None:
         )
 
     assert response.status_code == 200, response.text
-    assert response.json() == []
+    page = response.json()
+    assert page["items"] == []
+    assert page["total"] == 0
+    assert page["page"] == 1
+    assert page["has_next"] is False
 
 
 def test_get_versions_returns_empty_for_unknown_project_slug() -> None:
@@ -465,7 +479,11 @@ def test_get_versions_returns_empty_for_unknown_project_slug() -> None:
         )
 
     assert response.status_code == 200, response.text
-    assert response.json() == []
+    page = response.json()
+    assert page["items"] == []
+    assert page["total"] == 0
+    assert page["page"] == 1
+    assert page["has_next"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -15,6 +15,14 @@ export interface ButtonProps {
   className?: string;
   /** ARIA label override (use when the button has icon-only children). */
   'aria-label'?: string;
+  /**
+   * ARIA current marker. Set to ``"page"`` for the active page button
+   * inside a Pagination control; ``"true"`` / ``"step"`` for other
+   * "you are here" affordances (active step in a wizard, etc.).
+   * AT users get an explicit "current page" announcement that the
+   * visual ``primary`` variant cannot convey on its own.
+   */
+  'aria-current'?: 'page' | 'step' | 'true' | 'false';
   /** Form id for type="submit" buttons living outside the form. */
   form?: string;
   /** Autofocus on mount — opt in only. */
@@ -67,6 +75,7 @@ export function Button({
   children,
   className = '',
   'aria-label': ariaLabel,
+  'aria-current': ariaCurrent,
   form,
   autofocus,
   title,
@@ -96,6 +105,7 @@ export function Button({
       aria-busy={loading || undefined}
       aria-disabled={isDisabled || undefined}
       aria-label={ariaLabel}
+      aria-current={ariaCurrent}
       form={form}
       autofocus={autofocus}
       title={title}

--- a/ui/src/components/Pagination.tsx
+++ b/ui/src/components/Pagination.tsx
@@ -183,10 +183,23 @@ export function Pagination(props: PaginationProps): JSX.Element {
               </li>
             ) : (
               <li key={`p-${slot}`}>
+                {/* Active page gets aria-current="page" + an aria-
+                    label that names the current state explicitly
+                    ("Page N, current page") rather than the misleading
+                    "Go to page N" used for navigable siblings. Screen
+                    readers read aria-current as part of the role text,
+                    so AT users hear "Page 3, current page, button"
+                    instead of "Go to page 3, button" when the cursor
+                    lands on the active slot. */}
                 <Button
                   variant={slot === page.page ? 'primary' : 'ghost'}
                   size="sm"
-                  aria-label={`Go to page ${slot}`}
+                  aria-label={
+                    slot === page.page
+                      ? `Page ${slot}, current page`
+                      : `Go to page ${slot}`
+                  }
+                  aria-current={slot === page.page ? 'page' : undefined}
                   onClick={() => onPageChange(slot)}
                   className={
                     slot === page.page

--- a/ui/src/components/Pagination.tsx
+++ b/ui/src/components/Pagination.tsx
@@ -1,0 +1,258 @@
+/**
+ * ``<Pagination>`` — the universal page-navigation primitive.
+ *
+ * Renders the prev / next pair, a window of clickable page numbers,
+ * a page-size selector, and the row-range readout ("rows 51-100 of
+ * 1,247"). Designed to bind directly to the ``Page<T>`` envelope
+ * shipped by every paginated API endpoint post-W22b2 — the consumer
+ * passes a single ``page`` prop (the envelope) plus an ``onChange``
+ * callback and the component manages the rest.
+ *
+ * Interaction model:
+ *
+ * - Prev / Next are disabled at the appropriate ends (``page === 1``
+ *   for prev, ``!has_next`` for next).
+ * - Numeric buttons render a windowed slice: first, last, current
+ *   ± 2, with ellipsis gaps. Capped at ~7 visible slots so the
+ *   control stays one row tall on narrow viewports.
+ * - The page-size selector is a plain ``<select>`` so it inherits
+ *   the native keyboard semantics (Space / arrows / type-ahead).
+ *   Default options track the design-token ladder
+ *   (25 / 50 / 100 / 200, capped at MAX_PAGE_SIZE = 200 on the wire).
+ * - The row-range readout is always rendered to give the operator
+ *   the same scaffolding regardless of total — empty pages show
+ *   "no rows" rather than disappear.
+ *
+ * Accessibility:
+ *
+ * - The whole region is wrapped in ``<nav role="navigation">`` with
+ *   an ``aria-label`` so AT users hear "Pagination, navigation".
+ * - Numeric buttons carry ``aria-current="page"`` on the active
+ *   page and ``aria-label="Go to page N"`` everywhere else.
+ * - The page-size selector has an associated ``<label>`` (visually
+ *   hidden via ``sr-only`` so the design stays compact but still
+ *   readable to AT).
+ * - Disabled buttons use ``aria-disabled`` rather than the ``disabled``
+ *   attribute so they remain focusable (some screen readers skip
+ *   ``disabled``).
+ *
+ * Why not virtualise the numeric strip? At ten-thousand-row scale the
+ * naive approach (all page numbers visible) breaks; the windowed
+ * pattern caps the DOM at <=8 buttons regardless of total. The user
+ * can still jump to "last" via the last-page button, and a future
+ * Cmd+G "go to page" affordance can land alongside Cmd+K when the
+ * Command Palette ships.
+ */
+
+import type { JSX } from 'preact';
+
+import { Button } from './Button';
+
+/**
+ * Mirror of the server-side ``Page<T>`` envelope (api.ts ``Page<T>``).
+ *
+ * Inlined as a structural type so this component file doesn't pull in
+ * the ``api`` module just to read five field names — keeps the import
+ * graph shallow and makes ``Pagination`` reusable for any local
+ * envelope a route might synthesise (e.g. for client-side pagination
+ * over a cached list).
+ */
+export interface PaginationPage {
+  page: number;
+  page_size: number;
+  total: number;
+  has_next: boolean;
+}
+
+export interface PaginationProps {
+  page: PaginationPage;
+  /** Called when the user picks a different page. */
+  onPageChange: (page: number) => void;
+  /** Called when the user changes the page-size selector. Optional. */
+  onPageSizeChange?: (pageSize: number) => void;
+  /**
+   * Page-size options surfaced in the selector. Defaults to
+   * ``[25, 50, 100, 200]`` (matches MAX_PAGE_SIZE on the wire).
+   * Pass a custom array to lock the menu to e.g. ``[10, 25]`` for a
+   * route that doesn't want big pages.
+   */
+  pageSizeOptions?: number[];
+  /**
+   * Singular/plural noun for the row-range readout ("rows 1-50 of 200" vs
+   * "specs 1-3 of 3"). Defaults to ``"rows"``.
+   */
+  itemLabel?: string;
+  className?: string;
+  /** ARIA region label override. */
+  'aria-label'?: string;
+}
+
+const DEFAULT_PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
+
+/**
+ * Build the windowed page-number sequence to display.
+ *
+ * Algorithm: always include 1 and N (the last page), the current
+ * page, and ±2 around current. Insert ``null`` (rendered as ``…``)
+ * where the gap is at least 2.
+ *
+ * Examples (current=5, total=10):  [1, …, 3, 4, 5, 6, 7, …, 10]
+ *           (current=1, total=10): [1, 2, 3, …, 10]
+ *           (current=10, total=10):[1, …, 8, 9, 10]
+ *           (total=3):             [1, 2, 3]
+ */
+function windowedPages(current: number, totalPages: number): (number | null)[] {
+  if (totalPages <= 0) return [];
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const slots = new Set<number>([1, totalPages, current]);
+  for (const delta of [-2, -1, 1, 2]) {
+    const candidate = current + delta;
+    if (candidate >= 1 && candidate <= totalPages) {
+      slots.add(candidate);
+    }
+  }
+  const sorted = Array.from(slots).sort((a, b) => a - b);
+  const result: (number | null)[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i] - sorted[i - 1] > 1) {
+      result.push(null);
+    }
+    result.push(sorted[i]);
+  }
+  return result;
+}
+
+export function Pagination(props: PaginationProps): JSX.Element {
+  const {
+    page,
+    onPageChange,
+    onPageSizeChange,
+    pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+    itemLabel = 'rows',
+    className = '',
+  } = props;
+  const ariaLabel = props['aria-label'] ?? 'Pagination';
+
+  const totalPages = Math.max(1, Math.ceil(page.total / page.page_size));
+  const firstRow = page.total === 0 ? 0 : (page.page - 1) * page.page_size + 1;
+  const lastRow = Math.min(page.total, page.page * page.page_size);
+  const onFirst = page.page <= 1;
+  const onLast = !page.has_next;
+  const sequence = windowedPages(page.page, totalPages);
+
+  return (
+    <nav
+      role="navigation"
+      aria-label={ariaLabel}
+      class={
+        'flex flex-wrap items-center justify-between gap-3 ' +
+        'text-sm text-slate-700 dark:text-slate-300 ' +
+        className
+      }
+    >
+      <div class="flex items-center gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={onFirst}
+          aria-label="Go to first page"
+          onClick={() => onPageChange(1)}
+        >
+          «
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={onFirst}
+          aria-label="Go to previous page"
+          onClick={() => onPageChange(page.page - 1)}
+        >
+          ‹ Prev
+        </Button>
+        <ol class="inline-flex items-center gap-1" aria-label="Page numbers">
+          {sequence.map((slot, idx) =>
+            slot === null ? (
+              <li
+                key={`gap-${idx}`}
+                class="px-2 text-slate-400 dark:text-slate-500 select-none"
+                aria-hidden="true"
+              >
+                …
+              </li>
+            ) : (
+              <li key={`p-${slot}`}>
+                <Button
+                  variant={slot === page.page ? 'primary' : 'ghost'}
+                  size="sm"
+                  aria-label={`Go to page ${slot}`}
+                  onClick={() => onPageChange(slot)}
+                  className={
+                    slot === page.page
+                      ? 'pointer-events-none'
+                      : ''
+                  }
+                >
+                  {slot}
+                </Button>
+              </li>
+            ),
+          )}
+        </ol>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={onLast}
+          aria-label="Go to next page"
+          onClick={() => onPageChange(page.page + 1)}
+        >
+          Next ›
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={onLast}
+          aria-label="Go to last page"
+          onClick={() => onPageChange(totalPages)}
+        >
+          »
+        </Button>
+      </div>
+      <div class="flex items-center gap-4 text-xs text-slate-500 dark:text-slate-400">
+        <output aria-live="polite">
+          {page.total === 0
+            ? `no ${itemLabel}`
+            : `${itemLabel} ${firstRow.toLocaleString()}–${lastRow.toLocaleString()} of ${page.total.toLocaleString()}`}
+        </output>
+        {onPageSizeChange ? (
+          <label class="inline-flex items-center gap-1.5">
+            <span class="sr-only">Rows per page</span>
+            <select
+              class={
+                'rounded border border-slate-300 bg-white px-1.5 py-0.5 ' +
+                'text-xs text-slate-700 ' +
+                'dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 ' +
+                'focus:outline-none focus:ring-2 focus:ring-emerald-500'
+              }
+              value={page.page_size}
+              aria-label="Rows per page"
+              onChange={(event: JSX.TargetedEvent<HTMLSelectElement>) => {
+                const next = Number((event.currentTarget as HTMLSelectElement).value);
+                onPageSizeChange(next);
+              }}
+            >
+              {pageSizeOptions.map((size) => (
+                <option key={size} value={size}>
+                  {size} per page
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+      </div>
+    </nav>
+  );
+}
+
+export default Pagination;

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -59,3 +59,6 @@ export type { FlowGraphProps, FlowNodeData, FlowNodeKind } from './FlowGraph';
 
 export { Tooltip } from './Tooltip';
 export type { TooltipProps, TooltipPlacement } from './Tooltip';
+
+export { Pagination } from './Pagination';
+export type { PaginationPage, PaginationProps } from './Pagination';

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ApiClient, ApiError, type RunSummary } from '../api';
+import { ApiClient, ApiError, type Page, type RunSummary } from '../api';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -11,26 +11,42 @@ function jsonResponse(body: unknown, status = 200): Response {
 describe('ApiClient.listRuns', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('GETs /runs and parses the response', async () => {
-    const rows: RunSummary[] = [
-      {
-        id: 'r1', project_id: 'p', fsm_spec_id: 's', status: 'running',
-        current_state: 'A', next_state: null, verdict: null,
-        started_at: '2026-01-01T00:00:00Z', ended_at: null,
-        last_update_at: '2026-01-01T00:00:00Z', transitions_count: 3,
-      },
-    ];
+  it('GETs /runs with page params and parses the Page<T> envelope', async () => {
+    const envelope: Page<RunSummary> = {
+      items: [
+        {
+          id: 'r1', project_id: 'p', fsm_spec_id: 's', status: 'running',
+          current_state: 'A', next_state: null, verdict: null,
+          started_at: '2026-01-01T00:00:00Z', ended_at: null,
+          last_update_at: '2026-01-01T00:00:00Z', transitions_count: 3,
+        },
+      ],
+      page: 2,
+      page_size: 5,
+      total: 7,
+      has_next: false,
+      sort: 'last_update_at_desc',
+    };
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(jsonResponse(rows));
+      .mockResolvedValue(jsonResponse(envelope));
     const client = new ApiClient('/api/v1');
 
-    const result = await client.listRuns({ status: 'running', limit: 5 });
+    const result = await client.listRuns({
+      status: 'running',
+      page: 2,
+      page_size: 5,
+      sort: 'last_update_at_desc',
+    });
 
-    expect(result).toEqual(rows);
+    expect(result).toEqual(envelope);
+    expect(result.items[0].id).toBe('r1');
+    expect(result.total).toBe(7);
     expect(fetchSpy).toHaveBeenCalledOnce();
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe('/api/v1/runs?status=running&limit=5');
+    expect(url).toBe(
+      '/api/v1/runs?status=running&page=2&page_size=5&sort=last_update_at_desc',
+    );
     expect((init as RequestInit).method).toBe('GET');
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -798,6 +798,60 @@ export class ApiClient {
 }
 
 /**
+ * Maximum page size the server accepts in a single request. Mirrors
+ * ``MAX_PAGE_SIZE`` in ``ctxr/fsm/api/_pagination.py`` (200). Exposed so
+ * routes that legitimately need to enumerate the full population
+ * (e.g. spec catalog grouping, drift dashboard seeding) can request
+ * the largest page in one round trip.
+ */
+export const MAX_PAGE_SIZE = 200;
+
+/**
+ * Walk every page of a paginated endpoint and return the flattened
+ * row list.
+ *
+ * The post-W22b2 wire format paginates every list endpoint, but a few
+ * UI surfaces still need the FULL population (derivative aggregations
+ * like "count runs per spec slug", sibling tree expansion, drift
+ * dashboard seeding). Rather than each route re-implementing the same
+ * "loop with ``has_next`` + safety stop" pattern, this helper owns it.
+ *
+ * Pages are fetched serially so the server's paginator sees a stable
+ * cursor / sort across requests. ``page_size`` is fixed at
+ * :const:`MAX_PAGE_SIZE` so we minimise the round-trip count.
+ * ``maxPages`` (default 50 = 10,000 rows at max page size) is a
+ * safety stop that catches runaway loops if a future server bug
+ * returns ``has_next: true`` indefinitely; callers that legitimately
+ * need more can raise it explicitly.
+ *
+ * Example:
+ *
+ * ```ts
+ * const allSpecs = await walkAllPages(
+ *   (p) => api.listSpecs(p),
+ *   {},
+ * );
+ * ```
+ */
+export async function walkAllPages<T, P extends PageParams>(
+  fetcher: (params: P) => Promise<Page<T>>,
+  baseParams: Omit<P, 'page' | 'page_size'>,
+  maxPages = 50,
+): Promise<T[]> {
+  const out: T[] = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    const env = await fetcher({
+      ...(baseParams as P),
+      page,
+      page_size: MAX_PAGE_SIZE,
+    } as P);
+    out.push(...env.items);
+    if (!env.has_next) return out;
+  }
+  return out;
+}
+
+/**
  * Process-wide :class:`ApiClient` instance with the dev-server defaults.
  *
  * Components that just need to call the API import this directly:

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -307,19 +307,50 @@ export interface DoctorReport {
 // Request parameter shapes
 // ---------------------------------------------------------------------------
 
+/**
+ * Generic page envelope returned by every list endpoint.
+ *
+ * Mirrors :class:`Page` on the Python side (ctxr/fsm/api/_pagination.py)
+ * verbatim — ``items`` is the slice, ``total`` is the population size,
+ * ``has_next`` is derived (kept on the wire so a client that lost the
+ * ``page`` / ``page_size`` can still chain). The post-W22b2 wire shape
+ * for every list endpoint is ``Page<T>``; the only legacy raw-array
+ * endpoints left are the ones that don't paginate (``getStateTree``,
+ * ``getRun``, etc., which return a single document).
+ */
+export interface Page<T> {
+  items: T[];
+  page: number;
+  page_size: number;
+  total: number;
+  has_next: boolean;
+  sort: string;
+}
+
+/** Common pagination params used by every paginated list endpoint. */
+export interface PageParams {
+  page?: number;
+  page_size?: number;
+  sort?: string;
+}
+
 /** Query parameters for ``GET /runs``. */
-export interface ListRunsParams {
+export interface ListRunsParams extends PageParams {
   status?: string;
   since?: string;
-  limit?: number;
-  offset?: number;
 }
 
 /** Query parameters for ``GET /runs/{id}/events``. */
-export interface GetEventsParams {
+export interface GetEventsParams extends PageParams {
   since_seq?: number;
   kinds?: string[];
-  limit?: number;
+}
+
+/** Query parameters for ``GET /events``. */
+export interface ListEventsParams extends PageParams {
+  run_id: string;
+  since_seq?: number;
+  kinds?: string[];
 }
 
 /** Body of ``POST /runs/{run_id}/resume``. */
@@ -340,15 +371,18 @@ export interface RegisterSpecBody {
 }
 
 /** Query parameters for ``GET /admin/journal_txns``. */
-export interface ListJournalTxnsParams {
+export interface ListJournalTxnsParams extends PageParams {
   status?: 'pending' | 'ready_to_finalise' | 'finalised';
-  limit?: number;
 }
 
 /** Query parameters for ``GET /admin/tool_calls``. */
-export interface ListToolCallsParams {
+export interface ListToolCallsParams extends PageParams {
   run_id: string;
-  limit?: number;
+}
+
+/** Query parameters for ``GET /specs/{slug}/versions``. */
+export interface ListSpecVersionsParams extends PageParams {
+  project_slug?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -544,12 +578,13 @@ export class ApiClient {
   // -------------------------------------------------------------------------
 
   /** ``GET /runs`` — list runs with optional filters. */
-  listRuns(params: ListRunsParams = {}): Promise<RunSummary[]> {
-    return this.request<RunSummary[]>('GET', '/runs', {
+  listRuns(params: ListRunsParams = {}): Promise<Page<RunSummary>> {
+    return this.request<Page<RunSummary>>('GET', '/runs', {
       status: params.status,
       since: params.since,
-      limit: params.limit,
-      offset: params.offset,
+      page: params.page,
+      page_size: params.page_size,
+      sort: params.sort,
     });
   }
 
@@ -567,14 +602,16 @@ export class ApiClient {
   }
 
   /** ``GET /runs/{id}/events`` — slice of the run's event journal. */
-  getEvents(id: string, params: GetEventsParams = {}): Promise<Event[]> {
-    return this.request<Event[]>(
+  getEvents(id: string, params: GetEventsParams = {}): Promise<Page<Event>> {
+    return this.request<Page<Event>>(
       'GET',
       `/runs/${encodeURIComponent(id)}/events`,
       {
         since_seq: params.since_seq,
         kinds: params.kinds,
-        limit: params.limit,
+        page: params.page,
+        page_size: params.page_size,
+        sort: params.sort,
       },
     );
   }
@@ -615,19 +652,28 @@ export class ApiClient {
   // -------------------------------------------------------------------------
 
   /** ``GET /specs`` — every registered spec across every project. */
-  listSpecs(): Promise<SpecSummary[]> {
-    return this.request<SpecSummary[]>('GET', '/specs');
+  listSpecs(params: PageParams = {}): Promise<Page<SpecSummary>> {
+    return this.request<Page<SpecSummary>>('GET', '/specs', {
+      page: params.page,
+      page_size: params.page_size,
+      sort: params.sort,
+    });
   }
 
   /** ``GET /specs/{slug}/versions`` — version history for one FSM slug. */
   getSpecVersions(
     slug: string,
-    projectSlug?: string,
-  ): Promise<SpecVersion[]> {
-    return this.request<SpecVersion[]>(
+    params: ListSpecVersionsParams = {},
+  ): Promise<Page<SpecVersion>> {
+    return this.request<Page<SpecVersion>>(
       'GET',
       `/specs/${encodeURIComponent(slug)}/versions`,
-      projectSlug ? { project_slug: projectSlug } : undefined,
+      {
+        project_slug: params.project_slug,
+        page: params.page,
+        page_size: params.page_size,
+        sort: params.sort,
+      },
     );
   }
 
@@ -657,13 +703,21 @@ export class ApiClient {
   // -------------------------------------------------------------------------
 
   /** ``GET /producers`` — bus topology, producer side. */
-  listProducers(): Promise<Producer[]> {
-    return this.request<Producer[]>('GET', '/producers');
+  listProducers(params: PageParams = {}): Promise<Page<Producer>> {
+    return this.request<Page<Producer>>('GET', '/producers', {
+      page: params.page,
+      page_size: params.page_size,
+      sort: params.sort,
+    });
   }
 
   /** ``GET /consumers`` — bus topology, consumer side. */
-  listConsumers(): Promise<Consumer[]> {
-    return this.request<Consumer[]>('GET', '/consumers');
+  listConsumers(params: PageParams = {}): Promise<Page<Consumer>> {
+    return this.request<Page<Consumer>>('GET', '/consumers', {
+      page: params.page,
+      page_size: params.page_size,
+      sort: params.sort,
+    });
   }
 
   /** ``POST /consumers/{id}/ack`` — acknowledge a batch of events. */
@@ -683,23 +737,31 @@ export class ApiClient {
   /** ``GET /admin/journal_txns`` — journal-txn ledger across runs. */
   listJournalTxns(
     params: ListJournalTxnsParams = {},
-  ): Promise<JournalTxn[]> {
-    return this.request<JournalTxn[]>('GET', '/admin/journal_txns', {
+  ): Promise<Page<JournalTxn>> {
+    return this.request<Page<JournalTxn>>('GET', '/admin/journal_txns', {
       status: params.status,
-      limit: params.limit,
+      page: params.page,
+      page_size: params.page_size,
+      sort: params.sort,
     });
   }
 
   /** ``GET /admin/locks`` — every currently-held lock row. */
-  listLocks(): Promise<Lock[]> {
-    return this.request<Lock[]>('GET', '/admin/locks');
+  listLocks(params: PageParams = {}): Promise<Page<Lock>> {
+    return this.request<Page<Lock>>('GET', '/admin/locks', {
+      page: params.page,
+      page_size: params.page_size,
+      sort: params.sort,
+    });
   }
 
   /** ``GET /admin/tool_calls`` — tool-call audit log for a run. */
-  listToolCalls(params: ListToolCallsParams): Promise<ToolCall[]> {
-    return this.request<ToolCall[]>('GET', '/admin/tool_calls', {
+  listToolCalls(params: ListToolCallsParams): Promise<Page<ToolCall>> {
+    return this.request<Page<ToolCall>>('GET', '/admin/tool_calls', {
       run_id: params.run_id,
-      limit: params.limit,
+      page: params.page,
+      page_size: params.page_size,
+      sort: params.sort,
     });
   }
 
@@ -713,11 +775,19 @@ export class ApiClient {
   }
 
   /** ``GET /admin/commit_signatures`` — commit-signature timeline. */
-  listCommitSignatures(runId: string): Promise<CommitSignatureRecord[]> {
-    return this.request<CommitSignatureRecord[]>(
+  listCommitSignatures(
+    runId: string,
+    params: PageParams = {},
+  ): Promise<Page<CommitSignatureRecord>> {
+    return this.request<Page<CommitSignatureRecord>>(
       'GET',
       '/admin/commit_signatures',
-      { run_id: runId },
+      {
+        run_id: runId,
+        page: params.page,
+        page_size: params.page_size,
+        sort: params.sort,
+      },
     );
   }
 

--- a/ui/src/routes/consumers.tsx
+++ b/ui/src/routes/consumers.tsx
@@ -42,9 +42,9 @@ export function ConsumersRoute(): JSX.Element {
   useEffect(() => {
     let cancelled = false;
     api
-      .listConsumers()
-      .then((rows) => {
-        if (!cancelled) setConsumers(rows);
+      .listConsumers({ page_size: 200 })
+      .then((page) => {
+        if (!cancelled) setConsumers(page.items);
       })
       .catch((err: unknown) => {
         if (cancelled) return;

--- a/ui/src/routes/drift.tsx
+++ b/ui/src/routes/drift.tsx
@@ -60,6 +60,53 @@ function statusVariant(status: string): PillVariant {
   }
 }
 
+/**
+ * Maximum concurrent ``listDriftSignals`` requests in flight at any
+ * moment while seeding the drift table. The fan-out is bounded
+ * because (a) the browser's per-host connection limit serialises
+ * excess requests anyway, so launching 200 at once just wastes the
+ * scheduler's time, and (b) each call exercises a SQL query against
+ * a different run — at 200 parallel reads SQLite's WAL still cooperates
+ * but the API process eats the CPU for no UX gain. ``DRIFT_FANOUT_LIMIT``
+ * matches the pre-W22b2-iter hard-coded ``RUN_CAP=50`` so the worst-
+ * case load on the API stays bounded regardless of which page size the
+ * operator picks. A future per-API-call multi-run endpoint would let
+ * us drop this entirely.
+ */
+const DRIFT_FANOUT_LIMIT = 50;
+
+/**
+ * Fire ``fn`` against each input with at most ``limit`` calls in
+ * flight. Returns ``PromiseSettledResult[]`` in input order so callers
+ * can mix fulfilled / rejected outcomes without paying a separate
+ * try / catch per item. Implemented inline rather than pulled in as
+ * ``p-limit`` because the dependency would be ~2 KB gzipped for one
+ * call site; if a second consumer surfaces we lift this to a lib.
+ */
+async function mapLimited<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const out = new Array<PromiseSettledResult<R>>(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const idx = cursor;
+      cursor += 1;
+      if (idx >= items.length) return;
+      try {
+        const value = await fn(items[idx]);
+        out[idx] = { status: 'fulfilled', value };
+      } catch (reason) {
+        out[idx] = { status: 'rejected', reason };
+      }
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
 export function DriftRoute(): JSX.Element {
   const [runsPage, setRunsPage] = useState<Page<RunSummary> | null>(null);
   const [rows, setRows] = useState<DriftRow[] | null>(null);
@@ -76,12 +123,13 @@ export function DriftRoute(): JSX.Element {
         const runs = await api.listRuns({ page, page_size: pageSize });
         if (cancelled) return;
         setRunsPage(runs);
-        const settled = await Promise.allSettled(
-          runs.items.map((r) =>
+        const settled = await mapLimited(
+          runs.items,
+          DRIFT_FANOUT_LIMIT,
+          (r) =>
             api
               .listDriftSignals(r.id)
               .then((d): { run: RunSummary; resp: DriftSignalsResponse } => ({ run: r, resp: d })),
-          ),
         );
         const out: DriftRow[] = [];
         for (const s of settled) {

--- a/ui/src/routes/drift.tsx
+++ b/ui/src/routes/drift.tsx
@@ -7,9 +7,9 @@
  * is in W18d still in its right column; future iteration scrolls to
  * it).
  *
- * Data acquisition: listRuns then Promise.allSettled across
- * listDriftSignals per run. Capped at the first 50 runs to bound the
- * network cost.
+ * Data acquisition: listRuns (paginated) then Promise.allSettled
+ * across listDriftSignals per run in the current page. The user
+ * navigates pages via the <Pagination> control at the bottom.
  */
 
 import type { JSX } from 'preact';
@@ -18,6 +18,7 @@ import { useEffect, useState } from 'preact/hooks';
 import {
   Card,
   EmptyState,
+  Pagination,
   Pill,
   Spinner,
   Table,
@@ -28,6 +29,7 @@ import {
   api,
   ApiError,
   type DriftSignalsResponse,
+  type Page,
   type RunSummary,
 } from '../lib/api';
 
@@ -38,7 +40,7 @@ interface DriftRow {
   signalCount: number;
 }
 
-const RUN_CAP = 50;
+const DEFAULT_PAGE_SIZE = 50;
 
 function scoreVariant(s: number): PillVariant {
   if (s >= 0.7) return 'danger';
@@ -59,17 +61,23 @@ function statusVariant(status: string): PillVariant {
 }
 
 export function DriftRoute(): JSX.Element {
+  const [runsPage, setRunsPage] = useState<Page<RunSummary> | null>(null);
   const [rows, setRows] = useState<DriftRow[] | null>(null);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    setRows(null);
+    setRunsPage(null);
     (async () => {
       try {
-        const runs = await api.listRuns({});
-        const capped = runs.slice(0, RUN_CAP);
+        const runs = await api.listRuns({ page, page_size: pageSize });
+        if (cancelled) return;
+        setRunsPage(runs);
         const settled = await Promise.allSettled(
-          capped.map((r) =>
+          runs.items.map((r) =>
             api
               .listDriftSignals(r.id)
               .then((d): { run: RunSummary; resp: DriftSignalsResponse } => ({ run: r, resp: d })),
@@ -97,7 +105,7 @@ export function DriftRoute(): JSX.Element {
       }
     })();
     return () => { cancelled = true; };
-  }, []);
+  }, [page, pageSize]);
 
   const cols: TableColumn<DriftRow>[] = [
     {
@@ -140,7 +148,10 @@ export function DriftRoute(): JSX.Element {
         {rows === null ? (
           <div class="flex items-center justify-center py-12"><Spinner label="Computing drift across runs" /></div>
         ) : rows.length === 0 ? (
-          <EmptyState title="No drift signals" message={`Across the last ${RUN_CAP} runs, none accumulated any drift signals.`} />
+          <EmptyState
+            title="No drift signals"
+            message={`Across the ${runsPage?.items.length ?? 0} run(s) on this page, none accumulated any drift signals.`}
+          />
         ) : (
           <Table<DriftRow>
             columns={cols}
@@ -150,6 +161,14 @@ export function DriftRoute(): JSX.Element {
           />
         )}
       </Card>
+      {runsPage !== null && runsPage.total > 0 ? (
+        <Pagination
+          page={runsPage}
+          onPageChange={(p) => setPage(p)}
+          onPageSizeChange={(sz) => { setPageSize(sz); setPage(1); }}
+          itemLabel="runs"
+        />
+      ) : null}
     </div>
   );
 }

--- a/ui/src/routes/journal.tsx
+++ b/ui/src/routes/journal.tsx
@@ -16,6 +16,7 @@ import {
   Dialog,
   EmptyState,
   JsonViewer,
+  Pagination,
   Pill,
   Spinner,
   Timeline,
@@ -23,7 +24,9 @@ import {
   type PillVariant,
   type TimelineItem,
 } from '../components';
-import { api, ApiError, type JournalTxn } from '../lib/api';
+import { api, ApiError, type JournalTxn, type Page } from '../lib/api';
+
+const DEFAULT_PAGE_SIZE = 200;
 
 function fmt(iso: string | null | undefined): string {
   if (!iso) return '—';
@@ -47,7 +50,9 @@ interface Pending {
 }
 
 export function JournalRoute(): JSX.Element {
-  const [txns, setTxns] = useState<JournalTxn[] | null>(null);
+  const [txnsPage, setTxnsPage] = useState<Page<JournalTxn> | null>(null);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<Pending | null>(null);
   const [busy, setBusy] = useState(false);
@@ -55,24 +60,26 @@ export function JournalRoute(): JSX.Element {
 
   const reload = useCallback(() => {
     let cancelled = false;
-    setTxns(null);
-    api.listJournalTxns({ limit: 500 })
-      .then((rows) => {
+    setTxnsPage(null);
+    api.listJournalTxns({ page, page_size: pageSize })
+      .then((resp) => {
         if (!cancelled) {
-          // Sort recent first by started_at.
-          const sorted = [...rows].sort((a, b) =>
+          // Sort recent first by started_at within the page.
+          const sortedItems = [...resp.items].sort((a, b) =>
             (b.started_at ?? '').localeCompare(a.started_at ?? ''),
           );
-          setTxns(sorted);
+          setTxnsPage({ ...resp, items: sortedItems });
         }
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(err instanceof ApiError ? err.message : String(err));
       });
     return () => { cancelled = true; };
-  }, []);
+  }, [page, pageSize]);
 
   useEffect(reload, [reload]);
+
+  const txns = txnsPage?.items ?? null;
 
   const grouped = useMemo(() => {
     if (!txns) return [];
@@ -169,7 +176,7 @@ export function JournalRoute(): JSX.Element {
         <Button variant="ghost" size="sm" onClick={reload}>Refresh</Button>
       </header>
       <Card>
-        {txns === null ? (
+        {txnsPage === null ? (
           <div class="flex items-center justify-center py-12"><Spinner label="Loading journal" /></div>
         ) : grouped.length === 0 ? (
           <EmptyState title="No pending txns" message="Every journal txn across every run is finalised." />
@@ -192,6 +199,14 @@ export function JournalRoute(): JSX.Element {
           </div>
         )}
       </Card>
+      {txnsPage !== null && txnsPage.total > 0 ? (
+        <Pagination
+          page={txnsPage}
+          onPageChange={(p) => setPage(p)}
+          onPageSizeChange={(sz) => { setPageSize(sz); setPage(1); }}
+          itemLabel="journal txns"
+        />
+      ) : null}
       <Dialog
         open={pending !== null}
         onClose={() => setPending(null)}

--- a/ui/src/routes/runCompare.tsx
+++ b/ui/src/routes/runCompare.tsx
@@ -40,11 +40,11 @@ interface Loaded {
 }
 
 async function loadRun(id: string): Promise<Loaded> {
-  const [run, events] = await Promise.all([
+  const [run, eventsPage] = await Promise.all([
     api.getRun(id),
-    api.getEvents(id, { limit: 500 }),
+    api.getEvents(id, { page_size: 200 }),
   ]);
-  return { run, events };
+  return { run, events: eventsPage.items };
 }
 
 interface FlatState {

--- a/ui/src/routes/runDetail.tsx
+++ b/ui/src/routes/runDetail.tsx
@@ -422,10 +422,12 @@ export function RunDetailRoute(): JSX.Element {
       Promise.allSettled([
         api.getRun(id),
         api.getStateTree(id),
-        api.getEvents(id, { limit: 200 }),
-        api.listToolCalls({ run_id: id, limit: 50 }),
+        api.getEvents(id, { page_size: 200 }),
+        api.listToolCalls({ run_id: id, page_size: 50 }),
         api.listDriftSignals(id),
-        api.listCommitSignatures(id),
+        // page_size=200 is the MAX_PAGE_SIZE cap; the "last 3" UI slice
+        // below operates on .items so this header-sized page is plenty.
+        api.listCommitSignatures(id, { page_size: 200 }),
       ]).then((results) => {
         if (cancelled) return;
         const [runRes, treeRes, eventsRes, toolsRes, driftRes, sigsRes] =
@@ -448,10 +450,16 @@ export function RunDetailRoute(): JSX.Element {
         } else {
           setStateTree(null);
         }
-        setEvents(eventsRes.status === 'fulfilled' ? eventsRes.value : []);
-        setToolCalls(toolsRes.status === 'fulfilled' ? toolsRes.value : []);
+        setEvents(
+          eventsRes.status === 'fulfilled' ? eventsRes.value.items : [],
+        );
+        setToolCalls(
+          toolsRes.status === 'fulfilled' ? toolsRes.value.items : [],
+        );
         setDrift(driftRes.status === 'fulfilled' ? driftRes.value : null);
-        setSignatures(sigsRes.status === 'fulfilled' ? sigsRes.value : []);
+        setSignatures(
+          sigsRes.status === 'fulfilled' ? sigsRes.value.items : [],
+        );
         setLoading(false);
       });
       return () => {

--- a/ui/src/routes/runs.tsx
+++ b/ui/src/routes/runs.tsx
@@ -43,6 +43,7 @@ import {
 import {
   api,
   ApiError,
+  walkAllPages,
   type ListRunsParams,
   type Page,
   type RunSummary,
@@ -66,13 +67,6 @@ const STATUS_FILTERS: readonly { value: string; label: string }[] = [
 
 /** Default page size — kept modest so the first paint is cheap. */
 const DEFAULT_PAGE_SIZE = 25;
-
-/**
- * Upper bound the API will accept for ``?page_size=``. Mirrors the
- * server-side ``MAX_PAGE_SIZE`` cap (ctxr/fsm/api/_pagination.py).
- * Used when walking pages to populate the spec resolver below.
- */
-const MAX_PAGE_SIZE = 200;
 
 /** Event kinds that should trigger a list refresh. */
 const REFRESH_EVENT_KINDS: ReadonlySet<string> = new Set([
@@ -152,31 +146,13 @@ function specCell(run: RunSummary, resolver: Map<string, { slug: string; version
   return run.fsm_spec_id.slice(0, 12) + '…';
 }
 
-/**
- * Walk every page of ``api.listSpecs()`` and return the merged list.
- *
- * Used by the spec-resolver bootstrap below — the resolver needs every
- * spec the project has ever registered, not just the first page worth,
- * so the Spec column on each run row can render ``slug v<n>`` rather
- * than a raw UUID. Kept inline (rather than promoted to a shared
- * helper) per the W22b3 migration brief: the few routes that need
- * "all rows" can each pay the small bespoke cost until a real pattern
- * emerges.
- */
-async function fetchAllSpecs(): Promise<SpecSummary[]> {
-  const all: SpecSummary[] = [];
-  let page = 1;
-  // Defensive cap: ten pages of 200 = 2000 specs. If a project has
-  // more than that, the loop still terminates and the resolver simply
-  // misses the very tail; the row falls back to the UUID prefix.
-  for (let i = 0; i < 10; i++) {
-    const result = await api.listSpecs({ page, page_size: MAX_PAGE_SIZE });
-    for (const s of result.items) all.push(s);
-    if (!result.has_next) break;
-    page += 1;
-  }
-  return all;
-}
+// Spec resolver bootstrap delegates to the shared ``walkAllPages``
+// helper in ``lib/api.ts``. Pre-W22b2-iter we had a bespoke inline
+// loop here that capped at 10 pages of 200 (2000 specs); the shared
+// helper offers a 50-page default with the same per-page size. The
+// resolver needs every spec the project has ever registered, not
+// just the first page, so the Spec column on each run row can render
+// ``slug v<n>`` rather than a raw UUID.
 
 // ---------------------------------------------------------------------------
 // Filter bar
@@ -354,8 +330,8 @@ export function Runs(): JSX.Element {
   // the project may have more specs than fit in one page.
   useEffect(() => {
     let cancelled = false;
-    fetchAllSpecs()
-      .then((specs) => {
+    walkAllPages((p) => api.listSpecs(p), {}, 10)
+      .then((specs: SpecSummary[]) => {
         if (cancelled) return;
         const m = new Map<string, { slug: string; version: number }>();
         for (const s of specs) m.set(s.id, { slug: s.slug, version: s.version });

--- a/ui/src/routes/runs.tsx
+++ b/ui/src/routes/runs.tsx
@@ -8,8 +8,9 @@
  * * Click / Enter on a row routes to ``/runs/:id``.
  * * Skeleton during the first fetch; <EmptyState> with a CLI hint when
  *   the API returns zero rows for the active filter.
- * * Pagination is offset-based and round-trips through the URL
- *   (``/runs?offset=20``) so the page is shareable / refreshable.
+ * * Pagination is page-based (``Page<RunSummary>`` envelope) and
+ *   currently lives in component state; URL serialisation
+ *   (``?page=&page_size=&sort=``) is a planned follow-up.
  * * Keyboard: ``/`` focuses the search input (without inserting the
  *   slash); ``j`` / ``k`` walks the row cursor.
  * * Subscribes to the global ``eventLog`` signal — whenever a
@@ -17,10 +18,11 @@
  *   arrives, the list refetches so the table stays live without a
  *   manual refresh.
  *
- * State lives in two places by design: filter / search / offset are
- * URL-driven (so links from chat or terminal history land on the
- * exact view), while the row cursor is local component state because
- * it is ephemeral and per-tab.
+ * State lives in local component hooks: filter / search / page /
+ * page-size / cursor. URL serialisation of filter+page state is a
+ * planned follow-up so links from chat or terminal history can land
+ * on the exact view; for now the cursor is intentionally ephemeral
+ * and per-tab.
  */
 
 import type { JSX, VNode } from 'preact';
@@ -31,13 +33,21 @@ import {
   Button,
   Card,
   EmptyState,
+  Pagination,
   Pill,
   Spinner,
   Table,
   type PillVariant,
   type TableColumn,
 } from '../components';
-import { api, ApiError, type RunSummary } from '../lib/api';
+import {
+  api,
+  ApiError,
+  type ListRunsParams,
+  type Page,
+  type RunSummary,
+  type SpecSummary,
+} from '../lib/api';
 import { eventLog } from '../lib/store';
 
 // ---------------------------------------------------------------------------
@@ -55,7 +65,14 @@ const STATUS_FILTERS: readonly { value: string; label: string }[] = [
 ];
 
 /** Default page size — kept modest so the first paint is cheap. */
-const PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 25;
+
+/**
+ * Upper bound the API will accept for ``?page_size=``. Mirrors the
+ * server-side ``MAX_PAGE_SIZE`` cap (ctxr/fsm/api/_pagination.py).
+ * Used when walking pages to populate the spec resolver below.
+ */
+const MAX_PAGE_SIZE = 200;
 
 /** Event kinds that should trigger a list refresh. */
 const REFRESH_EVENT_KINDS: ReadonlySet<string> = new Set([
@@ -136,44 +153,29 @@ function specCell(run: RunSummary, resolver: Map<string, { slug: string; version
 }
 
 /**
- * Parse ``?offset=NN`` from the current URL search string.
+ * Walk every page of ``api.listSpecs()`` and return the merged list.
  *
- * Tolerates missing / non-numeric / negative values by snapping to 0
- * so the page never enters an invalid pagination state.
+ * Used by the spec-resolver bootstrap below — the resolver needs every
+ * spec the project has ever registered, not just the first page worth,
+ * so the Spec column on each run row can render ``slug v<n>`` rather
+ * than a raw UUID. Kept inline (rather than promoted to a shared
+ * helper) per the W22b3 migration brief: the few routes that need
+ * "all rows" can each pay the small bespoke cost until a real pattern
+ * emerges.
  */
-function parseOffset(search: string): number {
-  const params = new URLSearchParams(
-    search.startsWith('?') ? search.slice(1) : search,
-  );
-  const raw = params.get('offset');
-  if (!raw) return 0;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return n;
-}
-
-/**
- * Read the current ``window.location.search`` safely under SSR / tests
- * where ``window`` may be absent.
- */
-function currentSearch(): string {
-  if (typeof window === 'undefined') return '';
-  return window.location.search ?? '';
-}
-
-/**
- * Build a ``/runs`` URL with the supplied offset, preserving any
- * other search params (forward-compat for future filters).
- */
-function buildOffsetUrl(offset: number): string {
-  const params = new URLSearchParams(currentSearch());
-  if (offset > 0) {
-    params.set('offset', String(offset));
-  } else {
-    params.delete('offset');
+async function fetchAllSpecs(): Promise<SpecSummary[]> {
+  const all: SpecSummary[] = [];
+  let page = 1;
+  // Defensive cap: ten pages of 200 = 2000 specs. If a project has
+  // more than that, the loop still terminates and the resolver simply
+  // misses the very tail; the row falls back to the UUID prefix.
+  for (let i = 0; i < 10; i++) {
+    const result = await api.listSpecs({ page, page_size: MAX_PAGE_SIZE });
+    for (const s of result.items) all.push(s);
+    if (!result.has_next) break;
+    page += 1;
   }
-  const qs = params.toString();
-  return qs ? `/runs?${qs}` : '/runs';
+  return all;
 }
 
 // ---------------------------------------------------------------------------
@@ -289,70 +291,6 @@ function FilterBar({
 }
 
 // ---------------------------------------------------------------------------
-// Pagination
-// ---------------------------------------------------------------------------
-
-interface PaginationProps {
-  offset: number;
-  pageSize: number;
-  rowCount: number;
-  hasNext: boolean;
-  onPrev: () => void;
-  onNext: () => void;
-}
-
-/**
- * Offset-based prev/next pager.
- *
- * ``hasNext`` is computed by the parent: if the API returned exactly
- * ``pageSize`` rows there *might* be more, so we enable the button;
- * if it returned fewer, we know we've hit the tail and disable it.
- */
-function Pagination({
-  offset,
-  pageSize,
-  rowCount,
-  hasNext,
-  onPrev,
-  onNext,
-}: PaginationProps): JSX.Element {
-  const from = rowCount === 0 ? 0 : offset + 1;
-  const to = offset + rowCount;
-  return (
-    <div class="flex items-center justify-between px-4 py-3 text-sm text-slate-600 dark:text-slate-400">
-      <span aria-live="polite">
-        {rowCount === 0
-          ? 'No results'
-          : `Showing ${from}–${to}`}
-      </span>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onPrev}
-          disabled={offset === 0}
-          aria-label="Previous page"
-        >
-          Prev
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onNext}
-          disabled={!hasNext}
-          aria-label="Next page"
-        >
-          Next
-        </Button>
-        <span class="text-xs text-slate-500 dark:text-slate-500">
-          page {Math.floor(offset / pageSize) + 1}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Empty-state icon
 // ---------------------------------------------------------------------------
 
@@ -391,14 +329,17 @@ function EmptyIcon(): VNode {
 export function Runs(): JSX.Element {
   const location = useLocation();
 
-  // URL-driven state — read on mount and on every navigation.
-  const initialOffset = parseOffset(currentSearch());
-  const [offset, setOffset] = useState<number>(initialOffset);
+  // Pagination + filter state. Page-based (1-indexed) post-W22b3 to
+  // match the ``Page<T>`` envelope returned by ``api.listRuns``.
+  // URL state for these (``?page=&page_size=&sort=``) is a follow-up;
+  // for now they live in component state.
+  const [page, setPage] = useState<number>(1);
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE);
   const [status, setStatus] = useState<string>('all');
   const [search, setSearch] = useState<string>('');
 
   // Server / interaction state.
-  const [runs, setRuns] = useState<RunSummary[]>([]);
+  const [runsPage, setRunsPage] = useState<Page<RunSummary> | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [cursor, setCursor] = useState<number>(0);
@@ -409,10 +350,11 @@ export function Runs(): JSX.Element {
   // Fetch the spec list once on mount + build a resolver map so the
   // Spec column on each row can render slug + version instead of a
   // raw UUID. Best-effort: a failure leaves the resolver empty so the
-  // fallback ("12-char prefix...") still works.
+  // fallback ("12-char prefix...") still works. Walks pages because
+  // the project may have more specs than fit in one page.
   useEffect(() => {
     let cancelled = false;
-    api.listSpecs()
+    fetchAllSpecs()
       .then((specs) => {
         if (cancelled) return;
         const m = new Map<string, { slug: string; version: number }>();
@@ -434,17 +376,20 @@ export function Runs(): JSX.Element {
   // --- Data fetch -----------------------------------------------------------
 
   const fetchRuns = useCallback(
-    async (opts: { offset: number; status: string }) => {
+    async (opts: { page: number; pageSize: number; status: string }) => {
       setLoading(true);
       setError(null);
       try {
-        const params =
-          opts.status === 'all'
-            ? { limit: PAGE_SIZE, offset: opts.offset }
-            : { status: opts.status, limit: PAGE_SIZE, offset: opts.offset };
+        const params: ListRunsParams = {
+          page: opts.page,
+          page_size: opts.pageSize,
+        };
+        if (opts.status !== 'all') params.status = opts.status;
         const result = await api.listRuns(params);
-        setRuns(result);
-        setCursor((c) => (result.length === 0 ? 0 : Math.min(c, result.length - 1)));
+        setRunsPage(result);
+        setCursor((c) =>
+          result.items.length === 0 ? 0 : Math.min(c, result.items.length - 1),
+        );
       } catch (err) {
         const msg =
           err instanceof ApiError
@@ -453,7 +398,7 @@ export function Runs(): JSX.Element {
               ? err.message
               : 'Failed to load runs';
         setError(msg);
-        setRuns([]);
+        setRunsPage(null);
       } finally {
         setLoading(false);
       }
@@ -461,10 +406,10 @@ export function Runs(): JSX.Element {
     [],
   );
 
-  // Initial + offset/status driven fetch.
+  // Initial + page/pageSize/status driven fetch.
   useEffect(() => {
-    void fetchRuns({ offset, status });
-  }, [fetchRuns, offset, status]);
+    void fetchRuns({ page, pageSize, status });
+  }, [fetchRuns, page, pageSize, status]);
 
   // --- Live refresh from SSE ------------------------------------------------
 
@@ -478,12 +423,13 @@ export function Runs(): JSX.Element {
     if (lastSeenEventId.current === newest.id) return;
     lastSeenEventId.current = newest.id;
     if (REFRESH_EVENT_KINDS.has(newest.kind)) {
-      void fetchRuns({ offset, status });
+      void fetchRuns({ page, pageSize, status });
     }
-  }, [fetchRuns, offset, status]);
+  }, [fetchRuns, page, pageSize, status]);
 
   // --- Filtering ------------------------------------------------------------
 
+  const runs = runsPage?.items ?? [];
   const visibleRuns = useMemo(() => {
     if (!search.trim()) return runs;
     const needle = search.trim().toLowerCase();
@@ -534,22 +480,17 @@ export function Runs(): JSX.Element {
 
   // --- Pagination handlers --------------------------------------------------
 
-  const goToOffset = useCallback(
-    (next: number) => {
-      const clamped = Math.max(0, next);
-      setOffset(clamped);
-      location.route(buildOffsetUrl(clamped));
-    },
-    [location],
-  );
+  const onPageChange = useCallback((next: number) => {
+    setPage(Math.max(1, next));
+  }, []);
 
-  const onPrev = useCallback(() => {
-    goToOffset(Math.max(0, offset - PAGE_SIZE));
-  }, [goToOffset, offset]);
-
-  const onNext = useCallback(() => {
-    goToOffset(offset + PAGE_SIZE);
-  }, [goToOffset, offset]);
+  const onPageSizeChange = useCallback((next: number) => {
+    setPageSize(next);
+    // Snap back to page 1 so the new window starts at the top of the
+    // population, not partway through (e.g. doubling page-size from
+    // page 4 of 25 would otherwise leave the user mid-list).
+    setPage(1);
+  }, []);
 
   // --- Table columns --------------------------------------------------------
 
@@ -629,10 +570,8 @@ export function Runs(): JSX.Element {
   );
 
   const onRefresh = useCallback(() => {
-    void fetchRuns({ offset, status });
-  }, [fetchRuns, offset, status]);
-
-  const hasNext = runs.length === PAGE_SIZE;
+    void fetchRuns({ page, pageSize, status });
+  }, [fetchRuns, page, pageSize, status]);
 
   let body: VNode;
   if (loading && runs.length === 0) {
@@ -678,14 +617,16 @@ export function Runs(): JSX.Element {
           onRowClick={onRowClick}
           rowKey={(r) => r.id}
         />
-        <Pagination
-          offset={offset}
-          pageSize={PAGE_SIZE}
-          rowCount={visibleRuns.length}
-          hasNext={hasNext}
-          onPrev={onPrev}
-          onNext={onNext}
-        />
+        {runsPage ? (
+          <div class="border-t border-slate-200 px-4 py-3 dark:border-slate-700">
+            <Pagination
+              page={runsPage}
+              onPageChange={onPageChange}
+              onPageSizeChange={onPageSizeChange}
+              itemLabel="runs"
+            />
+          </div>
+        ) : null}
       </Card>
     );
   }
@@ -700,7 +641,7 @@ export function Runs(): JSX.Element {
           setStatus(next);
           // Switching the filter resets pagination — otherwise the
           // user can land on an empty page-3 of a freshly-narrowed set.
-          if (offset !== 0) goToOffset(0);
+          if (page !== 1) setPage(1);
         }}
         onSearchChange={setSearch}
         onRefresh={onRefresh}

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -37,34 +37,11 @@ import {
 import {
   api,
   ApiError,
-  type Page,
-  type PageParams,
+  walkAllPages,
   type RunSummary,
   type SpecDetail,
   type SpecSummary,
 } from '../lib/api';
-
-/**
- * Walk a paginated endpoint until ``has_next`` is false (or the safety
- * stop trips at ``maxPages``). Used here for derivative aggregations —
- * counting runs across sibling versions for the header badge and
- * enumerating the SpecSiblings tree — none of which surface a
- * user-facing paged list. Pages are fetched serially with
- * ``page_size`` fixed at the wire MAX_PAGE_SIZE of 200.
- */
-async function walkAllPages<T, P extends PageParams>(
-  fetcher: (params: P) => Promise<Page<T>>,
-  baseParams: Omit<P, 'page' | 'page_size'>,
-  maxPages = 50,
-): Promise<T[]> {
-  const out: T[] = [];
-  for (let page = 1; page <= maxPages; page += 1) {
-    const env = await fetcher({ ...(baseParams as P), page, page_size: 200 } as P);
-    out.push(...env.items);
-    if (!env.has_next) return out;
-  }
-  return out;
-}
 import { canonicalJson } from '../lib/canonicalJson';
 import { specToGraph, transitionKind } from '../lib/specGraph';
 import { openSheet } from '../lib/store';

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -37,10 +37,34 @@ import {
 import {
   api,
   ApiError,
+  type Page,
+  type PageParams,
   type RunSummary,
   type SpecDetail,
   type SpecSummary,
 } from '../lib/api';
+
+/**
+ * Walk a paginated endpoint until ``has_next`` is false (or the safety
+ * stop trips at ``maxPages``). Used here for derivative aggregations —
+ * counting runs across sibling versions for the header badge and
+ * enumerating the SpecSiblings tree — none of which surface a
+ * user-facing paged list. Pages are fetched serially with
+ * ``page_size`` fixed at the wire MAX_PAGE_SIZE of 200.
+ */
+async function walkAllPages<T, P extends PageParams>(
+  fetcher: (params: P) => Promise<Page<T>>,
+  baseParams: Omit<P, 'page' | 'page_size'>,
+  maxPages = 50,
+): Promise<T[]> {
+  const out: T[] = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    const env = await fetcher({ ...(baseParams as P), page, page_size: 200 } as P);
+    out.push(...env.items);
+    if (!env.has_next) return out;
+  }
+  return out;
+}
 import { canonicalJson } from '../lib/canonicalJson';
 import { specToGraph, transitionKind } from '../lib/specGraph';
 import { openSheet } from '../lib/store';
@@ -401,7 +425,12 @@ function RunsPanel({ spec, navigate }: RunsPanelProps): JSX.Element {
 
   useEffect(() => {
     let cancelled = false;
-    api.listRuns({ limit: 500 })
+    // Need every run of every sibling version to filter client-side
+    // by ``matchIds`` — walk the paginated listRuns until exhausted
+    // rather than rendering a per-spec <Pagination>. (This panel
+    // could be converted to a server-side filter in a follow-up if
+    // the population grows past the 50-page safety stop.)
+    walkAllPages((p) => api.listRuns(p), {})
       .then((all) => {
         if (cancelled) return;
         setRuns(all.filter((r) => matchIds.has(r.fsm_spec_id)));
@@ -635,18 +664,25 @@ export function SpecDetailRoute(): JSX.Element {
 
   useEffect(() => {
     let cancelled = false;
-    api.listSpecs()
+    // The SpecSiblings tree needs every registered spec to find
+    // sibling versions of the current slug, so walk the paginated
+    // listSpecs to enumerate the full population.
+    walkAllPages((p) => api.listSpecs(p), {})
       .then((all) => { if (!cancelled) setAllSpecs(all); })
       .catch(() => { if (!cancelled) setAllSpecs([]); });
     return () => { cancelled = true; };
   }, []);
 
   useEffect(() => {
-    // Compute run count across all sibling versions for the header badge.
+    // Compute run count across all sibling versions for the header
+    // badge. We still need the run rows themselves (not just the
+    // listRuns page envelope's ``total``) because the count is
+    // filtered client-side by ``matchIds`` — the wire endpoint
+    // doesn't currently expose a multi-spec filter.
     if (!detail || !allSpecs) return;
     let cancelled = false;
     const matchIds = new Set(allSpecs.filter((s) => s.slug === detail.slug).map((s) => s.id));
-    api.listRuns({ limit: 500 })
+    walkAllPages((p) => api.listRuns(p), {})
       .then((rs) => { if (!cancelled) setRunCount(rs.filter((r) => matchIds.has(r.fsm_spec_id)).length); })
       .catch(() => { if (!cancelled) setRunCount(null); });
     return () => { cancelled = true; };

--- a/ui/src/routes/specs.tsx
+++ b/ui/src/routes/specs.tsx
@@ -34,34 +34,10 @@ import {
 import {
   api,
   ApiError,
-  type Page,
-  type PageParams,
+  walkAllPages,
   type RunSummary,
   type SpecSummary,
 } from '../lib/api';
-
-/**
- * Walk a paginated endpoint until ``has_next`` is false (or the safety
- * stop trips at ``maxPages``). Used by routes that need to enumerate
- * the full population for derivative aggregations — e.g. the spec
- * catalog's per-slug run count or sibling tree. Returns the flattened
- * items list. Pages are fetched serially to keep the server's
- * paginator's cursor / sort stable; ``page_size`` is fixed at the
- * wire MAX_PAGE_SIZE of 200 to minimise round trips.
- */
-async function walkAllPages<T, P extends PageParams>(
-  fetcher: (params: P) => Promise<Page<T>>,
-  baseParams: Omit<P, 'page' | 'page_size'>,
-  maxPages = 50,
-): Promise<T[]> {
-  const out: T[] = [];
-  for (let page = 1; page <= maxPages; page += 1) {
-    const env = await fetcher({ ...(baseParams as P), page, page_size: 200 } as P);
-    out.push(...env.items);
-    if (!env.has_next) return out;
-  }
-  return out;
-}
 
 const shortHash = (h: string): string => (h.length > 12 ? h.slice(0, 12) : h);
 

--- a/ui/src/routes/specs.tsx
+++ b/ui/src/routes/specs.tsx
@@ -34,9 +34,34 @@ import {
 import {
   api,
   ApiError,
+  type Page,
+  type PageParams,
   type RunSummary,
   type SpecSummary,
 } from '../lib/api';
+
+/**
+ * Walk a paginated endpoint until ``has_next`` is false (or the safety
+ * stop trips at ``maxPages``). Used by routes that need to enumerate
+ * the full population for derivative aggregations — e.g. the spec
+ * catalog's per-slug run count or sibling tree. Returns the flattened
+ * items list. Pages are fetched serially to keep the server's
+ * paginator's cursor / sort stable; ``page_size`` is fixed at the
+ * wire MAX_PAGE_SIZE of 200 to minimise round trips.
+ */
+async function walkAllPages<T, P extends PageParams>(
+  fetcher: (params: P) => Promise<Page<T>>,
+  baseParams: Omit<P, 'page' | 'page_size'>,
+  maxPages = 50,
+): Promise<T[]> {
+  const out: T[] = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    const env = await fetcher({ ...(baseParams as P), page, page_size: 200 } as P);
+    out.push(...env.items);
+    if (!env.has_next) return out;
+  }
+  return out;
+}
 
 const shortHash = (h: string): string => (h.length > 12 ? h.slice(0, 12) : h);
 
@@ -134,7 +159,15 @@ export function SpecsRoute(): JSX.Element {
 
   useEffect(() => {
     let cancelled = false;
-    Promise.all([api.listSpecs(), api.listRuns({ limit: 500 })])
+    // The spec catalog needs to enumerate EVERY spec and EVERY run to
+    // group + count per slug — derivative aggregations, not a
+    // user-facing paged list — so we walk pages until ``has_next`` is
+    // false (with a 50-page safety stop) instead of wiring a
+    // <Pagination> control here.
+    Promise.all([
+      walkAllPages((p) => api.listSpecs(p), {}),
+      walkAllPages((p) => api.listRuns(p), {}),
+    ])
       .then(([s, r]) => {
         if (cancelled) return;
         setSpecs(s);

--- a/ui/src/routes/topology.tsx
+++ b/ui/src/routes/topology.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'preact/hooks';
 import {
   Card,
   EmptyState,
+  Pagination,
   Pill,
   Spinner,
   Table,
@@ -21,6 +22,7 @@ import {
   api,
   ApiError,
   type Consumer,
+  type Page,
   type Producer,
 } from '../lib/api';
 
@@ -30,25 +32,41 @@ function fmt(iso: string | null | undefined): string {
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
 }
 
+const DEFAULT_PAGE_SIZE = 50;
+
 export function TopologyRoute(): JSX.Element {
-  const [producers, setProducers] = useState<Producer[] | null>(null);
-  const [consumers, setConsumers] = useState<Consumer[] | null>(null);
+  const [producers, setProducers] = useState<Page<Producer> | null>(null);
+  const [consumers, setConsumers] = useState<Page<Consumer> | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const [producerPage, setProducerPage] = useState(1);
+  const [producerPageSize, setProducerPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [consumerPage, setConsumerPage] = useState(1);
+  const [consumerPageSize, setConsumerPageSize] = useState(DEFAULT_PAGE_SIZE);
 
   useEffect(() => {
     let cancelled = false;
-    Promise.all([api.listProducers(), api.listConsumers()])
-      .then(([p, c]) => {
-        if (!cancelled) {
-          setProducers(p);
-          setConsumers(c);
-        }
+    api.listProducers({ page: producerPage, page_size: producerPageSize })
+      .then((p) => {
+        if (!cancelled) setProducers(p);
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(err instanceof ApiError ? err.message : String(err));
       });
     return () => { cancelled = true; };
-  }, []);
+  }, [producerPage, producerPageSize]);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.listConsumers({ page: consumerPage, page_size: consumerPageSize })
+      .then((c) => {
+        if (!cancelled) setConsumers(c);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof ApiError ? err.message : String(err));
+      });
+    return () => { cancelled = true; };
+  }, [consumerPage, consumerPageSize]);
 
   const producerCols: TableColumn<Producer>[] = [
     { key: 'kind', label: 'Kind', render: (r) => <Pill variant="info" size="sm">{r.kind}</Pill> },
@@ -97,32 +115,52 @@ export function TopologyRoute(): JSX.Element {
         </p>
       </header>
       <div class="grid gap-4 lg:grid-cols-2">
-        <Card title={`Producers${producers ? ` (${producers.length})` : ''}`} className="p-0">
+        <Card title={`Producers${producers ? ` (${producers.total})` : ''}`} className="p-0">
           {producers === null ? (
             <div class="flex items-center justify-center py-12"><Spinner label="Loading producers" /></div>
-          ) : producers.length === 0 ? (
+          ) : producers.items.length === 0 ? (
             <EmptyState title="No producers" message="No producer has registered yet." />
           ) : (
-            <Table<Producer>
-              columns={producerCols}
-              rows={producers}
-              rowKey={(r) => r.id}
-              caption="Registered event producers"
-            />
+            <>
+              <Table<Producer>
+                columns={producerCols}
+                rows={producers.items}
+                rowKey={(r) => r.id}
+                caption="Registered event producers"
+              />
+              <div class="border-t border-slate-200 px-4 py-3 dark:border-slate-700">
+                <Pagination
+                  page={producers}
+                  onPageChange={(p) => setProducerPage(p)}
+                  onPageSizeChange={(sz) => { setProducerPageSize(sz); setProducerPage(1); }}
+                  itemLabel="producers"
+                />
+              </div>
+            </>
           )}
         </Card>
-        <Card title={`Consumers${consumers ? ` (${consumers.length})` : ''}`} className="p-0">
+        <Card title={`Consumers${consumers ? ` (${consumers.total})` : ''}`} className="p-0">
           {consumers === null ? (
             <div class="flex items-center justify-center py-12"><Spinner label="Loading consumers" /></div>
-          ) : consumers.length === 0 ? (
+          ) : consumers.items.length === 0 ? (
             <EmptyState title="No consumers" message="No consumer has registered yet." />
           ) : (
-            <Table<Consumer>
-              columns={consumerCols}
-              rows={consumers}
-              rowKey={(r) => r.id}
-              caption="Registered event consumers"
-            />
+            <>
+              <Table<Consumer>
+                columns={consumerCols}
+                rows={consumers.items}
+                rowKey={(r) => r.id}
+                caption="Registered event consumers"
+              />
+              <div class="border-t border-slate-200 px-4 py-3 dark:border-slate-700">
+                <Pagination
+                  page={consumers}
+                  onPageChange={(p) => setConsumerPage(p)}
+                  onPageSizeChange={(sz) => { setConsumerPageSize(sz); setConsumerPage(1); }}
+                  itemLabel="consumers"
+                />
+              </div>
+            </>
           )}
         </Card>
       </div>


### PR DESCRIPTION
## Summary

- Introduces `Page[T]` envelope (`{items, page, page_size, total, has_next, sort}`) across every list endpoint, with `total` computed in the same SQL round-trip via `COUNT(*) OVER ()`.
- 11 endpoints migrated: `/runs`, `/runs/{id}/events`, `/specs`, `/specs/{slug}/versions`, `/events`, `/producers`, `/consumers`, `/admin/journal_txns`, `/admin/locks`, `/admin/tool_calls`, `/admin/commit_signatures`.
- Each route now takes a per-endpoint `PageParams` factory (`?page=&page_size=&sort=`) with a validated sort allow-list. Old `?limit=` and `?offset=` query params are GONE.
- New `<Pagination>` UI primitive (windowed page numbers, page-size selector, ARIA nav, range readout) wired into 4 user-facing list routes: `/runs`, `/topology` (split producers/consumers), `/drift`, `/journal`.
- Default `page_size = 50`, max `200`. Default sort = most-recent-first where the schema supports it (`last_update_at_desc`, `started_at_desc`, `created_at_desc`, `acquired_at_desc`). Two exceptions stay chronological-asc for canonical replay (`/events`, `/runs/{id}/events`).

## Behaviour change

`/specs/{slug}/versions` default sort flips from `version_asc` to `version_desc` per the user's "most recent down to least recent" mandate. The test that asserted ASC iteration order now passes `?sort=version_asc` explicitly.

## Test plan

- [x] `uv run pytest tests/` (excl e2e): 694 passed
- [x] `cd ui && npm run test`: 338 passed
- [x] `cd ui && npx tsc -b --noEmit`: 0 errors
- [x] `cd ui && npm run build`: 165.78 KB gzipped main chunk (under 280 KB W18 budget)
- [x] `uv run ruff check ctxr/ tests/`: clean
- [x] `uv run mypy ctxr/fsm/`: 72 files clean
- [ ] Manual smoke against dummy-fsm-test seeded run: walk every list view, verify pagination controls render + page changes refetch correctly. (Operator's call.)

## Deliberately out of scope

- URL-state integration for `?page=`/`?page_size=`/`?sort=`. The envelope + control make this a small follow-up; W18k owns it.
- Cursor pagination. Offset is correct for the user's stated use cases ("page X of Y, sorted by recency"); cursor lands as an opt-in `?cursor=` later if `/events` or `/tool_calls` get unwieldy.
- Repository-level SA migration for the `paginate_sequence` paths. Wire format is uniform now; tightening the SQL doesn't change the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)