### PR TITLE
feat(w23-ssot): stage canonical reference docs into consumer .ctxr-fsm/memory/

### DIFF
--- a/ctxr/fsm/cli/install_memory_cmd.py
+++ b/ctxr/fsm/cli/install_memory_cmd.py
@@ -94,7 +94,13 @@ import typer
 
 from ctxr.fsm.cli._clients import McpClient
 from ctxr.fsm.cli._common import json_or_pretty
-from ctxr.fsm.memory import BOOTSTRAP_FILENAME, get_bootstrap_path, get_principles_path
+from ctxr.fsm.memory import (
+    BOOTSTRAP_FILENAME,
+    get_bootstrap_path,
+    get_principles_path,
+    get_ssot_doc_path,
+    list_ssot_doc_slugs,
+)
 
 __all__ = [
     "BootstrapStatus",
@@ -212,6 +218,33 @@ _CLAUDE_LINKED_PATH: Path = Path(".ctxr-fsm") / "memory" / "principles.claude.md
 _BOOTSTRAP_LINKED_PATH: Path = (
     Path(".ctxr-fsm") / "memory" / BOOTSTRAP_FILENAME
 )
+
+
+def _ssot_relative_paths() -> dict[str, Path]:
+    """Map each W23-SSOT slug to its staged relative path under the target.
+
+    Each canonical reference doc (AGENT_QUICKSTART.md, SKILL_TEMPLATE.md,
+    GATE_CONTRACT.md) is staged under ``.ctxr-fsm/memory/<filename>.md``
+    so any sibling skill or agent in the workspace can resolve the doc
+    via the same Claude ``@.ctxr-fsm/memory/<filename>.md`` import
+    convention used by principles.md and bootstrap.md. The slug list
+    comes from :func:`list_ssot_doc_slugs` so adding a new SSOT doc in
+    one place (``ctxr/fsm/memory/__init__.py``) automatically flows
+    through to staging + drift detection.
+
+    Codex and Cursor do NOT follow ``@`` imports, so this staging
+    applies only to the Claude install path. The Codex/Cursor adapters
+    inline the bootstrap body (the only SSOT doc that ships as part of
+    the principles contract); the broader SSOT reference docs are not
+    inlined because they are reference material a sibling skill links
+    to, not principles a single LLM session must internalise.
+    """
+
+    return {
+        slug: Path(".ctxr-fsm") / "memory" / get_ssot_doc_path(slug).name
+        for slug in list_ssot_doc_slugs()
+    }
+
 
 # The relative path Cursor uses for project-scoped rule files. We pick a
 # stable filename (``ctxr-fsm.mdc``) so the rule is greppable and so
@@ -579,6 +612,33 @@ def _materialise_bootstrap_doc(
     )
 
 
+def _materialise_ssot_docs(
+    target: Path,
+    *,
+    no_symlink: bool,
+) -> dict[str, str]:
+    """Stage every W23-SSOT canonical reference doc under ``target/.ctxr-fsm/memory/``.
+
+    Iterates :func:`_ssot_relative_paths` and runs each doc through
+    :func:`_materialise_package_file`. Returns a slug -> link_mode
+    mapping (``"symlink"`` or ``"copy"``) for inclusion in the install
+    summary. Applies to the Claude install path only — Codex and Cursor
+    do not follow ``@`` imports, so staging these docs under
+    ``.ctxr-fsm/memory/`` for them would create unreachable files.
+    """
+
+    modes: dict[str, str] = {}
+    for slug, relative_dest in _ssot_relative_paths().items():
+        _, mode = _materialise_package_file(
+            target,
+            get_ssot_doc_path(slug),
+            relative_dest,
+            no_symlink=no_symlink,
+        )
+        modes[slug] = mode
+    return modes
+
+
 def _build_claude_payload() -> str:
     """The payload for the CLAUDE.md marker block — a single ``@<path>`` import.
 
@@ -627,6 +687,14 @@ class _InstallResult:
     # ``tools/generate_memory_adapters.py``) and report ``None``
     # here because no separate file is materialised.
     bootstrap_link_mode: str | None = None
+    # ``ssot_link_modes`` records how each W23-SSOT canonical reference
+    # doc was staged for this client (slug -> ``"symlink"`` / ``"copy"``).
+    # Empty dict on dry-run and on Codex / Cursor — those clients do not
+    # follow ``@`` imports and the SSOT docs are reference material, not
+    # adapter content, so we do not inline them either. Drift on these
+    # docs is hash-detected on the Claude row via
+    # :func:`_check_ssot_status` (mirrors the bootstrap.md check).
+    ssot_link_modes: dict[str, str] | None = None
     note: str = ""
 
 
@@ -674,11 +742,13 @@ def _install_claude(
             installed_version=installed_version,
             link_mode=link_mode,
             bootstrap_link_mode=link_mode,
+            ssot_link_modes={slug: link_mode for slug in list_ssot_doc_slugs()},
             note=_diff_preview(existing_text, new_text),
         )
 
     _, link_mode = _materialise_claude_link(target, package_file, no_symlink=no_symlink)
     _, bootstrap_link_mode = _materialise_bootstrap_doc(target, no_symlink=no_symlink)
+    ssot_link_modes = _materialise_ssot_docs(target, no_symlink=no_symlink)
 
     existing_text = host_file.read_text(encoding="utf-8") if host_file.is_file() else ""
     new_block = _build_marker_block(
@@ -695,6 +765,7 @@ def _install_claude(
             installed_version=package_version,
             link_mode=link_mode,
             bootstrap_link_mode=bootstrap_link_mode,
+            ssot_link_modes=ssot_link_modes,
         )
 
     host_file.parent.mkdir(parents=True, exist_ok=True)
@@ -707,6 +778,7 @@ def _install_claude(
         installed_version=package_version,
         link_mode=link_mode,
         bootstrap_link_mode=bootstrap_link_mode,
+        ssot_link_modes=ssot_link_modes,
     )
 
 
@@ -903,6 +975,13 @@ class _CheckRow:
     installed_version: str | None
     status: MemoryInstallStatus
     bootstrap_status: BootstrapStatus = BootstrapStatus.not_installed
+    # ``ssot_statuses`` maps each W23-SSOT slug to a
+    # :class:`BootstrapStatus` (the same enum reused: ok / out_of_date /
+    # not_installed for Claude, inlined for codex / cursor where the
+    # docs are reference material reached through Claude's @ import
+    # alone). Drift on any SSOT doc is treated the same way as
+    # bootstrap drift for exit-code purposes.
+    ssot_statuses: dict[str, BootstrapStatus] | None = None
 
 
 def _sha256_file(path: Path) -> str:
@@ -943,11 +1022,40 @@ def _check_bootstrap_status(
     return BootstrapStatus.out_of_date
 
 
+def _check_ssot_statuses(
+    target: Path, package_ssot_hashes: dict[str, str]
+) -> dict[str, BootstrapStatus]:
+    """Per-slug drift check for the staged W23-SSOT canonical reference docs.
+
+    Mirrors :func:`_check_bootstrap_status` but iterates each SSOT slug:
+    compare the staged file's sha256 against the package source. Slugs
+    whose staged file is absent flip to
+    :attr:`BootstrapStatus.not_installed`; bytes-differ slugs flip to
+    :attr:`BootstrapStatus.out_of_date`. Applies to the Claude install
+    path only (the only path that stages the SSOT docs as separate
+    files on disk).
+    """
+
+    staged_paths = _ssot_relative_paths()
+    out: dict[str, BootstrapStatus] = {}
+    for slug, relative in staged_paths.items():
+        staged = target / relative
+        if not staged.is_file():
+            out[slug] = BootstrapStatus.not_installed
+            continue
+        if _sha256_file(staged) == package_ssot_hashes[slug]:
+            out[slug] = BootstrapStatus.ok
+        else:
+            out[slug] = BootstrapStatus.out_of_date
+    return out
+
+
 def _check_one(
     target: Path,
     detection: _ClientDetection,
     package_version: str | None,
     package_bootstrap_hash: str,
+    package_ssot_hashes: dict[str, str],
 ) -> _CheckRow:
     """Compute the status for one detected client.
 
@@ -957,12 +1065,22 @@ def _check_one(
     the principles adapter for those clients, so drift in bootstrap
     content surfaces via the principles version comparison rather
     than a separate hash check.
+
+    SSOT docs follow the same shape: Claude gets per-slug hash drift
+    via :func:`_check_ssot_statuses`; Codex / Cursor get the
+    :attr:`BootstrapStatus.inlined` sentinel uniformly across every
+    slug (the reference docs are reachable only through Claude's
+    ``@`` import — not inlined into the adapter — but for drift
+    purposes they are treated like the bootstrap doc, with drift
+    detected only on the staged-file client).
     """
     host = detection.host_file
     if detection.name == McpClient.claude.value:
         bootstrap_status = _check_bootstrap_status(target, package_bootstrap_hash)
+        ssot_statuses = _check_ssot_statuses(target, package_ssot_hashes)
     else:
         bootstrap_status = BootstrapStatus.inlined
+        ssot_statuses = {slug: BootstrapStatus.inlined for slug in package_ssot_hashes}
 
     if host is None or not host.is_file():
         return _CheckRow(
@@ -972,6 +1090,7 @@ def _check_one(
             installed_version=None,
             status=MemoryInstallStatus.not_installed,
             bootstrap_status=bootstrap_status,
+            ssot_statuses=ssot_statuses,
         )
 
     installed = _read_installed_version_from_text(
@@ -986,6 +1105,7 @@ def _check_one(
             installed_version=None,
             status=MemoryInstallStatus.missing,
             bootstrap_status=bootstrap_status,
+            ssot_statuses=ssot_statuses,
         )
     if installed == package_version:
         return _CheckRow(
@@ -995,6 +1115,7 @@ def _check_one(
             installed_version=installed,
             status=MemoryInstallStatus.ok,
             bootstrap_status=bootstrap_status,
+            ssot_statuses=ssot_statuses,
         )
     return _CheckRow(
         client=detection.name,
@@ -1003,6 +1124,7 @@ def _check_one(
         installed_version=installed,
         status=MemoryInstallStatus.out_of_date,
         bootstrap_status=bootstrap_status,
+        ssot_statuses=ssot_statuses,
     )
 
 
@@ -1126,6 +1248,7 @@ def run_install_memory(
                 "installed_version": r.installed_version,
                 "link_mode": r.link_mode,
                 "bootstrap_link_mode": r.bootstrap_link_mode,
+                "ssot_link_modes": r.ssot_link_modes,
                 "note": r.note,
             }
             for r in results
@@ -1232,9 +1355,17 @@ def install_memory(
             canonical_package_file.read_text(encoding="utf-8")
         )
         package_bootstrap_hash = _sha256_file(get_bootstrap_path())
+        package_ssot_hashes = {
+            slug: _sha256_file(get_ssot_doc_path(slug))
+            for slug in list_ssot_doc_slugs()
+        }
         rows = [
             _check_one(
-                resolved_target, d, package_version, package_bootstrap_hash
+                resolved_target,
+                d,
+                package_version,
+                package_bootstrap_hash,
+                package_ssot_hashes,
             )
             for d in detections
         ]
@@ -1255,11 +1386,29 @@ def install_memory(
             BootstrapStatus.out_of_date,
             BootstrapStatus.not_installed,
         }
+
+        def _any_ssot_drift(row: _CheckRow) -> bool:
+            """Return True iff any staged SSOT doc is drifted or absent.
+
+            The ``inlined`` sentinel (codex / cursor) is never a failure
+            on its own — for those clients the SSOT axis is checked
+            elsewhere via the principles version. Only the per-slug
+            ``out_of_date`` / ``not_installed`` statuses count as drift.
+            """
+
+            if not row.ssot_statuses:
+                return False
+            return any(
+                status in bootstrap_fail_statuses
+                for status in row.ssot_statuses.values()
+            )
+
         out_of_date = [
             r
             for r in rows
             if r.status in memory_fail_statuses
             or r.bootstrap_status in bootstrap_fail_statuses
+            or _any_ssot_drift(r)
         ]
         json_or_pretty(
             {
@@ -1273,6 +1422,10 @@ def install_memory(
                         "installed_version": r.installed_version,
                         "status": r.status.value,
                         "bootstrap_status": r.bootstrap_status.value,
+                        "ssot_statuses": {
+                            slug: status.value
+                            for slug, status in (r.ssot_statuses or {}).items()
+                        },
                     }
                     for r in rows
                 ],

--- a/ctxr/fsm/cli/install_memory_cmd.py
+++ b/ctxr/fsm/cli/install_memory_cmd.py
@@ -542,6 +542,33 @@ def _materialise_package_file(
     dest = target / relative_dest
     dest.parent.mkdir(parents=True, exist_ok=True)
 
+    # Idempotency early-exit: if the destination is already in the
+    # desired state, return without touching it. This keeps inode
+    # ctime/mtime stable across repeated install-memory runs, which
+    # the no-rewrite test in this module enforces.
+    #
+    # Symlink-mode requested + dest is the right symlink: keep it.
+    # Copy-mode requested + dest is a regular file with the same
+    # bytes: keep it. Any other shape (wrong symlink target, file
+    # when symlink was requested, symlink when copy was requested,
+    # mismatched bytes) falls through and gets re-materialised so
+    # the destination converges on the requested shape.
+    desired_symlink_target = Path(package_file).resolve()
+    if not no_symlink and dest.is_symlink():
+        try:
+            current_target: Path | None = dest.readlink()
+        except OSError:
+            current_target = None
+        if current_target == desired_symlink_target:
+            return dest, "symlink"
+    elif no_symlink and dest.is_file() and not dest.is_symlink():
+        try:
+            same_bytes = dest.read_bytes() == package_file.read_bytes()
+        except OSError:
+            same_bytes = False
+        if same_bytes:
+            return dest, "copy"
+
     # Remove any pre-existing entry (file, symlink, or broken symlink)
     # before re-materialising. ``Path.unlink`` with ``missing_ok=True``
     # handles all three cleanly without an explicit ``exists()`` race.
@@ -557,14 +584,13 @@ def _materialise_package_file(
         # outside the project dir (it's inside the installed package),
         # so a relative path across that boundary would be cosmetically
         # ugly. Resolving here also makes the symlink stable across a
-        # ``git mv`` of the project — the link always points back at
+        # ``git mv`` of the project, the link always points back at
         # the installed package.
-        rel_target = Path(package_file).resolve()
-        dest.symlink_to(rel_target)
+        dest.symlink_to(desired_symlink_target)
         return dest, "symlink"
     except (OSError, NotImplementedError):
         # Filesystem or platform doesn't support symlinks (Windows
-        # without dev mode, some FUSE mounts) — fall back to copy.
+        # without dev mode, some FUSE mounts), fall back to copy.
         shutil.copy2(package_file, dest)
         return dest, "copy"
 

--- a/ctxr/fsm/cli/install_memory_cmd.py
+++ b/ctxr/fsm/cli/install_memory_cmd.py
@@ -689,11 +689,14 @@ class _InstallResult:
     bootstrap_link_mode: str | None = None
     # ``ssot_link_modes`` records how each W23-SSOT canonical reference
     # doc was staged for this client (slug -> ``"symlink"`` / ``"copy"``).
-    # Empty dict on dry-run and on Codex / Cursor — those clients do not
-    # follow ``@`` imports and the SSOT docs are reference material, not
-    # adapter content, so we do not inline them either. Drift on these
-    # docs is hash-detected on the Claude row via
-    # :func:`_check_ssot_status` (mirrors the bootstrap.md check).
+    # Populated on Claude in every code path: real installs report the
+    # per-slug materialisation mode, and the dry-run path mirrors what
+    # would be written (one entry per slug at the implied mode).
+    # ``None`` on Codex / Cursor: those clients do not follow ``@``
+    # imports and the SSOT docs are reference material, not adapter
+    # content, so we do not inline them either. Drift on these docs is
+    # hash-detected on the Claude row via
+    # :func:`_check_ssot_statuses` (mirrors the bootstrap.md check).
     ssot_link_modes: dict[str, str] | None = None
     note: str = ""
 

--- a/tests/integration/memory/test_install_memory_ssot_staging.py
+++ b/tests/integration/memory/test_install_memory_ssot_staging.py
@@ -223,12 +223,21 @@ def test_install_memory_is_idempotent_for_ssot_docs(tmp_target: Path) -> None:
     _install_claude(tmp_target)
     memory_dir = _staged_memory_dir(tmp_target)
 
-    # Snapshot every staged file's bytes + mtime so we can detect any
-    # rewrite or duplication on the second pass.
-    snapshot: dict[str, tuple[bytes, float]] = {}
+    # Snapshot every staged file's bytes, mtime, and ctime_ns so we
+    # can detect any rewrite or duplication on the second pass.
+    #
+    # We MUST include ``st_ctime_ns`` (and not rely on ``st_mtime``
+    # alone). The staging copy path uses ``shutil.copy2``, which
+    # PRESERVES the source file's mtime, so a rewrite of identical
+    # bytes leaves ``st_mtime`` unchanged and the test would silently
+    # pass. ``st_ctime`` (inode change time) is NOT preserved by
+    # ``copy2`` and bumps on every replacement, so it is the metadata
+    # field that actually proves "no rewrite happened".
+    snapshot: dict[str, tuple[bytes, float, int]] = {}
     for filename in _EXPECTED_STAGED_FILES:
         staged = memory_dir / filename
-        snapshot[filename] = (staged.read_bytes(), staged.stat().st_mtime)
+        st = staged.stat()
+        snapshot[filename] = (staged.read_bytes(), st.st_mtime, st.st_ctime_ns)
 
     # Run install-memory again. The host CLAUDE.md already imports the
     # principles file via the marker block, so the patch is a no-op;
@@ -241,13 +250,16 @@ def test_install_memory_is_idempotent_for_ssot_docs(tmp_target: Path) -> None:
     expected_files = sorted(_EXPECTED_STAGED_FILES)
     assert actual_files == expected_files, actual_files
 
-    # The bytes match the snapshot (no content rewrite) AND the mtime is
-    # unchanged (the staging path is a true no-op: we did not even
-    # re-open + rewrite identical bytes).
+    # The bytes match the snapshot (no content rewrite), the mtime is
+    # unchanged (consistent with the source mtime not changing), and
+    # the ctime_ns is unchanged (the staging path is a true no-op: we
+    # did not even re-open + rewrite identical bytes).
     for filename in _EXPECTED_STAGED_FILES:
         staged = memory_dir / filename
+        st = staged.stat()
         assert staged.read_bytes() == snapshot[filename][0], filename
-        assert staged.stat().st_mtime == snapshot[filename][1], filename
+        assert st.st_mtime == snapshot[filename][1], filename
+        assert st.st_ctime_ns == snapshot[filename][2], filename
 
     # ``--check`` reports a clean tree (no SSOT drift).
     exit_code, check_payload = _run_check(tmp_target)

--- a/tests/integration/memory/test_install_memory_ssot_staging.py
+++ b/tests/integration/memory/test_install_memory_ssot_staging.py
@@ -241,10 +241,13 @@ def test_install_memory_is_idempotent_for_ssot_docs(tmp_target: Path) -> None:
     expected_files = sorted(_EXPECTED_STAGED_FILES)
     assert actual_files == expected_files, actual_files
 
-    # The bytes match the snapshot (no content rewrite).
+    # The bytes match the snapshot (no content rewrite) AND the mtime is
+    # unchanged (the staging path is a true no-op: we did not even
+    # re-open + rewrite identical bytes).
     for filename in _EXPECTED_STAGED_FILES:
         staged = memory_dir / filename
         assert staged.read_bytes() == snapshot[filename][0], filename
+        assert staged.stat().st_mtime == snapshot[filename][1], filename
 
     # ``--check`` reports a clean tree (no SSOT drift).
     exit_code, check_payload = _run_check(tmp_target)

--- a/tests/integration/memory/test_install_memory_ssot_staging.py
+++ b/tests/integration/memory/test_install_memory_ssot_staging.py
@@ -1,0 +1,358 @@
+"""Integration tests for ``ctxr-fsm install-memory`` staging the W23-SSOT docs.
+
+Contract (W23-SSOT):
+
+* For **Claude**, the canonical reference docs that ship inside the
+  ``ctxr-fsm`` package memory dir — ``AGENT_QUICKSTART.md``,
+  ``SKILL_TEMPLATE.md``, ``GATE_CONTRACT.md`` — are staged under
+  ``<target>/.ctxr-fsm/memory/<filename>.md`` alongside
+  ``principles.claude.md`` and ``bootstrap.md`` so any sibling skill or
+  agent in the workspace can resolve them via Claude's
+  ``@.ctxr-fsm/memory/<filename>.md`` import syntax.
+* For **Codex** and **Cursor**, the SSOT docs are NOT staged as
+  separate files — those clients don't follow ``@`` imports, and
+  unlike the bootstrap doc the SSOT docs are reference material rather
+  than principles a single LLM session must internalise, so inlining
+  them into the principles adapter would bloat that file without
+  payoff. The install summary therefore reports
+  ``ssot_link_modes: null`` for those clients.
+
+These tests drive the public CLI surface end-to-end (Typer's
+:class:`CliRunner` + tmpdir) and assert:
+
+1. Fresh project: ``install-memory --client claude`` stages every SSOT
+   doc under ``.ctxr-fsm/memory/`` and the staged bytes match the
+   package source. The ``ssot_link_modes`` JSON entry lists every
+   slug.
+2. Idempotency: re-running ``install-memory`` against an already-staged
+   target does not duplicate files, does not rewrite when content
+   matches by hash, and the second run reports the same staging mode.
+3. Drift detection: editing a staged SSOT doc in the consumer tree is
+   flagged by ``install-memory --check`` with a non-zero exit and the
+   per-slug ``ssot_statuses`` entry switches to ``out_of_date``.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ctxr.fsm.cli import app
+from ctxr.fsm.memory import get_ssot_doc_path, list_ssot_doc_slugs
+
+runner = CliRunner()
+
+
+# The five files install-memory must stage under .ctxr-fsm/memory/
+# after the Claude install path runs against a fresh project. Kept as
+# a tuple of filenames so test failures point at exactly which file
+# is missing rather than at an abstract "slug" set.
+_EXPECTED_STAGED_FILES: tuple[str, ...] = (
+    "principles.claude.md",
+    "bootstrap.md",
+    "AGENT_QUICKSTART.md",
+    "SKILL_TEMPLATE.md",
+    "GATE_CONTRACT.md",
+)
+
+
+@pytest.fixture
+def tmp_target() -> Iterator[Path]:
+    """Yield a fresh tempdir to use as the install ``--target`` root."""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp).resolve()
+
+
+def _staged_memory_dir(target: Path) -> Path:
+    return target / ".ctxr-fsm" / "memory"
+
+
+def _install_claude(target: Path) -> dict:
+    """Run ``install-memory --client claude --no-symlink`` and return the JSON payload.
+
+    ``--no-symlink`` keeps the staged bytes mutable for the drift
+    tests below (a symlink would update with the package source the
+    moment we mutate that, which is not what the drift case models).
+    """
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(target),
+            "--client",
+            "claude",
+            "--no-symlink",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return json.loads(result.stdout)
+
+
+def _run_check(target: Path) -> tuple[int, dict]:
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(target),
+            "--client",
+            "auto",
+            "--check",
+            "--json",
+        ],
+    )
+    return result.exit_code, json.loads(result.stdout)
+
+
+def _row_for(payload: dict, client: str) -> dict:
+    for row in payload["results"]:
+        if row["client"] == client:
+            return row
+    raise AssertionError(f"no row for {client!r} in {payload}")
+
+
+# ---------------------------------------------------------------------------
+# Fresh-install staging
+# ---------------------------------------------------------------------------
+
+
+def test_install_memory_stages_all_five_files_on_fresh_claude_project(
+    tmp_target: Path,
+) -> None:
+    """A fresh Claude install lands every SSOT + principles + bootstrap file."""
+
+    (tmp_target / "CLAUDE.md").write_text("", encoding="utf-8")
+
+    payload = _install_claude(tmp_target)
+
+    memory_dir = _staged_memory_dir(tmp_target)
+    for filename in _EXPECTED_STAGED_FILES:
+        staged = memory_dir / filename
+        assert staged.is_file(), f"expected staged file at {staged}"
+
+    # The staged bytes for every SSOT doc match the package source.
+    for slug in list_ssot_doc_slugs():
+        package_path = get_ssot_doc_path(slug)
+        staged = memory_dir / package_path.name
+        assert staged.read_bytes() == package_path.read_bytes(), slug
+
+    # The install summary surfaces ``ssot_link_modes`` for Claude.
+    claude_row = _row_for(payload, "claude")
+    assert claude_row["ssot_link_modes"] is not None
+    assert set(claude_row["ssot_link_modes"]) == set(list_ssot_doc_slugs())
+    # Every staged SSOT doc landed via ``copy`` (we passed --no-symlink).
+    for slug, mode in claude_row["ssot_link_modes"].items():
+        assert mode == "copy", (slug, mode)
+
+
+def test_install_memory_does_not_stage_ssot_for_codex(tmp_target: Path) -> None:
+    """Codex does not follow ``@`` imports, so SSOT docs stay un-staged."""
+
+    (tmp_target / "AGENTS.md").write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "codex",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    memory_dir = _staged_memory_dir(tmp_target)
+    for slug in list_ssot_doc_slugs():
+        package_path = get_ssot_doc_path(slug)
+        assert not (memory_dir / package_path.name).exists(), slug
+
+    payload = json.loads(result.stdout)
+    codex_row = _row_for(payload, "codex")
+    assert codex_row["ssot_link_modes"] is None, codex_row
+
+
+def test_install_memory_does_not_stage_ssot_for_cursor(tmp_target: Path) -> None:
+    """Cursor does not follow ``@`` imports either."""
+
+    (tmp_target / ".cursor" / "rules").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "cursor",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    memory_dir = _staged_memory_dir(tmp_target)
+    for slug in list_ssot_doc_slugs():
+        package_path = get_ssot_doc_path(slug)
+        assert not (memory_dir / package_path.name).exists(), slug
+
+    payload = json.loads(result.stdout)
+    cursor_row = _row_for(payload, "cursor")
+    assert cursor_row["ssot_link_modes"] is None, cursor_row
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_install_memory_is_idempotent_for_ssot_docs(tmp_target: Path) -> None:
+    """Re-running install-memory does not duplicate or rewrite matching files."""
+
+    (tmp_target / "CLAUDE.md").write_text("", encoding="utf-8")
+
+    _install_claude(tmp_target)
+    memory_dir = _staged_memory_dir(tmp_target)
+
+    # Snapshot every staged file's bytes + mtime so we can detect any
+    # rewrite or duplication on the second pass.
+    snapshot: dict[str, tuple[bytes, float]] = {}
+    for filename in _EXPECTED_STAGED_FILES:
+        staged = memory_dir / filename
+        snapshot[filename] = (staged.read_bytes(), staged.stat().st_mtime)
+
+    # Run install-memory again. The host CLAUDE.md already imports the
+    # principles file via the marker block, so the patch is a no-op;
+    # the staged files all match the package source, so they should
+    # not be rewritten either.
+    second = _install_claude(tmp_target)
+
+    # No new files in the memory dir.
+    actual_files = sorted(p.name for p in memory_dir.iterdir())
+    expected_files = sorted(_EXPECTED_STAGED_FILES)
+    assert actual_files == expected_files, actual_files
+
+    # The bytes match the snapshot (no content rewrite).
+    for filename in _EXPECTED_STAGED_FILES:
+        staged = memory_dir / filename
+        assert staged.read_bytes() == snapshot[filename][0], filename
+
+    # ``--check`` reports a clean tree (no SSOT drift).
+    exit_code, check_payload = _run_check(tmp_target)
+    assert exit_code == 0, check_payload
+    claude_row = _row_for(check_payload, "claude")
+    for slug, status in claude_row["ssot_statuses"].items():
+        assert status == "ok", (slug, status)
+
+    # The second install reports the same staging mode for every slug.
+    claude_row_second = _row_for(second, "claude")
+    assert claude_row_second["ssot_link_modes"] is not None
+    for slug, mode in claude_row_second["ssot_link_modes"].items():
+        assert mode == "copy", (slug, mode)
+
+
+# ---------------------------------------------------------------------------
+# Drift detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", list_ssot_doc_slugs())
+def test_check_flags_mutated_ssot_doc_as_out_of_date(
+    tmp_target: Path, slug: str
+) -> None:
+    """Editing a staged SSOT doc trips ``--check`` with a non-zero exit."""
+
+    (tmp_target / "CLAUDE.md").write_text("", encoding="utf-8")
+    _install_claude(tmp_target)
+
+    package_path = get_ssot_doc_path(slug)
+    staged = _staged_memory_dir(tmp_target) / package_path.name
+    assert staged.is_file(), staged
+
+    # Baseline: a clean install reports ``ok`` for every SSOT slug.
+    exit_code, payload = _run_check(tmp_target)
+    assert exit_code == 0, payload
+    claude_row = _row_for(payload, "claude")
+    assert claude_row["ssot_statuses"][slug] == "ok"
+
+    # Mutate the staged file (simulating accidental local edits or
+    # tooling drift).
+    staged.write_text("mutated\n", encoding="utf-8")
+
+    exit_code, payload = _run_check(tmp_target)
+    assert exit_code == 1, payload
+    claude_row = _row_for(payload, "claude")
+    assert claude_row["ssot_statuses"][slug] == "out_of_date"
+
+    # Other slugs stay clean.
+    for other_slug, status in claude_row["ssot_statuses"].items():
+        if other_slug == slug:
+            continue
+        assert status == "ok", (other_slug, status)
+
+    # Re-running install rewrites the staged copy back to the package
+    # source.
+    _install_claude(tmp_target)
+    exit_code, payload = _run_check(tmp_target)
+    assert exit_code == 0, payload
+    claude_row = _row_for(payload, "claude")
+    assert claude_row["ssot_statuses"][slug] == "ok"
+
+
+def test_check_flags_missing_ssot_doc_as_not_installed(tmp_target: Path) -> None:
+    """Deleting a staged SSOT doc trips ``--check`` with ``not_installed``."""
+
+    (tmp_target / "CLAUDE.md").write_text("", encoding="utf-8")
+    _install_claude(tmp_target)
+
+    # Remove one staged SSOT doc (pick the first slug for determinism).
+    slug = list_ssot_doc_slugs()[0]
+    staged = _staged_memory_dir(tmp_target) / get_ssot_doc_path(slug).name
+    staged.unlink()
+
+    exit_code, payload = _run_check(tmp_target)
+    assert exit_code == 1, payload
+    claude_row = _row_for(payload, "claude")
+    assert claude_row["ssot_statuses"][slug] == "not_installed"
+
+
+def test_check_reports_inlined_ssot_for_codex(tmp_target: Path) -> None:
+    """Codex's SSOT axis is uniformly ``inlined`` (no staged files to hash)."""
+
+    (tmp_target / "AGENTS.md").write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "install-memory",
+            "--target",
+            str(tmp_target),
+            "--client",
+            "codex",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    exit_code, payload = _run_check(tmp_target)
+    # No SSOT drift on codex, but principles may be reported clean or
+    # missing depending on the marker block — we only care about the
+    # SSOT axis here.
+    codex_row = _row_for(payload, "codex")
+    for slug, status in codex_row["ssot_statuses"].items():
+        assert status == "inlined", (slug, status)
+    # Sanity: every known slug surfaces in the report.
+    assert set(codex_row["ssot_statuses"]) == set(list_ssot_doc_slugs())
+    # Exit code can be 0 (clean install) here — the principles block
+    # was patched by the install above. The point of this test is the
+    # SSOT axis, not the principles axis.
+    assert exit_code in (0, 1), payload


### PR DESCRIPTION
## Summary

- Extends the Claude install-memory path to materialise the W23-SSOT canonical reference docs (`AGENT_QUICKSTART.md`, `SKILL_TEMPLATE.md`, `GATE_CONTRACT.md`) under `.ctxr-fsm/memory/<filename>.md`, alongside the already-staged `principles.claude.md` and `bootstrap.md`. Sibling skills can now resolve any of these docs via Claude's `@` import syntax instead of re-inlining the contract.
- Adds `ssot_link_modes` to the install summary and `ssot_statuses` to `install-memory --check` so per-slug drift surfaces with the existing non-zero-exit shape (mirrors `bootstrap_status`).
- Codex and Cursor skip SSOT staging on purpose: their LLMs don't follow `@` imports, and unlike `bootstrap.md` the SSOT docs are reference material rather than principles a single session must internalise. Drift-axis returns `inlined` for those clients for parity.

## Test plan

- [x] `uv run ruff check ctxr/ tests/` clean
- [x] `uv run mypy ctxr/fsm/` clean
- [x] `uv run pytest tests/unit/ tests/integration/ --ignore=tests/integration/e2e` (687 passed)
- [x] New `tests/integration/memory/test_install_memory_ssot_staging.py` covers fresh install (all five files land), idempotency (no rewrite when hashes match), per-slug drift detection via `--check`, and the codex/cursor `inlined` sentinel path.

Generated with [Claude Code](https://claude.com/claude-code)