### PR TITLE
feat(ui): 1-hop hover highlight on graph nodes + edges

### DIFF
--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -23,7 +23,7 @@
  * onNodeClick.
  */
 
-import { useEffect, useMemo, useRef } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { JSX } from 'preact';
 import dagre from 'dagre';
 import {
@@ -183,6 +183,26 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
   const currentRing = isCurrent
     ? 'ring-2 ring-amber-400 ring-offset-2 ring-offset-white dark:ring-offset-slate-900'
     : '';
+  // W23d 1-hop hover highlight. FlowGraph stamps three transient flags
+  // onto node.data while a hover is active:
+  //   data.isHovered    — this is the node the cursor is on (or one
+  //                       endpoint of the hovered edge)
+  //   data.highlighted  — this node is a neighbour (1 hop away) of the
+  //                       hovered node, or it is the source/target of
+  //                       the hovered edge
+  //   data.dimmed       — something else is hovered and this node is
+  //                       NOT in the highlighted set
+  // When nothing is hovered all three flags are false and the node
+  // renders unchanged.
+  const isHovered = data.isHovered === true;
+  const isHighlighted = data.highlighted === true;
+  const isDimmed = data.dimmed === true;
+  const hoverRing = isHovered
+    ? 'ring-2 ring-amber-400 ring-offset-2 ring-offset-white dark:ring-offset-slate-900'
+    : isHighlighted
+    ? 'ring-1 ring-amber-300 ring-offset-1 ring-offset-white dark:ring-offset-slate-900'
+    : '';
+  const dimClass = isDimmed ? 'opacity-30' : '';
   return (
     <div
       class={[
@@ -191,9 +211,15 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
         // the (fixed) node height. gap-1 gives the two rows even
         // breathing room.
         'flex flex-col gap-1 justify-center overflow-hidden',
+        // Smooth fade between dim / un-dim states. motion-reduce
+        // disables the transition for users with
+        // prefers-reduced-motion (existing pattern across the dashboard).
+        'transition-opacity duration-150 motion-reduce:transition-none',
         paletteClass,
         selected ? 'ring-2 ring-emerald-400 ring-offset-1' : '',
         currentRing,
+        hoverRing,
+        dimClass,
       ].join(' ')}
       style={{ width: `${NODE_WIDTH}px`, minHeight: `${NODE_HEIGHT}px` }}
     >
@@ -536,6 +562,45 @@ export function FlowGraph({
       el.removeEventListener('wheel', onWheel, { capture: true } as unknown as EventListenerOptions);
     };
   }, []);
+  // W23d 1-hop hover highlight state. Tracking the hovered node / edge
+  // here (not inside FsmNode / FsmEdge) keeps every node + edge aware
+  // of what the operator is pointing at, which is what lets us dim
+  // everything outside the 1-hop neighbourhood. Only one of these is
+  // ever non-null at a time; entering an edge clears the node hover
+  // and vice-versa to avoid an in-between flicker where both apply.
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
+
+  // Pre-compute the "highlighted set" — the set of node ids and edge
+  // ids that are 1 hop away from the current hover target. useMemo
+  // keyed on edges + the hover ids so we don't rebuild the set on
+  // every unrelated render (e.g. a viewport pan that re-renders the
+  // FlowGraph but doesn't change the topology).
+  const highlight = useMemo(() => {
+    const highlightedNodes = new Set<string>();
+    const highlightedEdges = new Set<string>();
+    if (hoveredNodeId !== null) {
+      highlightedNodes.add(hoveredNodeId);
+      for (const e of edges) {
+        if (e.source === hoveredNodeId || e.target === hoveredNodeId) {
+          highlightedEdges.add(e.id);
+          highlightedNodes.add(e.source);
+          highlightedNodes.add(e.target);
+        }
+      }
+    } else if (hoveredEdgeId !== null) {
+      const hoveredEdge = edges.find((e) => e.id === hoveredEdgeId);
+      if (hoveredEdge) {
+        highlightedEdges.add(hoveredEdge.id);
+        highlightedNodes.add(hoveredEdge.source);
+        highlightedNodes.add(hoveredEdge.target);
+      }
+    }
+    return { nodes: highlightedNodes, edges: highlightedEdges };
+  }, [edges, hoveredNodeId, hoveredEdgeId]);
+
+  const hoverActive = hoveredNodeId !== null || hoveredEdgeId !== null;
+
   const { positioned, edgeLabelPositions } = useMemo(() => {
     if (!autoLayout) {
       // Preserve caller-supplied positions but still tag every node
@@ -565,10 +630,26 @@ export function FlowGraph({
 
   const decoratedNodes = useMemo(
     () =>
-      positioned.map((n) =>
-        selectedNodeId && n.id === selectedNodeId ? { ...n, selected: true } : n,
-      ),
-    [positioned, selectedNodeId],
+      positioned.map((n) => {
+        const isHovered = hoveredNodeId === n.id;
+        const isHighlighted = !isHovered && highlight.nodes.has(n.id);
+        const isDimmed = hoverActive && !isHovered && !isHighlighted;
+        // Spread node.data so we don't drop any caller-set fields
+        // (kind, label, runStatus, isCurrent, etc.). The three hover
+        // flags are stripped back to undefined when nothing is hovered
+        // so FsmNode's `=== true` checks render the un-highlighted
+        // baseline.
+        const nextData = {
+          ...n.data,
+          isHovered,
+          highlighted: isHighlighted,
+          dimmed: isDimmed,
+        } as FlowNodeData;
+        const withSelection =
+          selectedNodeId && n.id === selectedNodeId ? { ...n, selected: true } : n;
+        return { ...withSelection, data: nextData };
+      }),
+    [positioned, selectedNodeId, hoveredNodeId, hoverActive, highlight],
   );
 
   const showMiniMap = miniMap ?? nodes.length > 10;
@@ -578,10 +659,61 @@ export function FlowGraph({
   // on every render; the previous version put this useMemo after the
   // empty-graph early return, which threw when the same FlowGraph
   // flipped between 0 nodes and >0 nodes (Copilot finding on PR #57).
-  const decoratedEdges = useMemo(
-    () => decorateEdges(edges, edgeLabelPositions),
-    [edges, edgeLabelPositions],
-  );
+  const decoratedEdges = useMemo(() => {
+    const base = decorateEdges(edges, edgeLabelPositions);
+    return base.map((e) => {
+      const isHovered = hoveredEdgeId === e.id;
+      const isHighlighted = !isHovered && highlight.edges.has(e.id);
+      const isDimmed = hoverActive && !isHovered && !isHighlighted;
+      const nextData = {
+        ...(e.data ?? {}),
+        isHovered,
+        highlighted: isHighlighted,
+        dimmed: isDimmed,
+      };
+      // Boost the SVG stroke when the edge is the hover target or a
+      // 1-hop neighbour. FsmEdge owns label pill opacity / colour via
+      // nextData; the path's stroke-width lives on style and is set
+      // here because BaseEdge consumes it directly.
+      const baseStrokeWidth =
+        typeof (e.style as { strokeWidth?: number } | undefined)?.strokeWidth === 'number'
+          ? ((e.style as { strokeWidth?: number }).strokeWidth as number)
+          : 1.5;
+      const nextStrokeWidth = isHovered
+        ? Math.max(baseStrokeWidth, 2.5)
+        : isHighlighted
+        ? Math.max(baseStrokeWidth, 2)
+        : baseStrokeWidth;
+      const nextStyle = {
+        ...(e.style ?? {}),
+        strokeWidth: nextStrokeWidth,
+        opacity: isDimmed ? 0.3 : 1,
+        // The path doesn't need a CSS class hook for the transition —
+        // BaseEdge renders a plain <path>. xyflow applies CSS via
+        // style only, so we set the transition inline.
+        transition: 'opacity 150ms ease-out, stroke-width 150ms ease-out',
+      };
+      return { ...e, data: nextData, style: nextStyle };
+    });
+  }, [edges, edgeLabelPositions, hoveredEdgeId, hoverActive, highlight]);
+
+  // React Flow's onNodeMouseEnter / Leave fire with (event, node);
+  // collapse to just the id and clear any active edge hover so the two
+  // hover states stay mutually exclusive.
+  const onNodeMouseEnter = useCallback((_e: unknown, node: { id: string }) => {
+    setHoveredNodeId(node.id);
+    setHoveredEdgeId(null);
+  }, []);
+  const onNodeMouseLeave = useCallback(() => {
+    setHoveredNodeId(null);
+  }, []);
+  const onEdgeMouseEnter = useCallback((_e: unknown, edge: { id: string }) => {
+    setHoveredEdgeId(edge.id);
+    setHoveredNodeId(null);
+  }, []);
+  const onEdgeMouseLeave = useCallback(() => {
+    setHoveredEdgeId(null);
+  }, []);
 
   if (nodes.length === 0) {
     return (
@@ -658,6 +790,10 @@ export function FlowGraph({
         onEdgeClick={(_e, edge) =>
           onEdgeClick?.(edge.id, edge.data as Record<string, unknown> | undefined)
         }
+        onNodeMouseEnter={onNodeMouseEnter}
+        onNodeMouseLeave={onNodeMouseLeave}
+        onEdgeMouseEnter={onEdgeMouseEnter}
+        onEdgeMouseLeave={onEdgeMouseLeave}
       >
         {background ? (
           <Background

--- a/ui/src/components/FsmEdge.tsx
+++ b/ui/src/components/FsmEdge.tsx
@@ -65,6 +65,14 @@ export interface FsmEdgeData extends Record<string, unknown> {
    *  sibling labels on a fan-out from stacking on the same midpoint
    *  band even when dagre reserved distinct slack for each. */
   dagreLabel?: { x: number; y: number };
+  /** W23d 1-hop hover highlight. Set by FlowGraph while a hover is
+   *  active. `isHovered` is the edge the cursor is on; `highlighted`
+   *  is a 1-hop neighbour (an edge that shares an endpoint with the
+   *  hovered node); `dimmed` is set on every edge that's neither the
+   *  hover target nor in the highlighted set. */
+  isHovered?: boolean;
+  highlighted?: boolean;
+  dimmed?: boolean;
 }
 
 /**
@@ -209,7 +217,20 @@ export function FsmEdge(props: EdgeProps): JSX.Element {
               edge coordinates. nodrag/nopan stop xyflow from hijacking
               pointer events when the user hovers/clicks the label. */}
           <div
-            class="pointer-events-auto nodrag nopan"
+            class={[
+              'pointer-events-auto nodrag nopan',
+              // W23d 1-hop hover highlight. The edge's underlying SVG
+              // path opacity is set on its `style` from FlowGraph, but
+              // the label pill lives in the EdgeLabelRenderer portal
+              // and needs its own dimming class. The spec calls for
+              // the pill to stay at full opacity when the edge itself
+              // is hovered (so the predicate text remains readable
+              // while the operator is reading it). `isHovered` and
+              // `highlighted` both keep full opacity; only the
+              // dimmed-but-not-highlighted state fades.
+              'transition-opacity duration-150 motion-reduce:transition-none',
+              ed.dimmed && !ed.isHovered && !ed.highlighted ? 'opacity-30' : '',
+            ].join(' ')}
             // eslint-disable-next-line react/forbid-dom-props -- per-edge position is computed from getSmoothStepPath
             style={{
               position: 'absolute',

--- a/ui/src/components/__tests__/FlowGraph.test.tsx
+++ b/ui/src/components/__tests__/FlowGraph.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { cleanup, render } from '@testing-library/preact';
+import { act, cleanup, render } from '@testing-library/preact';
 
 // Mock @xyflow/react before importing FlowGraph.
 let lastReactFlowProps: Record<string, unknown> | null = null;
@@ -329,6 +329,183 @@ describe('FlowGraph', () => {
       sourceId: 'a',
       targetId: 'b',
     }));
+  });
+
+  describe('W23d 1-hop hover highlight', () => {
+    // Helper to build a small graph: a -> b -> c with a side branch d
+    // attached to b. This gives us a node (b) with TWO neighbours
+    // (a + c) plus one unrelated node (d when hovering a, or d only
+    // when nothing else is hovered). The graph stays small enough to
+    // assert exact sets without hand-counting.
+    const buildGraph = (): {
+      nodes: Node<FlowNodeData>[];
+      edges: Edge[];
+    } => ({
+      nodes: [
+        { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'a' } },
+        { id: 'b', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'b' } },
+        { id: 'c', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'c' } },
+        { id: 'd', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'd' } },
+      ],
+      edges: [
+        { id: 'a-b', source: 'a', target: 'b', label: 'first' },
+        { id: 'b-c', source: 'b', target: 'c', label: 'next' },
+        { id: 'a-d', source: 'a', target: 'd', label: 'side' },
+      ],
+    });
+
+    test('no hover: every node + edge renders un-dimmed and un-highlighted', () => {
+      const { nodes, edges } = buildGraph();
+      render(<FlowGraph nodes={nodes} edges={edges} autoLayout={false} />);
+      const decoratedNodes = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      const decoratedEdges = lastReactFlowProps!.edges as Array<
+        Edge & { data?: { dimmed?: boolean; highlighted?: boolean; isHovered?: boolean } }
+      >;
+      // Baseline: nothing dimmed, nothing highlighted, nothing hovered.
+      for (const n of decoratedNodes) {
+        expect(n.data.dimmed).toBe(false);
+        expect(n.data.highlighted).toBe(false);
+        expect(n.data.isHovered).toBe(false);
+      }
+      for (const e of decoratedEdges) {
+        expect(e.data?.dimmed).toBe(false);
+        expect(e.data?.highlighted).toBe(false);
+        expect(e.data?.isHovered).toBe(false);
+      }
+    });
+
+    test('hovering node "a" highlights a + its neighbours (b, d) + the connecting edges; dims c + b-c', () => {
+      const { nodes, edges } = buildGraph();
+      render(<FlowGraph nodes={nodes} edges={edges} autoLayout={false} />);
+      const onNodeMouseEnter = lastReactFlowProps!.onNodeMouseEnter as (
+        e: unknown,
+        node: { id: string },
+      ) => void;
+      act(() => {
+        onNodeMouseEnter({}, { id: 'a' });
+      });
+      const decoratedNodes = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      const decoratedEdges = lastReactFlowProps!.edges as Array<
+        Edge & { data?: { dimmed?: boolean; highlighted?: boolean; isHovered?: boolean } }
+      >;
+      const byId = Object.fromEntries(decoratedNodes.map((n) => [n.id, n]));
+      // a is THE hover target.
+      expect(byId.a.data.isHovered).toBe(true);
+      expect(byId.a.data.dimmed).toBe(false);
+      // b and d are 1-hop neighbours of a (via a-b and a-d).
+      expect(byId.b.data.highlighted).toBe(true);
+      expect(byId.b.data.dimmed).toBe(false);
+      expect(byId.d.data.highlighted).toBe(true);
+      expect(byId.d.data.dimmed).toBe(false);
+      // c is 2 hops away — must be dimmed.
+      expect(byId.c.data.highlighted).toBe(false);
+      expect(byId.c.data.dimmed).toBe(true);
+
+      const edgesById = Object.fromEntries(decoratedEdges.map((e) => [e.id, e]));
+      expect(edgesById['a-b'].data?.highlighted).toBe(true);
+      expect(edgesById['a-b'].data?.dimmed).toBe(false);
+      expect(edgesById['a-d'].data?.highlighted).toBe(true);
+      expect(edgesById['a-d'].data?.dimmed).toBe(false);
+      expect(edgesById['b-c'].data?.highlighted).toBe(false);
+      expect(edgesById['b-c'].data?.dimmed).toBe(true);
+    });
+
+    test('hovering edge "a-b" highlights the edge + its endpoints (a, b); dims c, d and the other edges', () => {
+      const { nodes, edges } = buildGraph();
+      render(<FlowGraph nodes={nodes} edges={edges} autoLayout={false} />);
+      const onEdgeMouseEnter = lastReactFlowProps!.onEdgeMouseEnter as (
+        e: unknown,
+        edge: { id: string },
+      ) => void;
+      act(() => {
+        onEdgeMouseEnter({}, { id: 'a-b' });
+      });
+      const decoratedNodes = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      const decoratedEdges = lastReactFlowProps!.edges as Array<
+        Edge & {
+          data?: { dimmed?: boolean; highlighted?: boolean; isHovered?: boolean };
+          style?: { strokeWidth?: number; opacity?: number };
+        }
+      >;
+      const nodeById = Object.fromEntries(decoratedNodes.map((n) => [n.id, n]));
+      // Endpoints of a-b stay full opacity and pick up the subtle ring
+      // signal via data.highlighted.
+      expect(nodeById.a.data.highlighted).toBe(true);
+      expect(nodeById.a.data.dimmed).toBe(false);
+      expect(nodeById.b.data.highlighted).toBe(true);
+      expect(nodeById.b.data.dimmed).toBe(false);
+      // c and d are not endpoints of a-b -> dimmed.
+      expect(nodeById.c.data.dimmed).toBe(true);
+      expect(nodeById.d.data.dimmed).toBe(true);
+
+      const edgeById = Object.fromEntries(decoratedEdges.map((e) => [e.id, e]));
+      expect(edgeById['a-b'].data?.isHovered).toBe(true);
+      expect(edgeById['a-b'].data?.dimmed).toBe(false);
+      // Hovered edge gets a thicker stroke.
+      expect(edgeById['a-b'].style?.strokeWidth).toBeGreaterThan(1.5);
+      expect(edgeById['a-b'].style?.opacity).toBe(1);
+      // Other edges fade and stay at baseline stroke.
+      expect(edgeById['a-d'].data?.dimmed).toBe(true);
+      expect(edgeById['a-d'].style?.opacity).toBe(0.3);
+      expect(edgeById['b-c'].data?.dimmed).toBe(true);
+      expect(edgeById['b-c'].style?.opacity).toBe(0.3);
+    });
+
+    test('node hover then leave returns to the un-hovered baseline', () => {
+      const { nodes, edges } = buildGraph();
+      render(<FlowGraph nodes={nodes} edges={edges} autoLayout={false} />);
+      const onNodeMouseEnter = lastReactFlowProps!.onNodeMouseEnter as (
+        e: unknown,
+        node: { id: string },
+      ) => void;
+      const onNodeMouseLeave = lastReactFlowProps!.onNodeMouseLeave as (
+        e: unknown,
+        node: { id: string },
+      ) => void;
+      act(() => {
+        onNodeMouseEnter({}, { id: 'a' });
+      });
+      // Confirm at least one node is dimmed mid-hover, then leave and
+      // confirm nothing is dimmed.
+      let decoratedNodes = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      expect(decoratedNodes.some((n) => n.data.dimmed === true)).toBe(true);
+      act(() => {
+        onNodeMouseLeave({}, { id: 'a' });
+      });
+      decoratedNodes = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      expect(decoratedNodes.every((n) => n.data.dimmed === false)).toBe(true);
+      expect(decoratedNodes.every((n) => n.data.highlighted === false)).toBe(true);
+      expect(decoratedNodes.every((n) => n.data.isHovered === false)).toBe(true);
+    });
+
+    test('entering an edge clears any active node hover (mutually exclusive)', () => {
+      const { nodes, edges } = buildGraph();
+      render(<FlowGraph nodes={nodes} edges={edges} autoLayout={false} />);
+      const onNodeMouseEnter = lastReactFlowProps!.onNodeMouseEnter as (
+        e: unknown,
+        node: { id: string },
+      ) => void;
+      const onEdgeMouseEnter = lastReactFlowProps!.onEdgeMouseEnter as (
+        e: unknown,
+        edge: { id: string },
+      ) => void;
+      act(() => {
+        onNodeMouseEnter({}, { id: 'a' });
+      });
+      act(() => {
+        onEdgeMouseEnter({}, { id: 'b-c' });
+      });
+      const decoratedNodes = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      const byId = Object.fromEntries(decoratedNodes.map((n) => [n.id, n]));
+      // Node hover should be cleared; only b + c (endpoints of b-c)
+      // are highlighted now.
+      expect(byId.a.data.isHovered).toBe(false);
+      expect(byId.a.data.highlighted).toBe(false);
+      expect(byId.a.data.dimmed).toBe(true);
+      expect(byId.b.data.highlighted).toBe(true);
+      expect(byId.c.data.highlighted).toBe(true);
+      expect(byId.d.data.dimmed).toBe(true);
+    });
   });
 
   test('default direction is TB (top-to-bottom) when not specified', () => {


### PR DESCRIPTION
Hovering a node highlights it + all connected edges + neighbor nodes (1-hop). Hovering an edge highlights the edge + its two endpoint nodes. Dims everything else. Applies to /specs and /runs/:id via FlowGraph.