### PR TITLE
feat(ui): useDebouncedRefetch hook + run-detail sheet openers (infra)

### DIFF
--- a/ui/src/lib/__tests__/runDetailSheets.test.tsx
+++ b/ui/src/lib/__tests__/runDetailSheets.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for lib/runDetailSheets.ts.
+ *
+ * Coverage:
+ *   - opener idempotency: opening the same admin sheet twice leaves the
+ *     stack at length 1 (the second call is a no-op).
+ *   - distinct openers stack correctly: admin then state then edge
+ *     yields a stack of length 3 in that order.
+ *   - URL fragment: rendering the SheetHost while the openers are used
+ *     mirrors the TOP sheet's id into ``?sheet=...`` on
+ *     ``window.location``.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+
+import {
+  adminSheetId,
+  edgeSheetId,
+  openAdminSheet,
+  openEdgeSheet,
+  openStateEntrySheet,
+  stateEntrySheetId,
+} from '../runDetailSheets';
+import { sheetStack } from '../store';
+import { SheetHost } from '../../chrome/SheetHost';
+
+beforeEach(() => {
+  sheetStack.value = [];
+  // Reset URL so query-param assertions start clean.
+  window.history.replaceState({}, '', 'http://localhost/');
+});
+
+afterEach(() => {
+  cleanup();
+  sheetStack.value = [];
+  window.history.replaceState({}, '', 'http://localhost/');
+});
+
+describe('runDetailSheets opener idempotency', () => {
+  test('opening the same admin sheet twice does not duplicate the entry', () => {
+    expect(sheetStack.value).toEqual([]);
+    openAdminSheet({ runId: 'run-1' });
+    openAdminSheet({ runId: 'run-1' });
+    expect(sheetStack.value.length).toBe(1);
+    expect(sheetStack.value[0].id).toBe(adminSheetId('run-1'));
+  });
+
+  test('opening the same state-entry sheet twice does not duplicate', () => {
+    openStateEntrySheet({ entryId: 'evt-42', runId: 'run-1' });
+    openStateEntrySheet({ entryId: 'evt-42', runId: 'run-1' });
+    expect(sheetStack.value.length).toBe(1);
+    expect(sheetStack.value[0].id).toBe(stateEntrySheetId('evt-42'));
+  });
+
+  test('opening the same edge sheet twice does not duplicate', () => {
+    openEdgeSheet({ runId: 'run-1', fromStateId: 'a', toStateId: 'b' });
+    openEdgeSheet({ runId: 'run-1', fromStateId: 'a', toStateId: 'b' });
+    expect(sheetStack.value.length).toBe(1);
+    expect(sheetStack.value[0].id).toBe(edgeSheetId('a', 'b'));
+  });
+
+  test('reverse-direction edge is a DIFFERENT sheet', () => {
+    openEdgeSheet({ runId: 'run-1', fromStateId: 'a', toStateId: 'b' });
+    openEdgeSheet({ runId: 'run-1', fromStateId: 'b', toStateId: 'a' });
+    expect(sheetStack.value.length).toBe(2);
+  });
+
+  test('opener returns the resolved sheet id', () => {
+    const id = openAdminSheet({ runId: 'run-9' });
+    expect(id).toBe(adminSheetId('run-9'));
+  });
+});
+
+describe('runDetailSheets stacking', () => {
+  test('admin then state then edge stack to length 3 in order', () => {
+    openAdminSheet({ runId: 'run-1' });
+    openStateEntrySheet({ entryId: 'evt-42', runId: 'run-1' });
+    openEdgeSheet({ runId: 'run-1', fromStateId: 'a', toStateId: 'b' });
+    expect(sheetStack.value.length).toBe(3);
+    expect(sheetStack.value.map((e) => e.id)).toEqual([
+      adminSheetId('run-1'),
+      stateEntrySheetId('evt-42'),
+      edgeSheetId('a', 'b'),
+    ]);
+  });
+});
+
+describe('runDetailSheets URL fragment mirroring (via SheetHost)', () => {
+  test('TOP sheet id appears in ?sheet= when SheetHost is mounted', () => {
+    openAdminSheet({ runId: 'run-1' });
+    render(<SheetHost />);
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get('sheet')).toBe(adminSheetId('run-1'));
+  });
+
+  test('mirrors the TOP sheet id when multiple sheets are stacked', () => {
+    openAdminSheet({ runId: 'run-1' });
+    openStateEntrySheet({ entryId: 'evt-42', runId: 'run-1' });
+    render(<SheetHost />);
+    const url = new URL(window.location.href);
+    expect(url.searchParams.get('sheet')).toBe(stateEntrySheetId('evt-42'));
+  });
+});

--- a/ui/src/lib/__tests__/useDebouncedRefetch.test.tsx
+++ b/ui/src/lib/__tests__/useDebouncedRefetch.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tests for lib/useDebouncedRefetch.ts.
+ *
+ * Coverage:
+ *   - Idle window: bursty triggers collapse to one fire 200ms after the
+ *     LAST trigger.
+ *   - Max-wait safety net: sustained triggers (every 100ms) still fire
+ *     at the 1000ms mark.
+ *   - Unmount cancels a pending fire.
+ *   - flush() fires immediately and clears timers (so the wait timer
+ *     does not double-fire afterwards).
+ *   - cancel() drops the pending fire without invoking fn.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { renderHook } from '@testing-library/preact';
+
+import { useDebouncedRefetch } from '../useDebouncedRefetch';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useDebouncedRefetch', () => {
+  test('fires once per 200ms idle window', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    result.current.trigger();
+    result.current.trigger();
+    result.current.trigger();
+    expect(fn).not.toHaveBeenCalled();
+
+    // Just before the window expires: still nothing.
+    vi.advanceTimersByTime(199);
+    expect(fn).not.toHaveBeenCalled();
+
+    // At the 200ms mark: a single fire for the whole burst.
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('every new trigger resets the wait window', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    result.current.trigger();
+    vi.advanceTimersByTime(150);
+    result.current.trigger();
+    vi.advanceTimersByTime(150);
+    // 300ms elapsed total, but never 200ms of idleness — still no fire.
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(200);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('max-wait 1000ms forces a fire even under a sustained 100ms-cadence burst', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    // 9 triggers spaced 100ms apart — at t=900ms total. The wait-timer
+    // never gets to expire because each trigger arrives before 200ms
+    // of idleness; but the maxWait safety net (armed at t=0) must fire
+    // at t=1000.
+    for (let i = 0; i < 9; i += 1) {
+      result.current.trigger();
+      vi.advanceTimersByTime(100);
+    }
+    expect(fn).not.toHaveBeenCalled();
+
+    // Advance past the 1000ms ceiling counted from the first trigger.
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('unmount cancels a pending fire', () => {
+    const fn = vi.fn();
+    const { result, unmount } = renderHook(() => useDebouncedRefetch(fn));
+
+    result.current.trigger();
+    unmount();
+    vi.advanceTimersByTime(5000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('flush() fires immediately and clears timers (no double fire)', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    result.current.trigger();
+    result.current.flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // The wait timer must have been cleared — advancing past 200ms
+    // would otherwise produce a second fire.
+    vi.advanceTimersByTime(1500);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('flush() with nothing pending is a no-op', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    result.current.flush();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('cancel() drops the pending fire without invoking fn', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    result.current.trigger();
+    result.current.cancel();
+    vi.advanceTimersByTime(2000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test('honours custom wait + maxWait options', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() =>
+      useDebouncedRefetch(fn, { wait: 50, maxWait: 300 }),
+    );
+
+    result.current.trigger();
+    vi.advanceTimersByTime(49);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/runDetailSheets.ts
+++ b/ui/src/lib/runDetailSheets.ts
@@ -1,0 +1,116 @@
+/**
+ * Openers for the three run-detail inspection sheets — state-entry,
+ * edge, and admin. Each opener computes a stable id from its payload
+ * and short-circuits if a sheet with that id is already on the stack.
+ *
+ * Why these live in a dedicated module rather than each call site
+ * inlining ``openSheet({...})``:
+ *
+ *   - The id-shape contract (``state:<entryId>``, ``edge:<from>-<to>``,
+ *     ``admin:<runId>``) is shared by the run graph nodes, the journal
+ *     row context menu, and the run-detail header buttons. A single
+ *     authoritative computation prevents two call sites from producing
+ *     mismatched ids that look the same to a user but stack twice.
+ *   - The dedup semantics (skip when an entry with the same id is
+ *     already present) belong with the opener, not the global
+ *     ``openSheet`` mutator. Other sheets — Brief, command palette
+ *     detail panels — deliberately allow multiple stacked copies, so
+ *     the store cannot bake dedup in unconditionally.
+ *
+ * The opener returns the resolved sheet id so callers can mirror it
+ * to a URL fragment or focus the corresponding aside imperatively
+ * without re-deriving the string.
+ */
+
+import { openSheet, sheetStack, type SheetEntry } from './store';
+
+export interface StateEntrySheetPayload {
+  entryId: string;
+  runId: string;
+  title?: string;
+  /** Optional pre-built body. Defaults to ``null`` — the SheetHost
+   * tolerates a null body (renders an empty panel) so infra tests can
+   * exercise stacking without pulling in the inspector component. */
+  content?: SheetEntry['content'];
+}
+
+export interface EdgeSheetPayload {
+  runId: string;
+  fromStateId: string;
+  toStateId: string;
+  title?: string;
+  content?: SheetEntry['content'];
+}
+
+export interface AdminSheetPayload {
+  runId: string;
+  title?: string;
+  content?: SheetEntry['content'];
+}
+
+/** Stable id for a state-entry sheet. */
+export function stateEntrySheetId(entryId: string): string {
+  return `state:${entryId}`;
+}
+
+/** Stable id for an edge sheet (direction-sensitive). */
+export function edgeSheetId(fromStateId: string, toStateId: string): string {
+  return `edge:${fromStateId}-${toStateId}`;
+}
+
+/** Stable id for the admin sheet of a given run. */
+export function adminSheetId(runId: string): string {
+  return `admin:${runId}`;
+}
+
+/**
+ * Push ``entry`` onto the sheet stack ONLY if no entry with the same
+ * id is already present. Returns the resolved id either way so the
+ * caller can chain a "scroll into view" or URL-mirror without
+ * branching on whether the open was a no-op.
+ *
+ * Idempotency rule: the FIRST opener wins. A second opener with the
+ * same id is a no-op — we do not re-order the stack and we do not
+ * replace the existing entry's title or body. This is the contract
+ * the run graph relies on: rapidly hover-clicking the same node must
+ * not flash the panel.
+ */
+function pushUnique(entry: SheetEntry): string {
+  const exists = sheetStack.value.some((e) => e.id === entry.id);
+  if (!exists) openSheet(entry);
+  return entry.id;
+}
+
+export function openStateEntrySheet(payload: StateEntrySheetPayload): string {
+  const id = stateEntrySheetId(payload.entryId);
+  return pushUnique({
+    id,
+    title: payload.title ?? `State entry ${payload.entryId}`,
+    width: 'right-third',
+    content: payload.content ?? null,
+    urlFragment: id,
+  });
+}
+
+export function openEdgeSheet(payload: EdgeSheetPayload): string {
+  const id = edgeSheetId(payload.fromStateId, payload.toStateId);
+  return pushUnique({
+    id,
+    title:
+      payload.title ?? `Edge ${payload.fromStateId} → ${payload.toStateId}`,
+    width: 'right-third',
+    content: payload.content ?? null,
+    urlFragment: id,
+  });
+}
+
+export function openAdminSheet(payload: AdminSheetPayload): string {
+  const id = adminSheetId(payload.runId);
+  return pushUnique({
+    id,
+    title: payload.title ?? `Run admin · ${payload.runId}`,
+    width: 'right-half',
+    content: payload.content ?? null,
+    urlFragment: id,
+  });
+}

--- a/ui/src/lib/useDebouncedRefetch.ts
+++ b/ui/src/lib/useDebouncedRefetch.ts
@@ -1,0 +1,107 @@
+/**
+ * useDebouncedRefetch — coalesces high-frequency refetch triggers into a
+ * single bounded-latency call to ``fn``.
+ *
+ * Why a hook (rather than a plain ``debounce(fn, 200)`` utility):
+ *
+ *   - The run-detail view subscribes to an SSE firehose and wants to
+ *     refetch lists / topology / counters on every event burst. Naive
+ *     debounce starves the user under a sustained burst because every
+ *     new event resets the timer. We add a ``maxWait`` so the user
+ *     sees fresh data at least once per second even when events keep
+ *     arriving every 50ms.
+ *   - The hook owns the timer ids in refs that are cleared on unmount
+ *     so route changes don't leave a pending ``fn`` firing into an
+ *     unmounted tree. A free function debounce would leak.
+ *
+ * Defaults — ``wait=200ms`` matches the prefs-persistence debounce
+ * already used in ``store.ts`` (consistent perceived latency across the
+ * dashboard). ``maxWait=1000ms`` is the upper bound a user notices as
+ * "live" vs. "lagging".
+ */
+
+import { useEffect, useRef } from 'preact/hooks';
+
+export interface UseDebouncedRefetchOptions {
+  /** Reset-on-trigger window in ms. Default 200. */
+  wait?: number;
+  /** Hard upper bound between the first queued trigger and a fire. Default 1000. */
+  maxWait?: number;
+}
+
+export interface UseDebouncedRefetchHandle {
+  /** Queue a refetch. Subsequent calls within ``wait`` reset the timer. */
+  trigger: () => void;
+  /** Fire ``fn`` immediately if anything is pending and clear timers. */
+  flush: () => void;
+  /** Drop any pending fire without invoking ``fn``. */
+  cancel: () => void;
+}
+
+export function useDebouncedRefetch<T>(
+  fn: () => Promise<T> | T | void,
+  opts: UseDebouncedRefetchOptions = {},
+): UseDebouncedRefetchHandle {
+  const wait = opts.wait ?? 200;
+  const maxWait = opts.maxWait ?? 1000;
+
+  const waitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const maxTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firstQueuedAt = useRef<number | null>(null);
+  // Hold the latest ``fn`` in a ref so a stale closure from an earlier
+  // render is never invoked — callers commonly pass a fresh arrow on
+  // every render.
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  const clearTimers = (): void => {
+    if (waitTimer.current != null) {
+      clearTimeout(waitTimer.current);
+      waitTimer.current = null;
+    }
+    if (maxTimer.current != null) {
+      clearTimeout(maxTimer.current);
+      maxTimer.current = null;
+    }
+    firstQueuedAt.current = null;
+  };
+
+  const fire = (): void => {
+    clearTimers();
+    void fnRef.current();
+  };
+
+  const trigger = (): void => {
+    if (firstQueuedAt.current == null) {
+      firstQueuedAt.current = Date.now();
+      // Arm the maxWait safety net only on the first queued trigger of
+      // a burst; subsequent triggers within the burst leave it alone.
+      maxTimer.current = setTimeout(fire, maxWait);
+    }
+    if (waitTimer.current != null) clearTimeout(waitTimer.current);
+    waitTimer.current = setTimeout(fire, wait);
+  };
+
+  const flush = (): void => {
+    if (firstQueuedAt.current == null) {
+      // Nothing pending — flush is a no-op so callers can safely call
+      // it from cleanup paths without guarding.
+      return;
+    }
+    fire();
+  };
+
+  const cancel = (): void => {
+    clearTimers();
+  };
+
+  // Cleanup on unmount: drop any pending fire so the component cannot
+  // refetch into a torn-down tree.
+  useEffect(() => {
+    return () => {
+      clearTimers();
+    };
+  }, []);
+
+  return { trigger, flush, cancel };
+}


### PR DESCRIPTION
## Summary
- Adds `ui/src/lib/useDebouncedRefetch.ts`: a Preact hook that coalesces bursty refetch triggers with a configurable `wait` (default 200ms) and a `maxWait` safety net (default 1000ms) so the user is never starved under a sustained SSE event burst. Exposes `trigger / flush / cancel` and clears timers on unmount.
- Adds `ui/src/lib/runDetailSheets.ts`: three openers — `openStateEntrySheet`, `openEdgeSheet`, `openAdminSheet` — with stable id shapes (`state:<entryId>`, `edge:<from>-<to>`, `admin:<runId>`). Each opener is idempotent: a second open with the same id is a no-op, matching the inspector contract the run graph relies on. Returns the resolved id so callers can mirror it to a URL fragment.
- Pure infra only — no UI is wired to either module yet. Both are covered by unit tests against the live store signals + a brief `SheetHost` mount for the URL-fragment assertion.

This is PR 2 of 7, branched off PR 1 (`12e7d8f` / #80). No call sites in existing components are modified.

## Test plan
- [x] `npm run build` (tsc -b + vite build) — passes
- [x] `npm test` — 36 files, 409 tests pass (16 new across `useDebouncedRefetch.test.tsx` and `runDetailSheets.test.tsx`)
- [x] Idle-window debounce, max-wait safety net, unmount cancellation, flush idempotency
- [x] Sheet opener idempotency (state / edge / admin), reverse-direction edge produces a distinct sheet, distinct openers stack, top-sheet URL mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)