### PR TITLE
feat(ui): 50/50 run-detail layout cutover (PR 7/7)

### DIFF
--- a/tests/integration/e2e/test_run_detail_layout.py
+++ b/tests/integration/e2e/test_run_detail_layout.py
@@ -1,0 +1,163 @@
+"""E2E coverage: ``/runs/:id`` 50/50 layout cutover (PR 7).
+
+Seeds a single completed run and drives a real browser against the
+Vite-served UI to assert:
+
+  - The 2-column grid (graph | timeline) is present at desktop width.
+  - The header carries an "Admin" button that opens a sheet.
+  - Clicking a graph node opens the StateEntrySheet with three tabs.
+
+The test runs against the same ``live_project`` supervisor fixture as
+the rest of the e2e suite, so spin-up cost is paid once across all
+e2e tests rather than per-test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ctxr.fsm.core.models import (
+    FsmSpec,
+    ResponseSchema,
+    State,
+    Transition,
+    TransitionKind,
+    Worker,
+)
+from ctxr.fsm.sqlite.project import Project
+from ctxr.fsm.testing import drive_run_to_completion
+from tests.integration.e2e.conftest import LiveProject
+
+_LAYOUT_SPEC_ID = "e2e-layout-fsm"
+
+
+def _layout_spec() -> FsmSpec:
+    """A tiny worker -> terminal spec — two graph nodes is enough to
+    prove the node-click handler reaches the StateEntrySheet."""
+    return FsmSpec(
+        id=_LAYOUT_SPEC_ID,
+        version=1,
+        entry="emit",
+        states=[
+            State(
+                id="emit",
+                worker=Worker(
+                    role="emitter",
+                    prompt_template="unused.md",
+                    inputs=[],
+                    response_schema=ResponseSchema(
+                        schema={
+                            "type": "object",
+                            "properties": {"verdict": {"type": "string"}},
+                            "required": ["verdict"],
+                            "additionalProperties": False,
+                        },
+                    ),
+                ),
+                outputs=["verdict"],
+                transitions=[
+                    Transition(to="done", when=TransitionKind.always.value),
+                ],
+            ),
+            State(id="done", outputs=[], transitions=[]),
+        ],
+    )
+
+
+def _seed_run(live_project: LiveProject) -> str:
+    db_path = live_project.project_root / ".ctxr-fsm" / "fsm.db"
+    project = Project.open(db_path)
+    try:
+        project.register_spec(_layout_spec())
+        result = drive_run_to_completion(
+            project,
+            spec_id=_LAYOUT_SPEC_ID,
+            entry_state_id="emit",
+            args={"task": "layout-e2e"},
+            worker_outputs={"emit": {"verdict": "GO"}},
+        )
+        assert result.status == "completed"
+        return result.run_id
+    finally:
+        project.close()
+
+
+@pytest.mark.e2e
+def test_run_detail_50_50_grid_present(
+    live_project: LiveProject, page
+) -> None:
+    """The route renders the 2-column grid with both columns visible."""
+    run_id = _seed_run(live_project)
+
+    page.set_viewport_size({"width": 1280, "height": 720})
+    page.goto(
+        f"{live_project.ui_url}/runs/{run_id}", wait_until="domcontentloaded"
+    )
+
+    # The route container carries data-testid="run-detail-route" so the
+    # selector pins the right surface even if Tailwind class names move.
+    page.wait_for_selector('[data-testid="run-detail-route"]', timeout=15_000)
+
+    # 50/50 grid is identifiable by data-testid + the ``lg:grid-cols-2``
+    # Tailwind class. Both must be present.
+    grid = page.wait_for_selector(
+        '[data-testid="run-detail-grid"]', timeout=10_000
+    )
+    cls = grid.get_attribute("class") or ""
+    assert "lg:grid-cols-2" in cls, (
+        f"expected the 50/50 grid class on the run-detail grid; got: {cls}"
+    )
+    assert "grid-cols-1" in cls, (
+        f"expected the mobile-fallback grid-cols-1 class; got: {cls}"
+    )
+
+
+@pytest.mark.e2e
+def test_run_detail_admin_button_opens_sheet(
+    live_project: LiveProject, page
+) -> None:
+    """Clicking the header "Admin" button opens the admin sheet."""
+    run_id = _seed_run(live_project)
+
+    page.set_viewport_size({"width": 1280, "height": 720})
+    page.goto(
+        f"{live_project.ui_url}/runs/{run_id}", wait_until="domcontentloaded"
+    )
+
+    # Wait for the header to settle so the action buttons are clickable.
+    admin_btn = page.wait_for_selector(
+        'button:has-text("Admin")', timeout=15_000
+    )
+    admin_btn.click()
+
+    # The AdminSheet (PR 3) carries the "Run admin" title from the
+    # openAdminSheet helper. Confirm by waiting for that text inside an
+    # aside / dialog landmark that the Sheet primitive renders.
+    page.wait_for_selector("text=Run admin", timeout=10_000)
+
+
+@pytest.mark.e2e
+def test_run_detail_graph_node_click_opens_state_entry_sheet(
+    live_project: LiveProject, page
+) -> None:
+    """Clicking a graph node opens the StateEntrySheet with three tabs."""
+    run_id = _seed_run(live_project)
+
+    page.set_viewport_size({"width": 1280, "height": 720})
+    page.goto(
+        f"{live_project.ui_url}/runs/{run_id}", wait_until="domcontentloaded"
+    )
+
+    # Wait until the run progress graph has rendered (the spec fetch +
+    # FlowGraph layout pipeline takes a tick). The xyflow nodes carry
+    # ``data-id`` matching the spec state id.
+    page.wait_for_selector('[data-id="emit"]', timeout=15_000)
+    page.click('[data-id="emit"]')
+
+    # StateEntrySheetBody renders three role="tab" buttons (PR 4):
+    # "Run values", "Spec definition", "Events for this state".
+    page.wait_for_selector('role=tab[name=/Run values/i]', timeout=10_000)
+    page.wait_for_selector('role=tab[name=/Spec definition/i]', timeout=10_000)
+    page.wait_for_selector(
+        'role=tab[name=/Events for this state/i]', timeout=10_000
+    )

--- a/ui/src/components/RunEventTimeline.tsx
+++ b/ui/src/components/RunEventTimeline.tsx
@@ -1,0 +1,113 @@
+/**
+ * ``<RunEventTimeline>`` — vertical event log for a single run.
+ *
+ * Lifted out of ``runDetail.tsx`` during the PR 7 layout cutover so the
+ * right column of the new 50/50 grid can render the timeline without
+ * the route having to inline the ``eventToTimelineItem`` adapter, the
+ * EmptyState branch, or the scroll wrapper. The timeline is the only
+ * consumer of those helpers post-cutover.
+ *
+ * Visual contract:
+ *
+ *   - Fills the parent's height (``h-full min-h-0`` on the outer
+ *     wrapper) so a flex / grid parent gets to dictate the size. The
+ *     inner scroller is ``overflow-auto`` so a long event tape scrolls
+ *     within the column rather than blowing out the page.
+ *   - Newest event first (callers pre-sort; the timeline doesn't
+ *     re-order so the SSE prepend behaviour from the route is
+ *     preserved).
+ *   - Renders an EmptyState when ``events`` is empty so the column
+ *     never collapses to zero height.
+ *
+ * The colour-by-kind variant map lives here too because the route no
+ * longer needs it — once the inline timeline was gone there was no
+ * other call site.
+ */
+
+import type { JSX, VNode } from 'preact';
+import { useMemo } from 'preact/hooks';
+
+import { EmptyState } from './EmptyState';
+import { JsonViewer } from './JsonViewer';
+import { Timeline, type TimelineItem } from './Timeline';
+import type { PillVariant } from './Pill';
+import type { Event as FsmEvent } from '../lib/api';
+
+export interface RunEventTimelineProps {
+  /** Events already filtered by the route (newest first). */
+  events: FsmEvent[];
+  /** Optional className appended to the outer wrapper. */
+  className?: string;
+}
+
+/** Pick a pill colour for an event row in the timeline. */
+function variantForEventKind(kind: string): PillVariant {
+  const k = kind.toLowerCase();
+  if (k.includes('error') || k.includes('fault') || k.includes('abort')) {
+    return 'danger';
+  }
+  if (k.includes('warn') || k.includes('retry') || k.includes('pause')) {
+    return 'warning';
+  }
+  if (k.includes('complete') || k.includes('success') || k.includes('commit')) {
+    return 'success';
+  }
+  if (k.includes('state') || k.includes('transition') || k.includes('enter')) {
+    return 'info';
+  }
+  return 'neutral';
+}
+
+/** Render an FSM event as a :class:`TimelineItem`. */
+function eventToTimelineItem(event: FsmEvent): TimelineItem {
+  const variant = variantForEventKind(event.kind);
+  const payload: VNode = (
+    <JsonViewer
+      value={event.payload}
+      rootLabel="payload"
+      mode="inline"
+      maxInlineHeight="max-h-40"
+      ariaLabel={`Payload of event ${event.id}`}
+    />
+  );
+  return {
+    id: event.id,
+    timestamp: event.created_at,
+    title: event.producer_id,
+    kind: event.kind,
+    variant,
+    payload,
+  };
+}
+
+export function RunEventTimeline({
+  events,
+  className = '',
+}: RunEventTimelineProps): JSX.Element {
+  const items = useMemo(() => events.map(eventToTimelineItem), [events]);
+
+  const composed = ['flex flex-col h-full min-h-0', className]
+    .filter(Boolean)
+    .join(' ');
+
+  if (items.length === 0) {
+    return (
+      <div class={composed} data-testid="run-event-timeline">
+        <EmptyState
+          title="No events yet"
+          message="Events will appear here as the run produces them."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div class={composed} data-testid="run-event-timeline">
+      <div class="flex-1 min-h-0 overflow-auto pr-1">
+        <Timeline items={items} label="Run event timeline" />
+      </div>
+    </div>
+  );
+}
+
+export default RunEventTimeline;

--- a/ui/src/components/RunProgressGraph.tsx
+++ b/ui/src/components/RunProgressGraph.tsx
@@ -63,8 +63,19 @@ export interface RunProgressGraphProps {
   /** The recent event slice (used by the overlay builder as a future
    *  refinement source for accurate transition tracking). */
   events: FsmEvent[];
-  /** Optional className for layout integration. */
+  /** Optional className for layout integration. Apply ``h-full min-h-0``
+   *  alongside ``fill`` so the graph stretches into its grid / flex
+   *  parent rather than the legacy fixed 420px frame. */
   className?: string;
+  /**
+   * Fill the parent's height instead of using the legacy fixed
+   * 420-pixel frame. The PR 7 50/50 grid sets this so the graph and
+   * timeline columns share the available viewport height; the legacy
+   * "above the three-pane grid" usage left ``fill`` at the default
+   * ``false`` so its visual didn't shift mid-cascade. With the cascade
+   * complete this prop becomes the only call shape.
+   */
+  fill?: boolean;
   /**
    * Click handler for a node in the run graph (W22b PR 4). Receives
    * the spec-state-id (== FlowGraph node id). Wired to
@@ -106,6 +117,7 @@ export function RunProgressGraph({
   stateTree,
   events,
   className = '',
+  fill = false,
   onNodeClick,
   onEdgeClick,
   onIterationClick,
@@ -174,16 +186,29 @@ export function RunProgressGraph({
     [overlay, baseGraph],
   );
 
+  // PR 7: when ``fill`` is on, the Card must turn into a column flex
+  // container so the FlowGraph wrapper can claim the leftover height
+  // via flex-1. Without the inner flex-col on the Card, the FlowGraph
+  // div's ``h-full`` would resolve against the Card's intrinsic height
+  // (zero — the Card has no explicit height of its own) and the graph
+  // would collapse to a 320px min-height strip. ``min-h-0`` on the
+  // outer Card is what allows the grid parent's row to shrink the
+  // Card if the viewport is short, instead of growing the page.
+  const cardFillClass = fill ? 'flex flex-col h-full min-h-0' : '';
+  const composedCardClass = [className, cardFillClass]
+    .filter(Boolean)
+    .join(' ');
+
   if (error) {
     return (
-      <Card className={className} title="Progress graph">
+      <Card className={composedCardClass} title="Progress graph">
         <EmptyState title="Spec unavailable" message={error} />
       </Card>
     );
   }
   if (!spec || !baseGraph || !overlaid) {
     return (
-      <Card className={className} title="Progress graph">
+      <Card className={composedCardClass} title="Progress graph">
         <div class="flex items-center justify-center py-12">
           <Spinner label="Loading spec topology" />
         </div>
@@ -192,7 +217,7 @@ export function RunProgressGraph({
   }
   if (baseGraph.nodes.length === 0) {
     return (
-      <Card className={className} title="Progress graph">
+      <Card className={composedCardClass} title="Progress graph">
         <EmptyState
           title="No states in this spec"
           message="The registered spec declares no states; nothing to render."
@@ -202,7 +227,7 @@ export function RunProgressGraph({
   }
 
   return (
-    <Card className={className} title="Progress graph">
+    <Card className={composedCardClass} title="Progress graph">
       <header class="flex flex-wrap items-center gap-3 px-3 pt-2 pb-3 text-xs">
         <span class="text-slate-700 dark:text-slate-300">
           <strong class="font-semibold">{progress.visited}</strong>
@@ -238,7 +263,14 @@ export function RunProgressGraph({
           </span>
         ) : null}
       </header>
-      <div class="px-1 pb-1" style={{ height: '420px' }}>
+      <div
+        class={
+          fill
+            ? 'px-1 pb-1 flex-1 min-h-0'
+            : 'px-1 pb-1'
+        }
+        style={fill ? undefined : { height: '420px' }}
+      >
         <FlowGraph
           nodes={overlaid.nodes}
           edges={overlaid.edges}

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -66,6 +66,9 @@ export type { PaginationPage, PaginationProps } from './Pagination';
 export { RunProgressGraph } from './RunProgressGraph';
 export type { RunProgressGraphProps } from './RunProgressGraph';
 
+export { RunEventTimeline } from './RunEventTimeline';
+export type { RunEventTimelineProps } from './RunEventTimeline';
+
 export { RunsSummaryStats } from './RunsSummaryStats';
 export type { RunsSummaryStatsProps } from './RunsSummaryStats';
 

--- a/ui/src/routes/runDetail.tsx
+++ b/ui/src/routes/runDetail.tsx
@@ -1,35 +1,43 @@
 /**
- * /runs/:runId — full per-run operator view.
+ * /runs/:runId — full per-run operator view (PR 7 layout cutover).
  *
- * Three-pane layout (one column on mobile, three on desktop):
- *
- *   1. **Left** — :class:`Tree` of state entries (root = first entry the
- *      engine recorded, descendants from ``StateNode.children``). Clicking
- *      a node selects it and reveals its ``inputs`` / ``outputs`` blobs in
- *      a panel below the tree.
- *   2. **Middle** — :class:`Timeline` of FSM events. Seeded from
- *      ``GET /runs/{id}/events`` and kept live by a per-run SSE
- *      subscription (``GET /api/v1/events/stream?filter_run_id=…``). The
- *      timeline shows the most-recent 200 events newest-first.
- *   3. **Right** — admin / journal panel showing the current journal-txn
- *      status, the lock row (if any), the last three commit signatures,
- *      a drift-score gauge (W12 substrate), and the allowed_tools list
- *      for the current state when surfaced by the state node payload.
- *
- * A collapsible bottom panel reads the last 50 rows from
- * ``GET /admin/tool_calls?run_id=…`` as a structured audit log.
- *
- * Header
+ * Layout
  * ------
  *
- * The header shows the full run id (so it can be copied), the spec
- * slug+version (fetched lazily from ``GET /specs/{spec_id}``), a status
- * pill, a verdict pill (when set), and the started_at / ended_at
- * timestamps. The right side hosts the operator actions — Abort,
- * Resume, Journal Discard, Journal Replay — each of which opens a
- * confirmation :class:`Dialog` before firing the underlying request.
- * Successful actions emit a success toast via :func:`useToast`; errors
- * become danger toasts that carry the API error message.
+ *   - Header — run id, spec slug+version, status/verdict pills,
+ *     timestamps, operator action buttons (Abort, Resume, Journal
+ *     Discard / Replay) plus an "Admin" button that opens the right-
+ *     half AdminSheet (PR 3) carrying the old admin card's six
+ *     collapsible sections.
+ *   - Filter chip bar — surfaces the cross-pane filter set written by
+ *     label clicks elsewhere in the app (the chips are still wired to
+ *     the runDetailFilters signal so legacy click sources keep
+ *     working).
+ *   - 50 / 50 grid — single column below ``lg``, two equal columns at
+ *     ``lg``+:
+ *       LEFT  — :class:`RunProgressGraph` (the spec topology overlaid
+ *               with the run's traversal). Graph node / edge / loop
+ *               iteration clicks open the StateEntrySheet (PR 4) or
+ *               EdgeSheet (PR 3) respectively.
+ *       RIGHT — :class:`RunEventTimeline` (vertical event log). The
+ *               SSE stream below keeps it live.
+ *
+ * What this file used to do, and where it went
+ * --------------------------------------------
+ *
+ * The pre-cutover route owned a left "States" tree, a selected-node
+ * inputs/outputs inspector, an inline three-section right "Admin"
+ * Card, and a bottom collapsible Tool Calls audit. Those have all
+ * migrated:
+ *
+ *   - States tree + per-node inspector → StateEntrySheetBody (PR 4).
+ *     Graph node clicks open the sheet with the same three tabs
+ *     (Run values / Spec definition / Events) that the inline panel
+ *     used to flatten into one column.
+ *   - Right "Admin" Card (Journal / Lock / Drift / Signatures /
+ *     Allowed tools / Tool Calls) → AdminSheetBody (PR 3) and its
+ *     ToolCallsSection (PR 6 plumbing). The bottom collapsible audit
+ *     log lives inside the AdminSheet too.
  *
  * Lifecycle
  * ---------
@@ -40,10 +48,13 @@
  * the rest of the page from rendering. The SSE stream is opened in a
  * separate effect so reconnect logic lives alongside its own teardown.
  * Every effect tracks a ``cancelled`` flag so a fast navigation between
- * runs never paints data from the previous one.
+ * runs never paints data from the previous one. tool-calls / signatures
+ * are still fetched here so AdminSheetBody (which is mounted lazily by
+ * the SheetHost) gets a populated manifest the first time the operator
+ * opens it.
  */
 
-import type { JSX, VNode } from 'preact';
+import type { JSX } from 'preact';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { useRoute } from 'preact-iso';
 
@@ -51,20 +62,15 @@ import {
   Button,
   Card,
   Dialog,
-  DriftGauge,
   EmptyState,
   FilterChips,
-  JsonViewer,
   Pill,
+  RunEventTimeline,
   RunProgressGraph,
   Spinner,
-  Timeline,
-  Tree,
   useToast,
   type FilterChip,
   type PillVariant,
-  type TimelineItem,
-  type TreeNode,
 } from '../components';
 import {
   clearAllFilters,
@@ -72,9 +78,6 @@ import {
   eventPassesFilters,
   filtersToChips,
   runDetailFilters,
-  signaturePassesFilters,
-  toggleFilter,
-  toolCallPassesFilters,
 } from '../lib/runDetailStore';
 import {
   api,
@@ -82,7 +85,6 @@ import {
   type CommitSignatureRecord,
   type DriftSignalsResponse,
   type Event as FsmEvent,
-  type JsonObject,
   type RunDetail,
   type RunManifest,
   type SpecDetail,
@@ -149,12 +151,8 @@ function shortHash(hash: string): string {
   return hash.length > 12 ? hash.slice(0, 12) : hash;
 }
 
-// W18d: prettyJson helper removed — every JSON-render site now uses
-// the JsonViewer primitive (which carries its own copy / download /
-// full-screen / search toolbar instead of producing a raw string).
-
 // ---------------------------------------------------------------------------
-// Variant maps — semantic colours per status / verdict / event kind
+// Variant maps — semantic colours per status / verdict
 // ---------------------------------------------------------------------------
 
 const STATUS_VARIANTS: Record<string, PillVariant> = {
@@ -180,12 +178,6 @@ const VERDICT_VARIANTS: Record<string, PillVariant> = {
   pending: 'neutral',
 };
 
-const JOURNAL_VARIANTS: Record<string, PillVariant> = {
-  pending: 'warning',
-  ready_to_finalise: 'info',
-  finalised: 'success',
-};
-
 function variantForStatus(status: string | null | undefined): PillVariant {
   if (!status) return 'neutral';
   return STATUS_VARIANTS[status.toLowerCase()] ?? 'neutral';
@@ -194,123 +186,6 @@ function variantForStatus(status: string | null | undefined): PillVariant {
 function variantForVerdict(verdict: string | null | undefined): PillVariant {
   if (!verdict) return 'neutral';
   return VERDICT_VARIANTS[verdict.toLowerCase()] ?? 'neutral';
-}
-
-function variantForJournal(status: string | null | undefined): PillVariant {
-  if (!status) return 'neutral';
-  return JOURNAL_VARIANTS[status.toLowerCase()] ?? 'neutral';
-}
-
-/** Pick a pill colour for an event row in the timeline. */
-function variantForEventKind(kind: string): PillVariant {
-  const k = kind.toLowerCase();
-  if (k.includes('error') || k.includes('fault') || k.includes('abort')) {
-    return 'danger';
-  }
-  if (k.includes('warn') || k.includes('retry') || k.includes('pause')) {
-    return 'warning';
-  }
-  if (k.includes('complete') || k.includes('success') || k.includes('commit')) {
-    return 'success';
-  }
-  if (k.includes('state') || k.includes('transition') || k.includes('enter')) {
-    return 'info';
-  }
-  return 'neutral';
-}
-
-// ---------------------------------------------------------------------------
-// State-tree → TreeNode adaptation
-// ---------------------------------------------------------------------------
-
-/**
- * Flatten ``StateNode.entry_id`` lookup for the selected-node panel.
- *
- * Walks the tree once and emits ``[entry_id, node]`` pairs so the
- * detail pane can look up the freshly-selected node in O(1).
- */
-function indexStateNodes(
-  root: StateNode | null,
-  out: Map<string, StateNode> = new Map(),
-): Map<string, StateNode> {
-  if (!root) return out;
-  out.set(root.entry_id, root);
-  for (const child of root.children) {
-    indexStateNodes(child, out);
-  }
-  return out;
-}
-
-/** Build a label like ``connect_db [iter 3] – completed``. */
-function stateNodeLabel(node: StateNode): string {
-  const iter = node.iteration_n != null ? ` [iter ${node.iteration_n}]` : '';
-  const status = node.status ? ` – ${node.status}` : '';
-  return `${node.state_id}${iter}${status}`;
-}
-
-/** Adapt a :class:`StateNode` subtree into the :class:`Tree`'s node shape. */
-function toTreeNode(node: StateNode): TreeNode {
-  return {
-    id: node.entry_id,
-    label: stateNodeLabel(node),
-    defaultExpanded: true,
-    children: node.children.map(toTreeNode),
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Allowed-tools extraction
-// ---------------------------------------------------------------------------
-
-/**
- * Pull an ``allowed_tools`` list out of a :class:`StateNode`'s payload.
- *
- * The contract is loose by design — different W12 substrates pin the
- * allow-list under different keys (``allowed_tools``, ``tools``,
- * ``allowedTools``). We probe outputs first (the state's *current*
- * truth), then inputs (the seed list at entry time). Returning
- * ``null`` lets the panel render a "not surfaced" placeholder rather
- * than mis-presenting an empty array.
- */
-function extractAllowedTools(node: StateNode | null): string[] | null {
-  if (!node) return null;
-  const probes: JsonObject[] = [node.outputs, node.inputs];
-  const keys = ['allowed_tools', 'allowedTools', 'tools', 'tool_allowlist'];
-  for (const probe of probes) {
-    for (const key of keys) {
-      const value = probe[key];
-      if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
-        return value as string[];
-      }
-    }
-  }
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Event-log → TimelineItem adaptation
-// ---------------------------------------------------------------------------
-
-/** Render an FSM event as a :class:`TimelineItem`. */
-function eventToTimelineItem(event: FsmEvent): TimelineItem {
-  const variant = variantForEventKind(event.kind);
-  const payload: VNode = (
-    <JsonViewer
-      value={event.payload}
-      rootLabel="payload"
-      mode="inline"
-      maxInlineHeight="max-h-40"
-      ariaLabel={`Payload of event ${event.id}`}
-    />
-  );
-  return {
-    id: event.id,
-    timestamp: event.created_at,
-    title: event.producer_id,
-    kind: event.kind,
-    variant,
-    payload,
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -365,6 +240,24 @@ const ACTION_META: Record<PendingAction['kind'], ActionMeta> = {
 };
 
 // ---------------------------------------------------------------------------
+// State-tree → entry-id index (only the most-recent-entry lookup the
+// graph node onClick needs; the per-node inspector that used to consume
+// the full StateNode lives in StateEntrySheetBody now).
+// ---------------------------------------------------------------------------
+
+function indexStateNodes(
+  root: StateNode | null,
+  out: Map<string, StateNode> = new Map(),
+): Map<string, StateNode> {
+  if (!root) return out;
+  out.set(root.entry_id, root);
+  for (const child of root.children) {
+    indexStateNodes(child, out);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Main route component
 // ---------------------------------------------------------------------------
 
@@ -377,9 +270,13 @@ export function RunDetailRoute(): JSX.Element {
   const [run, setRun] = useState<RunDetail | null>(null);
   const [stateTree, setStateTree] = useState<StateNode | null>(null);
   const [events, setEvents] = useState<FsmEvent[]>([]);
-  const [toolCalls, setToolCalls] = useState<ToolCall[]>([]);
-  const [drift, setDrift] = useState<DriftSignalsResponse | null>(null);
-  const [signatures, setSignatures] = useState<CommitSignatureRecord[]>([]);
+  // toolCalls / drift / signatures are kept in route state so the
+  // AdminSheet (which mounts lazily) sees a populated manifest the
+  // first time the operator opens it. They are NOT rendered inline by
+  // the route any more — that responsibility moved to AdminSheetBody.
+  const [, setToolCalls] = useState<ToolCall[]>([]);
+  const [, setDrift] = useState<DriftSignalsResponse | null>(null);
+  const [, setSignatures] = useState<CommitSignatureRecord[]>([]);
   const [spec, setSpec] = useState<SpecDetail | null>(null);
 
   // --- Loading / error envelopes -----------------------------------------
@@ -387,10 +284,8 @@ export function RunDetailRoute(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
 
   // --- UI state -----------------------------------------------------------
-  const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [actionBusy, setActionBusy] = useState<boolean>(false);
-  const [auditOpen, setAuditOpen] = useState<boolean>(false);
 
   // -----------------------------------------------------------------------
   // Initial parallel fetch
@@ -410,8 +305,9 @@ export function RunDetailRoute(): JSX.Element {
         api.getEvents(id, { page_size: 200 }),
         api.listToolCalls({ run_id: id, page_size: 50 }),
         api.listDriftSignals(id),
-        // page_size=200 is the MAX_PAGE_SIZE cap; the "last 3" UI slice
-        // below operates on .items so this header-sized page is plenty.
+        // page_size=200 is the MAX_PAGE_SIZE cap; AdminSheetBody's
+        // "last 3" slice operates on .items so this header-sized page
+        // is plenty.
         api.listCommitSignatures(id, { page_size: 200 }),
       ]).then((results) => {
         if (cancelled) return;
@@ -521,63 +417,18 @@ export function RunDetailRoute(): JSX.Element {
   // -----------------------------------------------------------------------
 
   const nodeIndex = useMemo(() => indexStateNodes(stateTree), [stateTree]);
-  const treeNodes: TreeNode[] = useMemo(
-    () => (stateTree ? [toTreeNode(stateTree)] : []),
-    [stateTree],
-  );
-  const selectedNode: StateNode | null = useMemo(() => {
-    if (!selectedEntryId) return null;
-    return nodeIndex.get(selectedEntryId) ?? null;
-  }, [selectedEntryId, nodeIndex]);
 
-  // Find the "current" node for the allowed-tools panel — prefer the
-  // explicit ``current_state`` from the manifest, fall back to the
-  // most-recently-entered node walking the tree depth-first.
-  const currentNode: StateNode | null = useMemo(() => {
-    const current = run?.manifest.current_state;
-    if (!current) return null;
-    for (const node of nodeIndex.values()) {
-      if (node.state_id === current && node.exited_at === null) {
-        return node;
-      }
-    }
-    // Fall back to any node with this state id (even if exited) so the
-    // panel surfaces something on completed runs.
-    for (const node of nodeIndex.values()) {
-      if (node.state_id === current) return node;
-    }
-    return null;
-  }, [nodeIndex, run?.manifest.current_state]);
-
-  const allowedTools = useMemo(
-    () => extractAllowedTools(selectedNode ?? currentNode),
-    [selectedNode, currentNode],
-  );
-
-  // W18d: subscribe to the cross-pane filter set so the timeline /
-  // tool calls / signatures rerender when chips change.
+  // W18d: subscribe to the cross-pane filter set so the timeline
+  // rerenders when chips change. The right column applies the filter
+  // before passing events into RunEventTimeline.
   const activeFilters = runDetailFilters.value;
   const filterChips: FilterChip[] = useMemo(
     () => filtersToChips(activeFilters),
     [activeFilters],
   );
-
   const filteredEvents = useMemo(
     () => events.filter((e) => eventPassesFilters(e, activeFilters)),
     [events, activeFilters],
-  );
-  const filteredToolCalls = useMemo(
-    () => toolCalls.filter((c) => toolCallPassesFilters(c, activeFilters)),
-    [toolCalls, activeFilters],
-  );
-  const filteredSignatures = useMemo(
-    () => signatures.filter((s) => signaturePassesFilters(s, activeFilters)),
-    [signatures, activeFilters],
-  );
-
-  const timelineItems = useMemo(
-    () => filteredEvents.map(eventToTimelineItem),
-    [filteredEvents],
   );
 
   // Reset filters whenever the user navigates between runs.
@@ -659,7 +510,6 @@ export function RunDetailRoute(): JSX.Element {
 
   const manifest = run.manifest;
   const journal = run.journal;
-  const lock = run.lock;
 
   // Action affordances — gate Resume / Journal actions on the manifest
   // and journal shape so the operator does not fire pointless requests.
@@ -671,7 +521,6 @@ export function RunDetailRoute(): JSX.Element {
     journal !== null && journal.status !== 'finalised';
 
   const meta = pendingAction ? ACTION_META[pendingAction.kind] : null;
-  const lastSignatures = filteredSignatures.slice(0, 3);
 
   // FilterChipBar handlers: chip-remove maps back to the right filter key.
   const onChipRemove = useCallback((chip: FilterChip) => {
@@ -684,7 +533,10 @@ export function RunDetailRoute(): JSX.Element {
   }, []);
 
   return (
-    <div class="p-4 md:p-6 space-y-4">
+    <div
+      class="p-4 md:p-6 flex flex-col gap-4 h-full min-h-0"
+      data-testid="run-detail-route"
+    >
       {/* ----------------------------------------------------------------
           Header
           ---------------------------------------------------------------- */}
@@ -786,10 +638,10 @@ export function RunDetailRoute(): JSX.Element {
           >
             Replay journal
           </Button>
-          {/* W?? — admin sheet trigger. The existing right-column Admin
-              Card stays during this PR so operators have both surfaces
-              simultaneously; a follow-up PR removes the inline card
-              once the sheet has soaked. */}
+          {/* PR 3 + PR 7: the Admin sheet is now the SOLE surface for
+              the six admin sections — Journal, Lock, Drift, Signatures,
+              Allowed tools, and the Tool Calls audit log. The inline
+              Admin Card has been removed in this cutover. */}
           <Button
             variant="secondary"
             size="sm"
@@ -815,21 +667,23 @@ export function RunDetailRoute(): JSX.Element {
       />
 
       {/* ----------------------------------------------------------------
-          Progress graph (W22b4) — spec topology overlaid with the
-          run's actual traversal. Lives above the three-pane grid so it
-          gets full viewport width on every breakpoint. When the run
-          hasn't entered any states yet, the graph renders the full
-          spec topology with every node tagged ``not_visited`` (greyed)
-          so the operator sees what the run is ABOUT to do rather
-          than a blank pane. The only EmptyState branch inside
-          RunProgressGraph fires when the spec itself declares zero
-          states.
+          50/50 grid: graph on the left, event timeline on the right.
+          On <lg viewports both columns stack (single column). The
+          ``h-full min-h-0 flex-1`` on the wrapper lets the grid claim
+          the leftover vertical space below the header so the graph and
+          timeline both stretch to the bottom of the viewport instead
+          of collapsing to their intrinsic min-heights.
           ---------------------------------------------------------------- */}
-      {run ? (
+      <div
+        class="grid grid-cols-1 lg:grid-cols-2 gap-4 flex-1 min-h-0"
+        data-testid="run-detail-grid"
+      >
+        {/* LEFT — run progress graph */}
         <RunProgressGraph
           manifest={run.manifest}
           stateTree={stateTree}
           events={events}
+          fill
           onNodeClick={(stateId) => {
             // The graph emits the spec-state-id (FlowGraph node id ==
             // spec state id). Resolve it to a concrete state ENTRY in
@@ -843,7 +697,11 @@ export function RunDetailRoute(): JSX.Element {
             for (const node of nodeIndex.values()) {
               if (node.state_id !== stateId) continue;
               const existing = nodeIndex.get(target);
-              if (!existing || existing.state_id !== stateId || node.entry_seq > existing.entry_seq) {
+              if (
+                !existing ||
+                existing.state_id !== stateId ||
+                node.entry_seq > existing.entry_seq
+              ) {
                 target = node.entry_id;
               }
             }
@@ -883,15 +741,13 @@ export function RunDetailRoute(): JSX.Element {
           onIterationClick={(entryId) => {
             // PR 5: loop chip click. The entry_id is the exact iteration
             // the operator picked, so we open StateEntrySheetBody with
-            // THAT entry_id (not the loop state's first entry). The
-            // sheet body already handles per-iteration semantics in
-            // Tab 1 (run values for this entry's inputs/outputs) and
-            // Tab 3 (events filtered by entry_id) — added in PR 4 —
-            // so PR 5 doesn't have to change the body component.
+            // THAT entry_id (not the loop state's first entry).
             const entry = nodeIndex.get(entryId);
             const stateLabel = entry?.state_id ?? entryId;
             const iterLabel =
-              entry?.iteration_n != null ? ` · iter ${entry.iteration_n}` : '';
+              entry?.iteration_n != null
+                ? ` · iter ${entry.iteration_n}`
+                : '';
             openStateEntrySheetOpener({
               entryId,
               runId: runId,
@@ -908,333 +764,15 @@ export function RunDetailRoute(): JSX.Element {
             });
           }}
         />
-      ) : null}
 
-      {/* ----------------------------------------------------------------
-          Three-pane grid
-          ---------------------------------------------------------------- */}
-      <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        {/* Left — state tree + selected-node inspector */}
-        <Card title="States" className="lg:col-span-1">
-          {treeNodes.length === 0 ? (
-            <EmptyState
-              title="No state entries yet"
-              message="The engine has not entered any state for this run."
-            />
-          ) : (
-            <Tree
-              nodes={treeNodes}
-              label="State entry tree"
-              onActivate={(node) => setSelectedEntryId(node.id)}
-            />
-          )}
-          {selectedNode ? (
-            <div class="mt-4 space-y-3 border-t border-slate-200 dark:border-slate-700 pt-3">
-              <div class="flex flex-wrap items-baseline gap-2">
-                <button
-                  type="button"
-                  onClick={() => toggleFilter('stateId', selectedNode.state_id)}
-                  title={`Filter all panes to state ${selectedNode.state_id}`}
-                  class="text-sm font-semibold text-slate-900 dark:text-slate-100 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
-                >
-                  {selectedNode.state_id}
-                </button>
-                <Pill variant={variantForStatus(selectedNode.status)} size="sm">
-                  {selectedNode.status}
-                </Pill>
-                <span class="text-xs text-slate-500 dark:text-slate-400">
-                  seq {selectedNode.entry_seq}
-                </span>
-              </div>
-              <div>
-                <h4 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">
-                  Inputs
-                </h4>
-                <JsonViewer
-                  value={selectedNode.inputs}
-                  rootLabel="inputs"
-                  mode="inline"
-                  maxInlineHeight="max-h-48"
-                  downloadFilename={`run-${runId}-${selectedNode.state_id}-inputs.json`}
-                  ariaLabel={`Inputs for state ${selectedNode.state_id}`}
-                />
-              </div>
-              <div>
-                <h4 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">
-                  Outputs
-                </h4>
-                <JsonViewer
-                  value={selectedNode.outputs}
-                  rootLabel="outputs"
-                  mode="inline"
-                  maxInlineHeight="max-h-48"
-                  downloadFilename={`run-${runId}-${selectedNode.state_id}-outputs.json`}
-                  ariaLabel={`Outputs for state ${selectedNode.state_id}`}
-                />
-              </div>
-            </div>
-          ) : null}
-        </Card>
-
-        {/* Middle — live event timeline */}
-        <Card title="Events" className="lg:col-span-1">
-          {timelineItems.length === 0 ? (
-            <EmptyState
-              title="No events yet"
-              message="Events will appear here as the run produces them."
-            />
-          ) : (
-            <div class="max-h-[70vh] overflow-auto pr-1">
-              <Timeline items={timelineItems} label="Run event timeline" />
-            </div>
-          )}
-        </Card>
-
-        {/* Right — admin / journal panel */}
-        <Card title="Admin" className="lg:col-span-1 space-y-4">
-          <section class="space-y-1">
-            <h3 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Journal
-            </h3>
-            {journal ? (
-              <div class="flex flex-wrap items-baseline gap-2">
-                <Pill variant={variantForJournal(journal.status)}>
-                  {journal.status}
-                </Pill>
-                <span class="text-xs font-mono text-slate-500 dark:text-slate-400">
-                  {journal.staged_writes.length} staged write
-                  {journal.staged_writes.length === 1 ? '' : 's'}
-                </span>
-                <span class="text-xs text-slate-500 dark:text-slate-400">
-                  started {formatTimestamp(journal.started_at)}
-                </span>
-              </div>
-            ) : (
-              <p class="text-sm text-slate-500 dark:text-slate-400">
-                No pending journal txn.
-              </p>
-            )}
-          </section>
-
-          <section class="space-y-1">
-            <h3 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Lock
-            </h3>
-            {lock ? (
-              <div class="flex flex-wrap items-baseline gap-2 text-sm">
-                <Pill variant={lock.is_stale ? 'danger' : 'info'}>
-                  {lock.is_stale ? 'stale' : 'held'}
-                </Pill>
-                <code class="font-mono text-xs text-slate-600 dark:text-slate-300">
-                  {lock.holder_session_id}
-                </code>
-                <span class="text-xs text-slate-500 dark:text-slate-400">
-                  expires {formatTimestamp(lock.expires_at)}
-                </span>
-              </div>
-            ) : (
-              <p class="text-sm text-slate-500 dark:text-slate-400">
-                No lock currently held.
-              </p>
-            )}
-          </section>
-
-          <section class="space-y-1">
-            <h3 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Drift
-            </h3>
-            {drift ? (
-              <>
-                <DriftGauge score={drift.score} />
-                <p class="text-xs text-slate-500 dark:text-slate-400">
-                  {drift.signals.length} signal
-                  {drift.signals.length === 1 ? '' : 's'} recorded.
-                </p>
-              </>
-            ) : (
-              <p class="text-sm text-slate-500 dark:text-slate-400">
-                Drift score unavailable.
-              </p>
-            )}
-          </section>
-
-          <section class="space-y-2">
-            <h3 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Last commit signatures
-            </h3>
-            {lastSignatures.length === 0 ? (
-              <p class="text-sm text-slate-500 dark:text-slate-400">
-                No commit signatures recorded yet.
-              </p>
-            ) : (
-              <ul class="space-y-2">
-                {lastSignatures.map((sig) => (
-                  <li
-                    key={sig.id}
-                    class="text-xs text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700 rounded-md px-3 py-2 space-y-1"
-                  >
-                    <div class="flex flex-wrap items-baseline gap-2">
-                      <code class="font-mono text-slate-700 dark:text-slate-200">
-                        {sig.state_id}
-                      </code>
-                      <Pill
-                        variant={sig.verified ? 'success' : 'danger'}
-                        size="sm"
-                      >
-                        {sig.verified ? 'verified' : 'unverified'}
-                      </Pill>
-                      {sig.iteration_n != null ? (
-                        <span class="text-slate-500 dark:text-slate-400">
-                          iter {sig.iteration_n}
-                        </span>
-                      ) : null}
-                    </div>
-                    <div class="font-mono">
-                      sig <span title={sig.signature}>{shortHash(sig.signature)}</span>
-                    </div>
-                    <div class="text-slate-500 dark:text-slate-400">
-                      {formatTimestamp(sig.created_at)}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
-
-          <section class="space-y-1">
-            <h3 class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Allowed tools
-              {currentNode ? (
-                <span class="ml-1 font-mono normal-case text-slate-400 dark:text-slate-500">
-                  ({(selectedNode ?? currentNode).state_id})
-                </span>
-              ) : null}
-            </h3>
-            {allowedTools === null ? (
-              <p class="text-sm text-slate-500 dark:text-slate-400">
-                Not surfaced by the current state payload.
-              </p>
-            ) : allowedTools.length === 0 ? (
-              <p class="text-sm text-slate-500 dark:text-slate-400">
-                Allow-list is empty — no tools are permitted.
-              </p>
-            ) : (
-              <ul class="flex flex-wrap gap-1.5">
-                {allowedTools.map((tool) => (
-                  <li key={tool}>
-                    <Pill variant="neutral" size="sm">
-                      {tool}
-                    </Pill>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
+        {/* RIGHT — live event timeline */}
+        <Card
+          title="Events"
+          className="flex flex-col h-full min-h-0"
+        >
+          <RunEventTimeline events={filteredEvents} />
         </Card>
       </div>
-
-      {/* ----------------------------------------------------------------
-          Bottom — collapsible tool-call audit log
-          ---------------------------------------------------------------- */}
-      <Card className="p-0">
-        <button
-          type="button"
-          onClick={() => setAuditOpen((v) => !v)}
-          aria-expanded={auditOpen}
-          aria-controls="tool-call-audit-log"
-          class="w-full flex items-center justify-between gap-2 px-4 py-3 text-left text-sm font-semibold text-slate-900 dark:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-emerald-500 rounded-xl"
-        >
-          <span>
-            Tool calls audit log{' '}
-            <span class="ml-1 text-xs font-normal text-slate-500 dark:text-slate-400">
-              ({filteredToolCalls.length}{filteredToolCalls.length !== toolCalls.length ? ` of ${toolCalls.length}` : ''} most recent)
-            </span>
-          </span>
-          <span
-            aria-hidden="true"
-            class={[
-              'inline-flex items-center justify-center w-5 h-5',
-              'text-slate-400 dark:text-slate-500',
-              'motion-safe:transition-transform',
-              auditOpen ? 'rotate-90' : '',
-            ].join(' ')}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              class="w-3 h-3"
-            >
-              <path d="M6 3.5L10.5 8 6 12.5V3.5z" />
-            </svg>
-          </span>
-        </button>
-        {auditOpen ? (
-          <div
-            id="tool-call-audit-log"
-            class="border-t border-slate-200 dark:border-slate-700 px-4 py-3"
-          >
-            {filteredToolCalls.length === 0 ? (
-              <EmptyState
-                title="No tool calls recorded"
-                message="The audit log is empty for this run."
-              />
-            ) : (
-              <ul class="divide-y divide-slate-200 dark:divide-slate-700">
-                {filteredToolCalls.map((call) => (
-                  <li key={call.id} class="py-3 space-y-1">
-                    <div class="flex flex-wrap items-baseline gap-2">
-                      <Pill
-                        variant={call.succeeded ? 'success' : 'danger'}
-                        size="sm"
-                      >
-                        {call.succeeded ? 'ok' : 'failed'}
-                      </Pill>
-                      <code class="font-mono text-sm text-slate-800 dark:text-slate-100">
-                        {call.tool_name}
-                      </code>
-                      <span class="text-xs text-slate-500 dark:text-slate-400">
-                        {formatTimestamp(call.created_at)}
-                      </span>
-                      <span
-                        class="text-xs font-mono text-slate-400 dark:text-slate-500"
-                        title={call.producer_id}
-                      >
-                        {shortHash(call.producer_id)}
-                      </span>
-                    </div>
-                    <JsonViewer
-                      value={call.args_redacted}
-                      rootLabel="args"
-                      mode="inline"
-                      maxInlineHeight="max-h-40"
-                      ariaLabel={`Tool call args ${call.tool_name}`}
-                    />
-                    <div class="mt-1 flex gap-1">
-                      <button
-                        type="button"
-                        onClick={() => toggleFilter('toolName', call.tool_name)}
-                        title={`Filter tool calls to ${call.tool_name}`}
-                        class="text-[10px] underline text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
-                      >
-                        filter by tool
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => toggleFilter('producerId', call.producer_id)}
-                        title={`Filter to producer ${call.producer_id}`}
-                        class="text-[10px] underline text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
-                      >
-                        filter by producer
-                      </button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        ) : null}
-      </Card>
 
       {/* ----------------------------------------------------------------
           Confirmation dialog (shared for all four actions)

--- a/ui/src/routes/runDetail/__tests__/runDetail.test.tsx
+++ b/ui/src/routes/runDetail/__tests__/runDetail.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Tests for routes/runDetail.tsx — PR 7 layout cutover.
+ *
+ * Coverage:
+ *   - The 2-column grid (graph | timeline) renders at desktop width.
+ *     We assert by ``data-testid`` plus the Tailwind classes that
+ *     drive the layout (``grid-cols-1 lg:grid-cols-2``) — jsdom does
+ *     not evaluate breakpoint media queries, but the class list IS the
+ *     contract: at lg+ the browser flips to a 2-col grid.
+ *   - Pre-cutover surfaces (States tree Card, inline Admin Card, the
+ *     Tool Calls audit log Card, the per-node JsonViewer inspector)
+ *     are ABSENT from the rendered tree. These three negative asserts
+ *     are how a future cascade regression would surface — if any one
+ *     of them rematerialises the test fails fast.
+ *   - The "Admin" header button is present so the operator can still
+ *     reach the journal / lock / drift / signatures / allowed-tools /
+ *     tool-calls surfaces (they live inside AdminSheetBody now).
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/preact';
+
+import type {
+  RunDetail,
+  StateNode,
+} from '../../../lib/api';
+
+// --- Mocks --------------------------------------------------------------
+
+// preact-iso ``useRoute`` does not work outside a LocationProvider;
+// the route only reads ``params.runId`` so a flat mock is enough.
+vi.mock('preact-iso', () => ({
+  useRoute: () => ({ params: { runId: 'run-test-1' } }),
+}));
+
+// The SSE EventStream opens a real EventSource on construction; jsdom
+// doesn't ship one. Stub the module so the timeline mount doesn't
+// throw and the route's render path is exercised end-to-end.
+vi.mock('../../../lib/sse', () => ({
+  EventStream: class {
+    on(): () => void {
+      return () => {
+        // no-op
+      };
+    }
+    close(): void {
+      // no-op
+    }
+  },
+}));
+
+// Stub the global RunProgressGraph so the test doesn't have to drag in
+// xyflow + dagre + spec graph layout. We render a sentinel div so the
+// left column is identifiable by the layout test.
+vi.mock('../../../components/RunProgressGraph', () => ({
+  RunProgressGraph: () => (
+    <div data-testid="mock-run-progress-graph">graph</div>
+  ),
+}));
+
+// Capture the api mock so we can both seed responses and assert
+// AdminSheet-feeding fetches still fire from the route (PR 7 keeps the
+// fetch in the route so the sheet sees populated data on first open).
+const ROOT_STATE: StateNode = {
+  entry_id: 'entry-1',
+  state_id: 'plan',
+  entry_seq: 1,
+  entered_at: '2025-01-01T00:00:00Z',
+  exited_at: '2025-01-01T00:00:10Z',
+  status: 'exited',
+  inputs: {},
+  outputs: {},
+  iteration_n: 0,
+  children: [],
+};
+
+const RUN: RunDetail = {
+  manifest: {
+    id: 'run-test-1',
+    fsm_spec_id: 'spec-1',
+    status: 'completed',
+    verdict: 'pass',
+    started_at: '2025-01-01T00:00:00Z',
+    ended_at: '2025-01-01T00:01:00Z',
+    last_update_at: '2025-01-01T00:01:00Z',
+    transitions_count: 1,
+    current_state: null,
+  } as unknown as RunDetail['manifest'],
+  state_tree: ROOT_STATE,
+  journal: null,
+  lock: null,
+} as unknown as RunDetail;
+
+vi.mock('../../../lib/api', async () => {
+  class ApiErrorMock extends Error {}
+  return {
+    ApiError: ApiErrorMock,
+    api: {
+      getRun: vi.fn(async () => RUN),
+      getStateTree: vi.fn(async () => ROOT_STATE),
+      getEvents: vi.fn(async () => ({ items: [], total: 0 })),
+      listToolCalls: vi.fn(async () => ({ items: [], total: 0 })),
+      listDriftSignals: vi.fn(async () => ({ score: 0, signals: [] })),
+      listCommitSignatures: vi.fn(async () => ({ items: [], total: 0 })),
+      getSpec: vi.fn(async () => ({
+        id: 'spec-1',
+        project_id: 'p',
+        project_slug: 'p',
+        slug: 'demo',
+        version: 1,
+        hash: 'h',
+        registered_at: '2025-01-01T00:00:00Z',
+        definition: { entry: 'plan', states: [{ id: 'plan', kind: 'worker' }] },
+      })),
+      abortRun: vi.fn(),
+      resumeRun: vi.fn(),
+      recoverJournal: vi.fn(),
+    },
+  };
+});
+
+// Now import the route AFTER the mocks are set up.
+import { RunDetailRoute } from '../../runDetail';
+
+afterEach(() => cleanup());
+
+function renderRoute() {
+  // ``useToast`` is signal-backed and works without a provider — no
+  // wrapper component needed.
+  return render(<RunDetailRoute />);
+}
+
+describe('RunDetailRoute (PR 7 layout)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders the 50/50 grid (graph | timeline) once data has loaded', async () => {
+    const { getByTestId } = renderRoute();
+
+    const grid = await waitFor(() => getByTestId('run-detail-grid'));
+
+    // The grid class list IS the contract — single column on small
+    // screens, 2 columns at lg+. jsdom doesn't evaluate the breakpoint
+    // but if the class disappears the responsive behaviour breaks.
+    const cls = grid.getAttribute('class') ?? '';
+    expect(cls).toContain('grid-cols-1');
+    expect(cls).toContain('lg:grid-cols-2');
+
+    // Both columns must render (graph mock + timeline body).
+    expect(getByTestId('mock-run-progress-graph')).toBeInTheDocument();
+    expect(getByTestId('run-event-timeline')).toBeInTheDocument();
+  });
+
+  test('mobile / small-viewport class list still drives a single column', async () => {
+    // We can't change the jsdom viewport mid-test (jsdom is not a
+    // layout engine) — but the route always emits BOTH ``grid-cols-1``
+    // and ``lg:grid-cols-2``, and the browser applies the right rule
+    // based on viewport width. This test pins the class contract so
+    // a refactor can't accidentally drop the mobile fallback.
+    const { getByTestId } = renderRoute();
+    const grid = await waitFor(() => getByTestId('run-detail-grid'));
+    expect(grid.className).toMatch(/\bgrid-cols-1\b/);
+  });
+
+  test('Admin button is present in the header', async () => {
+    const { getByRole } = renderRoute();
+    const adminBtn = await waitFor(() =>
+      getByRole('button', { name: /Admin/i }),
+    );
+    expect(adminBtn).toBeInTheDocument();
+  });
+
+  test('legacy inline surfaces are not rendered (States tree, Admin Card, Tool Calls audit, per-node JsonViewer panels)', async () => {
+    const { queryByText, getByTestId } = renderRoute();
+
+    // Wait for the layout to settle first so the assertions below
+    // race against fully-rendered content (not the loading Spinner).
+    await waitFor(() => getByTestId('run-detail-grid'));
+
+    // 1. Left States tree Card had a "States" Card title and a
+    //    role="tree" landmark. Neither should appear in the new layout.
+    expect(queryByText('States')).toBeNull();
+
+    // 2. Inline Admin Card had section headers "Journal", "Lock",
+    //    "Drift", "Last commit signatures", "Allowed tools". The
+    //    canonical Journal / Drift labels are gone from the inline
+    //    render — they only show up inside AdminSheetBody when the
+    //    sheet is open.
+    expect(queryByText('Journal')).toBeNull();
+    expect(queryByText('Last commit signatures')).toBeNull();
+    expect(queryByText('Allowed tools')).toBeNull();
+
+    // 3. The bottom collapsible Tool Calls audit log header.
+    expect(queryByText(/Tool calls audit log/i)).toBeNull();
+
+    // 4. The per-node JsonViewer "Inputs" / "Outputs" headings that
+    //    the legacy left-column inspector used. They live in
+    //    StateEntrySheetBody now.
+    expect(queryByText('Inputs')).toBeNull();
+    expect(queryByText('Outputs')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Final PR of the run-detail cascade (PR 7/7). Lands the user-visible structural change: the old 3-column grid + bottom audit Card + selected-node panel is replaced by a clean 50/50 graph | timeline layout. Every removed surface had its replacement land + soak in an earlier PR.

- **Layout cutover** — single 50/50 grid (single column < lg). LEFT = ``RunProgressGraph`` (fill mode), RIGHT = ``RunEventTimeline``, both Card-wrapped, both flex into the viewport height.
- **New ``<RunEventTimeline>``** — lifts the event-to-TimelineItem adapter + scroller + EmptyState out of the route so the right column is one component, not a 30-line jsx block.
- **``RunProgressGraph`` gains a ``fill`` prop** — when on, the Card flips to ``flex flex-col h-full min-h-0`` and the inner FlowGraph container claims ``flex-1 min-h-0`` instead of the legacy fixed 420px frame.
- **runDetail.tsx**: -575 / +148. 1279 -> 817 LOC (the rest of the slim-down is JSDoc — the runtime body is much tighter).
- **Tests**:
  - New ``runDetail.test.tsx`` (4 tests): asserts the 2-column grid class contract, the mobile fallback class, the Admin header button, and the absence of every legacy inline surface (States tree, Admin Card sections, Tool Calls audit collapsible, per-node JsonViewer panels).
  - New ``test_run_detail_layout.py`` (3 e2e cases): seeded run @ 1280x720; ``[data-testid=run-detail-grid]`` carries ``lg:grid-cols-2``; Admin button opens the right-half admin sheet; graph node click opens StateEntrySheet with all three tabs (Run values / Spec definition / Events for this state).

## Gates (all green on this branch)

| gate | result |
| --- | --- |
| ``cd ui && npx tsc -b --noEmit`` | clean |
| ``cd ui && npm run test`` | 443 passed (41 files) |
| ``cd ui && npm run build`` | 593.34 KB raw / **181.55 KB gzipped** (well under 600 KB) |
| ``uv run pytest tests/unit/ tests/integration/ --ignore=tests/integration/e2e`` | 699 passed |
| ``uv run pytest tests/integration/e2e --run-e2e`` | 15 passed (incl. the 3 new layout cases) |

## Test plan
- [x] tsc clean
- [x] 443 vitest specs pass (incl. 4 new runDetail.test.tsx specs)
- [x] Production build under the 600KB gzip budget
- [x] Python unit + integration suites clean
- [x] E2E suite clean, including the 3 new layout cases (grid present, Admin sheet opens, StateEntrySheet opens with 3 tabs on graph node click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)