### PR TITLE
feat(w23-ssot): canonical reference docs (AGENT_QUICKSTART + SKILL_TEMPLATE + GATE_CONTRACT) + doctor --skill-consumer

### DIFF
--- a/ctxr/fsm/cli/doctor_cmd.py
+++ b/ctxr/fsm/cli/doctor_cmd.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import typer
 from rich.console import Console
 from rich.panel import Panel
 from sqlalchemy import func, select, text
@@ -73,6 +74,12 @@ from ctxr.fsm.cli.lifecycle.primitives import (
     read_active_mcp_file,
     read_pid_file,
     recall_port,
+)
+from ctxr.fsm.memory import (
+    get_bootstrap_path,
+    get_principles_path,
+    get_ssot_doc_path,
+    list_ssot_doc_slugs,
 )
 from ctxr.fsm.sqlite.connection import detect_journal_state
 from ctxr.fsm.sqlite.models_core import LockTable
@@ -336,6 +343,61 @@ def _active_mcp_for_table(
     return {"subsystems": merged}
 
 
+def _skill_consumer_report() -> dict[str, Any]:
+    """W23-SSOT: report on the canonical reference docs reachability.
+
+    A skill consumer asks: "is everything I need to drive an FSM run
+    actually present in this install?" The answer is yes when each of
+    the four pillar docs (principles, bootstrap, AGENT_QUICKSTART,
+    SKILL_TEMPLATE, GATE_CONTRACT) is readable inside the installed
+    package. We resolve each via the public ``ctxr.fsm.memory``
+    helpers so this check exercises the SAME code path skills use at
+    runtime, catching a stale install rather than a stale duplicate
+    constant.
+
+    Returned shape (designed for the JSON wire path)::
+
+        {
+          "status": "ok" | "missing_docs",
+          "principles_path": str,
+          "bootstrap_path": str,
+          "ssot_docs": {<slug>: {"path": str, "exists": bool}, ...},
+          "missing": [<slug>, ...],
+        }
+    """
+
+    missing: list[str] = []
+    out: dict[str, Any] = {
+        "principles_path": None,
+        "bootstrap_path": None,
+        "ssot_docs": {},
+    }
+
+    try:
+        out["principles_path"] = str(get_principles_path("claude"))
+    except FileNotFoundError:
+        missing.append("principles.claude.md")
+    try:
+        out["bootstrap_path"] = str(get_bootstrap_path())
+    except FileNotFoundError:
+        missing.append("bootstrap.md")
+
+    for slug in list_ssot_doc_slugs():
+        entry: dict[str, Any] = {"path": None, "exists": False}
+        try:
+            path = get_ssot_doc_path(slug)
+        except FileNotFoundError:
+            missing.append(slug)
+        else:
+            entry["path"] = str(path)
+            entry["exists"] = True
+        out["ssot_docs"][slug] = entry
+
+    out["status"] = "ok" if not missing else "missing_docs"
+    out["missing"] = missing
+    return out
+
+
 def _print_pretty_report(
     *,
     db_path: Path,
@@ -373,6 +435,19 @@ def _print_pretty_report(
 def doctor(
     db: Path | None = DB_OPTION,
     json_mode: bool = JSON_OPTION,
+    skill_consumer: bool = typer.Option(
+        False,
+        "--skill-consumer",
+        help=(
+            "Add a W23-SSOT 'skill consumer readiness' section to the "
+            "report. Verifies that the canonical reference docs "
+            "(AGENT_QUICKSTART, SKILL_TEMPLATE, GATE_CONTRACT, "
+            "principles, bootstrap) are reachable in the installed "
+            "package. Skills that depend on ctxr-fsm should call "
+            "this in CI to catch a stale install before a real run "
+            "discovers it."
+        ),
+    ),
 ) -> None:
     """Print a diagnostic report for the project DB and supervisor.
 
@@ -419,6 +494,8 @@ def doctor(
         "locks": {"count": locks},
         "supervisor": supervisor,
     }
+    if skill_consumer:
+        report["skill_consumer"] = _skill_consumer_report()
     if json_mode:
         # JSON path is the wire contract every script depends on; we
         # MUST emit the same shape every previous doctor invocation did.

--- a/ctxr/fsm/cli/doctor_cmd.py
+++ b/ctxr/fsm/cli/doctor_cmd.py
@@ -362,8 +362,18 @@ def _skill_consumer_report() -> dict[str, Any]:
           "principles_path": str,
           "bootstrap_path": str,
           "ssot_docs": {<slug>: {"path": str, "exists": bool}, ...},
-          "missing": [<slug>, ...],
+          "missing": [<slug>, ...],   # slugs only, e.g. "principles",
+                                      # "bootstrap", "agent_quickstart"
         }
+
+    The ``missing`` list is uniform: every entry is a short slug, not a
+    filename. Skills script against this list (``if "agent_quickstart"
+    in section["missing"]: ...``) so mixing slug + filename vocabularies
+    would make consumers special-case the "principles" / "bootstrap"
+    entries. The two non-SSOT pillars use the slugs ``"principles"`` and
+    ``"bootstrap"``; the SSOT pillars use whatever
+    :func:`list_ssot_doc_slugs` returns (``"agent_quickstart"``,
+    ``"skill_template"``, ``"gate_contract"``).
     """
 
     missing: list[str] = []
@@ -376,11 +386,11 @@ def _skill_consumer_report() -> dict[str, Any]:
     try:
         out["principles_path"] = str(get_principles_path("claude"))
     except FileNotFoundError:
-        missing.append("principles.claude.md")
+        missing.append("principles")
     try:
         out["bootstrap_path"] = str(get_bootstrap_path())
     except FileNotFoundError:
-        missing.append("bootstrap.md")
+        missing.append("bootstrap")
 
     for slug in list_ssot_doc_slugs():
         entry: dict[str, Any] = {"path": None, "exists": False}
@@ -404,6 +414,7 @@ def _print_pretty_report(
     revision: str | None,
     supervisor: dict[str, Any],
     supervisor_root: Path,
+    skill_consumer: dict[str, Any] | None = None,
 ) -> None:
     """Render the W14j Rich panel + subsystem table to stdout.
 
@@ -412,6 +423,13 @@ def _print_pretty_report(
     and that migrations are current. The table below sources its
     rows from :func:`_active_mcp_for_table` so the column shape is
     byte-identical to ``ctxr-fsm ensure`` and the supervisor banner.
+
+    When ``skill_consumer`` is provided (operator passed
+    ``--skill-consumer``), a one-line readiness summary is printed
+    underneath the subsystem table so the pretty surface mirrors the
+    information already in the ``--json`` envelope. Without this the
+    flag would be a silent no-op outside JSON mode — surfacing a stale
+    install only when an operator happens to inspect the JSON.
     """
     console = Console()
     db_repr = portable_project_repr(db_path)
@@ -430,6 +448,26 @@ def _print_pretty_report(
             project_root=supervisor_root,
         )
     )
+    if skill_consumer is not None:
+        # Total pillars = principles + bootstrap + every SSOT slug. We
+        # count from the section payload itself (rather than re-deriving)
+        # so the line stays in sync if the SSOT slug list grows.
+        ssot_docs = skill_consumer.get("ssot_docs") or {}
+        total = 2 + len(ssot_docs)
+        missing = skill_consumer.get("missing") or []
+        resolved = total - len(missing)
+        status = skill_consumer.get("status") or "unknown"
+        if status == "ok":
+            console.print(
+                f"[green]skill_consumer:[/green] OK "
+                f"({resolved}/{total} pillars resolved)"
+            )
+        else:
+            slug_list = ", ".join(missing) if missing else "(unknown)"
+            console.print(
+                f"[red]skill_consumer:[/red] missing_docs "
+                f"({resolved}/{total} pillars resolved; missing: {slug_list})"
+            )
 
 
 def doctor(
@@ -513,4 +551,5 @@ def doctor(
         revision=revision,
         supervisor=supervisor,
         supervisor_root=supervisor_root,
+        skill_consumer=report.get("skill_consumer") if skill_consumer else None,
     )

--- a/ctxr/fsm/cli/doctor_cmd.py
+++ b/ctxr/fsm/cli/doctor_cmd.py
@@ -348,7 +348,7 @@ def _skill_consumer_report() -> dict[str, Any]:
 
     A skill consumer asks: "is everything I need to drive an FSM run
     actually present in this install?" The answer is yes when each of
-    the four pillar docs (principles, bootstrap, AGENT_QUICKSTART,
+    the five pillar docs (principles, bootstrap, AGENT_QUICKSTART,
     SKILL_TEMPLATE, GATE_CONTRACT) is readable inside the installed
     package. We resolve each via the public ``ctxr.fsm.memory``
     helpers so this check exercises the SAME code path skills use at
@@ -359,9 +359,9 @@ def _skill_consumer_report() -> dict[str, Any]:
 
         {
           "status": "ok" | "missing_docs",
-          "principles_path": str,
-          "bootstrap_path": str,
-          "ssot_docs": {<slug>: {"path": str, "exists": bool}, ...},
+          "principles_path": str | None,   # None when the pillar is missing
+          "bootstrap_path": str | None,    # None when the pillar is missing
+          "ssot_docs": {<slug>: {"path": str | None, "exists": bool}, ...},
           "missing": [<slug>, ...],   # slugs only, e.g. "principles",
                                       # "bootstrap", "agent_quickstart"
         }

--- a/ctxr/fsm/memory/AGENT_QUICKSTART.md
+++ b/ctxr/fsm/memory/AGENT_QUICKSTART.md
@@ -1,0 +1,58 @@
+---
+name: ctxr-fsm-agent-quickstart
+version: 0.1.0
+audience: ai-agents
+---
+
+# ctxr-fsm: agent quickstart
+
+You are an AI agent driving an FSM-managed workflow. This is the five-minute version of how to do that correctly. The deep contract is in [`principles.md`](./principles.md); the bootstrap procedure is in [`bootstrap.md`](./bootstrap.md); the skill-authoring template is in [`SKILL_TEMPLATE.md`](./SKILL_TEMPLATE.md); the cross-FSM gate protocol is in [`GATE_CONTRACT.md`](./GATE_CONTRACT.md).
+
+## What an FSM run is
+
+A run is one execution of an FSM spec against a project DB. The spec declares states (worker / loop / inline / gate / terminal) and the transitions between them. The engine sequences advance; you (the LLM) supply only the worker outputs the engine asks for. You never decide what state runs next.
+
+## Lifecycle on the happy path
+
+1. `fsm.healthcheck()` — must return ok before any other call. If it fails, return MissingRequirement and STOP.
+2. `fsm.list_specs()` — find the spec slug you need; record its id.
+3. `fsm.start_run(spec_id, args)` — engine returns `run_id` + the first `Brief`.
+4. Loop:
+   - Read the `Brief` returned by `start_run` / the previous `commit_outputs`.
+   - If `brief.terminal == true`, the run is done. Stop.
+   - If `brief.has_worker == true`, dispatch a sub-agent with `brief.worker.prompt_template` + `brief.inputs`. Receive its outputs matching `brief.worker.response_schema`. Compute the cosignature. Call `fsm.commit_outputs(run_id, outputs, signature)`. Receive the next `Brief`.
+   - If the brief carries a gate (W23g): follow `GATE_CONTRACT.md`.
+5. On any error envelope from `commit_outputs`: re-read the brief, fix the output shape, retry. Never route around schema rejection.
+
+## The five things to remember
+
+1. **Bootstrap is one command, idempotent, fast.** `uv run ctxr-fsm ensure --json` returns `{status: "ready"}` in <500 ms on a warm project. Call it once per session. Do NOT skip it. See `bootstrap.md`.
+2. **The brief is your only input.** `brief.inputs` is what the engine resolved for you. `brief.worker.prompt_template` is what you (or the sub-agent you dispatch) consumes. If the template embeds `{{ ... }}` placeholders, the engine has already rendered them; you see the resolved string.
+3. **The schema is your only output shape.** `brief.worker.response_schema` is the contract. Validate yourself before commit. The server validates again and rejects mismatches with `error: output_schema_violation`. Fix the shape; do not work around it.
+4. **Your tool surface shrinks during a run.** `brief.allowed_tools` is the allowlist. You may also call `fsm.*`. Anything else feeds the drift detector and may auto-pause the run.
+5. **Observe every non-fsm tool call.** When you call Bash / Read / WebFetch / a sub-agent during an active run, follow with `fsm.observe_tool_call(...)`. Skipping this is itself a drift signal.
+
+## The cosignature
+
+Every `commit_outputs` carries `signature = sha256(brief_id || canonical_json(inputs) || canonical_json(outputs) || session_id)`. The server recomputes it and rejects mismatches with `error: signature_mismatch`. This makes fabricated outputs detectable. Do not skip the signature.
+
+`canonical_json` here is sorted keys, compact separators, UTF-8. The TypeScript companion lives at `ui/src/lib/canonicalJson.ts`.
+
+## What to do on a fault
+
+Run faulted? Do NOT improvise a retry. Call `fsm.inspect_journal(run_id)`, then either:
+- `fsm.recover_journal(run_id, action='discard'|'replay')` if the journal points at the right action, or
+- `fsm.resume_run(run_id, from_state=…)` if a specific state needs re-entry, or
+- escalate to a human via `fsm.abort_run(run_id, reason=…)`.
+
+## What to do on a gate
+
+A gate state (`state.kind == 'gate'`) pauses the run waiting for cross-run data. Call `fsm.resolve_gate(run_id, state_entry_seq, value=...)` with an inline value OR `binding=...` referencing another run's state output. See [`GATE_CONTRACT.md`](./GATE_CONTRACT.md) for the full protocol.
+
+## What to do if you want to AUTHOR a skill that uses fsm
+
+Read [`SKILL_TEMPLATE.md`](./SKILL_TEMPLATE.md). The template covers the spec module shape, inline-handler registration, worker prompt files, the SKILL.md preamble, and the test layout.
+
+## What this file is
+
+Shipped inside the `ctxr-fsm` package at `ctxr/fsm/memory/AGENT_QUICKSTART.md`. The canonical place for any agent's "how do I use this thing" question. Installed into consumer projects by `ctxr-fsm install-memory`; available directly via `importlib.resources` from any Python consumer.

--- a/ctxr/fsm/memory/AGENT_QUICKSTART.md
+++ b/ctxr/fsm/memory/AGENT_QUICKSTART.md
@@ -10,7 +10,7 @@ You are an AI agent driving an FSM-managed workflow. This is the five-minute ver
 
 ## What an FSM run is
 
-A run is one execution of an FSM spec against a project DB. The spec declares states (worker / loop / inline / gate / terminal) and the transitions between them. The engine sequences advance; you (the LLM) supply only the worker outputs the engine asks for. You never decide what state runs next.
+A run is one execution of an FSM spec against a project DB. The spec declares states (worker / loop / inline / terminal; `gate` is planned for W23g) and the transitions between them. The engine sequences advance; you (the LLM) supply only the worker outputs the engine asks for. You never decide what state runs next.
 
 ## Lifecycle on the happy path
 
@@ -45,9 +45,9 @@ Run faulted? Do NOT improvise a retry. Call `fsm.inspect_journal(run_id)`, then 
 - `fsm.resume_run(run_id, from_state=…)` if a specific state needs re-entry, or
 - escalate to a human via `fsm.abort_run(run_id, reason=…)`.
 
-## What to do on a gate
+## What to do on a gate (planned: W23g)
 
-A gate state (`state.kind == 'gate'`) pauses the run waiting for cross-run data. Call `fsm.resolve_gate(run_id, state_entry_seq, value=...)` with an inline value OR `binding=...` referencing another run's state output. See [`GATE_CONTRACT.md`](./GATE_CONTRACT.md) for the full protocol.
+Gates are not yet shipped. Once W23g lands, a gate state (`state.kind == 'gate'`) will pause the run waiting for cross-run data, and you will call `fsm.resolve_gate(run_id, state_entry_seq, value=...)` with an inline value OR `binding=...` referencing another run's state output. Until then, the `fsm.resolve_gate` MCP tool does not exist; do not attempt to call it. See [`GATE_CONTRACT.md`](./GATE_CONTRACT.md) for the design contract.
 
 ## What to do if you want to AUTHOR a skill that uses fsm
 

--- a/ctxr/fsm/memory/GATE_CONTRACT.md
+++ b/ctxr/fsm/memory/GATE_CONTRACT.md
@@ -1,0 +1,141 @@
+---
+name: ctxr-fsm-gate-contract
+version: 0.1.0
+audience: ai-agents
+---
+
+# ctxr-fsm: cross-FSM gate contract
+
+A **gate** is a state kind that pauses a run waiting for a value supplied from outside the run's own state environment. The value may be an LLM-supplied literal, or a binding that pulls another run's state output. Gates make M:N fan-in/fan-out trivially expressible without bespoke orchestrator stitching.
+
+This document specifies the protocol. The engine model lives in [`ctxr/fsm/core/models.py`](../core/models.py); the resolver MCP tool lives in [`ctxr/fsm/mcp/tools_runs.py`](../mcp/tools_runs.py).
+
+## State shape
+
+```python
+from ctxr.fsm.core.models import State, Gate, GateBinding, ResponseSchema, StateKind
+
+State(
+    id="await_review",
+    gate=Gate(
+        source_kind="run_output",   # OR "llm_supplied"
+        response_schema=ResponseSchema(schema_={...}),
+        max_age_ms=86_400_000,        # optional: reject sources older than 24h
+    ),
+    outputs=["review_verdict"],
+    transitions=[Transition(to="ship", when=TransitionKind.always)],
+)
+```
+
+### Rules
+
+1. Exactly one of `worker | loop | inline | gate | terminal` (`kind` property dispatches on this).
+2. `Gate.response_schema` is mandatory and is validated against the resolved value.
+3. `source_kind` is either `'run_output'` (read from another run's state) or `'llm_supplied'` (operator / LLM provides the value at resolve time).
+4. `Gate.bindings` may be pre-populated by the orchestrator at `start_run` time when the source run is already known; otherwise the LLM supplies the binding at resolve time.
+
+## Brief shape when a gate is current
+
+```jsonc
+{
+  "kind": "gate",
+  "state": "await_review",
+  "gate": {
+    "source_kind": "run_output",
+    "response_schema": { ... },
+    "bindings": []
+  },
+  "has_worker": false,
+  "terminal": false
+}
+```
+
+When you see `brief.kind == 'gate'`, you do NOT call `commit_outputs`. You call `fsm.resolve_gate`.
+
+## Resolver MCP tool
+
+```python
+fsm.resolve_gate(
+    run_id: str,
+    state_entry_seq: int,
+    *,
+    value: dict | None = None,         # LLM-supplied literal
+    binding: GateBinding | None = None,  # OR a reference to another run's state output
+)
+```
+
+Exactly one of `value` / `binding` is required.
+
+### `value` path
+
+The LLM passes the resolved value directly (e.g. operator typed it, or the LLM computed it from world knowledge). The server validates against `gate.response_schema` and lands the value in the run's environment under the gate's `target_field` (defaults to the gate state's first declared output).
+
+### `binding` path
+
+```python
+GateBinding(
+    source_run_id="<run-uuidv7>",     # the run to read from
+    source_spec_slug=None,             # optional; lets the server enforce spec match
+    source_state_id="qa",              # which state's outputs to read
+    source_field="verdict",            # which output field
+    target_field="review_verdict",     # name under which the value lands in THIS run's env
+)
+```
+
+The server reads `source_run_id`'s `source_state_id` outputs via the same plumbing that powers `fsm.get_run`. If `Gate.max_age_ms` is set, the source state's `exited_at` must be within that window; otherwise the gate rejects with `error: gate_source_stale`.
+
+## Events emitted
+
+- `gate_resolved` — value validated + landed in env. Payload: `{run_id, state_entry_seq, source_kind, target_field, value_hash}`.
+- `gate_resolution_failed` — schema mismatch, missing source, stale source, etc. Payload includes `error` + `details`.
+- `gate_binding_recorded` — for the `binding` path, a row lands in `gate_bindings` for cross-run topology queries.
+
+## Persistence
+
+The `gate_bindings` SQLite table records every resolved binding:
+
+```sql
+CREATE TABLE gate_bindings (
+    id TEXT PRIMARY KEY,
+    target_run_id TEXT NOT NULL,
+    target_state_entry_seq INTEGER NOT NULL,
+    source_run_id TEXT,
+    source_spec_slug TEXT,
+    source_state_id TEXT NOT NULL,
+    source_field TEXT NOT NULL,
+    target_field TEXT NOT NULL,
+    resolved_value_json TEXT,
+    resolved_at TEXT NOT NULL,
+    created_at TEXT NOT NULL
+) STRICT;
+CREATE INDEX gate_bindings_by_target ON gate_bindings (target_run_id);
+CREATE INDEX gate_bindings_by_source ON gate_bindings (source_run_id);
+```
+
+The two indexes power the dashboard's Bindings panels:
+- `/runs/:id` "Incoming" panel: `SELECT ... WHERE target_run_id = :id`.
+- `/runs/:id` "Outgoing" panel: `SELECT ... WHERE source_run_id = :id`.
+- `/links` topology view: `SELECT ... ORDER BY created_at DESC` (capped + paged).
+
+## Error envelopes
+
+| `error` | When | Action |
+|---|---|---|
+| `gate_value_required` | Brief is a gate; you called `commit_outputs`. | Call `fsm.resolve_gate` instead. |
+| `gate_value_or_binding_required` | Neither `value` nor `binding` supplied. | Provide exactly one. |
+| `gate_value_and_binding_conflict` | Both supplied. | Provide exactly one. |
+| `gate_schema_mismatch` | Resolved value fails `Gate.response_schema`. | Fix shape. |
+| `gate_source_run_not_found` | `binding.source_run_id` does not exist. | Verify run id. |
+| `gate_source_state_not_completed` | Source state has not produced outputs yet. | Wait, or pick a different source. |
+| `gate_source_stale` | Source's `exited_at` is older than `Gate.max_age_ms`. | Trigger a fresh source run. |
+| `gate_spec_slug_mismatch` | `binding.source_spec_slug` does not match the source run's spec. | Update the binding. |
+
+## Why gates and not subscriptions
+
+Subscriptions (`fsm.subscribe_events`) push events to a consumer; the consumer decides what to do. Gates pull a typed value INTO a state's environment so the engine can advance deterministically based on it. Gates are appropriate when the downstream FSM's behaviour depends on the upstream value; subscriptions are appropriate when the downstream FSM just wants to react.
+
+A skill that says "run code-review first, then if verdict=GO, deploy" is a gate use case: the deploy spec has a `await_review` gate state binding to code-review's `verdict` output. A skill that says "log every run completion to a CSV" is a subscription use case.
+
+## What this file is
+
+Shipped inside the `ctxr-fsm` package at `ctxr/fsm/memory/GATE_CONTRACT.md`. The canonical reference for any cross-run binding work. Installed into consumer projects by `ctxr-fsm install-memory`.

--- a/ctxr/fsm/memory/GATE_CONTRACT.md
+++ b/ctxr/fsm/memory/GATE_CONTRACT.md
@@ -6,14 +6,17 @@ audience: ai-agents
 
 # ctxr-fsm: cross-FSM gate contract
 
+> **Status: forward-looking (W23g, planned).** Gates are NOT yet shipped. As of this PR, `StateKind` is `worker | loop | inline | terminal` (no `gate`), and neither `Gate` / `GateBinding` types nor the `fsm.resolve_gate` MCP tool exist in the codebase. This document is the design contract that W23g will implement; do not assume any of the symbols below are importable or callable today.
+
 A **gate** is a state kind that pauses a run waiting for a value supplied from outside the run's own state environment. The value may be an LLM-supplied literal, or a binding that pulls another run's state output. Gates make M:N fan-in/fan-out trivially expressible without bespoke orchestrator stitching.
 
-This document specifies the protocol. The engine model lives in [`ctxr/fsm/core/models.py`](../core/models.py); the resolver MCP tool lives in [`ctxr/fsm/mcp/tools_runs.py`](../mcp/tools_runs.py).
+This document specifies the protocol. Once W23g lands, the engine model will live in [`ctxr/fsm/core/models.py`](../core/models.py) and the resolver MCP tool in [`ctxr/fsm/mcp/tools_runs.py`](../mcp/tools_runs.py).
 
 ## State shape
 
 ```python
-from ctxr.fsm.core.models import State, Gate, GateBinding, ResponseSchema, StateKind
+# W23g pseudocode — the Gate / GateBinding symbols below do not yet exist:
+# from ctxr.fsm.core.models import State, Gate, GateBinding, ResponseSchema, StateKind
 
 State(
     id="await_review",

--- a/ctxr/fsm/memory/SKILL_TEMPLATE.md
+++ b/ctxr/fsm/memory/SKILL_TEMPLATE.md
@@ -1,0 +1,180 @@
+---
+name: ctxr-fsm-skill-template
+version: 0.1.0
+audience: skill-authors
+---
+
+# ctxr-fsm: skill authoring template
+
+You're writing a skill that drives an FSM. This document is the contract: every skill in the ctxr-dev workspace follows the same shape so the LLM orchestrator can pick up any of them without bespoke wiring.
+
+The proof of this template in production is `skill-code-review` (15-state pipeline, 5 worker prompts, 9 inline handlers). Copy its shape.
+
+## Package layout
+
+```
+my-skill/
+├── pyproject.toml                       # name = "ctxr-skill-<name>"
+├── SKILL.md                             # bootstrap preamble + orchestrator loop
+├── my_skill/
+│   ├── __init__.py
+│   ├── spec.py                          # Pydantic FsmSpec instance + export
+│   ├── handlers.py                      # INLINE_HANDLERS dict[str, Callable]
+│   ├── install.py                       # register() one-shot
+│   └── workers/
+│       ├── planner.md
+│       ├── implementer.md
+│       └── verifier.md
+└── tests/
+    ├── test_inline_handlers/
+    └── test_end_to_end.py
+```
+
+## spec.py — the FsmSpec instance
+
+```python
+from ctxr.fsm.core.models import (
+    FsmSpec, State, Worker, Loop, InlineSpec, Transition,
+    Predicate, ResponseSchema, TransitionKind, StateKind,
+)
+
+PLAN_OUTPUT_SCHEMA = ResponseSchema(schema_={
+    "type": "object",
+    "required": ["commitments"],
+    "properties": {
+        "commitments": {"type": "array", "items": {"type": "string"}},
+    },
+})
+
+fsm: FsmSpec = FsmSpec(
+    id="my-skill",
+    version=1,
+    entry="plan",
+    states=[
+        State(
+            id="plan",
+            worker=Worker(
+                role="planner",
+                prompt_template=(
+                    "Plan the work.\n\n"
+                    "Output must match this shape:\n"
+                    "{{ response_schema | typescript }}"
+                ),
+                inputs=["args"],
+                response_schema=PLAN_OUTPUT_SCHEMA,
+            ),
+            outputs=["commitments"],
+            transitions=[Transition(to="implement", when=TransitionKind.always)],
+            allowed_tools=["Read"],
+        ),
+        # ... more states ...
+        State(id="done", outputs=[], transitions=[]),
+    ],
+)
+```
+
+### Rules
+
+1. **One `FsmSpec` instance per skill, named `fsm`.** Importers find it via `import my_skill.spec; spec = my_skill.spec.fsm`. The CLI's `ctxr-fsm spec register my_skill.spec:fsm` follows the same convention.
+2. **Use the Pydantic models from `ctxr.fsm.core.models`.** Never construct dicts by hand. The Pydantic constructors validate eagerly; broken specs fail at import, not at register.
+3. **Worker prompts may use Jinja2.** Reference `{{ response_schema | typescript }}`, `{{ inputs_schema | json }}`, `{{ allowed_tools }}`, `{{ spec.slug }}`, etc. See `ctxr/fsm/core/prompts.py` for the surface. Register-time validation smoke-renders every template; broken templates reject the spec.
+4. **Every transition is typed.** Use `TransitionKind.always` for unconditional, `TransitionKind.otherwise` for the catch-all of a conditional fan-out, `Predicate(expression="...")` for guarded edges. The DSL is documented in `ctxr/fsm/core/predicates.py`.
+5. **Every state lists `allowed_tools` explicitly.** Empty list means fsm.* only. Be precise; the drift detector watches.
+
+## handlers.py — inline handler registry
+
+```python
+from collections.abc import Callable
+from ctxr.fsm.core.inline_registry import InlineContext
+
+def _risk_tier_triage(ctx: InlineContext) -> dict:
+    # Deterministic: inspect ctx.inputs, return outputs matching
+    # the inline state's response_schema. No LLM involvement.
+    return {"tier": "low"}
+
+INLINE_HANDLERS: dict[str, Callable[[InlineContext], dict]] = {
+    "risk_tier_triage": _risk_tier_triage,
+    # one entry per state whose kind is 'inline'
+}
+```
+
+### Rules
+
+1. **Inline handlers are pure deterministic functions.** No LLM dispatch, no network calls, no filesystem mutation outside what the engine surfaces via `ctx.project`.
+2. **The dict key matches `InlineSpec.handler_id` in the spec.** Misalignment surfaces at engine advance time as `inline_handler_unregistered`.
+3. **Return values must match `inline_spec.response_schema`.** Engine validates; bad shapes fault the run.
+4. **Handlers may read prior-state outputs via `ctx.project`.** Examples: `ctx.project.aggregates.get(ctx.run_id, field='findings')`. Read-only; mutations are illegal.
+
+## install.py — one-shot registration
+
+```python
+from pathlib import Path
+from ctxr.fsm.sqlite import open_project
+from .handlers import INLINE_HANDLERS
+from .spec import fsm
+
+def register() -> None:
+    project = open_project(Path(".ctxr-fsm/fsm.db"))
+    project.register_spec(fsm)
+    project.register_inline_handlers(fsm.id, INLINE_HANDLERS)
+```
+
+Run via `uv run python -m my_skill.install`. Idempotent (registering the same spec at the same version is a no-op). Skill bootstrap should call this once per project.
+
+## SKILL.md — orchestrator preamble
+
+```markdown
+---
+name: my-skill
+requires:
+  fsm:
+    mcp_server: ctxr-fsm
+    min_version: "0.2.0"
+---
+
+# my-skill
+
+## Bootstrap
+
+Follow [`@.ctxr-fsm/memory/bootstrap.md`](.ctxr-fsm/memory/bootstrap.md) before any work below.
+
+Register this skill's handlers + spec once per project:
+
+```bash
+uv run python -m my_skill.install
+```
+
+## Run
+
+Drive the run via the fsm.* MCP tool family per [`@.ctxr-fsm/memory/AGENT_QUICKSTART.md`](.ctxr-fsm/memory/AGENT_QUICKSTART.md):
+
+1. `fsm.start_run('my-skill', {goal: "..."})` → captures `run_id` + first `Brief`.
+2. Loop: if `brief.terminal == true`, stop. Otherwise dispatch a sub-agent with `brief.worker.prompt_template` + `brief.inputs`; call `fsm.commit_outputs(run_id, outputs, signature)`; repeat.
+3. Inline states advance server-side without a brief surfacing to you.
+4. On error envelopes, follow Principle 4 in `principles.md`.
+```
+
+## tests/
+
+```
+tests/
+├── test_inline_handlers/
+│   └── test_risk_tier_triage.py      # one test file per handler
+└── test_end_to_end.py                 # one happy-path drive against a tmpdir DB
+```
+
+### Conventions
+
+- **One test file per inline handler.** Pure-function-style: feed an `InlineContext` fixture, assert the return value.
+- **One end-to-end test that drives the spec start-to-finish.** Simulates worker outputs (no real LLM). Asserts the final state, the event histogram, and the absence of pending journal txns.
+- **Test naming mirrors the Node legacy:** `test_<state_id>_*.py` for handler tests; the e2e file is the contract.
+
+## Out of template
+
+- Cross-skill gates: see [`GATE_CONTRACT.md`](./GATE_CONTRACT.md).
+- Verifier states: declare `State.verifier=VerifierSpec(...)` to gate `commit_outputs` behind majority-vote adversarial review. Optional; default is no verifier.
+- Worker prompt files in `workers/` are referenced as `prompt_template=Path("workers/planner.md").read_text()`. Keep them version-controlled alongside the spec.
+
+## What this file is
+
+Shipped inside the `ctxr-fsm` package at `ctxr/fsm/memory/SKILL_TEMPLATE.md`. The canonical reference for any skill author. Installed into consumer projects by `ctxr-fsm install-memory`.

--- a/ctxr/fsm/memory/SKILL_TEMPLATE.md
+++ b/ctxr/fsm/memory/SKILL_TEMPLATE.md
@@ -123,7 +123,9 @@ Run via `uv run python -m my_skill.install`. Idempotent (registering the same sp
 
 ## SKILL.md — orchestrator preamble
 
-```markdown
+The outer fence below uses four backticks so the inner ```bash``` block (and the YAML frontmatter delimiters) render verbatim inside the example. Reduce to three backticks only after stripping every nested fenced block.
+
+````markdown
 ---
 name: my-skill
 requires:
@@ -152,7 +154,7 @@ Drive the run via the fsm.* MCP tool family per [`@.ctxr-fsm/memory/AGENT_QUICKS
 2. Loop: if `brief.terminal == true`, stop. Otherwise dispatch a sub-agent with `brief.worker.prompt_template` + `brief.inputs`; call `fsm.commit_outputs(run_id, outputs, signature)`; repeat.
 3. Inline states advance server-side without a brief surfacing to you.
 4. On error envelopes, follow Principle 4 in `principles.md`.
-```
+````
 
 ## tests/
 

--- a/ctxr/fsm/memory/__init__.py
+++ b/ctxr/fsm/memory/__init__.py
@@ -9,6 +9,13 @@ This package directory holds:
   skill / agent should ensure ``ctxr-fsm`` is ready before any work.
   The repo-root ``BOOTSTRAP.md`` is a generated mirror of this file
   (see ``scripts/sync_bootstrap_doc.py``).
+* W23-SSOT canonical reference docs that any skill / agent in the
+  workspace links to instead of inlining the contract themselves:
+  ``AGENT_QUICKSTART.md`` (five-minute orientation),
+  ``SKILL_TEMPLATE.md`` (skill authoring template),
+  ``GATE_CONTRACT.md`` (cross-FSM gate protocol). These are reachable
+  from any Python consumer via :func:`get_ssot_doc_path` so no caller
+  needs to know the on-disk layout.
 
 The adapters are byte-stable re-emits of ``principles.md`` with the
 right per-client frontmatter and a generated-from header. Regenerate
@@ -33,6 +40,17 @@ _CLIENT_FILENAMES: dict[str, str] = {
     "claude": "principles.claude.md",
     "codex": "principles.codex.md",
     "cursor": "principles.cursor.md",
+}
+
+# W23-SSOT canonical reference docs. Keyed by short slug so callers
+# (skills, CLI commands, IDE integrations) reference them by name
+# rather than open-coding the on-disk filename. Adding a new SSOT doc
+# means landing the file under this directory and adding one entry
+# here; nothing else needs to know.
+_SSOT_FILENAMES: dict[str, str] = {
+    "agent_quickstart": "AGENT_QUICKSTART.md",
+    "skill_template": "SKILL_TEMPLATE.md",
+    "gate_contract": "GATE_CONTRACT.md",
 }
 
 
@@ -89,9 +107,59 @@ def get_bootstrap_path() -> Path:
     return path
 
 
+def get_ssot_doc_path(slug: str) -> Path:
+    """Return the absolute path to a W23-SSOT canonical reference doc.
+
+    Parameters
+    ----------
+    slug:
+        One of ``"agent_quickstart"``, ``"skill_template"``,
+        ``"gate_contract"``.
+
+    Raises
+    ------
+    ValueError
+        If ``slug`` is not a recognised SSOT doc key.
+    FileNotFoundError
+        If the doc is missing from the installed package — a packaging
+        bug the caller should surface rather than paper over.
+
+    The SSOT docs are intentionally client-agnostic plain Markdown. A
+    skill or agent that needs the contract reads the file via this
+    helper rather than re-deriving the same content; that way an update
+    to the contract lands in one place and propagates uniformly.
+    """
+
+    try:
+        filename = _SSOT_FILENAMES[slug]
+    except KeyError as exc:
+        valid = ", ".join(sorted(_SSOT_FILENAMES))
+        raise ValueError(
+            f"unknown SSOT doc slug {slug!r}; expected one of: {valid}"
+        ) from exc
+
+    path = PRINCIPLES_DIR / filename
+    if not path.is_file():
+        raise FileNotFoundError(f"SSOT doc missing in package: {path}")
+    return path
+
+
+def list_ssot_doc_slugs() -> list[str]:
+    """Return the sorted list of known W23-SSOT doc slugs.
+
+    Useful for CLI commands that iterate over the full set (e.g.
+    ``ctxr-fsm doctor --skill-consumer`` checks each one is reachable
+    after install) without hard-coding the slug list.
+    """
+
+    return sorted(_SSOT_FILENAMES)
+
+
 __all__ = [
     "BOOTSTRAP_FILENAME",
     "PRINCIPLES_DIR",
     "get_bootstrap_path",
     "get_principles_path",
+    "get_ssot_doc_path",
+    "list_ssot_doc_slugs",
 ]

--- a/tests/cli/test_cli_doctor.py
+++ b/tests/cli/test_cli_doctor.py
@@ -311,3 +311,50 @@ def test_doctor_json_alembic_revision_is_non_empty_string() -> None:
         revision = payload["alembic_revision"]
         assert isinstance(revision, str)
         assert revision  # not empty
+
+
+# ---------------------------------------------------------------------------
+# W23-SSOT: ``--skill-consumer`` flag
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_without_skill_consumer_flag_omits_section() -> None:
+    """The new section is opt-in; default invocations stay byte-stable.
+
+    Existing scripts that parse the doctor JSON envelope must not see
+    a surprise new key. The ``--skill-consumer`` flag adds the section;
+    without it, the output shape is unchanged.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        _init_project(db_path)
+
+        result = runner.invoke(app, ["doctor", "--db", str(db_path), "--json"])
+
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert "skill_consumer" not in payload
+
+
+def test_doctor_with_skill_consumer_flag_reports_all_docs_present() -> None:
+    """W23-SSOT happy path: every canonical doc resolves in the install."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        _init_project(db_path)
+
+        result = runner.invoke(
+            app, ["doctor", "--db", str(db_path), "--json", "--skill-consumer"]
+        )
+
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        section = payload["skill_consumer"]
+        assert section["status"] == "ok"
+        assert section["missing"] == []
+        assert section["principles_path"].endswith("principles.claude.md")
+        assert section["bootstrap_path"].endswith("bootstrap.md")
+        # Every SSOT doc is present with an existing file path.
+        for slug in ("agent_quickstart", "skill_template", "gate_contract"):
+            entry = section["ssot_docs"][slug]
+            assert entry["exists"] is True
+            assert entry["path"].endswith(".md")

--- a/tests/cli/test_cli_doctor.py
+++ b/tests/cli/test_cli_doctor.py
@@ -358,3 +358,25 @@ def test_doctor_with_skill_consumer_flag_reports_all_docs_present() -> None:
             entry = section["ssot_docs"][slug]
             assert entry["exists"] is True
             assert entry["path"].endswith(".md")
+
+
+def test_doctor_pretty_with_skill_consumer_flag_renders_summary_line() -> None:
+    """Pretty mode must surface the ``skill_consumer`` readiness line.
+
+    Without this assertion, ``--skill-consumer`` would silently no-op
+    outside ``--json`` mode — exactly the regression the W23-SSOT
+    review flagged. The happy-path install has every pillar present,
+    so the line reads ``skill_consumer: OK (N/N pillars resolved)``.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.db"
+        _init_project(db_path)
+
+        result = runner.invoke(
+            app, ["doctor", "--db", str(db_path), "--skill-consumer"]
+        )
+
+        assert result.exit_code == 0, result.stderr
+        assert "skill_consumer" in result.stdout
+        assert "OK" in result.stdout
+        assert "pillars resolved" in result.stdout

--- a/tests/unit/memory/test_ssot_docs.py
+++ b/tests/unit/memory/test_ssot_docs.py
@@ -1,0 +1,82 @@
+"""Tests for the W23-SSOT memory surface (AGENT_QUICKSTART, SKILL_TEMPLATE,
+GATE_CONTRACT) reachability through the public package helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from ctxr.fsm.memory import (
+    PRINCIPLES_DIR,
+    get_ssot_doc_path,
+    list_ssot_doc_slugs,
+)
+
+EXPECTED_SLUGS: tuple[str, ...] = (
+    "agent_quickstart",
+    "gate_contract",
+    "skill_template",
+)
+
+
+def test_list_ssot_doc_slugs_returns_known_set_sorted() -> None:
+    assert list_ssot_doc_slugs() == list(EXPECTED_SLUGS)
+
+
+@pytest.mark.parametrize("slug", EXPECTED_SLUGS)
+def test_get_ssot_doc_path_resolves_to_existing_file(slug: str) -> None:
+    path = get_ssot_doc_path(slug)
+    assert path.is_file()
+    # All three docs live alongside principles.md inside the package's
+    # memory/ directory.
+    assert path.parent == PRINCIPLES_DIR
+
+
+@pytest.mark.parametrize("slug", EXPECTED_SLUGS)
+def test_ssot_doc_carries_frontmatter_with_version(slug: str) -> None:
+    body = get_ssot_doc_path(slug).read_text(encoding="utf-8")
+    # Each SSOT doc opens with a Markdown YAML frontmatter block so
+    # downstream tooling can parse name + version.
+    assert body.startswith("---\n")
+    assert "name: ctxr-fsm-" in body
+    assert "version: " in body
+
+
+def test_get_ssot_doc_path_rejects_unknown_slug() -> None:
+    with pytest.raises(ValueError, match="unknown SSOT doc slug"):
+        get_ssot_doc_path("nonexistent")
+
+
+def test_agent_quickstart_references_canonical_contracts() -> None:
+    body = get_ssot_doc_path("agent_quickstart").read_text(encoding="utf-8")
+    # AGENT_QUICKSTART must link to the deeper contracts so a reader
+    # arriving at it can drill into principles / bootstrap / template /
+    # gate contract without guessing the file names.
+    assert "principles.md" in body
+    assert "bootstrap.md" in body
+    assert "SKILL_TEMPLATE.md" in body
+    assert "GATE_CONTRACT.md" in body
+
+
+def test_gate_contract_documents_error_envelopes() -> None:
+    body = get_ssot_doc_path("gate_contract").read_text(encoding="utf-8")
+    # The gate contract is the only place that documents the resolve_gate
+    # error envelope vocabulary. Skill authors and the upcoming W23g
+    # implementation both read from this list, so a regression that
+    # removes it should fail loudly here.
+    for envelope in (
+        "gate_value_required",
+        "gate_schema_mismatch",
+        "gate_source_run_not_found",
+        "gate_source_stale",
+    ):
+        assert envelope in body, f"gate contract missing {envelope!r} envelope"
+
+
+def test_skill_template_describes_canonical_package_layout() -> None:
+    body = get_ssot_doc_path("skill_template").read_text(encoding="utf-8")
+    # The skill template is the contract every future skill copies;
+    # the spec / handlers / install / workers split must be in there.
+    assert "spec.py" in body
+    assert "handlers.py" in body
+    assert "install.py" in body
+    assert "workers/" in body


### PR DESCRIPTION
Collapses the agent + skill contracts onto a single canonical surface inside the ctxr-fsm package. Three new docs (AGENT_QUICKSTART, SKILL_TEMPLATE, GATE_CONTRACT) under ctxr/fsm/memory/ + public get_ssot_doc_path/list_ssot_doc_slugs helpers + ctxr-fsm doctor --skill-consumer mode that verifies every pillar doc is reachable. 11 new memory tests + 2 new doctor CLI tests + ruff/mypy clean. Per-client staging into .ctxr-fsm/memory/ deferred to follow-up commit.