### PR TITLE
feat(ui): run-graph node/edge click sheets + current-state pulse

### DIFF
--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -183,6 +183,12 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
   const currentRing = isCurrent
     ? 'ring-2 ring-amber-400 ring-offset-2 ring-offset-white dark:ring-offset-slate-900'
     : '';
+  // W22b PR 4: the run graph's current node gets a continuous amber
+  // ring pulse on top of the static ring above so the operator's eye
+  // lands on the active state at a glance even on a busy graph. The
+  // `fsm-pulse-current` class is owned by theme.css and respects
+  // prefers-reduced-motion (falls back to a static amber outline).
+  const currentPulse = isCurrent ? 'fsm-pulse-current' : '';
   // W23d 1-hop hover highlight. FlowGraph stamps three transient flags
   // onto node.data while a hover is active:
   //   data.isHovered    — this is the node the cursor is on (or one
@@ -218,6 +224,7 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
         paletteClass,
         selected ? 'ring-2 ring-emerald-400 ring-offset-1' : '',
         currentRing,
+        currentPulse,
         hoverRing,
         dimClass,
       ].join(' ')}

--- a/ui/src/components/RunProgressGraph.tsx
+++ b/ui/src/components/RunProgressGraph.tsx
@@ -65,6 +65,24 @@ export interface RunProgressGraphProps {
   events: FsmEvent[];
   /** Optional className for layout integration. */
   className?: string;
+  /**
+   * Click handler for a node in the run graph (W22b PR 4). Receives
+   * the spec-state-id (== FlowGraph node id). Wired to
+   * ``openStateEntrySheet`` in the run-detail route so a click opens
+   * the per-state inspector sheet.
+   */
+  onNodeClick?: (nodeId: string) => void;
+  /**
+   * Click handler for an edge in the run graph (W22b PR 4). Receives
+   * the (from, to) spec-state-id pair. Wired to ``openEdgeSheet`` in
+   * the run-detail route so a click opens the edge inspector sheet.
+   *
+   * The pair is direction-sensitive: ``(source, target)`` matches the
+   * orientation of the spec-declared transition, NOT necessarily the
+   * order in which the run traversed it (a loop edge fires this same
+   * handler with its declared direction).
+   */
+  onEdgeClick?: (fromId: string, toId: string) => void;
 }
 
 interface SpecCache {
@@ -81,6 +99,8 @@ export function RunProgressGraph({
   stateTree,
   events,
   className = '',
+  onNodeClick,
+  onEdgeClick,
 }: RunProgressGraphProps): JSX.Element {
   const [spec, setSpec] = useState<SpecCache | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -214,6 +234,30 @@ export function RunProgressGraph({
         <FlowGraph
           nodes={overlaid.nodes}
           edges={overlaid.edges}
+          onNodeClick={
+            onNodeClick
+              ? (id: string) => onNodeClick(id)
+              : undefined
+          }
+          onEdgeClick={
+            onEdgeClick
+              ? (_id: string, data?: Record<string, unknown>) => {
+                  // FlowGraph's onEdgeClick forwards (edge.id, edge.data);
+                  // decorateEdges stamps `sourceId` + `targetId` onto
+                  // edge.data so consumers don't have to re-walk the
+                  // edge list to recover the endpoints. Falling back to
+                  // the id-split is intentionally avoided — edge ids are
+                  // not guaranteed to encode the (from, to) pair (e.g.
+                  // parallel edges between the same nodes get
+                  // disambiguating suffixes).
+                  const fromId = typeof data?.sourceId === 'string' ? data.sourceId : null;
+                  const toId = typeof data?.targetId === 'string' ? data.targetId : null;
+                  if (fromId !== null && toId !== null) {
+                    onEdgeClick(fromId, toId);
+                  }
+                }
+              : undefined
+          }
         />
       </div>
     </Card>

--- a/ui/src/components/__tests__/RunProgressGraph.test.tsx
+++ b/ui/src/components/__tests__/RunProgressGraph.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * Tests for components/RunProgressGraph.tsx — PR 4 additions.
+ *
+ * Coverage:
+ *   - onNodeClick fires with the spec-state-id (== FlowGraph node id)
+ *     when the user clicks a node on the run graph.
+ *   - The current state (manifest.current_state) renders with the
+ *     ``fsm-pulse-current`` class so the pulse animation engages.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/preact';
+
+// Mock @xyflow/react the same way FlowGraph.test does so jsdom doesn't
+// need to layout a real React Flow surface. We capture the props the
+// FlowGraph forwards to ReactFlow so the test can drive the
+// onNodeClick / onEdgeClick handlers synthetically AND inspect the
+// node classes the FsmNode renderer would receive via decoratedNodes.
+let lastReactFlowProps: Record<string, unknown> | null = null;
+vi.mock('@xyflow/react', () => ({
+  ReactFlow: (props: Record<string, unknown> & { children?: unknown; nodeTypes?: Record<string, unknown> }) => {
+    lastReactFlowProps = props;
+    // Render each node via its FsmNode type so the test can assert the
+    // amber pulse class lands on the current node's DOM.
+    const Fsm = (props.nodeTypes?.fsmNode ?? null) as
+      | ((p: { data: Record<string, unknown>; selected?: boolean }) => any)
+      | null;
+    const nodes = (props.nodes as Array<{
+      id: string;
+      data: Record<string, unknown>;
+      selected?: boolean;
+    }>) ?? [];
+    return (
+      <div data-testid="mock-react-flow">
+        {Fsm
+          ? nodes.map((n) => (
+              <div key={n.id} data-node-id={n.id}>
+                {Fsm({ data: n.data, selected: n.selected })}
+              </div>
+            ))
+          : null}
+        {props.children as any}
+      </div>
+    );
+  },
+  Background: () => <div data-testid="bg" />,
+  Controls: () => <div data-testid="controls" />,
+  MiniMap: () => <div data-testid="minimap" />,
+  Handle: () => null,
+  BaseEdge: () => null,
+  EdgeLabelRenderer: (p: { children?: unknown }) => <>{p.children as any}</>,
+  getSmoothStepPath: () => ['M0,0 L1,1', 0, 0, 0, 0],
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+  BackgroundVariant: { Dots: 'dots', Lines: 'lines', Cross: 'cross' },
+  MarkerType: { ArrowClosed: 'arrowclosed', Arrow: 'arrow' },
+  PanOnScrollMode: { Free: 'free', Vertical: 'vertical', Horizontal: 'horizontal' },
+}));
+vi.mock('@xyflow/react/dist/style.css', () => ({}));
+
+// Mock the api so RunProgressGraph's spec fetch resolves with a known
+// shape without touching the network. The minimal spec contains TWO
+// states (plan + execute) so the overlay has a node to mark current.
+vi.mock('../../lib/api', async () => {
+  class ApiErrorMock extends Error {}
+  return {
+    ApiError: ApiErrorMock,
+    api: {
+      getSpec: vi.fn(async () => ({
+        id: 'spec-1',
+        project_id: 'p',
+        project_slug: 'p',
+        slug: 'demo',
+        version: 1,
+        hash: 'h',
+        registered_at: '2025-01-01T00:00:00Z',
+        definition: {
+          entry: 'plan',
+          states: [
+            { id: 'plan', kind: 'worker' },
+            { id: 'execute', kind: 'state' },
+          ],
+        },
+      })),
+    },
+  };
+});
+
+import { RunProgressGraph } from '../RunProgressGraph';
+import type { RunManifest, StateNode } from '../../lib/api';
+
+const MANIFEST: RunManifest = {
+  id: 'R',
+  project_id: 'P',
+  fsm_spec_id: 'spec-1',
+  fsm_spec_hash: 'h',
+  status: 'running',
+  current_state: 'plan',
+  next_state: null,
+  verdict: null,
+  started_at: '2025-01-01T00:00:00Z',
+  ended_at: null,
+  last_update_at: '2025-01-01T00:00:00Z',
+  paused_at: null,
+  pause_reason: null,
+  parent_run_id: null,
+  resume_history: [],
+  args: {},
+  metadata: {},
+  transitions_count: 0,
+};
+
+const STATE_TREE: StateNode = {
+  entry_id: 'entry-1',
+  state_id: 'plan',
+  entry_seq: 1,
+  entered_at: '2025-01-01T00:00:00Z',
+  exited_at: null,
+  status: 'entered',
+  inputs: {},
+  outputs: {},
+  iteration_n: null,
+  children: [],
+};
+
+beforeEach(() => {
+  lastReactFlowProps = null;
+});
+afterEach(() => cleanup());
+
+describe('RunProgressGraph — PR 4 additions', () => {
+  test('onNodeClick fires with the node id when ReactFlow dispatches a click', async () => {
+    const onNodeClick = vi.fn();
+    render(
+      <RunProgressGraph
+        manifest={MANIFEST}
+        stateTree={STATE_TREE}
+        events={[]}
+        onNodeClick={onNodeClick}
+      />,
+    );
+    // Wait until the spec fetch resolves and the FlowGraph mock has
+    // received its props (the component renders a Spinner until then).
+    await waitFor(() => {
+      expect(lastReactFlowProps).not.toBeNull();
+      expect(
+        (lastReactFlowProps!.nodes as Array<{ id: string }>).length,
+      ).toBeGreaterThan(0);
+    });
+    const rfOnNodeClick = lastReactFlowProps!.onNodeClick as (
+      e: unknown,
+      node: { id: string; data: Record<string, unknown> },
+    ) => void;
+    rfOnNodeClick({}, { id: 'plan', data: { kind: 'worker', label: 'plan' } });
+    expect(onNodeClick).toHaveBeenCalledWith('plan');
+  });
+
+  test('onEdgeClick fires with (fromId, toId) extracted from edge.data', async () => {
+    const onEdgeClick = vi.fn();
+    render(
+      <RunProgressGraph
+        manifest={MANIFEST}
+        stateTree={STATE_TREE}
+        events={[]}
+        onEdgeClick={onEdgeClick}
+      />,
+    );
+    await waitFor(() => {
+      expect(lastReactFlowProps).not.toBeNull();
+    });
+    const rfOnEdgeClick = lastReactFlowProps!.onEdgeClick as (
+      e: unknown,
+      edge: { id: string; data?: Record<string, unknown> },
+    ) => void;
+    rfOnEdgeClick(
+      {},
+      {
+        id: 'plan->execute',
+        data: { sourceId: 'plan', targetId: 'execute' },
+      },
+    );
+    expect(onEdgeClick).toHaveBeenCalledWith('plan', 'execute');
+  });
+
+  test('the current state node renders with the fsm-pulse-current animation class', async () => {
+    const { container } = render(
+      <RunProgressGraph
+        manifest={MANIFEST}
+        stateTree={STATE_TREE}
+        events={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(lastReactFlowProps).not.toBeNull();
+    });
+    // The current node is the one whose id matches manifest.current_state.
+    // The mock ReactFlow wraps each node renderer in a div tagged
+    // data-node-id so the test can find the node card via DOM query.
+    const currentWrapper = container.querySelector('[data-node-id="plan"]');
+    expect(currentWrapper).not.toBeNull();
+    // The fsm-pulse-current class lives on the inner fsm-node card.
+    const card = currentWrapper!.querySelector('.fsm-node');
+    expect(card).not.toBeNull();
+    expect(card!.className).toContain('fsm-pulse-current');
+    // A non-current node must NOT carry the pulse class.
+    const otherWrapper = container.querySelector('[data-node-id="execute"]');
+    expect(otherWrapper).not.toBeNull();
+    const otherCard = otherWrapper!.querySelector('.fsm-node');
+    expect(otherCard).not.toBeNull();
+    expect(otherCard!.className).not.toContain('fsm-pulse-current');
+  });
+});

--- a/ui/src/routes/runDetail.tsx
+++ b/ui/src/routes/runDetail.tsx
@@ -90,8 +90,14 @@ import {
   type ToolCall,
 } from '../lib/api';
 import { openSheet } from '../lib/store';
+import {
+  openEdgeSheet as openEdgeSheetOpener,
+  openStateEntrySheet as openStateEntrySheetOpener,
+} from '../lib/runDetailSheets';
 import { EventStream } from '../lib/sse';
 import { AdminSheetBody } from './runDetail/AdminSheetBody';
+import { EdgeSheetBody } from './runDetail/EdgeSheetBody';
+import { StateEntrySheetBody } from './runDetail/StateEntrySheetBody';
 
 /**
  * Helper: open the run-admin sheet for ``runId``.
@@ -824,6 +830,56 @@ export function RunDetailRoute(): JSX.Element {
           manifest={run.manifest}
           stateTree={stateTree}
           events={events}
+          onNodeClick={(stateId) => {
+            // The graph emits the spec-state-id (FlowGraph node id ==
+            // spec state id). Resolve it to a concrete state ENTRY in
+            // the loaded tree: prefer the most-recently-entered entry
+            // for that state so a loop iteration opens the active
+            // entry rather than the first one. Falls back to the
+            // state id itself when no entry has landed yet so the
+            // sheet can render the "Entry not in tree" EmptyState
+            // instead of swallowing the click.
+            let target: string = stateId;
+            for (const node of nodeIndex.values()) {
+              if (node.state_id !== stateId) continue;
+              const existing = nodeIndex.get(target);
+              if (!existing || existing.state_id !== stateId || node.entry_seq > existing.entry_seq) {
+                target = node.entry_id;
+              }
+            }
+            openStateEntrySheetOpener({
+              entryId: target,
+              runId: runId,
+              title: `State entry · ${stateId}`,
+              content: (
+                <StateEntrySheetBody
+                  entryId={target}
+                  runId={runId}
+                  stateTree={stateTree}
+                  spec={spec}
+                  events={events}
+                />
+              ),
+            });
+          }}
+          onEdgeClick={(fromId, toId) => {
+            openEdgeSheetOpener({
+              runId: runId,
+              fromStateId: fromId,
+              toStateId: toId,
+              title: `Edge · ${fromId} → ${toId}`,
+              content: (
+                <EdgeSheetBody
+                  fromStateId={fromId}
+                  toStateId={toId}
+                  runId={runId}
+                  stateTree={stateTree}
+                  spec={spec}
+                  events={events}
+                />
+              ),
+            });
+          }}
         />
       ) : null}
 

--- a/ui/src/routes/runDetail/EdgeSheetBody.tsx
+++ b/ui/src/routes/runDetail/EdgeSheetBody.tsx
@@ -1,0 +1,395 @@
+/**
+ * Body component for the run-detail edge Sheet.
+ *
+ * Rendered inside :class:`SheetHost` when the operator clicks an edge
+ * in the run progress graph. The body lays out:
+ *
+ *   - Source state KeyValueTable (id, kind, status of the matching
+ *     run entry if any).
+ *   - Target state KeyValueTable (same shape).
+ *   - The transition's predicate text, syntax-highlighted via the
+ *     shared :func:`tokenisePredicate` helper.
+ *   - The ``transition_taken`` event for this edge if it landed in the
+ *     loaded event slice, with its ``when_taken_at`` timestamp.
+ *   - A "Not taken in this run" banner when neither the state tree nor
+ *     the events show the edge firing.
+ */
+
+import type { JSX } from 'preact';
+import { useMemo } from 'preact/hooks';
+
+import { JsonViewer } from '../../components/JsonViewer';
+import { KeyValueTable, type KvRow } from '../../components/KeyValueTable';
+import { Pill, type PillVariant } from '../../components/Pill';
+import { EmptyState } from '../../components/EmptyState';
+import type {
+  Event as FsmEvent,
+  SpecDetail,
+  StateNode,
+} from '../../lib/api';
+import {
+  classForPredicateKind,
+  tokenisePredicate,
+} from '../../lib/predicateTokens';
+
+export interface EdgeSheetBodyProps {
+  fromStateId: string;
+  toStateId: string;
+  runId: string;
+  stateTree: StateNode | null;
+  spec: SpecDetail | null;
+  events: FsmEvent[];
+}
+
+/** Variant for a state's run status — matches the pattern used in
+ *  StateEntrySheetBody / runDetail.tsx so the same colour means the
+ *  same thing across the run-detail surface. */
+function variantForStatus(status: string | null | undefined): PillVariant {
+  if (!status) return 'neutral';
+  const s = status.toLowerCase();
+  if (s === 'completed' || s === 'exited' || s === 'succeeded') return 'success';
+  if (s === 'faulted' || s === 'failed' || s === 'aborted') return 'danger';
+  if (s === 'paused' || s === 'waiting') return 'warning';
+  if (s === 'running' || s === 'entered' || s === 'in_progress') return 'info';
+  return 'neutral';
+}
+
+/** Format an ISO timestamp the same way the rest of run-detail does. */
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso ?? '—';
+  }
+}
+
+/** Walk the state tree and emit every entry. */
+function collectEntries(root: StateNode | null): StateNode[] {
+  if (!root) return [];
+  const out: StateNode[] = [];
+  const walk = (n: StateNode): void => {
+    out.push(n);
+    for (const child of n.children) walk(child);
+  };
+  walk(root);
+  return out;
+}
+
+/** Find the most recently-entered run entry for ``state_id``. We
+ *  prefer the highest ``entry_seq`` so a state that was visited
+ *  multiple times (loop iteration) reports its current snapshot. */
+function findLatestEntry(
+  entries: StateNode[],
+  stateId: string,
+): StateNode | null {
+  let latest: StateNode | null = null;
+  for (const e of entries) {
+    if (e.state_id !== stateId) continue;
+    if (!latest || e.entry_seq > latest.entry_seq) {
+      latest = e;
+    }
+  }
+  return latest;
+}
+
+/** Find the spec-side state object for ``state_id`` (mirrors the same
+ *  helper in StateEntrySheetBody but kept private here so the two
+ *  sheets stay independently importable for testing). */
+function findSpecState(
+  spec: SpecDetail | null,
+  stateId: string,
+): Record<string, unknown> | null {
+  if (!spec) return null;
+  const def = spec.definition as { states?: unknown };
+  const states = Array.isArray(def?.states) ? def.states : [];
+  for (const s of states) {
+    if (s && typeof s === 'object') {
+      const obj = s as Record<string, unknown>;
+      if (obj.id === stateId) return obj;
+    }
+  }
+  return null;
+}
+
+/** Extract the human-readable predicate text from a transition's
+ *  ``when`` payload. Mirrors specGraph.predicateLabel() so the edge
+ *  inspector text matches the on-graph edge label byte-for-byte. */
+function predicateOf(
+  transition: Record<string, unknown> | null,
+): string {
+  if (!transition) return '';
+  const when = transition.when;
+  if (typeof when === 'string') return when;
+  if (when && typeof when === 'object') {
+    const obj = when as Record<string, unknown>;
+    if (typeof obj.predicate === 'string') return obj.predicate;
+    if (typeof obj.expression === 'string') return obj.expression;
+    if (typeof obj.criteria === 'string') return obj.criteria;
+  }
+  return '';
+}
+
+/** Find the declared transition spec from ``fromState`` to ``toStateId``.
+ *  Returns the first matching transition since the spec allows multiple
+ *  declared transitions between the same endpoint pair (e.g. a
+ *  predicate + otherwise fallback). The edge sheet shows the predicate
+ *  on the first match; future iterations may extend to show all
+ *  parallel transitions. */
+function findTransition(
+  fromState: Record<string, unknown> | null,
+  toStateId: string,
+): Record<string, unknown> | null {
+  if (!fromState) return null;
+  const transitions = Array.isArray(fromState.transitions)
+    ? (fromState.transitions as unknown[])
+    : [];
+  for (const t of transitions) {
+    if (t && typeof t === 'object') {
+      const obj = t as Record<string, unknown>;
+      if (obj.to === toStateId) return obj;
+    }
+  }
+  return null;
+}
+
+/** True when the event represents the transition from ``fromStateId``
+ *  to ``toStateId`` actually firing. The engine's ``transition_taken``
+ *  event encodes the endpoints under either ``from``/``to`` or
+ *  ``from_state``/``to_state`` depending on the wire-format version
+ *  the producer emitted; we probe both pairs so the filter doesn't
+ *  silently drop a relevant event. */
+function eventIsThisTransition(
+  event: FsmEvent,
+  fromStateId: string,
+  toStateId: string,
+): boolean {
+  if (!event.kind.toLowerCase().includes('transition')) return false;
+  const p = event.payload as Record<string, unknown>;
+  const from =
+    (typeof p.from === 'string' && p.from) ||
+    (typeof p.from_state === 'string' && p.from_state) ||
+    null;
+  const to =
+    (typeof p.to === 'string' && p.to) ||
+    (typeof p.to_state === 'string' && p.to_state) ||
+    null;
+  return from === fromStateId && to === toStateId;
+}
+
+/** Extract the ``when_taken_at`` timestamp from a transition_taken
+ *  event payload, with fallbacks to common spellings. */
+function pickWhenTakenAt(event: FsmEvent | null): string | null {
+  if (!event) return null;
+  const p = event.payload as Record<string, unknown>;
+  const candidates = [p.when_taken_at, p.whenTakenAt, p.taken_at];
+  for (const c of candidates) {
+    if (typeof c === 'string') return c;
+  }
+  // Fall back to the event's own created_at so the operator always
+  // sees SOME timestamp for a recorded transition.
+  return event.created_at;
+}
+
+export function EdgeSheetBody({
+  fromStateId,
+  toStateId,
+  runId,
+  stateTree,
+  spec,
+  events,
+}: EdgeSheetBodyProps): JSX.Element {
+  const entries = useMemo(() => collectEntries(stateTree), [stateTree]);
+  const fromEntry = useMemo(
+    () => findLatestEntry(entries, fromStateId),
+    [entries, fromStateId],
+  );
+  const toEntry = useMemo(
+    () => findLatestEntry(entries, toStateId),
+    [entries, toStateId],
+  );
+  const fromSpec = useMemo(
+    () => findSpecState(spec, fromStateId),
+    [spec, fromStateId],
+  );
+  const transition = useMemo(
+    () => findTransition(fromSpec, toStateId),
+    [fromSpec, toStateId],
+  );
+  const predicate = predicateOf(transition);
+  const tokens = useMemo(
+    () => (predicate ? tokenisePredicate(predicate) : []),
+    [predicate],
+  );
+
+  const transitionEvent = useMemo(() => {
+    for (const e of events) {
+      if (eventIsThisTransition(e, fromStateId, toStateId)) return e;
+    }
+    return null;
+  }, [events, fromStateId, toStateId]);
+
+  // "Taken" is true when EITHER the run actually traversed parent->child
+  // in the state tree (fromEntry has a child whose state_id == toStateId)
+  // OR we observed a transition_taken event for this edge. The state-tree
+  // signal is authoritative; the event signal lets us reflect transitions
+  // that landed via a non-tree edge (loop back-edge) without waiting for
+  // the next state tree refresh.
+  const takenViaTree =
+    fromEntry !== null &&
+    fromEntry.children.some((c) => c.state_id === toStateId);
+  const taken = takenViaTree || transitionEvent !== null;
+
+  const fromRows: KvRow[] = useMemo(() => {
+    const rows: KvRow[] = [
+      { key: 'state_id', value: fromStateId },
+    ];
+    if (fromSpec?.kind) rows.push({ key: 'kind', value: String(fromSpec.kind) });
+    if (fromEntry) {
+      rows.push({ key: 'status', value: fromEntry.status });
+      rows.push({ key: 'entered_at', value: formatTimestamp(fromEntry.entered_at) });
+      rows.push({ key: 'exited_at', value: formatTimestamp(fromEntry.exited_at) });
+    } else {
+      rows.push({ key: 'visited', value: false });
+    }
+    return rows;
+  }, [fromStateId, fromSpec, fromEntry]);
+
+  const toRows: KvRow[] = useMemo(() => {
+    const toSpec = findSpecState(spec, toStateId);
+    const rows: KvRow[] = [
+      { key: 'state_id', value: toStateId },
+    ];
+    if (toSpec?.kind) rows.push({ key: 'kind', value: String(toSpec.kind) });
+    if (toEntry) {
+      rows.push({ key: 'status', value: toEntry.status });
+      rows.push({ key: 'entered_at', value: formatTimestamp(toEntry.entered_at) });
+      rows.push({ key: 'exited_at', value: formatTimestamp(toEntry.exited_at) });
+    } else {
+      rows.push({ key: 'visited', value: false });
+    }
+    return rows;
+  }, [spec, toStateId, toEntry]);
+
+  return (
+    <div
+      class="p-3 space-y-4"
+      data-testid="edge-sheet-body"
+      data-from={fromStateId}
+      data-to={toStateId}
+    >
+      <header class="flex flex-wrap items-baseline gap-2">
+        <code class="font-mono text-sm text-slate-900 dark:text-slate-100">
+          {fromStateId}
+        </code>
+        <span class="text-slate-400">→</span>
+        <code class="font-mono text-sm text-slate-900 dark:text-slate-100">
+          {toStateId}
+        </code>
+        <Pill variant={taken ? 'success' : 'neutral'} size="sm">
+          {taken ? 'taken' : 'not taken'}
+        </Pill>
+        <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500">
+          run {runId}
+        </span>
+      </header>
+
+      <section>
+        <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+          source state
+          {fromEntry ? (
+            <Pill variant={variantForStatus(fromEntry.status)} size="sm" className="ml-2">
+              {fromEntry.status}
+            </Pill>
+          ) : null}
+        </h4>
+        <KeyValueTable rows={fromRows} caption={`Source state ${fromStateId}`} />
+      </section>
+
+      <section>
+        <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+          target state
+          {toEntry ? (
+            <Pill variant={variantForStatus(toEntry.status)} size="sm" className="ml-2">
+              {toEntry.status}
+            </Pill>
+          ) : null}
+        </h4>
+        <KeyValueTable rows={toRows} caption={`Target state ${toStateId}`} />
+      </section>
+
+      <section>
+        <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+          predicate
+        </h4>
+        {predicate ? (
+          <code
+            class="block font-mono text-xs leading-relaxed whitespace-pre-wrap break-words px-2 py-1.5 rounded bg-amber-900/80 dark:bg-amber-900/70 border border-amber-500 dark:border-amber-600 text-amber-50"
+            title={predicate}
+          >
+            {tokens.map((t, i) => (
+              <span key={i} class={classForPredicateKind(t.kind)}>
+                {t.text}
+              </span>
+            ))}
+          </code>
+        ) : (
+          <p class="text-xs text-slate-500 dark:text-slate-400">
+            No predicate declared for this transition (typically ``always`` /
+            ``otherwise``).
+          </p>
+        )}
+      </section>
+
+      <section>
+        <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+          transition event
+        </h4>
+        {transitionEvent ? (
+          <div class="space-y-2">
+            <KeyValueTable
+              rows={[
+                { key: 'kind', value: transitionEvent.kind },
+                { key: 'producer_id', value: transitionEvent.producer_id },
+                {
+                  key: 'when_taken_at',
+                  value: formatTimestamp(pickWhenTakenAt(transitionEvent)),
+                },
+              ]}
+              caption="Transition event metadata"
+            />
+            <JsonViewer
+              value={transitionEvent.payload}
+              rootLabel="payload"
+              mode="inline"
+              maxInlineHeight="max-h-48"
+              ariaLabel={`Transition event ${transitionEvent.id} payload`}
+            />
+          </div>
+        ) : taken ? (
+          <p class="text-xs text-slate-500 dark:text-slate-400">
+            Edge traversal recorded in the state tree, but the
+            ``transition_taken`` event has not landed in the loaded slice.
+          </p>
+        ) : (
+          <EmptyState
+            title="Not taken in this run"
+            message="Neither the state tree nor the loaded events show this edge firing."
+          />
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default EdgeSheetBody;

--- a/ui/src/routes/runDetail/StateEntrySheetBody.tsx
+++ b/ui/src/routes/runDetail/StateEntrySheetBody.tsx
@@ -1,0 +1,403 @@
+/**
+ * Body component for the run-detail state-entry Sheet.
+ *
+ * Rendered inside :class:`SheetHost` when the operator clicks a node in
+ * the run progress graph. The body is a three-tab Tabs composite:
+ *
+ *   1. "Run values" — flat metadata about the actual entry the run
+ *      recorded (state_id, status, entered/exited timestamps, iteration
+ *      counter) plus the JsonViewer for the inputs + outputs blobs, and
+ *      a brief / cosignature info row when the matching events are
+ *      present in the loaded slice.
+ *   2. "Spec definition" — mounts the existing :class:`StateInspectorBody`
+ *      so the operator sees the same spec-side metadata they would on
+ *      the spec route, without leaving the run page.
+ *   3. "Events for this state" — a deduped Timeline of events whose
+ *      payload references this ``entry_id`` (or whose canonical
+ *      ``state_entry_id`` / ``entry_id`` field matches).
+ *
+ * The component is intentionally stateful at the tab-id level only —
+ * every data lookup is a pure derivation from the props, so the same
+ * sheet can be re-rendered with fresh event slices without losing the
+ * operator's tab selection.
+ */
+
+import type { JSX } from 'preact';
+import { useMemo, useState } from 'preact/hooks';
+
+import { JsonViewer } from '../../components/JsonViewer';
+import { KeyValueTable, type KvRow } from '../../components/KeyValueTable';
+import { StateInspectorBody } from '../../components/StateInspectorBody';
+import { Tabs, type TabSpec } from '../../components/Tabs';
+import { Timeline, type TimelineItem } from '../../components/Timeline';
+import { EmptyState } from '../../components/EmptyState';
+import { Pill, type PillVariant } from '../../components/Pill';
+import type {
+  Event as FsmEvent,
+  SpecDetail,
+  StateNode,
+} from '../../lib/api';
+
+export interface StateEntrySheetBodyProps {
+  entryId: string;
+  runId: string;
+  stateTree: StateNode | null;
+  /** The full spec record loaded by the run-detail route. ``null`` is
+   *  tolerated so the sheet can render the "Run values" tab even when
+   *  the spec fetch failed (the "Spec definition" tab falls back to a
+   *  short EmptyState in that case). */
+  spec: SpecDetail | null;
+  /** Recent event slice (the same ``events`` the route already loaded).
+   *  We dedupe + filter inside the sheet rather than ask the parent to
+   *  pre-filter so the sheet stays self-contained for testing. */
+  events: FsmEvent[];
+}
+
+/** Tab ids — exported so tests can target them by string instead of
+ *  re-implementing the tab list in the test file. */
+export const STATE_ENTRY_TAB_IDS = ['run', 'spec', 'events'] as const;
+export type StateEntryTabId = (typeof STATE_ENTRY_TAB_IDS)[number];
+
+/** Walk the state tree once to find the entry by id. Returns ``null``
+ *  when not found so the caller can render an EmptyState. */
+function findEntry(root: StateNode | null, entryId: string): StateNode | null {
+  if (!root) return null;
+  if (root.entry_id === entryId) return root;
+  for (const child of root.children) {
+    const hit = findEntry(child, entryId);
+    if (hit !== null) return hit;
+  }
+  return null;
+}
+
+/** Find the spec-side state object for ``state_id``. The spec
+ *  definition's ``states`` array is the loose JSON shape FsmSpec dumps
+ *  on register — we type it loosely so the lookup stays robust if a
+ *  future field migration adds keys. */
+function findSpecState(
+  spec: SpecDetail | null,
+  stateId: string,
+): Record<string, unknown> | null {
+  if (!spec) return null;
+  const def = spec.definition as { states?: unknown };
+  const states = Array.isArray(def?.states) ? def.states : [];
+  for (const s of states) {
+    if (s && typeof s === 'object') {
+      const obj = s as Record<string, unknown>;
+      if (obj.id === stateId) return obj;
+    }
+  }
+  return null;
+}
+
+/** Status -> Pill variant — mirrors the run-detail header's palette. */
+function variantForStatus(status: string | null | undefined): PillVariant {
+  if (!status) return 'neutral';
+  const s = status.toLowerCase();
+  if (s === 'completed' || s === 'exited' || s === 'succeeded') return 'success';
+  if (s === 'faulted' || s === 'failed' || s === 'aborted') return 'danger';
+  if (s === 'paused' || s === 'waiting') return 'warning';
+  if (s === 'running' || s === 'entered' || s === 'in_progress') return 'info';
+  return 'neutral';
+}
+
+/** Render an ISO timestamp as a locale-friendly string, or '—' when missing. */
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso ?? '—';
+  }
+}
+
+/** True when the event's payload references this entry_id. The engine
+ *  encodes the linkage under one of several keys depending on the
+ *  event kind (worker_committed uses ``state_entry_id``, transition
+ *  events use ``entry_id``, brief events use ``state_entry_id``); we
+ *  probe all three so the filter doesn't silently drop a relevant
+ *  event when a future event kind picks the alternate spelling. */
+function eventReferencesEntry(event: FsmEvent, entryId: string): boolean {
+  const p = event.payload;
+  if (!p || typeof p !== 'object') return false;
+  const candidates = [
+    (p as Record<string, unknown>).state_entry_id,
+    (p as Record<string, unknown>).entry_id,
+    (p as Record<string, unknown>).entryId,
+  ];
+  return candidates.some((v) => typeof v === 'string' && v === entryId);
+}
+
+/** Pick the most recent ``worker_committed`` event for this entry so
+ *  we can surface its cosignature + brief id in the run-values tab.
+ *  Returns ``null`` when no committing event has landed yet. */
+function findCommitEvent(
+  events: FsmEvent[],
+  entryId: string,
+): FsmEvent | null {
+  for (const event of events) {
+    if (!eventReferencesEntry(event, entryId)) continue;
+    const k = event.kind.toLowerCase();
+    if (k.includes('commit')) return event;
+  }
+  return null;
+}
+
+/** Extract the cosignature scalar from a commit event payload. The
+ *  field name is ``signature`` per the engine's
+ *  ``commit_outputs`` wire format. */
+function pickSignature(event: FsmEvent | null): string | null {
+  if (!event) return null;
+  const p = event.payload as Record<string, unknown>;
+  const sig = p.signature ?? p.cosignature;
+  return typeof sig === 'string' ? sig : null;
+}
+
+/** Extract the brief id from a commit event payload. */
+function pickBriefId(event: FsmEvent | null): string | null {
+  if (!event) return null;
+  const p = event.payload as Record<string, unknown>;
+  const b = p.brief_id ?? p.briefId;
+  return typeof b === 'string' ? b : null;
+}
+
+/** Variant lookup for event-kind pills shown in the timeline. */
+function variantForEventKind(kind: string): PillVariant {
+  const k = kind.toLowerCase();
+  if (k.includes('error') || k.includes('fault') || k.includes('abort')) {
+    return 'danger';
+  }
+  if (k.includes('warn') || k.includes('retry') || k.includes('pause')) {
+    return 'warning';
+  }
+  if (k.includes('complete') || k.includes('success') || k.includes('commit')) {
+    return 'success';
+  }
+  if (k.includes('state') || k.includes('transition') || k.includes('enter')) {
+    return 'info';
+  }
+  return 'neutral';
+}
+
+export function StateEntrySheetBody({
+  entryId,
+  runId,
+  stateTree,
+  spec,
+  events,
+}: StateEntrySheetBodyProps): JSX.Element {
+  const [activeTab, setActiveTab] = useState<StateEntryTabId>('run');
+
+  const entry = useMemo(() => findEntry(stateTree, entryId), [stateTree, entryId]);
+  const specState = useMemo(
+    () => (entry ? findSpecState(spec, entry.state_id) : null),
+    [spec, entry],
+  );
+  const matchingEvents = useMemo(
+    () => events.filter((e) => eventReferencesEntry(e, entryId)),
+    [events, entryId],
+  );
+  const commitEvent = useMemo(
+    () => findCommitEvent(matchingEvents, entryId),
+    [matchingEvents, entryId],
+  );
+
+  // -- Tab 1: run values --------------------------------------------------
+  const runRows: KvRow[] = useMemo(() => {
+    if (!entry) return [];
+    const rows: KvRow[] = [
+      { key: 'state_id', value: entry.state_id },
+      { key: 'entry_id', value: entry.entry_id },
+      { key: 'entry_seq', value: entry.entry_seq },
+      { key: 'status', value: entry.status },
+      { key: 'entered_at', value: formatTimestamp(entry.entered_at) },
+      { key: 'exited_at', value: formatTimestamp(entry.exited_at) },
+    ];
+    if (entry.iteration_n != null) {
+      rows.push({ key: 'iteration_n', value: entry.iteration_n });
+    }
+    return rows;
+  }, [entry]);
+
+  const signature = pickSignature(commitEvent);
+  const briefId = pickBriefId(commitEvent);
+
+  // Pre-compute Pill colour for the status row so the tab body shows
+  // the same semantic colour the run-detail header uses for this same
+  // entry. The header chip lives next to the KeyValueTable rather than
+  // inside it so the KV table stays a flat scalar grid.
+  const statusVariant = entry ? variantForStatus(entry.status) : 'neutral';
+
+  const runPanel: JSX.Element = entry ? (
+    <div class="p-3 space-y-4" data-testid="state-entry-run-panel">
+      <div class="flex flex-wrap items-baseline gap-2">
+        <code class="font-mono text-sm text-slate-900 dark:text-slate-100">
+          {entry.state_id}
+        </code>
+        <Pill variant={statusVariant} size="sm">
+          {entry.status}
+        </Pill>
+        <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500">
+          run {runId}
+        </span>
+      </div>
+      <KeyValueTable rows={runRows} caption="Run-recorded entry metadata" />
+      <section>
+        <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+          inputs
+        </h4>
+        <JsonViewer
+          value={entry.inputs}
+          rootLabel="inputs"
+          mode="inline"
+          maxInlineHeight="max-h-64"
+          downloadFilename={`run-${runId}-${entry.state_id}-inputs.json`}
+          ariaLabel={`Inputs for state entry ${entry.entry_id}`}
+        />
+      </section>
+      <section>
+        <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+          outputs
+        </h4>
+        <JsonViewer
+          value={entry.outputs}
+          rootLabel="outputs"
+          mode="inline"
+          maxInlineHeight="max-h-64"
+          downloadFilename={`run-${runId}-${entry.state_id}-outputs.json`}
+          ariaLabel={`Outputs for state entry ${entry.entry_id}`}
+        />
+      </section>
+      {commitEvent ? (
+        <section>
+          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+            commit / cosignature
+          </h4>
+          <KeyValueTable
+            rows={[
+              ...(briefId ? [{ key: 'brief_id', value: briefId }] : []),
+              ...(signature ? [{ key: 'signature', value: signature }] : []),
+              { key: 'committed_at', value: formatTimestamp(commitEvent.created_at) },
+            ]}
+            caption="Cosignature info"
+          />
+        </section>
+      ) : (
+        <p class="text-xs text-slate-500 dark:text-slate-400">
+          No commit event observed in the loaded slice.
+        </p>
+      )}
+    </div>
+  ) : (
+    <EmptyState
+      title="Entry not in tree"
+      message={`No state entry with id ${entryId} found in the loaded state tree.`}
+    />
+  );
+
+  // -- Tab 2: spec definition --------------------------------------------
+  const specPanel: JSX.Element = specState ? (
+    <StateInspectorBody
+      state={specState}
+      isEntry={
+        typeof (spec?.definition as { entry?: unknown } | undefined)?.entry === 'string' &&
+        (spec?.definition as { entry?: string }).entry === (specState.id as string)
+      }
+    />
+  ) : (
+    <EmptyState
+      title="Spec state unavailable"
+      message={
+        spec === null
+          ? 'The spec definition for this run is not loaded.'
+          : entry === null
+          ? 'No entry known; cannot resolve the spec state.'
+          : `Spec contains no state with id ${entry.state_id}.`
+      }
+    />
+  );
+
+  // -- Tab 3: events for this state --------------------------------------
+  const timelineItems: TimelineItem[] = useMemo(() => {
+    const seen = new Set<string>();
+    const items: TimelineItem[] = [];
+    for (const event of matchingEvents) {
+      if (seen.has(event.id)) continue;
+      seen.add(event.id);
+      items.push({
+        id: event.id,
+        timestamp: event.created_at,
+        title: event.producer_id,
+        kind: event.kind,
+        variant: variantForEventKind(event.kind),
+        payload: (
+          <JsonViewer
+            value={event.payload}
+            rootLabel="payload"
+            mode="inline"
+            maxInlineHeight="max-h-40"
+            ariaLabel={`Payload of event ${event.id}`}
+          />
+        ),
+      });
+    }
+    return items;
+  }, [matchingEvents]);
+
+  const eventsPanel: JSX.Element =
+    timelineItems.length === 0 ? (
+      <EmptyState
+        title="No events for this entry"
+        message="The loaded event slice has no rows scoped to this state entry."
+      />
+    ) : (
+      <div class="p-3" data-testid="state-entry-events-panel">
+        <Timeline
+          items={timelineItems}
+          label={`Events for state entry ${entryId}`}
+        />
+      </div>
+    );
+
+  const tabs: TabSpec[] = [
+    { id: 'run', label: 'Run values' },
+    { id: 'spec', label: 'Spec definition' },
+    {
+      id: 'events',
+      label: 'Events for this state',
+      // Surface the count badge so the operator sees how many events
+      // belong to this entry without opening the tab.
+      badge: (
+        <span class="inline-flex items-center justify-center min-w-[18px] h-[18px] text-[10px] font-mono rounded-full bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 px-1.5">
+          {timelineItems.length}
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <Tabs
+      tabs={tabs}
+      activeTab={activeTab}
+      onChange={(id) => setActiveTab(id as StateEntryTabId)}
+      panels={{
+        run: runPanel,
+        spec: specPanel,
+        events: eventsPanel,
+      }}
+      ariaLabel={`State entry ${entryId} inspector`}
+    />
+  );
+}
+
+export default StateEntrySheetBody;

--- a/ui/src/routes/runDetail/__tests__/EdgeSheetBody.test.tsx
+++ b/ui/src/routes/runDetail/__tests__/EdgeSheetBody.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Tests for routes/runDetail/EdgeSheetBody.tsx.
+ *
+ * Coverage:
+ *   - "Not taken in this run" branch: a spec edge between two states
+ *     that the run never traversed (no parent->child link in the tree
+ *     and no transition_taken event) renders the EmptyState message.
+ *   - "Taken" branch: the same edge with the run's state tree
+ *     containing the parent/child link AND a transition event present
+ *     renders the event's when_taken_at row and a "taken" pill.
+ */
+
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, render } from '@testing-library/preact';
+
+import { EdgeSheetBody } from '../EdgeSheetBody';
+import type { Event as FsmEvent, SpecDetail, StateNode } from '../../../lib/api';
+
+afterEach(() => cleanup());
+
+const FROM = 'plan_phase';
+const TO = 'execute_phase';
+
+const SPEC: SpecDetail = {
+  id: 'spec-1',
+  project_id: 'p',
+  project_slug: 'p',
+  slug: 'demo',
+  version: 1,
+  hash: 'h',
+  registered_at: '2025-01-01T00:00:00Z',
+  definition: {
+    entry: FROM,
+    states: [
+      {
+        id: FROM,
+        kind: 'worker',
+        transitions: [
+          // A non-trivial predicate so the EdgeSheetBody renders the
+          // predicate text via the tokenised highlighter.
+          { to: TO, when: "tier == 'trivial' AND len(risk_signals) == 0" },
+        ],
+      },
+      { id: TO, kind: 'state' },
+    ],
+  },
+};
+
+const TREE_NOT_TAKEN: StateNode = {
+  entry_id: 'entry-from',
+  state_id: FROM,
+  entry_seq: 1,
+  entered_at: '2025-01-01T00:00:00Z',
+  exited_at: null,
+  status: 'entered',
+  inputs: {},
+  outputs: {},
+  iteration_n: null,
+  // No children -> no parent/child link -> edge not taken via tree.
+  children: [],
+};
+
+const TREE_TAKEN: StateNode = {
+  entry_id: 'entry-from',
+  state_id: FROM,
+  entry_seq: 1,
+  entered_at: '2025-01-01T00:00:00Z',
+  exited_at: '2025-01-01T00:00:02Z',
+  status: 'exited',
+  inputs: {},
+  outputs: {},
+  iteration_n: null,
+  children: [
+    {
+      entry_id: 'entry-to',
+      state_id: TO,
+      entry_seq: 2,
+      entered_at: '2025-01-01T00:00:02Z',
+      exited_at: null,
+      status: 'entered',
+      inputs: {},
+      outputs: {},
+      iteration_n: null,
+      children: [],
+    },
+  ],
+};
+
+const TRANSITION_EVENT: FsmEvent = {
+  id: 'evt-tt',
+  run_id: 'R',
+  kind: 'transition_taken',
+  producer_id: 'engine',
+  payload: {
+    from: FROM,
+    to: TO,
+    when_taken_at: '2025-01-01T00:00:02Z',
+  },
+  created_at: '2025-01-01T00:00:02Z',
+  seq: 5,
+};
+
+describe('EdgeSheetBody', () => {
+  test('renders "Not taken in this run" when the edge was never traversed', () => {
+    const { getByText, getByTestId } = render(
+      <EdgeSheetBody
+        fromStateId={FROM}
+        toStateId={TO}
+        runId="R"
+        stateTree={TREE_NOT_TAKEN}
+        spec={SPEC}
+        events={[]}
+      />,
+    );
+    expect(getByTestId('edge-sheet-body')).toBeInTheDocument();
+    expect(getByText('Not taken in this run')).toBeInTheDocument();
+    expect(getByText('not taken')).toBeInTheDocument();
+    // The predicate text from the spec is still rendered (the section
+    // shows the spec-declared guard even when the edge never fired).
+    // Tokens render via spans; assert on a fragment that appears in
+    // the predicate so we don't depend on the exact token splitting.
+    expect(getByText(/risk_signals/)).toBeInTheDocument();
+  });
+
+  test('renders the taken case with the transition event metadata', () => {
+    const { getByText, queryByText } = render(
+      <EdgeSheetBody
+        fromStateId={FROM}
+        toStateId={TO}
+        runId="R"
+        stateTree={TREE_TAKEN}
+        spec={SPEC}
+        events={[TRANSITION_EVENT]}
+      />,
+    );
+    expect(getByText('taken')).toBeInTheDocument();
+    expect(getByText('when_taken_at')).toBeInTheDocument();
+    expect(getByText('transition_taken')).toBeInTheDocument();
+    // The not-taken EmptyState must NOT render in the taken case.
+    expect(queryByText('Not taken in this run')).toBeNull();
+  });
+
+  test('renders predicate text via tokenised highlighter spans', () => {
+    const { container } = render(
+      <EdgeSheetBody
+        fromStateId={FROM}
+        toStateId={TO}
+        runId="R"
+        stateTree={TREE_NOT_TAKEN}
+        spec={SPEC}
+        events={[]}
+      />,
+    );
+    // The tokenised predicate code block carries the amber-pill
+    // background classes; assert that the predicate <code> element
+    // exists and contains the predicate fragments.
+    const code = container.querySelector('code[title*="risk_signals"]');
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toContain('tier');
+    expect(code?.textContent).toContain('risk_signals');
+  });
+});

--- a/ui/src/routes/runDetail/__tests__/StateEntrySheetBody.test.tsx
+++ b/ui/src/routes/runDetail/__tests__/StateEntrySheetBody.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Tests for routes/runDetail/StateEntrySheetBody.tsx.
+ *
+ * Coverage:
+ *   - The three tabs (Run values / Spec definition / Events for this
+ *     state) all render and the operator can switch between them via
+ *     the role="tab" buttons.
+ *   - Tab 2 mounts StateInspectorBody (assert the inspector's metadata
+ *     "id" / "kind" row labels show up once the tab is active).
+ *   - Tab 3 filters the events by entry_id (an event whose payload
+ *     references the entry id appears; an unrelated event does not).
+ */
+
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+
+import { StateEntrySheetBody } from '../StateEntrySheetBody';
+import type { Event as FsmEvent, SpecDetail, StateNode } from '../../../lib/api';
+
+afterEach(() => cleanup());
+
+const ENTRY_ID = 'entry-abc';
+const STATE_ID = 'plan_phase';
+
+const STATE_TREE: StateNode = {
+  entry_id: ENTRY_ID,
+  state_id: STATE_ID,
+  entry_seq: 1,
+  entered_at: '2025-01-01T00:00:00Z',
+  exited_at: null,
+  status: 'entered',
+  inputs: { x: 1 },
+  outputs: { y: 2 },
+  iteration_n: 0,
+  children: [],
+};
+
+const SPEC: SpecDetail = {
+  id: 'spec-1',
+  project_id: 'p',
+  project_slug: 'p',
+  slug: 'demo',
+  version: 1,
+  hash: 'h',
+  registered_at: '2025-01-01T00:00:00Z',
+  definition: {
+    entry: STATE_ID,
+    states: [
+      {
+        id: STATE_ID,
+        kind: 'worker',
+        worker: { role: 'planner' },
+      },
+      { id: 'other', kind: 'state' },
+    ],
+  },
+};
+
+const RELATED_EVENT: FsmEvent = {
+  id: 'evt-1',
+  run_id: 'R',
+  kind: 'state_entered',
+  producer_id: 'engine',
+  payload: { state_entry_id: ENTRY_ID },
+  created_at: '2025-01-01T00:00:01Z',
+  seq: 1,
+};
+
+const COMMIT_EVENT: FsmEvent = {
+  id: 'evt-2',
+  run_id: 'R',
+  kind: 'worker_committed',
+  producer_id: 'engine',
+  payload: {
+    state_entry_id: ENTRY_ID,
+    signature: 'sig-deadbeef',
+    brief_id: 'brief-xyz',
+  },
+  created_at: '2025-01-01T00:00:02Z',
+  seq: 2,
+};
+
+const UNRELATED_EVENT: FsmEvent = {
+  id: 'evt-3',
+  run_id: 'R',
+  kind: 'state_entered',
+  producer_id: 'engine',
+  payload: { state_entry_id: 'some-other-entry' },
+  created_at: '2025-01-01T00:00:03Z',
+  seq: 3,
+};
+
+describe('StateEntrySheetBody', () => {
+  test('renders all three tabs with the expected labels', () => {
+    const { getByRole } = render(
+      <StateEntrySheetBody
+        entryId={ENTRY_ID}
+        runId="R"
+        stateTree={STATE_TREE}
+        spec={SPEC}
+        events={[RELATED_EVENT, COMMIT_EVENT, UNRELATED_EVENT]}
+      />,
+    );
+    expect(getByRole('tab', { name: /Run values/ })).toBeInTheDocument();
+    expect(getByRole('tab', { name: /Spec definition/ })).toBeInTheDocument();
+    expect(getByRole('tab', { name: /Events for this state/ })).toBeInTheDocument();
+  });
+
+  test('tab 1 (default) shows the run-recorded metadata for this entry', () => {
+    const { getAllByText, getByTestId } = render(
+      <StateEntrySheetBody
+        entryId={ENTRY_ID}
+        runId="R"
+        stateTree={STATE_TREE}
+        spec={SPEC}
+        events={[RELATED_EVENT, COMMIT_EVENT, UNRELATED_EVENT]}
+      />,
+    );
+    expect(getByTestId('state-entry-run-panel')).toBeInTheDocument();
+    expect(getAllByText('state_id').length).toBeGreaterThan(0);
+    expect(getAllByText('entered_at').length).toBeGreaterThan(0);
+    expect(getAllByText('signature').length).toBeGreaterThan(0);
+  });
+
+  test('tab 2 mounts StateInspectorBody (id / kind metadata rows)', () => {
+    const { getByRole, getByText } = render(
+      <StateEntrySheetBody
+        entryId={ENTRY_ID}
+        runId="R"
+        stateTree={STATE_TREE}
+        spec={SPEC}
+        events={[]}
+      />,
+    );
+    fireEvent.click(getByRole('tab', { name: /Spec definition/ }));
+    // StateInspectorBody renders these two row labels at the top of its
+    // metadata table; they are NOT rendered by the run-values tab so
+    // their presence is a reliable proof the inspector mounted.
+    expect(getByText('id')).toBeInTheDocument();
+    expect(getByText('kind')).toBeInTheDocument();
+    // The inspector also surfaces the spec-side worker.role row for
+    // states with a worker block.
+    expect(getByText('worker.role')).toBeInTheDocument();
+  });
+
+  test('tab 3 filters the event list by entry_id', () => {
+    const { getByRole, getByTestId, queryByText } = render(
+      <StateEntrySheetBody
+        entryId={ENTRY_ID}
+        runId="R"
+        stateTree={STATE_TREE}
+        spec={SPEC}
+        events={[RELATED_EVENT, COMMIT_EVENT, UNRELATED_EVENT]}
+      />,
+    );
+    fireEvent.click(getByRole('tab', { name: /Events for this state/ }));
+    const eventsPanel = getByTestId('state-entry-events-panel');
+    // Both related events should render — their kinds appear inside the
+    // timeline as Pill text. The unrelated event's id is unique so we
+    // can prove it does NOT render anywhere in the panel.
+    expect(eventsPanel.textContent).toContain('state_entered');
+    expect(eventsPanel.textContent).toContain('worker_committed');
+    // No row from the unrelated event id should appear.
+    expect(queryByText(/some-other-entry/)).toBeNull();
+  });
+
+  test('renders an EmptyState when the entry id is not in the tree', () => {
+    const { getByText } = render(
+      <StateEntrySheetBody
+        entryId="unknown"
+        runId="R"
+        stateTree={STATE_TREE}
+        spec={SPEC}
+        events={[]}
+      />,
+    );
+    expect(getByText('Entry not in tree')).toBeInTheDocument();
+  });
+});

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -145,3 +145,39 @@ body {
   padding: 0 1px;
   color: inherit;
 }
+
+/* Amber ring pulse used by the RunProgressGraph's current-state node.
+   The animation paints a single expanding amber shadow ring that fades
+   out at 70 % then continues invisibly to 100 % so the next iteration
+   restarts cleanly without flashing. Tuned around the W22b amber-500
+   token (rgba(251,191,36,*)) so the colour matches the existing
+   "current" pill and ring legend on the run graph header.
+
+   The infinite loop runs at 1.6 s per cycle — slow enough that the
+   movement is calming, fast enough that the operator's eye lands on
+   the active node within the first scan. */
+@keyframes fsm-amber-ring-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.6);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(251, 191, 36, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(251, 191, 36, 0);
+  }
+}
+
+.fsm-pulse-current {
+  animation: fsm-amber-ring-pulse 1.6s ease-out infinite;
+}
+
+/* Respect the operator's reduced-motion preference: the pulsing ring
+   is replaced with a static amber outline so the "current" affordance
+   is still present without continuous animation. */
+@media (prefers-reduced-motion: reduce) {
+  .fsm-pulse-current {
+    animation: none;
+    outline: 2px solid rgb(251 191 36);
+  }
+}


### PR DESCRIPTION
## Summary

PR 4 of the run-progress-graph polish series.

- `RunProgressGraph` accepts new `onNodeClick(nodeId)` + `onEdgeClick(fromId, toId)` props and forwards them to `FlowGraph`. The edge handler unpacks `(sourceId, targetId)` from the `decorateEdges`-stamped `edge.data` so callers get a typed pair rather than a synthetic edge id.
- `FlowGraph.FsmNode` now applies a new `fsm-pulse-current` class when `data.isCurrent` is true. `theme.css` defines a 1.6 s amber ring `box-shadow` keyframe + a `prefers-reduced-motion` fallback that swaps the animation for a static amber outline.
- New `routes/runDetail/StateEntrySheetBody.tsx` — three-tab body (`Run values`, `Spec definition`, `Events for this state`). Tab 2 mounts the shared `StateInspectorBody`; tab 3 filters events by `entry_id` and dedupes into a Timeline.
- New `routes/runDetail/EdgeSheetBody.tsx` — source/target `KeyValueTable`s, syntax-highlighted predicate via `tokenisePredicate`, `transition_taken` event metadata, and an `EmptyState` for the not-taken case.
- `runDetail.tsx` wires both openers to the graph clicks and passes the fully-built sheet body via the existing `runDetailSheets` openers.

## Test plan

- [x] `vitest run` — 424/424 passing, including 11 new tests in this PR
- [x] `tsc --noEmit` — clean
- [x] `vite build` — succeeds
- [ ] Manual: click a node on `/runs/:id` graph and confirm the 3-tab state-entry sheet opens; click an edge and confirm the edge sheet opens with the predicate highlighted; confirm the current state pulses amber

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)