### PR TITLE
feat(ui): AdminSheetBody + 6 collapsible sections + Admin header button

### DIFF
--- a/ui/src/routes/runDetail.tsx
+++ b/ui/src/routes/runDetail.tsx
@@ -84,11 +84,35 @@ import {
   type Event as FsmEvent,
   type JsonObject,
   type RunDetail,
+  type RunManifest,
   type SpecDetail,
   type StateNode,
   type ToolCall,
 } from '../lib/api';
+import { openSheet } from '../lib/store';
 import { EventStream } from '../lib/sse';
+import { AdminSheetBody } from './runDetail/AdminSheetBody';
+
+/**
+ * Helper: open the run-admin sheet for ``runId``.
+ *
+ * Exposed as a route-local function so the header button stays a thin
+ * onClick handler and the SheetHost contract (``{ id, title, content }``)
+ * lives next to the body component it routes to.
+ */
+export function openAdminSheet(params: {
+  runId: string;
+  manifest: RunManifest;
+}): void {
+  const { runId, manifest } = params;
+  openSheet({
+    id: `admin:${runId}`,
+    title: 'Run admin',
+    width: 'right-half',
+    urlFragment: `admin-${runId}`,
+    content: <AdminSheetBody runId={runId} manifest={manifest} />,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Formatting helpers
@@ -755,6 +779,19 @@ export function RunDetailRoute(): JSX.Element {
             onClick={() => setPendingAction({ kind: 'journal-replay' })}
           >
             Replay journal
+          </Button>
+          {/* W?? — admin sheet trigger. The existing right-column Admin
+              Card stays during this PR so operators have both surfaces
+              simultaneously; a follow-up PR removes the inline card
+              once the sheet has soaked. */}
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() =>
+              openAdminSheet({ runId: manifest.id, manifest })
+            }
+          >
+            Admin
           </Button>
         </div>
       </header>

--- a/ui/src/routes/runDetail/AdminSheetBody.tsx
+++ b/ui/src/routes/runDetail/AdminSheetBody.tsx
@@ -1,0 +1,58 @@
+/**
+ * Body component for the run-detail Admin sheet.
+ *
+ * Rendered inside :class:`SheetHost` when the operator opens the
+ * "Admin" button in the run-detail header. The body is a vertical
+ * stack of six :class:`CollapsibleSection` panels — Journal, Lock,
+ * Drift, Commit signatures, Allowed tools, Tool calls — each a
+ * self-contained component that owns its own initial fetch + state.
+ *
+ * Why each section owns its own fetch (rather than this body driving
+ * a single ``Promise.allSettled``):
+ *   - one slow endpoint should not block the others from rendering;
+ *   - the planned PR 6 SSE-debounced refetch is per-section (the same
+ *     channel never refreshes every panel simultaneously);
+ *   - bodies are easier to unit-test in isolation when state is local.
+ *
+ * The existing right-column Admin Card on /runs/:id is NOT removed in
+ * this PR — operators have both surfaces simultaneously so nothing
+ * breaks during rollout. PR 4 (or later) deletes the inline card once
+ * the sheet has soaked.
+ */
+
+import type { JSX } from 'preact';
+
+import type { RunManifest } from '../../lib/api';
+import { JournalSection } from './admin/JournalSection';
+import { LockSection } from './admin/LockSection';
+import { DriftSection } from './admin/DriftSection';
+import { SignaturesSection } from './admin/SignaturesSection';
+import { AllowedToolsSection } from './admin/AllowedToolsSection';
+import { ToolCallsSection } from './admin/ToolCallsSection';
+
+export interface AdminSheetBodyProps {
+  runId: string;
+  manifest: RunManifest;
+}
+
+export function AdminSheetBody({
+  runId,
+  manifest,
+}: AdminSheetBodyProps): JSX.Element {
+  return (
+    <div
+      class="flex flex-col gap-3"
+      data-testid="admin-sheet-body"
+      data-run-id={runId}
+    >
+      <JournalSection runId={runId} />
+      <LockSection runId={runId} />
+      <DriftSection runId={runId} />
+      <SignaturesSection runId={runId} />
+      <AllowedToolsSection manifest={manifest} />
+      <ToolCallsSection runId={runId} />
+    </div>
+  );
+}
+
+export default AdminSheetBody;

--- a/ui/src/routes/runDetail/admin/AllowedToolsSection.tsx
+++ b/ui/src/routes/runDetail/admin/AllowedToolsSection.tsx
@@ -1,0 +1,139 @@
+/**
+ * Admin-sheet section: allowed_tools surfaced by the current state.
+ *
+ * Derives the list from ``manifest.current_state`` by fetching the
+ * spec (lazily, once) and probing its state map for an
+ * ``allowed_tools`` / ``tools`` / ``allowedTools`` array under the
+ * current state. Falling back across key variants keeps the section
+ * tolerant of W12-substrate naming differences (the same probe pattern
+ * runDetail.tsx uses against StateNode payloads).
+ *
+ * When the manifest has no current_state (run hasn't entered any state
+ * yet, or has terminated), the section renders a "not surfaced" hint
+ * rather than fetching a spec it won't index.
+ */
+
+import type { JSX } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+
+import {
+  EmptyState,
+  Pill,
+  Spinner,
+} from '../../../components';
+import {
+  api,
+  ApiError,
+  type RunManifest,
+  type SpecDetail,
+} from '../../../lib/api';
+import { CollapsibleSection } from './CollapsibleSection';
+
+const KEYS = ['allowed_tools', 'allowedTools', 'tools', 'tool_allowlist'];
+
+function extractAllowedToolsForState(
+  spec: SpecDetail | null,
+  stateId: string | null,
+): string[] | null {
+  if (!spec || !stateId) return null;
+  const def = spec.definition as Record<string, unknown> | undefined;
+  if (!def) return null;
+  const states = def.states as Record<string, unknown> | undefined;
+  if (!states) return null;
+  const node = states[stateId] as Record<string, unknown> | undefined;
+  if (!node) return null;
+  for (const key of KEYS) {
+    const value = node[key];
+    if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+      return value as string[];
+    }
+  }
+  return null;
+}
+
+export interface AllowedToolsSectionProps {
+  manifest: RunManifest;
+}
+
+export function AllowedToolsSection({
+  manifest,
+}: AllowedToolsSectionProps): JSX.Element {
+  const [spec, setSpec] = useState<SpecDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSpec(null);
+    setError(null);
+    setLoading(true);
+    api
+      .getSpec(manifest.fsm_spec_id)
+      .then((s) => {
+        if (cancelled) return;
+        setSpec(s);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof ApiError ? err.message : String(err));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [manifest.fsm_spec_id]);
+
+  const allowed = useMemo(
+    () => extractAllowedToolsForState(spec, manifest.current_state),
+    [spec, manifest.current_state],
+  );
+
+  const trailing = allowed ? (
+    <Pill variant="neutral" size="sm">
+      {allowed.length}
+    </Pill>
+  ) : undefined;
+
+  return (
+    <CollapsibleSection
+      id="admin-allowed-tools"
+      title={
+        manifest.current_state
+          ? `Allowed tools (${manifest.current_state})`
+          : 'Allowed tools'
+      }
+      trailing={trailing}
+    >
+      {error ? (
+        <EmptyState title="Failed to load spec" message={error} />
+      ) : loading ? (
+        <Spinner label="Loading allowed tools" />
+      ) : !manifest.current_state ? (
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          Run has no current state — allow-list not applicable.
+        </p>
+      ) : allowed === null ? (
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          Not surfaced by the current state's spec entry.
+        </p>
+      ) : allowed.length === 0 ? (
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          Allow-list is empty — no tools are permitted.
+        </p>
+      ) : (
+        <ul class="flex flex-wrap gap-1.5">
+          {allowed.map((tool) => (
+            <li key={tool}>
+              <Pill variant="neutral" size="sm">
+                {tool}
+              </Pill>
+            </li>
+          ))}
+        </ul>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+export default AllowedToolsSection;

--- a/ui/src/routes/runDetail/admin/CollapsibleSection.tsx
+++ b/ui/src/routes/runDetail/admin/CollapsibleSection.tsx
@@ -1,0 +1,99 @@
+/**
+ * Small accordion primitive shared by the admin sheet's six sections.
+ *
+ * The right-column Admin Card on /runs/:id renders its sections inline
+ * with fixed-weight headings; in the sheet we want the same Card chrome
+ * but with an expand/collapse toggle so the operator can scan a long
+ * stack and only open the one they care about. Native ``<details>``
+ * would also work, but the surrounding chrome (Pill counts, error
+ * pills, focus styles) is easier to compose with our own button than
+ * with the disclosure widget's restricted styling surface.
+ *
+ * The header button is keyboard-friendly (Enter / Space toggle) and the
+ * caret rotates 90° on open so the visual state matches the aria one.
+ * When ``defaultOpen`` is true, the section mounts already expanded —
+ * pass it for the section the operator is most likely to inspect first
+ * (the run-scoped journal txn).
+ */
+
+import type { ComponentChildren, JSX, VNode } from 'preact';
+import { useCallback, useState } from 'preact/hooks';
+
+export interface CollapsibleSectionProps {
+  /** Stable id; used as the aria-controls target for the disclosure. */
+  id: string;
+  /** Heading text (or a VNode for a Pill-decorated label). */
+  title: ComponentChildren;
+  /** Optional right-aligned slot (e.g. row count Pill or refresh button). */
+  trailing?: VNode;
+  /** Body — only rendered when expanded so child fetches don't fire
+   *  until the operator opens the section. */
+  children: ComponentChildren;
+  /** Expanded on first mount. Default ``false``. */
+  defaultOpen?: boolean;
+}
+
+export function CollapsibleSection({
+  id,
+  title,
+  trailing,
+  children,
+  defaultOpen = false,
+}: CollapsibleSectionProps): JSX.Element {
+  const [open, setOpen] = useState<boolean>(defaultOpen);
+  const onToggle = useCallback(() => setOpen((v) => !v), []);
+
+  const panelId = `${id}-panel`;
+  const headerId = `${id}-header`;
+
+  return (
+    <section
+      class="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+      aria-labelledby={headerId}
+    >
+      <button
+        type="button"
+        id={headerId}
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-controls={panelId}
+        class="w-full flex items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-slate-900 dark:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-emerald-500 rounded-xl"
+      >
+        <span class="flex items-center gap-2 min-w-0 truncate">
+          <span
+            aria-hidden="true"
+            class={[
+              'inline-flex items-center justify-center w-4 h-4 shrink-0',
+              'text-slate-400 dark:text-slate-500',
+              'motion-safe:transition-transform',
+              open ? 'rotate-90' : '',
+            ].join(' ')}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              class="w-3 h-3"
+            >
+              <path d="M6 3.5L10.5 8 6 12.5V3.5z" />
+            </svg>
+          </span>
+          <span class="truncate">{title}</span>
+        </span>
+        {trailing ? <span class="shrink-0">{trailing}</span> : null}
+      </button>
+      {open ? (
+        <div
+          id={panelId}
+          role="region"
+          aria-labelledby={headerId}
+          class="border-t border-slate-200 dark:border-slate-700 px-3 py-3 text-sm"
+        >
+          {children}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export default CollapsibleSection;

--- a/ui/src/routes/runDetail/admin/DriftSection.tsx
+++ b/ui/src/routes/runDetail/admin/DriftSection.tsx
@@ -1,0 +1,136 @@
+/**
+ * Admin-sheet section: drift score + individual signals for this run.
+ *
+ * Mirrors the gauge already rendered in the right-column Admin Card on
+ * /runs/:id, plus a list of the underlying signals so an operator can
+ * see WHICH ones contributed when the aggregate score crosses the
+ * danger threshold. The gauge lives here as a local helper (not yet
+ * exported from components/) so this section is self-contained until
+ * PR 1's shared DriftGauge lands on this branch.
+ */
+
+import type { JSX } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+import {
+  EmptyState,
+  Pill,
+  Spinner,
+} from '../../../components';
+import { api, ApiError, type DriftSignalsResponse } from '../../../lib/api';
+import { CollapsibleSection } from './CollapsibleSection';
+
+/** Visual gauge for a drift score in the ``[0, 1]`` band. */
+function DriftGauge({ score }: { score: number }): JSX.Element {
+  const clamped = Math.max(0, Math.min(1, score));
+  const pct = Math.round(clamped * 100);
+  const tone =
+    clamped >= 0.7
+      ? 'bg-red-500'
+      : clamped >= 0.4
+      ? 'bg-amber-500'
+      : 'bg-emerald-500';
+  return (
+    <div class="space-y-1">
+      <div class="flex items-baseline justify-between text-xs text-slate-500 dark:text-slate-400">
+        <span>Drift score</span>
+        <span class="font-mono text-slate-700 dark:text-slate-200">
+          {clamped.toFixed(3)}
+        </span>
+      </div>
+      <div
+        class="h-2 w-full rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden"
+        role="progressbar"
+        aria-label="Drift score"
+        aria-valuemin={0}
+        aria-valuemax={1}
+        aria-valuenow={clamped}
+      >
+        <div
+          class={`h-full ${tone} motion-safe:transition-[width] motion-safe:duration-300`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export interface DriftSectionProps {
+  runId: string;
+}
+
+export function DriftSection({ runId }: DriftSectionProps): JSX.Element {
+  const [drift, setDrift] = useState<DriftSignalsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDrift(null);
+    setError(null);
+    setLoaded(false);
+    api
+      .listDriftSignals(runId)
+      .then((res) => {
+        if (cancelled) return;
+        setDrift(res);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof ApiError ? err.message : String(err));
+        setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  const trailing = drift ? (
+    <Pill variant="neutral" size="sm">
+      {drift.signals.length}
+    </Pill>
+  ) : undefined;
+
+  return (
+    <CollapsibleSection id="admin-drift" title="Drift" trailing={trailing}>
+      {error ? (
+        <EmptyState title="Failed to load drift signals" message={error} />
+      ) : !loaded ? (
+        <Spinner label="Loading drift" />
+      ) : !drift ? (
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          Drift score unavailable.
+        </p>
+      ) : (
+        <div class="space-y-3">
+          <DriftGauge score={drift.score} />
+          {drift.signals.length === 0 ? (
+            <p class="text-xs text-slate-500 dark:text-slate-400">
+              No signals recorded.
+            </p>
+          ) : (
+            <ul class="space-y-1.5">
+              {drift.signals.map((s) => (
+                <li
+                  key={s.id}
+                  class="flex flex-wrap items-baseline gap-2 text-xs text-slate-600 dark:text-slate-300"
+                >
+                  <Pill variant="warning" size="sm">
+                    {s.signal_kind}
+                  </Pill>
+                  <span class="font-mono">weight {s.weight.toFixed(2)}</span>
+                  <code class="font-mono text-slate-500 dark:text-slate-400">
+                    {s.producer_id}
+                  </code>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+export default DriftSection;

--- a/ui/src/routes/runDetail/admin/JournalSection.tsx
+++ b/ui/src/routes/runDetail/admin/JournalSection.tsx
@@ -1,0 +1,130 @@
+/**
+ * Admin-sheet section: journal txns for this run.
+ *
+ * The `/admin/journal_txns` endpoint does not yet accept a ``run_id``
+ * filter (see ``ListJournalTxnsParams`` in lib/api.ts — only ``status``
+ * is plumbed through). We page through a generously-sized response and
+ * filter client-side so the section can render a run-scoped subset
+ * today without waiting on a server change. Volume is bounded by the
+ * MAX_PAGE_SIZE cap on the server (200).
+ *
+ * Each row mirrors the inline journal block in the existing
+ * right-column Admin Card (status Pill, staged-write count, started_at
+ * timestamp) plus a JsonViewer for the staged writes payload so an
+ * operator can inspect what the engine is about to replay.
+ */
+
+import type { JSX } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+import {
+  EmptyState,
+  JsonViewer,
+  Pill,
+  Spinner,
+  type PillVariant,
+} from '../../../components';
+import { api, ApiError, type JournalTxn } from '../../../lib/api';
+import { CollapsibleSection } from './CollapsibleSection';
+
+const JOURNAL_VARIANTS: Record<string, PillVariant> = {
+  pending: 'warning',
+  ready_to_finalise: 'info',
+  finalised: 'success',
+};
+
+function variantForJournal(status: string): PillVariant {
+  return JOURNAL_VARIANTS[status.toLowerCase()] ?? 'neutral';
+}
+
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? (iso ?? '—') : d.toLocaleString();
+}
+
+export interface JournalSectionProps {
+  runId: string;
+}
+
+export function JournalSection({ runId }: JournalSectionProps): JSX.Element {
+  const [txns, setTxns] = useState<JournalTxn[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setTxns(null);
+    setError(null);
+    api
+      .listJournalTxns({ page_size: 200 })
+      .then((page) => {
+        if (cancelled) return;
+        setTxns(page.items.filter((t) => t.run_id === runId));
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof ApiError ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  const count = txns?.length ?? 0;
+  const trailing =
+    txns === null ? undefined : (
+      <Pill variant="neutral" size="sm">
+        {count}
+      </Pill>
+    );
+
+  return (
+    <CollapsibleSection
+      id="admin-journal"
+      title="Journal"
+      trailing={trailing}
+      defaultOpen={true}
+    >
+      {error ? (
+        <EmptyState title="Failed to load journal" message={error} />
+      ) : txns === null ? (
+        <Spinner label="Loading journal" />
+      ) : txns.length === 0 ? (
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          No journal txns recorded for this run.
+        </p>
+      ) : (
+        <ul class="space-y-3">
+          {txns.map((txn) => (
+            <li
+              key={txn.id}
+              class="rounded-md border border-slate-200 dark:border-slate-700 px-3 py-2 space-y-1"
+            >
+              <div class="flex flex-wrap items-baseline gap-2">
+                <Pill variant={variantForJournal(txn.status)} size="sm">
+                  {txn.status}
+                </Pill>
+                <span class="text-xs font-mono text-slate-500 dark:text-slate-400">
+                  {txn.staged_writes.length} staged write
+                  {txn.staged_writes.length === 1 ? '' : 's'}
+                </span>
+                <span class="text-xs text-slate-500 dark:text-slate-400">
+                  started {formatTimestamp(txn.started_at)}
+                </span>
+              </div>
+              <JsonViewer
+                value={{ staged_writes: txn.staged_writes }}
+                rootLabel="staged_writes"
+                mode="inline"
+                maxInlineHeight="max-h-40"
+                ariaLabel={`Staged writes for journal txn ${txn.id}`}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+export default JournalSection;

--- a/ui/src/routes/runDetail/admin/LockSection.tsx
+++ b/ui/src/routes/runDetail/admin/LockSection.tsx
@@ -1,0 +1,99 @@
+/**
+ * Admin-sheet section: lock rows for this run.
+ *
+ * The /admin/locks endpoint returns every currently-held lock; this
+ * section filters client-side to the rows whose run_id matches the
+ * inspected run so an operator sees only the locks they can act on
+ * from this surface.
+ */
+
+import type { JSX } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+import {
+  EmptyState,
+  Pill,
+  Spinner,
+} from '../../../components';
+import { api, ApiError, type Lock } from '../../../lib/api';
+import { CollapsibleSection } from './CollapsibleSection';
+
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? (iso ?? '—') : d.toLocaleString();
+}
+
+export interface LockSectionProps {
+  runId: string;
+}
+
+export function LockSection({ runId }: LockSectionProps): JSX.Element {
+  const [locks, setLocks] = useState<Lock[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLocks(null);
+    setError(null);
+    api
+      .listLocks({ page_size: 200 })
+      .then((page) => {
+        if (cancelled) return;
+        setLocks(page.items.filter((l) => l.run_id === runId));
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof ApiError ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  const count = locks?.length ?? 0;
+  const trailing =
+    locks === null ? undefined : (
+      <Pill variant="neutral" size="sm">
+        {count}
+      </Pill>
+    );
+
+  return (
+    <CollapsibleSection id="admin-lock" title="Lock" trailing={trailing}>
+      {error ? (
+        <EmptyState title="Failed to load locks" message={error} />
+      ) : locks === null ? (
+        <Spinner label="Loading locks" />
+      ) : locks.length === 0 ? (
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          No lock currently held.
+        </p>
+      ) : (
+        <ul class="space-y-2">
+          {locks.map((lock) => (
+            <li
+              key={`${lock.run_id}:${lock.holder_session_id}`}
+              class="flex flex-wrap items-baseline gap-2 text-sm"
+            >
+              <Pill variant="info" size="sm">
+                held
+              </Pill>
+              <code class="font-mono text-xs text-slate-600 dark:text-slate-300">
+                {lock.holder_session_id}
+              </code>
+              <span class="text-xs text-slate-500 dark:text-slate-400">
+                acquired {formatTimestamp(lock.acquired_at)}
+              </span>
+              <span class="text-xs text-slate-500 dark:text-slate-400">
+                expires {formatTimestamp(lock.expires_at)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+export default LockSection;

--- a/ui/src/routes/runDetail/admin/SignaturesSection.tsx
+++ b/ui/src/routes/runDetail/admin/SignaturesSection.tsx
@@ -1,0 +1,122 @@
+/**
+ * Admin-sheet section: commit-signature timeline for this run.
+ *
+ * The right-column Admin Card shows only the last 3 signatures; the
+ * sheet surface trades a smaller header for room to scroll the full
+ * history, so this section renders every row the server returned at
+ * page_size=200 (the server-side MAX_PAGE_SIZE cap).
+ */
+
+import type { JSX } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+import {
+  EmptyState,
+  Pill,
+  Spinner,
+} from '../../../components';
+import {
+  api,
+  ApiError,
+  type CommitSignatureRecord,
+} from '../../../lib/api';
+import { CollapsibleSection } from './CollapsibleSection';
+
+function shortHash(hash: string): string {
+  return hash.length > 12 ? hash.slice(0, 12) : hash;
+}
+
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? (iso ?? '—') : d.toLocaleString();
+}
+
+export interface SignaturesSectionProps {
+  runId: string;
+}
+
+export function SignaturesSection({
+  runId,
+}: SignaturesSectionProps): JSX.Element {
+  const [sigs, setSigs] = useState<CommitSignatureRecord[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSigs(null);
+    setError(null);
+    api
+      .listCommitSignatures(runId, { page_size: 200 })
+      .then((page) => {
+        if (cancelled) return;
+        setSigs(page.items);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof ApiError ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  const trailing = sigs ? (
+    <Pill variant="neutral" size="sm">
+      {sigs.length}
+    </Pill>
+  ) : undefined;
+
+  return (
+    <CollapsibleSection
+      id="admin-signatures"
+      title="Commit signatures"
+      trailing={trailing}
+    >
+      {error ? (
+        <EmptyState title="Failed to load signatures" message={error} />
+      ) : sigs === null ? (
+        <Spinner label="Loading signatures" />
+      ) : sigs.length === 0 ? (
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          No commit signatures recorded yet.
+        </p>
+      ) : (
+        <ul class="space-y-2">
+          {sigs.map((sig) => (
+            <li
+              key={sig.id}
+              class="text-xs text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700 rounded-md px-3 py-2 space-y-1"
+            >
+              <div class="flex flex-wrap items-baseline gap-2">
+                <code class="font-mono text-slate-700 dark:text-slate-200">
+                  {sig.state_id}
+                </code>
+                <Pill
+                  variant={sig.verified ? 'success' : 'danger'}
+                  size="sm"
+                >
+                  {sig.verified ? 'verified' : 'unverified'}
+                </Pill>
+                {sig.iteration_n != null ? (
+                  <span class="text-slate-500 dark:text-slate-400">
+                    iter {sig.iteration_n}
+                  </span>
+                ) : null}
+              </div>
+              <div class="font-mono">
+                sig{' '}
+                <span title={sig.signature}>{shortHash(sig.signature)}</span>
+              </div>
+              <div class="text-slate-500 dark:text-slate-400">
+                {formatTimestamp(sig.created_at)}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+export default SignaturesSection;

--- a/ui/src/routes/runDetail/admin/ToolCallsSection.tsx
+++ b/ui/src/routes/runDetail/admin/ToolCallsSection.tsx
@@ -1,0 +1,200 @@
+/**
+ * Admin-sheet section: tool-call audit log for this run.
+ *
+ * Mirrors the bottom collapsible "Tool calls audit log" on /runs/:id
+ * with two extras suited to the sheet surface:
+ *
+ *   1. **Local filter chips** for ``ok`` / ``failed`` status (toggle by
+ *      tap; cleared by re-tapping). Independent of the page-wide
+ *      runDetailFilters signal so opening the sheet doesn't surprise
+ *      the operator's existing filter set on the main view.
+ *   2. **Per-row JsonViewer** for ``args_redacted`` so the operator can
+ *      inspect what the producer actually called the tool with.
+ */
+
+import type { JSX } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+
+import {
+  EmptyState,
+  FilterChips,
+  JsonViewer,
+  Pill,
+  Spinner,
+  type FilterChip,
+} from '../../../components';
+import { api, ApiError, type ToolCall } from '../../../lib/api';
+import { CollapsibleSection } from './CollapsibleSection';
+
+function shortHash(hash: string): string {
+  return hash.length > 12 ? hash.slice(0, 12) : hash;
+}
+
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? (iso ?? '—') : d.toLocaleString();
+}
+
+type StatusFilter = 'all' | 'ok' | 'failed';
+
+export interface ToolCallsSectionProps {
+  runId: string;
+}
+
+export function ToolCallsSection({
+  runId,
+}: ToolCallsSectionProps): JSX.Element {
+  const [calls, setCalls] = useState<ToolCall[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  useEffect(() => {
+    let cancelled = false;
+    setCalls(null);
+    setError(null);
+    api
+      .listToolCalls({ run_id: runId, page_size: 100 })
+      .then((page) => {
+        if (cancelled) return;
+        setCalls(page.items);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof ApiError ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  const filtered = useMemo(() => {
+    if (!calls) return [];
+    if (statusFilter === 'all') return calls;
+    return calls.filter((c) =>
+      statusFilter === 'ok' ? c.succeeded : !c.succeeded,
+    );
+  }, [calls, statusFilter]);
+
+  const chips: FilterChip[] = useMemo(() => {
+    if (statusFilter === 'all') return [];
+    return [
+      {
+        id: `status:${statusFilter}`,
+        kind: 'status',
+        label: `status: ${statusFilter}`,
+      },
+    ];
+  }, [statusFilter]);
+
+  const trailing = calls ? (
+    <Pill variant="neutral" size="sm">
+      {filtered.length === calls.length
+        ? filtered.length
+        : `${filtered.length}/${calls.length}`}
+    </Pill>
+  ) : undefined;
+
+  return (
+    <CollapsibleSection
+      id="admin-tool-calls"
+      title="Tool calls"
+      trailing={trailing}
+    >
+      {error ? (
+        <EmptyState title="Failed to load tool calls" message={error} />
+      ) : calls === null ? (
+        <Spinner label="Loading tool calls" />
+      ) : (
+        <div class="space-y-3">
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              aria-pressed={statusFilter === 'ok'}
+              onClick={() =>
+                setStatusFilter((v) => (v === 'ok' ? 'all' : 'ok'))
+              }
+              class={[
+                'inline-flex items-center px-2 py-0.5 text-xs rounded-md border',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
+                statusFilter === 'ok'
+                  ? 'bg-emerald-100 border-emerald-300 text-emerald-800 dark:bg-emerald-900/40 dark:border-emerald-700 dark:text-emerald-200'
+                  : 'border-slate-300 text-slate-600 dark:border-slate-600 dark:text-slate-300',
+              ].join(' ')}
+            >
+              ok
+            </button>
+            <button
+              type="button"
+              aria-pressed={statusFilter === 'failed'}
+              onClick={() =>
+                setStatusFilter((v) => (v === 'failed' ? 'all' : 'failed'))
+              }
+              class={[
+                'inline-flex items-center px-2 py-0.5 text-xs rounded-md border',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500',
+                statusFilter === 'failed'
+                  ? 'bg-red-100 border-red-300 text-red-800 dark:bg-red-900/40 dark:border-red-700 dark:text-red-200'
+                  : 'border-slate-300 text-slate-600 dark:border-slate-600 dark:text-slate-300',
+              ].join(' ')}
+            >
+              failed
+            </button>
+            <FilterChips
+              chips={chips}
+              onRemove={() => setStatusFilter('all')}
+              onClear={() => setStatusFilter('all')}
+              ariaLabel="Tool call filters"
+            />
+          </div>
+          {filtered.length === 0 ? (
+            <EmptyState
+              title="No tool calls"
+              message={
+                calls.length === 0
+                  ? 'The audit log is empty for this run.'
+                  : 'No tool calls match the current filter.'
+              }
+            />
+          ) : (
+            <ul class="divide-y divide-slate-200 dark:divide-slate-700">
+              {filtered.map((call) => (
+                <li key={call.id} class="py-3 space-y-1">
+                  <div class="flex flex-wrap items-baseline gap-2">
+                    <Pill
+                      variant={call.succeeded ? 'success' : 'danger'}
+                      size="sm"
+                    >
+                      {call.succeeded ? 'ok' : 'failed'}
+                    </Pill>
+                    <code class="font-mono text-sm text-slate-800 dark:text-slate-100">
+                      {call.tool_name}
+                    </code>
+                    <span class="text-xs text-slate-500 dark:text-slate-400">
+                      {formatTimestamp(call.created_at)}
+                    </span>
+                    <span
+                      class="text-xs font-mono text-slate-400 dark:text-slate-500"
+                      title={call.producer_id}
+                    >
+                      {shortHash(call.producer_id)}
+                    </span>
+                  </div>
+                  <JsonViewer
+                    value={call.args_redacted}
+                    rootLabel="args"
+                    mode="inline"
+                    maxInlineHeight="max-h-40"
+                    ariaLabel={`Tool call args ${call.tool_name}`}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+export default ToolCallsSection;

--- a/ui/src/routes/runDetail/admin/__tests__/AdminSheetBody.test.tsx
+++ b/ui/src/routes/runDetail/admin/__tests__/AdminSheetBody.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Tests for routes/runDetail/AdminSheetBody.tsx + its six section
+ * components.
+ *
+ * The body is mounted with a synthetic ``manifest`` and an ``api``
+ * mock so every section completes its initial fetch synchronously
+ * (``vi.mock`` resolves all six list endpoints + ``getSpec`` with
+ * canned shapes). We then assert:
+ *
+ *   1. all six sections render with the expected heading text;
+ *   2. the Journal section is open by default (per
+ *      ``defaultOpen={true}`` in JournalSection.tsx);
+ *   3. the remaining sections are collapsed and toggle on click.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from '@testing-library/preact';
+
+vi.mock('../../../../lib/api', async () => {
+  const sigPage = {
+    items: [
+      {
+        id: 'sig-1',
+        run_id: 'R',
+        state_id: 'start',
+        iteration_n: 1,
+        brief_id: 'B',
+        inputs_hash: 'aaaaaaaaaaaa',
+        outputs_hash: 'bbbbbbbbbbbb',
+        session_id: 'S',
+        signature: 'cccccccccccc',
+        verified: true,
+        created_at: '2025-01-01T00:00:00Z',
+      },
+    ],
+    page: 1,
+    page_size: 200,
+    total: 1,
+    has_next: false,
+    sort: '',
+  };
+  const journalPage = {
+    items: [
+      {
+        id: 'jt-1',
+        run_id: 'R',
+        status: 'pending',
+        staged_writes: [{ k: 'v' }],
+        started_at: '2025-01-01T00:00:00Z',
+        ready_at: null,
+        finalised_at: null,
+      },
+      {
+        // belongs to a different run -- must be filtered out client-side.
+        id: 'jt-2',
+        run_id: 'OTHER',
+        status: 'finalised',
+        staged_writes: [],
+        started_at: '2025-01-01T00:00:00Z',
+        ready_at: null,
+        finalised_at: null,
+      },
+    ],
+    page: 1,
+    page_size: 200,
+    total: 2,
+    has_next: false,
+    sort: '',
+  };
+  const locksPage = {
+    items: [
+      {
+        run_id: 'R',
+        holder_session_id: 'sess-1',
+        acquired_at: '2025-01-01T00:00:00Z',
+        expires_at: '2025-01-01T01:00:00Z',
+      },
+    ],
+    page: 1,
+    page_size: 200,
+    total: 1,
+    has_next: false,
+    sort: '',
+  };
+  const toolsPage = {
+    items: [
+      {
+        id: 'tc-1',
+        run_id: 'R',
+        producer_id: 'agent-foo',
+        tool_name: 'Bash',
+        args_redacted: { cmd: 'ls' },
+        succeeded: true,
+        created_at: '2025-01-01T00:00:00Z',
+      },
+    ],
+    page: 1,
+    page_size: 100,
+    total: 1,
+    has_next: false,
+    sort: '',
+  };
+  const drift = {
+    run_id: 'R',
+    score: 0.42,
+    signals: [
+      {
+        id: 'd-1',
+        run_id: 'R',
+        producer_id: 'p',
+        signal_kind: 'tool_outside_allowlist',
+        weight: 0.5,
+        payload: {},
+        created_at: '2025-01-01T00:00:00Z',
+      },
+    ],
+  };
+  const spec = {
+    id: 'spec-1',
+    slug: 'demo',
+    version: 1,
+    project_id: 'p',
+    project_slug: null,
+    fsm_hash: '',
+    created_at: '2025-01-01T00:00:00Z',
+    description: '',
+    definition: {
+      states: {
+        start: { allowed_tools: ['Bash', 'Read'] },
+      },
+    },
+  };
+  class ApiErrorMock extends Error {}
+  return {
+    ApiError: ApiErrorMock,
+    api: {
+      listJournalTxns: vi.fn(async () => journalPage),
+      listLocks: vi.fn(async () => locksPage),
+      listToolCalls: vi.fn(async () => toolsPage),
+      listDriftSignals: vi.fn(async () => drift),
+      listCommitSignatures: vi.fn(async () => sigPage),
+      getSpec: vi.fn(async () => spec),
+    },
+  };
+});
+
+import { AdminSheetBody } from '../../AdminSheetBody';
+import type { RunManifest } from '../../../../lib/api';
+
+const MANIFEST: RunManifest = {
+  id: 'R',
+  project_id: 'P',
+  fsm_spec_id: 'spec-1',
+  fsm_spec_hash: 'h',
+  status: 'running',
+  current_state: 'start',
+  next_state: null,
+  verdict: null,
+  started_at: '2025-01-01T00:00:00Z',
+  ended_at: null,
+  last_update_at: '2025-01-01T00:00:00Z',
+  paused_at: null,
+  pause_reason: null,
+  parent_run_id: null,
+  resume_history: [],
+  args: {},
+  metadata: {},
+  transitions_count: 0,
+};
+
+beforeEach(() => {
+  cleanup();
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe('AdminSheetBody', () => {
+  test('renders all six section headings', async () => {
+    const { getByText } = render(
+      <AdminSheetBody runId="R" manifest={MANIFEST} />,
+    );
+    expect(getByText('Journal')).toBeInTheDocument();
+    expect(getByText('Lock')).toBeInTheDocument();
+    expect(getByText('Drift')).toBeInTheDocument();
+    expect(getByText('Commit signatures')).toBeInTheDocument();
+    expect(getByText('Allowed tools (start)')).toBeInTheDocument();
+    expect(getByText('Tool calls')).toBeInTheDocument();
+  });
+
+  test('Journal section is expanded by default and shows filtered txns', async () => {
+    const { getByText, queryByText } = render(
+      <AdminSheetBody runId="R" manifest={MANIFEST} />,
+    );
+    const header = getByText('Journal').closest('button')!;
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    // The "OTHER" run's txn must be filtered out client-side; only the
+    // matching one renders.
+    await waitFor(() => {
+      expect(getByText('pending')).toBeInTheDocument();
+    });
+    expect(queryByText('finalised')).toBeNull();
+  });
+
+  test('Lock section collapsed by default, expand toggles aria-expanded', () => {
+    const { getByText, getAllByRole } = render(
+      <AdminSheetBody runId="R" manifest={MANIFEST} />,
+    );
+    const lockHeader = getByText('Lock').closest('button')!;
+    expect(lockHeader.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(lockHeader);
+    expect(lockHeader.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(lockHeader);
+    expect(lockHeader.getAttribute('aria-expanded')).toBe('false');
+    // sanity: there are at least six section headers in total.
+    const buttons = getAllByRole('button').filter((b) =>
+      b.hasAttribute('aria-expanded'),
+    );
+    expect(buttons.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test('Drift / Signatures / AllowedTools / ToolCalls all toggle', async () => {
+    const { getByText } = render(
+      <AdminSheetBody runId="R" manifest={MANIFEST} />,
+    );
+    for (const title of [
+      'Drift',
+      'Commit signatures',
+      'Allowed tools (start)',
+      'Tool calls',
+    ]) {
+      const header = getByText(title).closest('button')!;
+      expect(header.getAttribute('aria-expanded')).toBe('false');
+      fireEvent.click(header);
+      expect(header.getAttribute('aria-expanded')).toBe('true');
+    }
+    // After expanding AllowedTools the resolved spec allow-list renders
+    // as <li> Pills inside the section's region. Bash also appears in
+    // the ToolCalls section's tool_name column, so we scope the query
+    // to the allow-list region by walking the heading button -> next
+    // sibling (the role="region" panel).
+    const allowedHeader = getByText('Allowed tools (start)').closest('button')!;
+    const allowedRegion = allowedHeader.parentElement!.querySelector(
+      '[role="region"]',
+    )! as HTMLElement;
+    await waitFor(() => {
+      const items = Array.from(allowedRegion.querySelectorAll('li')).map(
+        (li) => li.textContent?.trim(),
+      );
+      expect(items).toContain('Bash');
+      expect(items).toContain('Read');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New right-half sheet (`AdminSheetBody`) hosting six self-contained collapsible sections — **Journal**, **Lock**, **Drift**, **Commit signatures**, **Allowed tools**, **Tool calls** — under `routes/runDetail/admin/`.
- New **Admin** button in the run-detail header opens the sheet via `openSheet({ content: <AdminSheetBody …/> })`; uses the existing SheetHost `content`-as-VNode contract (no registry needed).
- Each section owns its own initial fetch + state so one slow endpoint cannot block siblings, and so PR 6's planned per-section debounced SSE refetch can land without touching the body.
- The existing right-column Admin Card on `/runs/:id` is **kept** in this PR — operators get both surfaces simultaneously; a later PR removes the inline card once the sheet has soaked.
- 4 new test cases (396 total, was 392) covering all six headings, Journal default-open + client-side `run_id` filter, and aria-expanded toggle on every other section.

## Test plan

- [x] `npm test` — 34 files, 396 tests passed
- [x] `npm run build` — clean (one pre-existing dynamic-import warning, unrelated)
- [ ] Manual: open a run, click **Admin**, confirm each section loads + expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)