### PR TITLE
fix(w23a): /specs TypeError + ApiResponseShapeError defensive layers

### DIFF
--- a/.github/workflows/e2e-on-pr.yml
+++ b/.github/workflows/e2e-on-pr.yml
@@ -1,0 +1,84 @@
+# W23a — Playwright E2E gate on every PR that touches UI / API / e2e.
+#
+# Triggered on PRs targeting `main` (or any branch) when the diff
+# includes `ui/src/**`, `ctxr/fsm/api/**`, or `tests/integration/e2e/**`.
+# Doc-only PRs and changes outside those paths skip this workflow
+# (no false-positive runs, no wasted CI budget).
+#
+# This is the "no regression" gate the W23a-deep plan requires after
+# the /specs TypeError surprise: the autouse console-audit fixture
+# defined in tests/integration/e2e/conftest.py asserts ZERO unhandled
+# JS errors during every e2e test body, so the bug class that bit
+# users (a wire-format mismatch crashing every consumer with a raw
+# TypeError) cannot land again without failing CI.
+#
+# Single-OS (Linux) for speed. Chromium-only — Firefox/WebKit add ~3 min
+# each for marginal coverage at this UI's scope; revisit if cross-browser
+# regressions surface.
+
+name: E2E — Playwright
+
+on:
+  pull_request:
+    paths:
+      - 'ui/src/**'
+      - 'ctxr/fsm/api/**'
+      - 'tests/integration/e2e/**'
+      - '.github/workflows/e2e-on-pr.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E (Playwright Chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: '0.5.11'
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: 'ui/package-lock.json'
+
+      # Install UI deps + build the production bundle. Vite dev server
+      # is what ``ctxr-fsm ensure`` spins up at e2e time, so we don't
+      # need ``npm run build`` for the e2e itself — but caching the
+      # node_modules makes the supervisor's UI spawn fast.
+      - name: Install UI deps
+        run: npm ci
+        working-directory: ui
+
+      - name: Install Python deps (incl. e2e group)
+        run: uv sync --all-extras --group e2e
+
+      - name: Install Playwright browsers
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run e2e suite
+        run: uv run pytest tests/integration/e2e/ --run-e2e -v --tb=short
+        env:
+          # Cap concurrent Playwright workers to keep memory + supervisor
+          # spin-up time bounded. The session-scoped ``live_project``
+          # fixture means each xdist worker would spawn its own
+          # supervisor; one worker keeps the run hermetic.
+          PYTEST_ADDOPTS: '--maxfail=5'

--- a/.github/workflows/e2e-on-pr.yml
+++ b/.github/workflows/e2e-on-pr.yml
@@ -38,7 +38,15 @@ jobs:
   e2e:
     name: E2E (Playwright Chromium)
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # 25min ceiling: ``playwright install --with-deps chromium`` runs
+    # ``apt-get update`` + a ~200 MB browser download, which on a cold
+    # hosted runner with a slow azure apt mirror routinely consumes
+    # 8-10 minutes by itself. The prior 12min cap killed the job mid
+    # apt download with the actual e2e suite still pending; the tests
+    # themselves complete in under 2 minutes locally, so 25min is the
+    # smallest budget that absorbs the install jitter without hiding
+    # genuine test hangs.
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -180,9 +180,16 @@ app: FastAPI = FastAPI(
 # OPTIONS without the ``Authorization`` header, which would otherwise
 # trip ``require_auth`` and respond with 401 / 403 instead of the
 # expected CORS headers).
+#
+# ``allow_origin_regex`` covers every loopback dev origin (any port on
+# ``localhost`` / ``127.0.0.1``) so the e2e harness, which spawns the
+# UI on an ephemeral port, can reach the API's ``/healthz`` from the
+# browser without each test having to wire ``$CTXR_FSM_API_CORS_ORIGINS``
+# per-port. Production stays locked down to the explicit allowlist.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_resolve_cors_origins(),
+    allow_origin_regex=r"^http://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/ctxr/fsm/api/__init__.py
+++ b/ctxr/fsm/api/__init__.py
@@ -185,11 +185,19 @@ app: FastAPI = FastAPI(
 # ``localhost`` / ``127.0.0.1``) so the e2e harness, which spawns the
 # UI on an ephemeral port, can reach the API's ``/healthz`` from the
 # browser without each test having to wire ``$CTXR_FSM_API_CORS_ORIGINS``
-# per-port. Production stays locked down to the explicit allowlist.
+# per-port. The regex is enabled only when ``CTXR_FSM_API_TOKEN`` is
+# unset (dev mode) so production — which always sets the token — stays
+# locked down to the explicit allowlist and does not silently broaden
+# its CORS policy to every loopback caller.
+_loopback_regex: str | None = (
+    r"^http://(localhost|127\.0\.0\.1)(:\d+)?$"
+    if not os.environ.get("CTXR_FSM_API_TOKEN")
+    else None
+)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_resolve_cors_origins(),
-    allow_origin_regex=r"^http://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_origin_regex=_loopback_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/ctxr/fsm/mcp/server.py
+++ b/ctxr/fsm/mcp/server.py
@@ -357,7 +357,25 @@ def main(
             mcp.settings.host = host
             mcp.settings.port = port
             _LOG.info("starting MCP server on http://%s:%s (sse)", host, port)
-            mcp.run(transport="sse")
+            # Wrap FastMCP's Starlette app with CORSMiddleware so the
+            # browser-side InfoTopBar can probe ``/healthz`` cross-origin
+            # from the Vite dev server (any loopback port). FastMCP's
+            # built-in ``mcp.run(transport='sse')`` would skip this; we
+            # call uvicorn directly with the wrapped app instead. The
+            # regex matches every loopback dev origin so the e2e harness
+            # (ephemeral Vite port) Just Works without per-port wiring.
+            import uvicorn
+            from starlette.middleware.cors import CORSMiddleware
+
+            sse_app = mcp.sse_app()
+            sse_app.add_middleware(
+                CORSMiddleware,
+                allow_origin_regex=r"^http://(localhost|127\.0\.0\.1)(:\d+)?$",
+                allow_credentials=True,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
+            uvicorn.run(sse_app, host=host, port=port, log_level="info")
         else:
             # Defensive — Literal narrows at the type level but a
             # runtime caller (e.g. a typo from the CLI shim) could

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,4 +208,5 @@ testpaths = ["tests"]
 markers = [
   "e2e: end-to-end UI tests (Playwright). Require the 'e2e' dependency group and 'playwright install chromium'. Skipped automatically when those are not present.",
   "keeps_rich_color: opt this test out of the W18a conftest fixture that sets NO_COLOR=1 / COLUMNS=200. Use it when the test deliberately asserts on Rich ANSI SGR output (e.g. the render-table colour tests).",
+  "allow_console_errors: opt this e2e test out of the W23a console-error audit autouse fixture. Reserve for tests that deliberately exercise a UI error path (e.g. the stale-bundle / SPA-fallback regression tests). Without this marker every e2e test asserts ZERO uncaught JS errors during its body.",
 ]

--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -92,13 +92,58 @@ def _run_ensure(project_root: Path, timeout_s: float = 60.0) -> dict:
     return json.loads(result.stdout)
 
 
-def _wait_for_url(url: str, *, timeout_s: float, accept_status_below: int = 500) -> None:
+def _read_supervisor_logs(project_root: Path, *, tail_bytes: int = 32_768) -> str:
+    """Return the tail of the supervisor log dir, joined for diagnostics.
+
+    The supervisor forwards each child's stdout/stderr to its own
+    stderr with a ``[ctxr-fsm supervisor]`` / ``[<child>]`` prefix and
+    persists rotating files under ``.ctxr-fsm/logs/``. On CI we can
+    only see what we print, so when a wait-for-url times out we dump
+    the tail of every log file so the failure is diagnosable instead
+    of opaque (the symptom was ``ConnectionRefusedError`` without any
+    hint about whether npm crashed, Vite was still pre-bundling, or
+    the port was simply taken).
+    """
+    logs_dir = project_root / ".ctxr-fsm" / "logs"
+    if not logs_dir.is_dir():
+        return f"<no supervisor logs at {logs_dir}>"
+    chunks: list[str] = []
+    for log_file in sorted(logs_dir.glob("*.log")):
+        try:
+            with log_file.open("rb") as fh:
+                fh.seek(0, os.SEEK_END)
+                size = fh.tell()
+                start = max(0, size - tail_bytes)
+                fh.seek(start)
+                blob = fh.read().decode("utf-8", errors="replace")
+        except OSError as exc:
+            chunks.append(f"--- {log_file.name} (unreadable: {exc!r}) ---")
+            continue
+        chunks.append(f"--- {log_file.name} (tail {len(blob)}B) ---\n{blob}")
+    if not chunks:
+        return f"<supervisor logs dir {logs_dir} is empty>"
+    return "\n".join(chunks)
+
+
+def _wait_for_url(
+    url: str,
+    *,
+    timeout_s: float,
+    accept_status_below: int = 500,
+    project_root: Path | None = None,
+) -> None:
     """Poll ``url`` until it returns < ``accept_status_below`` or timeout.
 
     Vite's dev server and uvicorn typically need 1-3s after the
     supervisor reports them as "spawned" before they actually accept
     sockets. The Vite ready signal in particular is asynchronous to
-    the child-process PID being live. We poll on a 100ms cadence.
+    the child-process PID being live, and on a GH-hosted runner cold
+    start (first esbuild prebundle + uvicorn import-graph priming)
+    the wait can routinely exceed 20s. We poll on a 100ms cadence.
+
+    On timeout, if ``project_root`` is provided, dump the tail of the
+    supervisor log files so a CI failure is diagnosable instead of
+    surfacing only ``ConnectionRefusedError``.
     """
     deadline = time.monotonic() + timeout_s
     last_error: Exception | None = None
@@ -110,9 +155,12 @@ def _wait_for_url(url: str, *, timeout_s: float, accept_status_below: int = 500)
         except (urllib.error.URLError, ConnectionError, TimeoutError) as exc:
             last_error = exc
         time.sleep(0.1)
+    diag = ""
+    if project_root is not None:
+        diag = "\n--- supervisor logs ---\n" + _read_supervisor_logs(project_root)
     raise TimeoutError(
         f"timed out after {timeout_s}s waiting for {url} "
-        f"(last error: {last_error!r})"
+        f"(last error: {last_error!r}){diag}"
     )
 
 
@@ -188,8 +236,19 @@ def live_project(tmp_path_factory: pytest.TempPathFactory) -> Generator[LiveProj
         # process is alive, but Vite + uvicorn need a moment more
         # before they accept connections. Poll healthz before
         # handing off to tests.
-        _wait_for_url(f"{api_url}/healthz", timeout_s=20.0)
-        _wait_for_url(ui_url, timeout_s=20.0)
+        # 60s ceiling: Vite cold start on GH-hosted runners with a
+        # first-time esbuild prebundle + uvicorn import-graph priming
+        # routinely exceeds the old 20s window. The poll cadence is
+        # 100ms, so a healthy local boot still hands off in under 2s;
+        # the budget only bites on CI cold starts. Pass
+        # ``project_root`` so timeouts dump the supervisor log tail
+        # (npm/Vite/uvicorn stderr forwarded via the supervisor) into
+        # the failure message — opaque ``ConnectionRefusedError`` is
+        # what made the original CI flake un-diagnosable.
+        _wait_for_url(
+            f"{api_url}/healthz", timeout_s=60.0, project_root=project_root
+        )
+        _wait_for_url(ui_url, timeout_s=60.0, project_root=project_root)
         yield LiveProject(
             project_root=project_root,
             api_url=api_url,

--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -199,3 +199,97 @@ def live_project(tmp_path_factory: pytest.TempPathFactory) -> Generator[LiveProj
     finally:
         _kill_supervisor(project_root)
         shutil.rmtree(root_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# W23a: Universal "no console errors" autouse fixture
+# ---------------------------------------------------------------------------
+
+
+# URL prefixes / message patterns that legitimately log to console in dev mode
+# and don't indicate a real bug. Kept TIGHT to avoid masking actual API
+# failures — a broad "Failed to load resource" wildcard would mask the
+# /specs TypeError that prompted W23a.
+_IGNORED_CONSOLE_PREFIXES: tuple[str, ...] = (
+    # Vite HMR client noise when the dev server is reloading or briefly down.
+    "[vite] failed to connect to websocket",
+    # /favicon.ico 404 is browser-default and not the API's concern.
+    "Failed to load resource: the server responded with a status of 404 (Not Found) @ http://",
+)
+
+
+def _is_ignored_console_message(text: str, url: str | None) -> bool:
+    """Return True for known-acceptable console errors in dev mode.
+
+    Any error not matched here fails the autouse audit. The list is
+    intentionally narrow so a real regression cannot hide behind a
+    permissive wildcard.
+    """
+    if any(text.startswith(p) for p in _IGNORED_CONSOLE_PREFIXES):
+        return True
+    # favicon misses in particular surface as ``Failed to load resource``
+    # with the resource URL in a separate field on some Playwright versions.
+    return url is not None and url.endswith("/favicon.ico")
+
+
+@pytest.fixture(autouse=True)
+def _console_audit(request: pytest.FixtureRequest) -> Generator[None]:
+    """Fail any e2e test whose page logged a console.error or threw.
+
+    W23a-deep mandate: the /specs TypeError that prompted this wave was
+    a console error the existing tests didn't catch. From now on every
+    e2e test that requests the ``page`` fixture also asserts that the
+    page produced ZERO uncaught errors during the test body. Opt out
+    per-test with ``@pytest.mark.allow_console_errors`` (reserved for
+    tests deliberately exercising a UI error path).
+
+    The fixture is autouse so collection-time inclusion is implicit;
+    tests that DO NOT request ``page`` (no Playwright surface) are
+    no-ops because the fixture only activates when ``page`` is in the
+    request's resolved fixturenames.
+    """
+    if request.node.get_closest_marker("allow_console_errors") is not None:
+        yield
+        return
+    # The ``page`` fixture is lazy — if a test never requests it we
+    # skip the wiring entirely. Detection: look up the fixture name in
+    # the test's resolved fixture set.
+    if "page" not in request.fixturenames:
+        yield
+        return
+
+    # Pull the Playwright page fixture by name (the Playwright pytest
+    # integration registers it as a normal pytest fixture).
+    page = request.getfixturevalue("page")
+
+    console_errors: list[str] = []
+    page_errors: list[str] = []
+
+    def _on_console(msg) -> None:
+        if msg.type != "error":
+            return
+        url = None
+        try:
+            url = msg.location.get("url") if msg.location else None
+        except Exception:
+            url = None
+        if _is_ignored_console_message(msg.text, url):
+            return
+        console_errors.append(msg.text)
+
+    def _on_pageerror(err) -> None:
+        page_errors.append(repr(err))
+
+    page.on("console", _on_console)
+    page.on("pageerror", _on_pageerror)
+
+    yield
+
+    diag_lines: list[str] = []
+    for e in console_errors:
+        diag_lines.append(f"  console.error: {e}")
+    for e in page_errors:
+        diag_lines.append(f"  pageerror:     {e}")
+    assert not console_errors and not page_errors, (
+        "JS console / uncaught errors during e2e test:\n" + "\n".join(diag_lines)
+    )

--- a/tests/integration/e2e/test_ui_specs_route.py
+++ b/tests/integration/e2e/test_ui_specs_route.py
@@ -132,11 +132,18 @@ def _clear_project(db_path) -> None:
 
 
 def _seed_spec(db_path, slug: str) -> str:
-    """Register a single spec; return its registered spec_id."""
+    """Register a single spec; return its registered spec_id (UUIDv7 PK).
+
+    ``project.register_spec`` returns a ``SpecRegistered`` value object
+    with shape ``{spec: RegisteredSpec, created: bool}``. The UI's
+    /specs row click routes to ``/specs/{r.latest.id}`` (the row PK,
+    not the slug), so we hand the same PK back to the test for its
+    ``page.wait_for_url(...)`` assertion.
+    """
     project = Project.open(db_path)
     try:
         registered = project.register_spec(_spec(slug))
-        return registered.id
+        return registered.spec.id
     finally:
         project.close()
 
@@ -185,7 +192,13 @@ def test_specs_route_empty_state_no_js_errors(
         f"expected empty items[] after clear, got {body[:200]}"
     )
 
-    page.goto(f"{live_project.ui_url}/specs", wait_until="networkidle")
+    # ``networkidle`` never resolves here: the topbar's /healthz poll
+    # and the live SSE event channel keep the network "busy" forever,
+    # so Playwright would always burn the 30s wait. Wait on DOM-ready
+    # then on the route's <h1>Specs</h1> heading; both are reliable
+    # and bounded.
+    page.goto(f"{live_project.ui_url}/specs", wait_until="domcontentloaded")
+    page.get_by_role("heading", name="Specs", level=1).wait_for(timeout=15_000)
 
     # The empty-state copy from specs.tsx — "No specs registered" /
     # "ctxr-fsm spec register". Either substring is fine; we want the
@@ -215,7 +228,9 @@ def test_specs_route_seeded_renders_specs_with_run_counts(
     _seed_run(db_path, "e2e-specs-alpha")
     _seed_run(db_path, "e2e-specs-beta")
 
-    page.goto(f"{live_project.ui_url}/specs", wait_until="networkidle")
+    # See empty-state test above for why we avoid ``networkidle``.
+    page.goto(f"{live_project.ui_url}/specs", wait_until="domcontentloaded")
+    page.get_by_role("heading", name="Specs", level=1).wait_for(timeout=15_000)
 
     body_text = page.locator("body").inner_text(timeout=5000)
     assert "e2e-specs-alpha" in body_text, (
@@ -235,7 +250,9 @@ def test_specs_route_row_click_navigates_to_detail(
     _clear_project(db_path)
     spec_id = _seed_spec(db_path, "e2e-specs-navtest")
 
-    page.goto(f"{live_project.ui_url}/specs", wait_until="networkidle")
+    # See empty-state test above for why we avoid ``networkidle``.
+    page.goto(f"{live_project.ui_url}/specs", wait_until="domcontentloaded")
+    page.get_by_role("heading", name="Specs", level=1).wait_for(timeout=15_000)
 
     # Find the row that contains the slug text and click it. The
     # Table component (ui/src/components/Table.tsx) renders each row
@@ -251,6 +268,10 @@ def test_specs_route_row_click_navigates_to_detail(
 
     # Detail header should render the slug as part of its title; the
     # exact copy lives in specDetail.tsx and may carry a version pill.
+    # Wait for the slug text to appear (the route ships a "Loading spec"
+    # shim while it fetches the detail payload; asserting on body text
+    # the moment the URL flips reads the shim, not the resolved page).
+    page.get_by_text("e2e-specs-navtest").first.wait_for(timeout=15_000)
     body_text = page.locator("body").inner_text(timeout=5000)
     assert "e2e-specs-navtest" in body_text, (
         f"detail page should show the slug; got: {body_text[:500]}"

--- a/tests/integration/e2e/test_ui_specs_route.py
+++ b/tests/integration/e2e/test_ui_specs_route.py
@@ -1,0 +1,257 @@
+"""W23a E2E coverage for /specs.
+
+The user reported ``TypeError: env.items is not iterable`` on /specs
+and explicitly asked: "make sure you cover e2e tests properly, with
+runs and specs available in UI." These tests are the regression gate.
+
+Every test runs under the autouse ``_console_audit`` fixture (see
+``conftest.py``) which asserts zero unhandled JS errors during the
+test body — so the original TypeError would have been caught here
+even without a body assertion.
+
+Test matrix:
+
+* ``empty_state_no_js_errors``: fresh DB, navigate to /specs, assert
+  the empty-state copy renders and no JS errors fire (the W23a
+  defensive layer in ``walkAllPages`` + ``request`` is what makes
+  this clean).
+* ``seeded_renders_specs_with_run_counts``: 2 specs + 3 runs split
+  across them; both rows visible with the right run counts.
+* ``row_click_navigates_to_detail``: clicking a spec row routes to
+  /specs/<id> and the detail header renders.
+
+The seeded variants reuse the same ``_seed_spec()`` + driver helpers
+the existing ``test_ui_shows_seeded_run.py`` battery uses, so the
+fixture cost stays session-scoped.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+
+import pytest
+
+from ctxr.fsm.core.models import (
+    FsmSpec,
+    ResponseSchema,
+    State,
+    Transition,
+    TransitionKind,
+    Worker,
+)
+from ctxr.fsm.sqlite.project import Project
+from ctxr.fsm.testing import drive_run_to_completion
+from tests.integration.e2e.conftest import LiveProject
+
+
+def _spec(slug: str) -> FsmSpec:
+    """One-state spec keyed by ``slug`` so we can seed multiple distinct specs."""
+    return FsmSpec(
+        id=slug,
+        version=1,
+        entry="emit",
+        states=[
+            State(
+                id="emit",
+                worker=Worker(
+                    role="emitter",
+                    prompt_template="unused.md",
+                    inputs=[],
+                    response_schema=ResponseSchema(
+                        schema={
+                            "type": "object",
+                            "properties": {"verdict": {"type": "string"}},
+                            "required": ["verdict"],
+                            "additionalProperties": False,
+                        },
+                    ),
+                ),
+                outputs=["verdict"],
+                transitions=[
+                    Transition(to="done", when=TransitionKind.always.value),
+                ],
+            ),
+            State(id="done", outputs=[], transitions=[]),
+        ],
+    )
+
+
+def _clear_project(db_path) -> None:
+    """Reset the live project's DB to a clean state.
+
+    Each test starts from zero specs + zero runs so empty-state
+    assertions are deterministic. We delete from the actual SQLite
+    tables (rather than re-materialising the fixture) so the
+    supervisor keeps the same handle open — the WAL is what the
+    write goes through, no schema change required.
+    """
+    project = Project.open(db_path)
+    try:
+        # The session_factory + connection gives us a transactional
+        # surface that respects FK cascades declared in models_core.py.
+        with project.session_factory() as session:
+            from ctxr.fsm.sqlite.models_core import (
+                AggregateTable,
+                FsmSpecTable,
+                LockTable,
+                RunSessionTable,
+                RunTable,
+                StateTable,
+                TransitionTable,
+                WorkerArtifactTable,
+            )
+            from ctxr.fsm.sqlite.models_enforcement import (
+                CommitSignatureTable,
+                CommitTokenTable,
+                DriftSignalTable,
+                JournalTxnTable,
+                ToolCallTable,
+            )
+            from ctxr.fsm.sqlite.models_events import (
+                EventDeliveryTable,
+                EventTable,
+                ProducerTable,
+            )
+
+            # Order matters: children before parents to satisfy FKs even
+            # though most have ON DELETE CASCADE — being explicit avoids
+            # surprises if a future migration loosens a cascade.
+            for table in (
+                CommitSignatureTable, CommitTokenTable, DriftSignalTable,
+                ToolCallTable, JournalTxnTable, LockTable,
+                EventDeliveryTable, EventTable,
+                AggregateTable, WorkerArtifactTable, TransitionTable, StateTable,
+                RunSessionTable, RunTable,
+                ProducerTable,
+                FsmSpecTable,
+            ):
+                session.execute(table.__table__.delete())  # type: ignore[attr-defined]
+            session.commit()
+    finally:
+        project.close()
+
+
+def _seed_spec(db_path, slug: str) -> str:
+    """Register a single spec; return its registered spec_id."""
+    project = Project.open(db_path)
+    try:
+        registered = project.register_spec(_spec(slug))
+        return registered.id
+    finally:
+        project.close()
+
+
+def _seed_run(db_path, slug: str) -> str:
+    """Register the spec if missing + drive one run to completion."""
+    project = Project.open(db_path)
+    try:
+        project.register_spec(_spec(slug))
+        result = drive_run_to_completion(
+            project,
+            spec_id=slug,
+            entry_state_id="emit",
+            args={"task": f"e2e-specs-{slug}"},
+            worker_outputs={"emit": {"verdict": "GO"}},
+        )
+        assert result.status == "completed"
+        return result.run_id
+    finally:
+        project.close()
+
+
+@pytest.mark.e2e
+def test_specs_route_empty_state_no_js_errors(
+    live_project: LiveProject, page
+) -> None:
+    """Fresh DB → /specs renders empty state AND fires zero JS errors.
+
+    This is the exact bug class the user reported: pre-W23a the
+    walkAllPages helper would crash on an undefined ``env.items``
+    when the Vite proxy mis-routed. With the defensive layer in
+    place + the autouse console-audit fixture, a regression would
+    surface here as a test failure on either the missing copy OR a
+    console error during navigation.
+    """
+    db_path = live_project.project_root / ".ctxr-fsm" / "fsm.db"
+    _clear_project(db_path)
+
+    # Sanity check the REST surface — if the API returns garbage we
+    # want the test to read as "backend broken" not "UI broken".
+    specs_url = f"{live_project.api_url}/api/v1/specs"
+    with urllib.request.urlopen(specs_url, timeout=10) as resp:
+        body = resp.read().decode("utf-8")
+    assert '"items":' in body, f"API at {specs_url} returned non-envelope: {body[:200]}"
+    assert '"items":[]' in body.replace(" ", ""), (
+        f"expected empty items[] after clear, got {body[:200]}"
+    )
+
+    page.goto(f"{live_project.ui_url}/specs", wait_until="networkidle")
+
+    # The empty-state copy from specs.tsx — "No specs registered" /
+    # "ctxr-fsm spec register". Either substring is fine; we want the
+    # operator-facing hint visible, not a stack trace.
+    body_text = page.locator("body").inner_text(timeout=5000)
+    assert "No specs registered" in body_text or "spec register" in body_text, (
+        f"expected empty-state copy on /specs; got body:\n{body_text[:500]}"
+    )
+
+
+@pytest.mark.e2e
+def test_specs_route_seeded_renders_specs_with_run_counts(
+    live_project: LiveProject, page
+) -> None:
+    """Two specs + three runs across them all surface on /specs.
+
+    Validates the happy path the user actually wants: the table
+    renders every registered spec, the run-count column reflects the
+    real cross-spec aggregation, and zero JS errors fire.
+    """
+    db_path = live_project.project_root / ".ctxr-fsm" / "fsm.db"
+    _clear_project(db_path)
+
+    # Seed 2 specs + 3 runs (2 on the first, 1 on the second). Run
+    # ids are returned but we only need their presence on the wire.
+    _seed_run(db_path, "e2e-specs-alpha")
+    _seed_run(db_path, "e2e-specs-alpha")
+    _seed_run(db_path, "e2e-specs-beta")
+
+    page.goto(f"{live_project.ui_url}/specs", wait_until="networkidle")
+
+    body_text = page.locator("body").inner_text(timeout=5000)
+    assert "e2e-specs-alpha" in body_text, (
+        f"expected alpha slug on /specs; got body:\n{body_text[:800]}"
+    )
+    assert "e2e-specs-beta" in body_text, (
+        f"expected beta slug on /specs; got body:\n{body_text[:800]}"
+    )
+
+
+@pytest.mark.e2e
+def test_specs_route_row_click_navigates_to_detail(
+    live_project: LiveProject, page
+) -> None:
+    """Clicking a spec row navigates to /specs/<id> with the detail header."""
+    db_path = live_project.project_root / ".ctxr-fsm" / "fsm.db"
+    _clear_project(db_path)
+    spec_id = _seed_spec(db_path, "e2e-specs-navtest")
+
+    page.goto(f"{live_project.ui_url}/specs", wait_until="networkidle")
+
+    # Find the row that contains the slug text and click it. The
+    # Table component (ui/src/components/Table.tsx) renders each row
+    # as a <tr> with the row payload's data bubbled up via onRowClick.
+    row = page.locator("tr", has_text="e2e-specs-navtest").first
+    row.wait_for(timeout=5000)
+    row.click()
+
+    # After click the route navigates via navigateTo() at specs.tsx:125
+    # which does pushState + dispatch popstate. Wait for the URL to
+    # change rather than the body — body has loading shim first.
+    page.wait_for_url(f"**/specs/{spec_id}", timeout=5000)
+
+    # Detail header should render the slug as part of its title; the
+    # exact copy lives in specDetail.tsx and may carry a version pill.
+    body_text = page.locator("body").inner_text(timeout=5000)
+    assert "e2e-specs-navtest" in body_text, (
+        f"detail page should show the slug; got: {body_text[:500]}"
+    )

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ApiClient, ApiError, type Page, type RunSummary } from '../api';
+import {
+  ApiClient,
+  ApiError,
+  ApiResponseShapeError,
+  isPageEnvelope,
+  walkAllPages,
+  type Page,
+  type RunSummary,
+} from '../api';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -56,5 +64,182 @@ describe('ApiClient.listRuns', () => {
     );
     const client = new ApiClient('/api/v1');
     await expect(client.listRuns()).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+// W23a Layer 2: defensive content-type + JSON-parse guards on every
+// 2xx response. The pre-W23a code path silently coerced an HTML body
+// into a string and handed it back as the response payload, which
+// crashed downstream consumers with the reported "env.items is not
+// iterable" TypeError. These tests pin the new behaviour: a 2xx
+// response with the wrong content-type, or a 2xx response whose body
+// fails to parse as JSON, becomes a typed `ApiResponseShapeError` with
+// a recovery hint the route-level UX can act on.
+describe('ApiClient.request — content-type + JSON-parse guards (W23a)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('throws ApiResponseShapeError when a 2xx body has text/html (Vite SPA fallback)', async () => {
+    // ``Response`` bodies are single-shot — they can be consumed only once.
+    // Use ``mockImplementation`` so each call gets a fresh Response,
+    // letting us assert both ``rejects`` and the typed error payload.
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response('<!doctype html><html><body>not the api</body></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        }),
+      ),
+    );
+    const client = new ApiClient('/api/v1');
+    await expect(client.listRuns()).rejects.toBeInstanceOf(ApiResponseShapeError);
+    try {
+      await client.listRuns();
+    } catch (err) {
+      // hint contains the actionable advice; received carries the raw body for diagnostics.
+      expect(err).toBeInstanceOf(ApiResponseShapeError);
+      const e = err as ApiResponseShapeError;
+      expect(e.hint).toContain('SPA shell');
+      expect(typeof e.received).toBe('string');
+      expect(String(e.received)).toContain('<!doctype html>');
+    }
+  });
+
+  it('throws ApiResponseShapeError when content-type is missing but body is non-JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('plaintext payload', { status: 200 }),
+    );
+    const client = new ApiClient('/api/v1');
+    await expect(client.listRuns()).rejects.toBeInstanceOf(ApiResponseShapeError);
+  });
+
+  it('throws ApiResponseShapeError when content-type is JSON but body fails to parse', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('not-json-{[', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const client = new ApiClient('/api/v1');
+    await expect(client.listRuns()).rejects.toBeInstanceOf(ApiResponseShapeError);
+  });
+
+  it('returns undefined for 204 No Content without invoking the shape guards', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+    const client = new ApiClient('/api/v1');
+    // 204 returns undefined typed as T — the abortRun endpoint shape uses this.
+    const result = await client.abortRun('00000000-0000-0000-0000-000000000000');
+    expect(result).toBeUndefined();
+  });
+
+  it('accepts application/json with valid body (happy path unchanged)', async () => {
+    const envelope: Page<RunSummary> = {
+      items: [],
+      page: 1,
+      page_size: 50,
+      total: 0,
+      has_next: false,
+      sort: 'last_update_at_desc',
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(envelope));
+    const client = new ApiClient('/api/v1');
+    const result = await client.listRuns();
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it('accepts vendor-specific +json content-types (e.g. application/vnd.api+json)', async () => {
+    const envelope: Page<RunSummary> = {
+      items: [],
+      page: 1,
+      page_size: 50,
+      total: 0,
+      has_next: false,
+      sort: 'last_update_at_desc',
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(envelope), {
+        status: 200,
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+      }),
+    );
+    const client = new ApiClient('/api/v1');
+    const result = await client.listRuns();
+    expect(result.items).toEqual([]);
+  });
+});
+
+// W23a Layer 1: defensive envelope-shape check inside walkAllPages.
+// Even if Layer 2 lets a malformed payload through (e.g. valid JSON
+// that doesn't match Page<T>), the helper must surface a typed error
+// rather than crash with TypeError on `out.push(...env.items)`.
+describe('walkAllPages — envelope-shape guard (W23a)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('throws ApiResponseShapeError when fetcher resolves to a non-envelope (raw array)', async () => {
+    const fetcher = vi.fn().mockResolvedValue([] as unknown as Page<RunSummary>);
+    await expect(walkAllPages(fetcher, {})).rejects.toBeInstanceOf(ApiResponseShapeError);
+  });
+
+  it('throws ApiResponseShapeError when fetcher resolves to a Page-shaped object missing items', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue({ page: 1, page_size: 50, total: 0, has_next: false, sort: 'x' } as unknown as Page<RunSummary>);
+    await expect(walkAllPages(fetcher, {})).rejects.toBeInstanceOf(ApiResponseShapeError);
+  });
+
+  it('throws ApiResponseShapeError when fetcher resolves to a Page-shaped object missing has_next', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue({ items: [], page: 1, page_size: 50, total: 0, sort: 'x' } as unknown as Page<RunSummary>);
+    await expect(walkAllPages(fetcher, {})).rejects.toBeInstanceOf(ApiResponseShapeError);
+  });
+
+  it('walks pages happily when every fetch returns a valid envelope', async () => {
+    const row = (i: number): RunSummary => ({
+      id: `r${i}`, project_id: 'p', fsm_spec_id: 's', status: 'completed',
+      current_state: 'A', next_state: null, verdict: null,
+      started_at: '2026-01-01T00:00:00Z', ended_at: null,
+      last_update_at: '2026-01-01T00:00:00Z', transitions_count: 0,
+    });
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [row(1), row(2)], page: 1, page_size: 2, total: 4, has_next: true, sort: 'x' } as Page<RunSummary>)
+      .mockResolvedValueOnce({ items: [row(3), row(4)], page: 2, page_size: 2, total: 4, has_next: false, sort: 'x' } as Page<RunSummary>);
+    const all = await walkAllPages(fetcher as never, {});
+    expect(all.map((r) => r.id)).toEqual(['r1', 'r2', 'r3', 'r4']);
+  });
+
+  it('terminates at the maxPages safety cap if a buggy server returns has_next forever', async () => {
+    const fetcher = vi.fn().mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 200,
+      total: 999,
+      has_next: true,
+      sort: 'x',
+    } as Page<RunSummary>);
+    const all = await walkAllPages(fetcher as never, {}, 3);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(all).toEqual([]);
+  });
+});
+
+describe('isPageEnvelope', () => {
+  it('returns true for a well-formed envelope', () => {
+    expect(isPageEnvelope({ items: [], has_next: false, page: 1, page_size: 50, total: 0, sort: 'x' })).toBe(true);
+  });
+  it('returns false for null / arrays / primitives', () => {
+    expect(isPageEnvelope(null)).toBe(false);
+    expect(isPageEnvelope([])).toBe(false);
+    expect(isPageEnvelope('string')).toBe(false);
+    expect(isPageEnvelope(42)).toBe(false);
+  });
+  it('returns false for objects missing items', () => {
+    expect(isPageEnvelope({ has_next: false })).toBe(false);
+  });
+  it('returns false for objects where has_next is not boolean', () => {
+    expect(isPageEnvelope({ items: [], has_next: 'true' })).toBe(false);
   });
 });

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -5,6 +5,7 @@ import {
   ApiResponseShapeError,
   isPageEnvelope,
   walkAllPages,
+  type ListRunsParams,
   type Page,
   type RunSummary,
 } from '../api';
@@ -207,7 +208,12 @@ describe('walkAllPages — envelope-shape guard (W23a)', () => {
       .fn()
       .mockResolvedValueOnce({ items: [row(1), row(2)], page: 1, page_size: 2, total: 4, has_next: true, sort: 'x' } as Page<RunSummary>)
       .mockResolvedValueOnce({ items: [row(3), row(4)], page: 2, page_size: 2, total: 4, has_next: false, sort: 'x' } as Page<RunSummary>);
-    const all = await walkAllPages(fetcher as never, {});
+    const all = await walkAllPages<RunSummary, ListRunsParams>(
+      fetcher as unknown as (
+        params: ListRunsParams,
+      ) => Promise<Page<RunSummary>>,
+      {},
+    );
     expect(all.map((r) => r.id)).toEqual(['r1', 'r2', 'r3', 'r4']);
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -449,6 +449,35 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Raised when a 2xx response from the API carries a payload shape the
+ * caller cannot use — wrong content-type (HTML instead of JSON), a JSON
+ * body that fails to parse, or a Page envelope missing required fields.
+ *
+ * Distinct from :class:`ApiError` so route-level UX can render an
+ * actionable "UI / server out of sync" affordance (Reload page) rather
+ * than the generic "Failed to load X" with the server's error message.
+ * The triggers are typically operator-facing rather than server-side
+ * bugs: a stale UI bundle, a dev-server proxy mis-route, a CDN edge
+ * cache returning HTML where JSON was expected.
+ *
+ * ``received`` carries the actual payload (the HTML body or the
+ * malformed envelope) so diagnostics can show the operator exactly
+ * what the server returned. ``hint`` is the human-readable guidance
+ * for recovery.
+ */
+export class ApiResponseShapeError extends Error {
+  readonly received: unknown;
+  readonly hint: string;
+
+  constructor(message: string, received: unknown, hint: string) {
+    super(`${message} — ${hint}`);
+    this.name = 'ApiResponseShapeError';
+    this.received = received;
+    this.hint = hint;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -584,6 +613,7 @@ export class ApiClient {
 
     const rawText = await response.text();
     let parsed: unknown = undefined;
+    let parseFailed = false;
     if (rawText.length > 0) {
       try {
         parsed = JSON.parse(rawText);
@@ -591,6 +621,7 @@ export class ApiClient {
         // Non-JSON body — keep ``parsed`` as undefined and surface the
         // raw text via the error path below if the response failed.
         parsed = rawText;
+        parseFailed = true;
       }
     }
 
@@ -604,6 +635,34 @@ export class ApiClient {
           ? `API ${method} ${path} failed (HTTP ${response.status}): ${detail}`
           : `API ${method} ${path} failed (HTTP ${response.status})`;
       throw new ApiError(response.status, detail, parsed, message);
+    }
+
+    // W23a Layer 2: a 2xx response with a non-JSON body is a wire
+    // violation — the most common trigger is the Vite dev-server SPA
+    // fallback serving ``index.html`` because the proxied API target
+    // isn't reachable on the configured port. Pre-W23a the code below
+    // silently returned the HTML string as if it were the response
+    // payload, which then crashed every downstream consumer that read
+    // ``.items`` / ``.id`` / etc. on a string. Surface it as a typed
+    // error instead so route-level code can render an actionable
+    // "UI / server out of sync" affordance.
+    const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
+    const looksJson = contentType.includes('application/json') || contentType.includes('+json');
+    if (rawText.length > 0 && !looksJson) {
+      const sniff = rawText.slice(0, 80).replace(/\s+/g, ' ');
+      throw new ApiResponseShapeError(
+        `Expected JSON from ${method} ${path}, got ${contentType || 'unknown content-type'}`,
+        rawText,
+        'Endpoint may be unregistered or the dev-server proxy may have fallen ' +
+          `back to the SPA shell. First 80 bytes: "${sniff}".`,
+      );
+    }
+    if (rawText.length > 0 && parseFailed) {
+      throw new ApiResponseShapeError(
+        `Body of ${method} ${path} was not valid JSON`,
+        rawText,
+        'Server returned a non-JSON 2xx body — likely an HTML error page or a misconfigured proxy.',
+      );
     }
 
     return parsed as T;
@@ -895,10 +954,45 @@ export async function walkAllPages<T, P extends PageParams>(
       page,
       page_size: MAX_PAGE_SIZE,
     } as P);
+    // W23a Layer 1: defensive envelope-shape check. If something
+    // upstream returned a non-Page<T> body the existing ``ApiClient``
+    // checks should have caught it (W23a Layer 2 — content-type +
+    // JSON-parse guards on every 2xx), but defence in depth catches
+    // the residual cases: a fetcher swap in tests that returned a
+    // raw array, a future endpoint that opted out of Page<T>, a
+    // genuinely missing ``items``/``has_next`` field after a partial
+    // wire-format rollback. Surfaces as ApiResponseShapeError so the
+    // calling route can render a "reload page" affordance rather
+    // than crashing with ``TypeError: env.items is not iterable``.
+    if (!isPageEnvelope<T>(env)) {
+      throw new ApiResponseShapeError(
+        'walkAllPages: fetcher returned a non-Page<T> envelope',
+        env,
+        'The UI bundle expects {items, page, has_next, ...} from this ' +
+          'endpoint. Common causes: (1) the API process is unreachable on ' +
+          'the dev-server proxy port (Vite served the SPA shell instead), ' +
+          '(2) the UI bundle is stale relative to the server. Refresh the ' +
+          'page; if it persists, restart the supervisor.',
+      );
+    }
     out.push(...env.items);
     if (!env.has_next) return out;
   }
   return out;
+}
+
+/**
+ * Type guard for a ``Page<T>`` envelope shape. Defensive predicate the
+ * helper functions use before spreading ``items`` so a wire-format
+ * regression surfaces as a typed error rather than a JS TypeError.
+ */
+export function isPageEnvelope<T>(v: unknown): v is Page<T> {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    Array.isArray((v as { items?: unknown }).items) &&
+    typeof (v as { has_next?: unknown }).has_next === 'boolean'
+  );
 }
 
 /**

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -618,8 +618,9 @@ export class ApiClient {
       try {
         parsed = JSON.parse(rawText);
       } catch {
-        // Non-JSON body — keep ``parsed`` as undefined and surface the
-        // raw text via the error path below if the response failed.
+        // Non-JSON body: assign the raw text to ``parsed`` (as a string) so the
+        // error path below can surface it via ApiError when the response failed,
+        // and flip ``parseFailed`` so success-path callers can shape-guard.
         parsed = rawText;
         parseFailed = true;
       }

--- a/ui/src/routes/specs.tsx
+++ b/ui/src/routes/specs.tsx
@@ -23,6 +23,7 @@ import type { JSX } from 'preact';
 import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import {
+  Button,
   Card,
   EmptyState,
   Pill,
@@ -34,6 +35,7 @@ import {
 import {
   api,
   ApiError,
+  ApiResponseShapeError,
   walkAllPages,
   type RunSummary,
   type SpecSummary,
@@ -128,10 +130,17 @@ function navigateTo(path: string): void {
   window.dispatchEvent(new PopStateEvent('popstate'));
 }
 
+/** Discriminated error state — distinguishes a transient server failure
+ *  (renders a generic empty-state) from a wire-shape regression (renders
+ *  a Reload-page affordance with operator-facing recovery hint). */
+type LoadError =
+  | { kind: 'api'; message: string }
+  | { kind: 'shape'; message: string };
+
 export function SpecsRoute(): JSX.Element {
   const [specs, setSpecs] = useState<SpecSummary[] | null>(null);
   const [runs, setRuns] = useState<RunSummary[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<LoadError | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -150,7 +159,16 @@ export function SpecsRoute(): JSX.Element {
         setRuns(r);
       })
       .catch((err: unknown) => {
-        if (!cancelled) setError(err instanceof ApiError ? err.message : String(err));
+        if (cancelled) return;
+        // W23a: distinguish a wire-shape regression from a generic API
+        // failure so the operator gets an actionable "Reload page"
+        // affordance rather than the same "Failed to load" string they
+        // would see from any 5xx.
+        if (err instanceof ApiResponseShapeError) {
+          setError({ kind: 'shape', message: err.message });
+        } else {
+          setError({ kind: 'api', message: err instanceof ApiError ? err.message : String(err) });
+        }
       });
     return () => { cancelled = true; };
   }, []);
@@ -209,7 +227,32 @@ export function SpecsRoute(): JSX.Element {
 
   let body: JSX.Element;
   if (error) {
-    body = <EmptyState title="Failed to load specs" message={error} />;
+    // Wire-shape errors get an explicit reload affordance — the
+    // operator's recovery path is "refresh the page" (stale UI) or
+    // "restart the supervisor" (proxy mis-route). Generic API errors
+    // surface the server message as-is and rely on the operator to
+    // diagnose via Settings / doctor.
+    if (error.kind === 'shape') {
+      body = (
+        <EmptyState
+          title="UI / server out of sync"
+          message={error.message}
+          action={
+            <Button
+              variant="primary"
+              size="md"
+              onClick={() => {
+                if (typeof window !== 'undefined') window.location.reload();
+              }}
+            >
+              Reload page
+            </Button>
+          }
+        />
+      );
+    } else {
+      body = <EmptyState title="Failed to load specs" message={error.message} />;
+    }
   } else if (rows === null) {
     body = (
       <div class="flex items-center justify-center py-12">


### PR DESCRIPTION
## Summary

User report: visiting /specs throws `TypeError: env.items is not iterable (cannot read property undefined)`. Root cause: the Vite dev-server SPA fallback can serve `index.html` (200 OK + `text/html`) when the API target isn't reachable on the proxied port; `ApiClient.request` silently coerced the HTML body into a string and handed it back as the response payload, which then crashed every `.items` consumer.

This PR ships the three-layer defensive fix from the W23a deep plan: a typed `ApiResponseShapeError`, content-type + JSON-parse guards in `ApiClient.request`, and an envelope-shape guard in `walkAllPages`. Route-level UX in /specs distinguishes wire-shape errors (Reload-page affordance) from generic API failures.

## Tests

- 15 new vitest cases covering all three layers (`ui/src/lib/__tests__/api.test.ts`).
- 353/353 passing.
- `npx tsc -b --noEmit`: 0 errors.

## Follow-ups (next commits on this PR)

- Propagate `LoadError` discrimination to runs.tsx + specDetail.tsx.
- Universal "no console errors" Playwright fixture.
- 5 new `/specs` e2e tests + 1 stale-bundle test.
- `.github/workflows/e2e-on-pr.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)