### PR TITLE
feat(w22b3): sticky info-rich topbar — branding, project, subsystems

### DIFF
--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -465,13 +465,17 @@ def get_current_project(project: ProjectDep, request: Request) -> ProjectMetadat
     # than 500ing.
     # ``.ctxr-fsm/active-mcp.json`` writes each subsystem's primary URL
     # under the key ``http_url`` (see
-    # :func:`ctxr.fsm.cli.lifecycle.supervisor._subsystem_payload`); the
-    # API row additionally carries a ``docs_url``. We map both to
-    # ``SubsystemInfo.base_url`` so the UI doesn't need to know about
-    # the on-disk key vocabulary — its only contract is "give me a URL
-    # I can show + a healthz URL I can probe". The original draft of
-    # this route incorrectly looked for ``base_url`` and produced an
-    # empty subsystems map even with a live supervisor.
+    # :func:`ctxr.fsm.cli.lifecycle.supervisor._subsystem_payload`); we
+    # map that to ``SubsystemInfo.base_url`` so the UI doesn't need to
+    # know about the on-disk key vocabulary — its only contract is
+    # "give me a URL I can show + a healthz URL I can probe". The
+    # API row's ``docs_url`` is NOT carried into ``SubsystemInfo`` —
+    # the route derives Swagger separately from the request below
+    # (``swagger_url``) so the topbar gets a dedicated pill rather
+    # than burying the docs link inside the API row. The original
+    # draft of this route incorrectly read ``base_url`` from the
+    # discovery doc and produced an empty subsystems map even with a
+    # live supervisor.
     subsystems: dict[str, SubsystemInfo] = {}
     if project_root_str is not None:
         doc = read_active_mcp_file(Path(project_root_str))

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -56,6 +56,7 @@ the exact predicate.
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -73,6 +74,9 @@ from ctxr.fsm.cli.lifecycle.primitives import read_active_mcp_file
 from ctxr.fsm.sqlite import Project
 
 __all__ = ["ProjectMetadata", "app", "lifespan_handler"]
+
+
+_LOG = logging.getLogger(__name__)
 
 
 # ── CORS allowlist construction ────────────────────────────────────
@@ -441,6 +445,17 @@ def get_current_project(project: ProjectDep, request: Request) -> ProjectMetadat
         # UI's info-rich topbar would lose its slug for a transient DB
         # blip and the operator would see "no project yet" rather than
         # the real error context (the rest of the payload still lands).
+        # We DO log the exception at WARNING with full traceback so a
+        # real DB / schema failure is debuggable from the server log
+        # rather than vanishing into a silent "no project bound" pill.
+        _LOG.warning(
+            "Failed to derive project_slug for /api/v1/projects/current; "
+            "the topbar will render 'no project bound'. This is a soft "
+            "failure (the rest of ProjectMetadata still lands) but the "
+            "stack trace below is the canonical source for diagnosing "
+            "the underlying issue.",
+            exc_info=True,
+        )
         project_slug = None
 
     # Subsystem map — read the supervisor's discovery doc from

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -61,7 +61,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -69,6 +69,7 @@ import ctxr.fsm
 from ctxr.fsm.api import _state
 from ctxr.fsm.api._deps import ProjectDep, require_auth
 from ctxr.fsm.api._paths import looks_like_filesystem_db_path, project_root_and_relative
+from ctxr.fsm.cli.lifecycle.primitives import read_active_mcp_file
 from ctxr.fsm.sqlite import Project
 
 __all__ = ["ProjectMetadata", "app", "lifespan_handler"]
@@ -209,21 +210,93 @@ class ReadinessResponse(BaseModel):
     )
 
 
+class SubsystemInfo(BaseModel):
+    """One row of the ``ProjectMetadata.subsystems`` map.
+
+    Mirrors the per-subsystem block written by the supervisor into
+    ``.ctxr-fsm/active-mcp.json`` (mcp / api / ui). The UI topbar
+    surfaces this so an operator can see at a glance which subsystem
+    is up + click through to its endpoint (Swagger, the UI itself,
+    the MCP SSE healthz, etc.) without leaving the dashboard.
+
+    ``healthz_url`` is the probe the supervisor uses to verify the
+    subsystem is live before writing the discovery doc, so the UI
+    can re-probe it on demand to show "healthy / degraded" badges
+    next to the URL. ``base_url`` is the human-clickable link the
+    operator wants. ``pid`` is included so the UI can show
+    "subsystem owned by pid 42 on this host", useful when two
+    operators are debugging the same project from different
+    terminals.
+    """
+
+    base_url: str = Field(..., description="Primary URL for this subsystem (the human-clickable one).")
+    healthz_url: str | None = Field(
+        None,
+        description="Health probe URL. ``None`` when the subsystem doesn't expose a separate healthz path.",
+    )
+    pid: int | None = Field(
+        None,
+        description="Process ID of the subsystem worker. ``None`` when not reported by the supervisor.",
+    )
+
+
 class ProjectMetadata(BaseModel):
     """Metadata payload returned by ``GET /api/v1/projects/current``.
 
     W22 added ``project_root`` + ``db_path_relative`` so the UI
     topbar / Settings surface can render portable, committable
     project-relative paths instead of absolute filesystem strings.
-    Future waves will extend this further with a project name (slug
-    pulled from ``.ctxr-fsm/``), registered spec + run counts, and
-    workspace metadata; the route already exists so the UI can issue
-    a single discovery call against a running API and know it's
-    talking to a live, project-bound server.
+    W22b3 extends the payload with the operator-facing project slug
+    (read from the ``projects`` table) and the live ``subsystems``
+    map read from ``.ctxr-fsm/active-mcp.json`` so the info-rich
+    topbar can show "you're connected to ``my-project`` on
+    ``/Users/dev/work/my-project`` with mcp+api+ui all green" as a
+    single discovery roundtrip. Swagger is derived from the API's
+    own base_url (``/docs``) rather than threaded through
+    active-mcp.json because Swagger is just a route on the API
+    process, not a separate subsystem.
     """
 
     fsm_version: str = Field(..., description="The ``ctxr.fsm`` package version.")
     project_open: bool = Field(..., description="Whether the :class:`Project` is bound.")
+    project_slug: str | None = Field(
+        None,
+        description=(
+            "The slug of the default project row in the ``projects``"
+            " table. ``None`` when the projects table is empty (a"
+            " freshly-migrated DB with no project rows yet — the seeded"
+            " ``default`` row is created lazily by"
+            " :meth:`Project.start_run`)."
+        ),
+    )
+    swagger_url: str = Field(
+        ...,
+        description=(
+            "Absolute URL of the API's auto-generated OpenAPI viewer."
+            " Derived from the incoming request's ``base_url`` so the"
+            " value is correct regardless of how the API is mounted"
+            " (loopback, dev proxy, future reverse-proxy)."
+        ),
+    )
+    api_base_url: str = Field(
+        ...,
+        description=(
+            "Absolute base URL of this API. Same derivation as"
+            " ``swagger_url``; exposed so the UI can build deep links"
+            " into the JSON API without re-deriving the prefix."
+        ),
+    )
+    subsystems: dict[str, SubsystemInfo] = Field(
+        default_factory=dict,
+        description=(
+            "Subsystem-name -> :class:`SubsystemInfo` mapping read"
+            " verbatim from ``.ctxr-fsm/active-mcp.json``. Empty when"
+            " the supervisor hasn't written the discovery doc yet"
+            " (cold boot before ``ctxr-fsm serve`` completes its"
+            " healthz polls, or when ``project_root`` is None). The"
+            " canonical subsystem names are ``mcp``, ``api``, ``ui``."
+        ),
+    )
     db_path: str = Field(
         ...,
         description=(
@@ -313,7 +386,7 @@ def readyz() -> ReadinessResponse:
     tags=["projects"],
     dependencies=[Depends(require_auth)],
 )
-def get_current_project(project: ProjectDep) -> ProjectMetadata:
+def get_current_project(project: ProjectDep, request: Request) -> ProjectMetadata:
     """Return metadata about the currently open project.
 
     The :class:`Project` handle exposes the SQLAlchemy engine, whose
@@ -352,12 +425,68 @@ def get_current_project(project: ProjectDep) -> ProjectMetadata:
         # relative path the raw url.database would be relative too,
         # contradicting the doc.
         db_path = str(Path(db_url_database).resolve())
+    # Project slug — first row of the ``projects`` table. Schema reserves
+    # multi-project mounts as a future extension; today there's at most
+    # one project row per DB. ``None`` when the table is empty (lazy
+    # seeded by ``Project.start_run``) — UI renders "no project yet"
+    # rather than crashing the discovery call.
+    project_slug: str | None = None
+    try:
+        with project.session_factory() as session:
+            projects = project.projects.list(session)
+        if projects:
+            project_slug = projects[0].slug
+    except Exception:
+        # Never let metadata derivation fail the discovery route — the
+        # UI's info-rich topbar would lose its slug for a transient DB
+        # blip and the operator would see "no project yet" rather than
+        # the real error context (the rest of the payload still lands).
+        project_slug = None
+
+    # Subsystem map — read the supervisor's discovery doc from
+    # ``<project_root>/.ctxr-fsm/active-mcp.json``. Tolerate every
+    # failure mode (file missing, malformed, partial keys) with an
+    # empty map so the topbar shows "no subsystems reported" rather
+    # than 500ing.
+    subsystems: dict[str, SubsystemInfo] = {}
+    if project_root_str is not None:
+        doc = read_active_mcp_file(Path(project_root_str))
+        if doc is not None:
+            raw_subsystems = doc.get("subsystems")
+            if isinstance(raw_subsystems, dict):
+                for name, block in raw_subsystems.items():
+                    if not isinstance(block, dict):
+                        continue
+                    base = block.get("base_url")
+                    if not isinstance(base, str) or not base:
+                        continue
+                    healthz = block.get("healthz_url")
+                    pid = block.get("pid")
+                    subsystems[str(name)] = SubsystemInfo(
+                        base_url=base,
+                        healthz_url=healthz if isinstance(healthz, str) else None,
+                        pid=pid if isinstance(pid, int) else None,
+                    )
+
+    # Swagger + API base URL — ``request.base_url`` carries scheme +
+    # host + port + root_path (always trailing-slashed). Hard-code
+    # ``/docs`` since FastAPI's default Swagger mount lives there;
+    # avoids importing the app inside its own route to read
+    # ``app.docs_url``.
+    base_url = str(request.base_url).rstrip("/")
+    api_base_url = base_url
+    swagger_url = f"{base_url}/docs"
+
     return ProjectMetadata(
         fsm_version=ctxr.fsm.__version__,
         project_open=True,
+        project_slug=project_slug,
         db_path=db_path,
         project_root=project_root_str,
         db_path_relative=db_relative,
+        swagger_url=swagger_url,
+        api_base_url=api_base_url,
+        subsystems=subsystems,
     )
 
 

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -448,6 +448,15 @@ def get_current_project(project: ProjectDep, request: Request) -> ProjectMetadat
     # failure mode (file missing, malformed, partial keys) with an
     # empty map so the topbar shows "no subsystems reported" rather
     # than 500ing.
+    # ``.ctxr-fsm/active-mcp.json`` writes each subsystem's primary URL
+    # under the key ``http_url`` (see
+    # :func:`ctxr.fsm.cli.lifecycle.supervisor._subsystem_payload`); the
+    # API row additionally carries a ``docs_url``. We map both to
+    # ``SubsystemInfo.base_url`` so the UI doesn't need to know about
+    # the on-disk key vocabulary — its only contract is "give me a URL
+    # I can show + a healthz URL I can probe". The original draft of
+    # this route incorrectly looked for ``base_url`` and produced an
+    # empty subsystems map even with a live supervisor.
     subsystems: dict[str, SubsystemInfo] = {}
     if project_root_str is not None:
         doc = read_active_mcp_file(Path(project_root_str))
@@ -457,7 +466,7 @@ def get_current_project(project: ProjectDep, request: Request) -> ProjectMetadat
                 for name, block in raw_subsystems.items():
                     if not isinstance(block, dict):
                         continue
-                    base = block.get("base_url")
+                    base = block.get("http_url")
                     if not isinstance(base, str) or not base:
                         continue
                     healthz = block.get("healthz_url")
@@ -468,14 +477,22 @@ def get_current_project(project: ProjectDep, request: Request) -> ProjectMetadat
                         pid=pid if isinstance(pid, int) else None,
                     )
 
-    # Swagger + API base URL — ``request.base_url`` carries scheme +
-    # host + port + root_path (always trailing-slashed). Hard-code
-    # ``/docs`` since FastAPI's default Swagger mount lives there;
-    # avoids importing the app inside its own route to read
-    # ``app.docs_url``.
-    base_url = str(request.base_url).rstrip("/")
-    api_base_url = base_url
-    swagger_url = f"{base_url}/docs"
+    # Swagger + API base URL derivation. ``request.base_url`` is the
+    # bare ASGI mount point (scheme + host + port + root_path); the
+    # JSON routes in this app all live under the ``/api/v1`` prefix
+    # (this route itself is at ``/api/v1/projects/current``), so
+    # ``api_base_url`` MUST carry that prefix or every deep link the
+    # UI builds against it will 404. The original draft of this route
+    # returned the bare host URL, which produced broken links for
+    # consumers building URLs off the field.
+    #
+    # Swagger lives at ``/docs`` on the FastAPI app — outside the
+    # ``/api/v1`` prefix because FastAPI mounts the docs viewer at the
+    # app root by default. We hard-code that suffix here rather than
+    # importing the app inside its own route to read ``app.docs_url``.
+    host_url = str(request.base_url).rstrip("/")
+    api_base_url = f"{host_url}/api/v1"
+    swagger_url = f"{host_url}/docs"
 
     return ProjectMetadata(
         fsm_version=ctxr.fsm.__version__,

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -49,11 +49,9 @@ import { effect } from '@preact/signals';
 import { LocationProvider, Router, Route, useLocation } from 'preact-iso';
 
 import { ToastContainer } from './components';
-import { Pill } from './components';
-import { EventStream, type ConnectionState } from './lib/sse';
+import { EventStream } from './lib/sse';
 import {
   appendEvent,
-  connectionState,
   setConnectionState,
 } from './lib/store';
 import { ROUTES } from './routes';
@@ -62,7 +60,7 @@ import { CommandPalette } from './chrome/CommandPalette';
 import { KeyboardHelp } from './chrome/KeyboardHelp';
 import { NotificationCentre } from './chrome/NotificationCentre';
 import { ThemeApplier } from './chrome/ThemeApplier';
-import { TopBarExtras } from './chrome/TopBarExtras';
+import { InfoTopBar } from './chrome/InfoTopBar';
 
 // ---------------------------------------------------------------------------
 // SSE wiring
@@ -227,88 +225,11 @@ function Sidebar(): JSX.Element {
   );
 }
 
-/**
- * Map an SSE connection state to a Pill variant + human label.
- *
- * The mapping intentionally collapses ``'closed'`` into the danger
- * variant alongside ``'error'``: from the user's perspective both mean
- * "we are not getting live updates". The distinction matters only to
- * the SSE wrapper itself.
- */
-function connectionPillProps(state: ConnectionState): {
-  variant: 'success' | 'warning' | 'danger';
-  label: string;
-  title: string;
-} {
-  switch (state) {
-    case 'open':
-      return {
-        variant: 'success',
-        label: 'Live',
-        title: 'Connected to the event stream',
-      };
-    case 'connecting':
-      return {
-        variant: 'warning',
-        label: 'Reconnecting',
-        title: 'Re-establishing the event stream',
-      };
-    case 'error':
-    case 'closed':
-    default:
-      return {
-        variant: 'danger',
-        label: 'Offline',
-        title: 'Event stream disconnected — retrying',
-      };
-  }
-}
-
-/**
- * Top bar — currently just hosts the connection-state pill on the right.
- *
- * Wrapped in a ``<header role="banner">`` so it appears as a landmark
- * and is announced as the page banner. The pill is given a live region
- * (``aria-live="polite"``) so screen-reader users hear the transition
- * once it settles rather than on every intermediate flicker.
- */
-function TopBar(): JSX.Element {
-  const state = connectionState.value;
-  const { variant, label, title } = connectionPillProps(state);
-  return (
-    <header
-      role="banner"
-      class="flex h-14 items-center justify-end border-b border-slate-200 bg-white px-6 dark:border-slate-700 dark:bg-slate-800"
-    >
-      <div
-        aria-live="polite"
-        aria-atomic="true"
-        class="flex items-center gap-2"
-      >
-        <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-          Stream
-        </span>
-        <Pill variant={variant} title={title} aria-label={`Event stream: ${label}`}>
-          <span
-            aria-hidden="true"
-            class={[
-              'inline-block h-2 w-2 rounded-full',
-              variant === 'success' && 'bg-emerald-500',
-              variant === 'warning' && 'bg-amber-500',
-              variant === 'danger' && 'bg-red-500',
-            ]
-              .filter(Boolean)
-              .join(' ')}
-          />
-          {label}
-        </Pill>
-      </div>
-      <div class="ml-3 pl-3 border-l border-slate-200 dark:border-slate-700">
-        <TopBarExtras />
-      </div>
-    </header>
-  );
-}
+// connectionPillProps was extracted to ``ui/src/lib/connectionPill.ts``
+// in W22b3 so the new InfoTopBar can share the same mapping with the
+// rest of the chrome surface. The inline TopBar component was retired
+// in the same wave; InfoTopBar (chrome/InfoTopBar.tsx) renders the
+// info-rich sticky header end-to-end.
 
 // ---------------------------------------------------------------------------
 // Route stubs
@@ -370,7 +291,7 @@ function Shell(): JSX.Element {
     <div class="flex h-screen w-screen overflow-hidden bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100">
       <Sidebar />
       <div class="flex min-w-0 flex-1 flex-col">
-        <TopBar />
+        <InfoTopBar />
         <main id="main" class="min-h-0 flex-1 overflow-auto" tabIndex={-1}>
           <Router>
             {ROUTES.map((r) => (

--- a/ui/src/chrome/InfoTopBar.tsx
+++ b/ui/src/chrome/InfoTopBar.tsx
@@ -38,10 +38,12 @@
  * Data acquisition: one call to ``api.getCurrentProject()`` at mount
  * + a window-focus refetch so a user who tabs back from Swagger sees
  * fresh subsystem state without a manual refresh. Health probes
- * (the ``healthz_url`` field) are re-issued in a small ``mapLimited``
- * fan-out so the pills can show green / amber / red rather than just
- * "configured". Failures collapse to a muted pill — the topbar must
- * never error out the dashboard.
+ * (the ``healthz_url`` field) are re-issued serially in metadata
+ * order — the canonical subsystem count is three (mcp / api / ui),
+ * so a serial walk completes in well under a second; a future
+ * deployment with more subsystems can lift the fan-out pattern from
+ * ``routes/drift.tsx`` (``mapLimited``). Failures collapse to a
+ * muted pill — the topbar must never error out the dashboard.
  *
  * Why a separate component rather than extending ``app.tsx``'s inline
  * ``TopBar`` directly? Two reasons: (a) the data layer is async
@@ -216,8 +218,14 @@ export function InfoTopBar(): JSX.Element {
     };
   }, []);
 
-  // Health probes whenever the metadata refreshes. Capped fan-out so a
-  // future "10 subsystems" scenario doesn't carpet-bomb the API at boot.
+  // Health probes whenever the metadata refreshes. Issued SERIALLY
+  // (one ``await`` per iteration) — the canonical subsystem count is
+  // three (mcp / api / ui), so a serial walk gives us back-to-back
+  // 200-ms-ish probes that complete inside half a second total. If a
+  // future deployment lifts the subsystem count past five-ish, this
+  // is the spot to bolt on the ``mapLimited`` pattern from
+  // routes/drift.tsx (the same fan-out cap). Today the simpler shape
+  // is easier to read.
   useEffect(() => {
     if (!metadata) return;
     let cancelled = false;

--- a/ui/src/chrome/InfoTopBar.tsx
+++ b/ui/src/chrome/InfoTopBar.tsx
@@ -226,9 +226,24 @@ export function InfoTopBar(): JSX.Element {
   // is the spot to bolt on the ``mapLimited`` pattern from
   // routes/drift.tsx (the same fan-out cap). Today the simpler shape
   // is easier to read.
+  //
+  // Stale-state contract: every metadata refresh starts by REPLACING
+  // (not merging into) the probe map. Without this reset, a previous
+  // metadata that reported ``mcp``/``api``/``ui`` but a fresh one
+  // that omits ``api`` would leave the swagger/api probes "healthy"
+  // from the previous round even though the subsystems no longer
+  // exist. Same hazard when switching projects: subsystems lingering
+  // from project A would render alongside project B's set.
   useEffect(() => {
     if (!metadata) return;
     let cancelled = false;
+    // Reset to the per-subsystem ``unknown`` baseline before re-probing
+    // so any subsystem that vanished from the new metadata loses its
+    // stale healthy/degraded indicator.
+    const initial: Record<string, ProbeStatus> = {};
+    for (const name of Object.keys(metadata.subsystems)) initial[name] = 'unknown';
+    initial.swagger = 'unknown';
+    setProbes(initial);
     (async () => {
       const next: Record<string, ProbeStatus> = {};
       const subs = Object.entries(metadata.subsystems);

--- a/ui/src/chrome/InfoTopBar.tsx
+++ b/ui/src/chrome/InfoTopBar.tsx
@@ -105,13 +105,36 @@ const PROBE_VARIANT: Record<ProbeStatus, PillVariant> = {
   degraded: 'danger',
 };
 
-/** Render an absolute path relative to ``$HOME`` when possible. */
+/**
+ * Render an absolute project path in a portable form for the topbar.
+ *
+ * The browser has no native ``$HOME`` introspection, but a screenshot
+ * of an absolute ``/Users/alice/...`` path leaks the operator's
+ * username + filesystem layout. We work around the missing primitive
+ * with a heuristic that recognises the macOS / Linux home prefixes
+ * and replaces the leading ``/Users/<name>`` (or ``/home/<name>``)
+ * with ``~``. An optional ``window.__FSM_HOME__`` override is honoured
+ * first for installs that set it explicitly (e.g. a future Electron
+ * shell). The pre-fix draft relied ONLY on ``__FSM_HOME__`` which
+ * nothing in the repo populated, so paths were never condensed —
+ * contradicting the screenshot-portability promise.
+ */
 function condenseHome(path: string | null | undefined): string {
   if (!path) return '';
   const home =
     typeof window !== 'undefined' &&
     (window as Window & { __FSM_HOME__?: string }).__FSM_HOME__;
   if (home && path.startsWith(home)) return `~${path.slice(home.length)}`;
+  // Heuristic fallback: ``/Users/<name>/...`` (macOS) or
+  // ``/home/<name>/...`` (most Linux distros). Both are
+  // username-prefixed so redacting to ``~/...`` removes the
+  // personally-identifying segment without losing the rest of the
+  // path. Match is anchored to the start so a project literally
+  // named ``Users/foo`` deeper in the tree isn't mangled.
+  const macMatch = /^\/Users\/[^/]+(\/.*)?$/.exec(path);
+  if (macMatch) return `~${macMatch[1] ?? ''}`;
+  const linuxMatch = /^\/home\/[^/]+(\/.*)?$/.exec(path);
+  if (linuxMatch) return `~${linuxMatch[1] ?? ''}`;
   return path;
 }
 
@@ -257,8 +280,11 @@ export function InfoTopBar(): JSX.Element {
         setProbes((prev) => ({ ...prev, [name]: next[name] }));
       }
       // Swagger inherits the API process's outcome — same Python
-      // server, same uvicorn worker.
-      if ('api' in next) {
+      // server, same uvicorn worker. Guarded by the same ``cancelled``
+      // check the inner loop uses so a fast-unmount (operator
+      // navigates away mid-probe) doesn't schedule a state update on
+      // a torn-down component.
+      if (!cancelled && 'api' in next) {
         setProbes((prev) => ({ ...prev, swagger: next.api }));
       }
     })();
@@ -323,7 +349,13 @@ export function InfoTopBar(): JSX.Element {
           Colour reflects the health probe outcome:
           neutral=probing, success=healthy, danger=degraded. */}
       <nav aria-label="Subsystem availability" class="flex flex-wrap items-center gap-1.5">
-        {views.length === 0 && metadata !== null ? (
+        {/* The empty-state branch keys off the SOURCE map size
+            (metadata.subsystems), not the synthesised views array,
+            because buildViews always appends a synthetic Swagger row.
+            Pre-fix this branch was unreachable: even with a totally
+            empty discovery doc, views.length stayed at 1 (Swagger)
+            and the "supervisor not running" hint never surfaced. */}
+        {metadata !== null && Object.keys(metadata.subsystems).length === 0 ? (
           <span class="text-[10px] text-slate-500 dark:text-slate-400 italic">
             no subsystems reported (supervisor not running)
           </span>

--- a/ui/src/chrome/InfoTopBar.tsx
+++ b/ui/src/chrome/InfoTopBar.tsx
@@ -1,0 +1,375 @@
+/**
+ * Info-rich topbar — replaces the W18c bare "Stream" + TopBarExtras header.
+ *
+ * The W22b3 mandate from the user:
+ *
+ *   "UI header (sticky?) should not just contain ctxr-fsm slug, it
+ *    should beautifully write with human language that it's finite
+ *    state machine, what is the cwd where it is installed, what is
+ *    the project name, basic information, indicators of availability
+ *    for mcp, api, swagger etc. It should look very intensive,
+ *    maximum explanatory."
+ *
+ * The header therefore renders FOUR information bands in one sticky
+ * row:
+ *
+ *   1. BRANDING  — ``ctxr-fsm`` wordmark + tagline ("Finite state
+ *      machine substrate") so a first-time visitor reading the
+ *      header knows what they're looking at without scrolling.
+ *   2. PROJECT   — project slug + project root path (relative to
+ *      $HOME when possible, never absolute on a shared screenshot).
+ *      The slug answers "which project" and the path answers "where
+ *      on disk".
+ *   3. SUBSYSTEMS — clickable pills for each subsystem the
+ *      supervisor knows about (MCP / API / Swagger / UI). Each pill
+ *      is a real ``<a>`` with the discovered URL, so the operator
+ *      can jump straight to Swagger or the UI from the dashboard.
+ *      Healthy / degraded state is colour-coded; the pill is muted
+ *      when the subsystem isn't reported.
+ *   4. CONNECTION — the existing SSE stream pill, kept where the
+ *      user already learned to look (right edge), with the
+ *      TopBarExtras menu cluster trailing.
+ *
+ * The bar is sticky-positioned (``sticky top-0 z-10``) so it stays
+ * pinned to the viewport top across long pages without floating
+ * over the existing chrome's stacking context. ``backdrop-blur``
+ * keeps the row legible when content scrolls behind it.
+ *
+ * Data acquisition: one call to ``api.getCurrentProject()`` at mount
+ * + a window-focus refetch so a user who tabs back from Swagger sees
+ * fresh subsystem state without a manual refresh. Health probes
+ * (the ``healthz_url`` field) are re-issued in a small ``mapLimited``
+ * fan-out so the pills can show green / amber / red rather than just
+ * "configured". Failures collapse to a muted pill — the topbar must
+ * never error out the dashboard.
+ *
+ * Why a separate component rather than extending ``app.tsx``'s inline
+ * ``TopBar`` directly? Two reasons: (a) the data layer is async
+ * (signal + effect + fetch) and lifting it into ``app.tsx`` would
+ * inflate that file past the W18a shell-thinness rule, and (b)
+ * future polish passes will tightly couple a Cmd+K target list to
+ * the subsystem map — keeping the home for both side-by-side here
+ * is the right shape.
+ */
+
+import type { JSX } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+
+import { Pill, type PillVariant } from '../components';
+import { connectionPillProps } from '../lib/connectionPill';
+import { connectionState } from '../lib/store';
+import {
+  api,
+  ApiError,
+  type ProjectMetadata,
+  type SubsystemInfo,
+} from '../lib/api';
+
+import { TopBarExtras } from './TopBarExtras';
+
+const HEALTHZ_TIMEOUT_MS = 1500;
+
+/**
+ * Health-probe outcomes for a subsystem. ``unknown`` is the initial
+ * state (probe in flight or not run yet). ``healthy`` means the
+ * ``healthz_url`` returned 2xx. ``degraded`` covers every other case
+ * (non-2xx, network error, timeout).
+ */
+type ProbeStatus = 'unknown' | 'healthy' | 'degraded';
+
+interface SubsystemView {
+  name: string;
+  base_url: string;
+  swagger_url: string | null;
+  pid: number | null;
+  probe: ProbeStatus;
+  /** Human-friendly label rendered on the pill ("MCP", "API", …). */
+  label: string;
+  /** Mouse-hover hint with all available metadata. */
+  title: string;
+}
+
+/**
+ * Display order for subsystems. Anything reported by the supervisor
+ * that doesn't appear in this list falls back to alphabetical at the
+ * end — so a future subsystem (e.g. "metrics") doesn't disappear from
+ * the header just because the priority isn't wired here yet.
+ */
+const SUBSYSTEM_ORDER: readonly string[] = ['mcp', 'api', 'ui', 'swagger'];
+
+const PROBE_VARIANT: Record<ProbeStatus, PillVariant> = {
+  unknown: 'neutral',
+  healthy: 'success',
+  degraded: 'danger',
+};
+
+/** Render an absolute path relative to ``$HOME`` when possible. */
+function condenseHome(path: string | null | undefined): string {
+  if (!path) return '';
+  const home =
+    typeof window !== 'undefined' &&
+    (window as Window & { __FSM_HOME__?: string }).__FSM_HOME__;
+  if (home && path.startsWith(home)) return `~${path.slice(home.length)}`;
+  return path;
+}
+
+/**
+ * Probe ``healthz_url`` once with an abort-after-timeout. Returns
+ * ``healthy`` on 2xx, ``degraded`` for any other outcome (non-2xx /
+ * network error / timeout). Never throws.
+ */
+async function probeHealth(url: string): Promise<ProbeStatus> {
+  if (typeof fetch === 'undefined') return 'unknown';
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HEALTHZ_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal, credentials: 'omit' });
+    return res.ok ? 'healthy' : 'degraded';
+  } catch {
+    return 'degraded';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Build the per-subsystem display row from the discovery doc.
+ *
+ * ``swagger`` is synthesised from ``metadata.swagger_url`` rather
+ * than coming through ``subsystems`` — Swagger lives on the API
+ * process so it shares the API's healthz outcome; we still render it
+ * as its own pill so an operator can click straight through.
+ */
+function buildViews(metadata: ProjectMetadata): SubsystemView[] {
+  const views: SubsystemView[] = [];
+  for (const name of Object.keys(metadata.subsystems)) {
+    const info: SubsystemInfo = metadata.subsystems[name];
+    views.push({
+      name,
+      base_url: info.base_url,
+      swagger_url: null,
+      pid: info.pid,
+      probe: 'unknown',
+      label: name.toUpperCase(),
+      title: [
+        `${name} subsystem`,
+        `URL: ${info.base_url}`,
+        info.healthz_url ? `Health: ${info.healthz_url}` : null,
+        info.pid != null ? `PID: ${info.pid}` : null,
+      ].filter(Boolean).join(' · '),
+    });
+  }
+  // Swagger is a synthetic row: it lives at /docs on the API process,
+  // not in the subsystems map. We surface it as its own pill so the
+  // operator's first instinct ("show me the API docs") gets a
+  // dedicated affordance instead of being buried under "API".
+  views.push({
+    name: 'swagger',
+    base_url: metadata.swagger_url,
+    swagger_url: metadata.swagger_url,
+    pid: null,
+    probe: 'unknown',
+    label: 'Swagger',
+    title: `OpenAPI / Swagger UI · ${metadata.swagger_url}`,
+  });
+
+  // Sort by SUBSYSTEM_ORDER, then alphabetically for the tail.
+  return views.sort((a, b) => {
+    const ai = SUBSYSTEM_ORDER.indexOf(a.name);
+    const bi = SUBSYSTEM_ORDER.indexOf(b.name);
+    if (ai >= 0 && bi >= 0) return ai - bi;
+    if (ai >= 0) return -1;
+    if (bi >= 0) return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function InfoTopBar(): JSX.Element {
+  const [metadata, setMetadata] = useState<ProjectMetadata | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [probes, setProbes] = useState<Record<string, ProbeStatus>>({});
+
+  // Initial fetch + re-fetch on focus.
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const m = await api.getCurrentProject();
+        if (cancelled) return;
+        setMetadata(m);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof ApiError ? err.message : String(err));
+      }
+    };
+    load();
+    const onFocus = () => { void load(); };
+    if (typeof window !== 'undefined') {
+      window.addEventListener('focus', onFocus);
+    }
+    return () => {
+      cancelled = true;
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('focus', onFocus);
+      }
+    };
+  }, []);
+
+  // Health probes whenever the metadata refreshes. Capped fan-out so a
+  // future "10 subsystems" scenario doesn't carpet-bomb the API at boot.
+  useEffect(() => {
+    if (!metadata) return;
+    let cancelled = false;
+    (async () => {
+      const next: Record<string, ProbeStatus> = {};
+      const subs = Object.entries(metadata.subsystems);
+      for (const [name, info] of subs) {
+        if (!info.healthz_url) {
+          next[name] = 'unknown';
+          continue;
+        }
+        next[name] = await probeHealth(info.healthz_url);
+        if (cancelled) return;
+        setProbes((prev) => ({ ...prev, [name]: next[name] }));
+      }
+      // Swagger inherits the API process's outcome — same Python
+      // server, same uvicorn worker.
+      if ('api' in next) {
+        setProbes((prev) => ({ ...prev, swagger: next.api }));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [metadata]);
+
+  const views = useMemo<SubsystemView[]>(() => {
+    if (!metadata) return [];
+    return buildViews(metadata).map((v) => ({ ...v, probe: probes[v.name] ?? v.probe }));
+  }, [metadata, probes]);
+
+  const connection = connectionPillProps(connectionState.value);
+  const projectRoot = condenseHome(metadata?.project_root);
+
+  return (
+    <header
+      role="banner"
+      class={
+        'sticky top-0 z-10 ' +
+        'backdrop-blur bg-white/85 dark:bg-slate-900/85 ' +
+        'border-b border-slate-200 dark:border-slate-700 ' +
+        'flex flex-wrap items-center gap-x-6 gap-y-2 px-6 py-2'
+      }
+    >
+      {/* Band 1: branding. The two-line treatment communicates "what
+          tool is this" at first glance — the wordmark is the slug,
+          the tagline names the substrate in plain English so a
+          newcomer who lands on the dashboard isn't left guessing. */}
+      <div class="flex flex-col leading-tight">
+        <span class="text-base font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+          ctxr-fsm
+        </span>
+        <span class="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-400">
+          Finite state machine substrate
+        </span>
+      </div>
+
+      {/* Band 2: project. ``project_slug`` answers "which project?";
+          the home-condensed root answers "where on disk?". When the
+          API is older / the DB is in-memory, ``project_slug`` and
+          ``project_root`` are null — render an explicit "no project
+          bound" label so the operator doesn't read "blank" as a bug. */}
+      {metadata ? (
+        <div class="flex flex-col leading-tight min-w-0">
+          <span
+            class="text-sm font-medium text-slate-900 dark:text-slate-100 truncate max-w-[24rem]"
+            title={metadata.project_slug ?? 'no project bound'}
+          >
+            {metadata.project_slug ?? <em class="text-slate-500 dark:text-slate-400">no project bound</em>}
+          </span>
+          <span
+            class="text-[10px] font-mono text-slate-500 dark:text-slate-400 truncate max-w-[24rem]"
+            title={metadata.project_root ?? ''}
+          >
+            {projectRoot || <span class="italic">project root unknown</span>}
+          </span>
+        </div>
+      ) : null}
+
+      {/* Band 3: subsystem pills. Each pill is a real <a> with the
+          discovered URL so the operator can click straight through.
+          Colour reflects the health probe outcome:
+          neutral=probing, success=healthy, danger=degraded. */}
+      <nav aria-label="Subsystem availability" class="flex flex-wrap items-center gap-1.5">
+        {views.length === 0 && metadata !== null ? (
+          <span class="text-[10px] text-slate-500 dark:text-slate-400 italic">
+            no subsystems reported (supervisor not running)
+          </span>
+        ) : null}
+        {views.map((v) => (
+          <a
+            key={v.name}
+            href={v.base_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1"
+            title={v.title}
+            aria-label={`${v.label} subsystem · ${v.probe}`}
+          >
+            <Pill variant={PROBE_VARIANT[v.probe]} size="sm">
+              <span aria-hidden="true" class={
+                'inline-block h-1.5 w-1.5 rounded-full mr-1 ' +
+                (v.probe === 'healthy'
+                  ? 'bg-emerald-500'
+                  : v.probe === 'degraded'
+                  ? 'bg-red-500'
+                  : 'bg-slate-400')
+              } />
+              {v.label}
+            </Pill>
+          </a>
+        ))}
+      </nav>
+
+      {error ? (
+        <span class="text-[10px] text-red-700 dark:text-red-300">
+          metadata: {error}
+        </span>
+      ) : null}
+
+      <div class="flex-1" />
+
+      {/* Band 4: connection + extras. The connection pill keeps its
+          historical right-edge position so existing muscle memory
+          (operators who learned where "Stream" lives) isn't broken
+          by the rest of the redesign. */}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        class="flex items-center gap-2"
+      >
+        <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Stream
+        </span>
+        <Pill variant={connection.variant} title={connection.title} aria-label={`Event stream: ${connection.label}`}>
+          <span
+            aria-hidden="true"
+            class={[
+              'inline-block h-2 w-2 rounded-full',
+              connection.variant === 'success' && 'bg-emerald-500',
+              connection.variant === 'warning' && 'bg-amber-500',
+              connection.variant === 'danger' && 'bg-red-500',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          />
+          {connection.label}
+        </Pill>
+      </div>
+      <div class="pl-3 border-l border-slate-200 dark:border-slate-700">
+        <TopBarExtras />
+      </div>
+    </header>
+  );
+}
+
+export default InfoTopBar;

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -303,6 +303,42 @@ export interface DoctorReport {
   lock_count: number;
 }
 
+/**
+ * One row of the ``ProjectMetadata.subsystems`` map.
+ *
+ * Mirrors :class:`SubsystemInfo` in ``ctxr/fsm/api/__init__.py``. The
+ * supervisor's discovery doc (``.ctxr-fsm/active-mcp.json``) carries
+ * one of these per running subsystem (``mcp`` / ``api`` / ``ui``);
+ * the info-rich topbar uses them to render a clickable status pill
+ * for each subsystem with the right URL + a re-probe target.
+ */
+export interface SubsystemInfo {
+  base_url: string;
+  healthz_url: string | null;
+  pid: number | null;
+}
+
+/**
+ * Response shape of ``GET /api/v1/projects/current``.
+ *
+ * Mirrors :class:`ProjectMetadata` in ``ctxr/fsm/api/__init__.py``.
+ * ``project_slug`` / ``project_root`` / ``db_path_relative`` /
+ * ``subsystems`` are all population-state-dependent (empty when the
+ * supervisor hasn't written ``active-mcp.json`` yet, or when the DB
+ * is in-memory).
+ */
+export interface ProjectMetadata {
+  fsm_version: string;
+  project_open: boolean;
+  project_slug: string | null;
+  db_path: string;
+  project_root: string | null;
+  db_path_relative: string | null;
+  swagger_url: string;
+  api_base_url: string;
+  subsystems: Record<string, SubsystemInfo>;
+}
+
 // ---------------------------------------------------------------------------
 // Request parameter shapes
 // ---------------------------------------------------------------------------
@@ -794,6 +830,20 @@ export class ApiClient {
   /** ``POST /admin/db/doctor`` — diagnostic dump of the project DB. */
   doctor(): Promise<DoctorReport> {
     return this.request<DoctorReport>('POST', '/admin/db/doctor');
+  }
+
+  /**
+   * ``GET /projects/current`` — full project + subsystem discovery doc.
+   *
+   * Returns everything the info-rich topbar needs to render in one
+   * round-trip: fsm version, project slug, project root, db_path
+   * (absolute + relative), Swagger / API base URLs derived from the
+   * request, and the supervisor's subsystem map (mcp / api / ui base
+   * URLs + healthz URLs + pids) read from
+   * ``<project_root>/.ctxr-fsm/active-mcp.json``.
+   */
+  getCurrentProject(): Promise<ProjectMetadata> {
+    return this.request<ProjectMetadata>('GET', '/projects/current');
   }
 }
 

--- a/ui/src/lib/connectionPill.ts
+++ b/ui/src/lib/connectionPill.ts
@@ -1,0 +1,43 @@
+/**
+ * SSE connection-pill mapping.
+ *
+ * Shared between the original ``app.tsx`` TopBar and the W22b3
+ * ``InfoTopBar`` so the live / reconnecting / offline labelling stays
+ * single-sourced. The ``'closed'`` state collapses into ``danger``
+ * alongside ``'error'`` because both mean "no live updates" from the
+ * user's perspective — the distinction matters only to the SSE
+ * wrapper.
+ */
+
+import type { ConnectionState } from './sse';
+
+export interface ConnectionPillProps {
+  variant: 'success' | 'warning' | 'danger';
+  label: string;
+  title: string;
+}
+
+export function connectionPillProps(state: ConnectionState): ConnectionPillProps {
+  switch (state) {
+    case 'open':
+      return {
+        variant: 'success',
+        label: 'Live',
+        title: 'Connected to the event stream',
+      };
+    case 'connecting':
+      return {
+        variant: 'warning',
+        label: 'Reconnecting',
+        title: 'Re-establishing the event stream',
+      };
+    case 'error':
+    case 'closed':
+    default:
+      return {
+        variant: 'danger',
+        label: 'Offline',
+        title: 'Event stream disconnected — retrying',
+      };
+  }
+}


### PR DESCRIPTION
## Summary

- Sticky info-rich header replacing the bare "Stream" topbar. Four bands: branding (ctxr-fsm wordmark + "Finite state machine substrate" tagline), project (slug + condensed project root), subsystems (clickable pills for MCP / API / UI / Swagger, colour-coded by live health probe), connection (existing SSE pill + extras).
- Server: ``ProjectMetadata`` gains ``project_slug``, ``swagger_url``, ``api_base_url``, and a ``subsystems`` map read from ``.ctxr-fsm/active-mcp.json``. New ``SubsystemInfo`` model wraps each row (base_url + healthz_url + pid).
- Client: ``api.getCurrentProject()`` + matching ``ProjectMetadata`` / ``SubsystemInfo`` interfaces.
- UI: ``ui/src/chrome/InfoTopBar.tsx`` (~340 LOC), ``ui/src/lib/connectionPill.ts`` (extracted from app.tsx). Inline ``TopBar`` retired; ``app.tsx`` now mounts ``<InfoTopBar />`` directly.
- Sticky via ``sticky top-0 z-10`` + backdrop-blur so the header stays legible over scrolling content. Refetches metadata on window focus; health probes have a 1.5s abort timeout and degrade silently.

## Test plan

- [x] ``uv run pytest tests/`` (excl e2e): 694 passed
- [x] ``cd ui && npm run test``: 338 passed
- [x] ``cd ui && npx tsc -b --noEmit``: 0 errors
- [x] ``cd ui && npm run build``: 165 KB gzipped main chunk (under 280 KB budget)
- [x] ``uv run ruff check ctxr/ tests/``: clean
- [x] ``uv run mypy ctxr/fsm/``: 72 files clean
- [ ] Manual smoke against ``dummy-fsm-test`` seeded run: load the UI, verify (a) branding renders, (b) project slug + condensed home path render, (c) MCP / API / UI / Swagger pills appear with the right URLs and colour-code green when the supervisor's healthz returns 200, (d) clicking the Swagger pill opens ``/docs`` in a new tab, (e) the SSE Stream pill remains in its right-edge position. (Operator's call.)

## Deliberately out of scope

- Live health re-probe on a timer. Initial mount + window-focus refetch is enough for the typical operator flow.
- Cmd+K integration for the subsystem URLs. Data shape is ready; wiring lands in W18c polish.
- Per-subsystem PID badge. The data is in the title tooltip; surfacing it visually clutters the chrome without a concrete operator workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)