### PR TITLE
feat(ui): RunEventTimeline freshness flash + debounced SSE refetches

### DIFF
--- a/ui/src/components/RunEventTimeline.tsx
+++ b/ui/src/components/RunEventTimeline.tsx
@@ -7,30 +7,37 @@
  * EmptyState branch, or the scroll wrapper. The timeline is the only
  * consumer of those helpers post-cutover.
  *
- * Visual contract:
+ * PR 6 freshness flash
+ * --------------------
  *
- *   - Fills the parent's height (``h-full min-h-0`` on the outer
- *     wrapper) so a flex / grid parent gets to dictate the size. The
- *     inner scroller is ``overflow-auto`` so a long event tape scrolls
- *     within the column rather than blowing out the page.
- *   - Newest event first (callers pre-sort; the timeline doesn't
- *     re-order so the SSE prepend behaviour from the route is
- *     preserved).
- *   - Renders an EmptyState when ``events`` is empty so the column
- *     never collapses to zero height.
+ * SSE-driven prepends arrive at the head of the ``events`` prop. Each
+ * newly-arrived id gets an amber background flash for ~2 s so the
+ * operator's eye lands on the new row instead of scanning the whole
+ * tape looking for what changed. The flash is implemented as a
+ * ``data-fresh="true"`` attribute on the row plus a CSS rule in
+ * ``theme.css`` so the colour transition is GPU-driven and respects
+ * the ``prefers-reduced-motion`` media query.
  *
- * The colour-by-kind variant map lives here too because the route no
- * longer needs it — once the inline timeline was gone there was no
- * other call site.
+ * Why we render the rows inline rather than via ``<Timeline>``: the
+ * shared :class:`Timeline` primitive does not (yet) accept a per-row
+ * data attribute. Re-implementing the small row markup here keeps the
+ * shared component pure and lets the timeline own its flash mechanism
+ * without leaking the SSE freshness concern into every other Timeline
+ * caller.
+ *
+ * The ``entryIdFilter`` prop narrows the tape to events whose
+ * ``payload.state_id`` (the most common reference) or ``entry_id``
+ * matches a single state entry — used by panels that scope a
+ * per-entry slice of the run (eg. the StateEntrySheet's "Events" tab,
+ * if it ever wires the timeline directly).
  */
 
 import type { JSX, VNode } from 'preact';
-import { useMemo } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import { EmptyState } from './EmptyState';
 import { JsonViewer } from './JsonViewer';
-import { Timeline, type TimelineItem } from './Timeline';
-import type { PillVariant } from './Pill';
+import { Pill, type PillVariant } from './Pill';
 import type { Event as FsmEvent } from '../lib/api';
 
 export interface RunEventTimelineProps {
@@ -38,6 +45,11 @@ export interface RunEventTimelineProps {
   events: FsmEvent[];
   /** Optional className appended to the outer wrapper. */
   className?: string;
+  /**
+   * Optional entry-id filter. When set, only events whose payload
+   * references this entry (via ``entry_id`` or ``state_id``) render.
+   */
+  entryIdFilter?: string;
 }
 
 /** Pick a pill colour for an event row in the timeline. */
@@ -58,10 +70,37 @@ function variantForEventKind(kind: string): PillVariant {
   return 'neutral';
 }
 
-/** Render an FSM event as a :class:`TimelineItem`. */
-function eventToTimelineItem(event: FsmEvent): TimelineItem {
-  const variant = variantForEventKind(event.kind);
-  const payload: VNode = (
+/** Map a variant to its dot bg class (Timeline's colour scheme, kept in sync). */
+function dotClass(variant: PillVariant): string {
+  if (variant === 'success') return 'bg-emerald-500';
+  if (variant === 'warning') return 'bg-amber-500';
+  if (variant === 'danger') return 'bg-red-500';
+  if (variant === 'info') return 'bg-slate-400';
+  return 'bg-slate-300 dark:bg-slate-600';
+}
+
+/** Format an ISO timestamp as locale ``YYYY-MM-DD HH:MM:SS``. */
+function formatTimestamp(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** Render the payload as an inline JsonViewer (lazy / collapsed). */
+function payloadFor(event: FsmEvent): VNode {
+  return (
     <JsonViewer
       value={event.payload}
       rootLabel="payload"
@@ -70,32 +109,99 @@ function eventToTimelineItem(event: FsmEvent): TimelineItem {
       ariaLabel={`Payload of event ${event.id}`}
     />
   );
-  return {
-    id: event.id,
-    timestamp: event.created_at,
-    title: event.producer_id,
-    kind: event.kind,
-    variant,
-    payload,
-  };
 }
+
+/** Predicate: does the event reference the given entry id? */
+function eventMatchesEntry(event: FsmEvent, entryId: string): boolean {
+  const p = (event.payload ?? {}) as Record<string, unknown>;
+  if (typeof p.entry_id === 'string' && p.entry_id === entryId) return true;
+  if (typeof p.state_id === 'string' && p.state_id === entryId) return true;
+  return false;
+}
+
+const FRESHNESS_MS = 2000;
 
 export function RunEventTimeline({
   events,
   className = '',
+  entryIdFilter,
 }: RunEventTimelineProps): JSX.Element {
-  const items = useMemo(() => events.map(eventToTimelineItem), [events]);
+  const filtered = useMemo(() => {
+    if (!entryIdFilter) return events;
+    return events.filter((e) => eventMatchesEntry(e, entryIdFilter));
+  }, [events, entryIdFilter]);
+
+  // --- Freshness tracking -------------------------------------------------
+  // Track ids we have already "seen" so a remount with a preloaded list
+  // does not flash every row amber on first paint. Only ids that appear
+  // AFTER the first render (ie. SSE prepends) get the flash.
+  const seenIdsRef = useRef<Set<string>>(new Set());
+  const initialisedRef = useRef<boolean>(false);
+  const timeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+  const [freshIds, setFreshIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const seen = seenIdsRef.current;
+    if (!initialisedRef.current) {
+      // Seed with the initial events so the first paint is calm.
+      for (const e of events) seen.add(e.id);
+      initialisedRef.current = true;
+      return;
+    }
+    const newIds: string[] = [];
+    for (const e of events) {
+      if (!seen.has(e.id)) {
+        seen.add(e.id);
+        newIds.push(e.id);
+      }
+    }
+    if (newIds.length === 0) return;
+    setFreshIds((prev) => {
+      const next = new Set(prev);
+      for (const id of newIds) next.add(id);
+      return next;
+    });
+    for (const id of newIds) {
+      const existing = timeoutsRef.current.get(id);
+      if (existing != null) clearTimeout(existing);
+      const handle = setTimeout(() => {
+        timeoutsRef.current.delete(id);
+        setFreshIds((prev) => {
+          if (!prev.has(id)) return prev;
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }, FRESHNESS_MS);
+      timeoutsRef.current.set(id, handle);
+    }
+  }, [events]);
+
+  // Clear pending flash timers on unmount so we don't fire setState into
+  // a torn-down tree (eg. when the route is navigated away mid-flash).
+  useEffect(() => {
+    return () => {
+      for (const h of timeoutsRef.current.values()) clearTimeout(h);
+      timeoutsRef.current.clear();
+    };
+  }, []);
 
   const composed = ['flex flex-col h-full min-h-0', className]
     .filter(Boolean)
     .join(' ');
 
-  if (items.length === 0) {
+  if (filtered.length === 0) {
     return (
       <div class={composed} data-testid="run-event-timeline">
         <EmptyState
           title="No events yet"
-          message="Events will appear here as the run produces them."
+          message={
+            entryIdFilter
+              ? 'No events reference this state entry.'
+              : 'Events will appear here as the run produces them.'
+          }
         />
       </div>
     );
@@ -104,7 +210,54 @@ export function RunEventTimeline({
   return (
     <div class={composed} data-testid="run-event-timeline">
       <div class="flex-1 min-h-0 overflow-auto pr-1">
-        <Timeline items={items} label="Run event timeline" />
+        <ol class="relative" aria-label="Run event timeline">
+          {filtered.map((event, index) => {
+            const variant = variantForEventKind(event.kind);
+            const isLast = index === filtered.length - 1;
+            const isFresh = freshIds.has(event.id);
+            return (
+              <li
+                key={event.id}
+                data-event-id={event.id}
+                data-fresh={isFresh ? 'true' : 'false'}
+                class="relative flex gap-3 pb-4 last:pb-0 rounded-md"
+              >
+                {!isLast ? (
+                  <span
+                    aria-hidden="true"
+                    class="absolute left-[7px] top-4 bottom-0 w-px bg-slate-200 dark:bg-slate-700"
+                  />
+                ) : null}
+                <span
+                  aria-hidden="true"
+                  class={[
+                    'mt-1.5 h-[14px] w-[14px] rounded-full ring-2 ring-white dark:ring-slate-900 shrink-0',
+                    dotClass(variant),
+                  ].join(' ')}
+                />
+                <div class="flex-1 min-w-0">
+                  <div class="flex flex-wrap items-baseline gap-2">
+                    <time
+                      dateTime={event.created_at}
+                      class="font-mono text-xs text-slate-500 dark:text-slate-400"
+                    >
+                      {formatTimestamp(event.created_at)}
+                    </time>
+                    <Pill variant={variant} size="sm">
+                      {event.kind}
+                    </Pill>
+                    <span class="text-sm font-medium text-slate-900 dark:text-slate-100">
+                      {event.producer_id}
+                    </span>
+                  </div>
+                  <div class="mt-1 text-sm text-slate-700 dark:text-slate-300">
+                    {payloadFor(event)}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
       </div>
     </div>
   );

--- a/ui/src/components/__tests__/RunEventTimeline.test.tsx
+++ b/ui/src/components/__tests__/RunEventTimeline.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for ``RunEventTimeline`` — the freshness flash and entry-id
+ * filter behaviour introduced in PR 6 of the /runs/:id redesign.
+ *
+ * The flash is asserted via the row's ``data-fresh`` attribute (the
+ * CSS rule that consumes it lives in ``theme.css`` and is exercised by
+ * the browser, not jsdom; the attribute is the contract).
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/preact';
+
+import { RunEventTimeline } from '../RunEventTimeline';
+import type { Event as FsmEvent } from '../../lib/api';
+
+function makeEvent(overrides: Partial<FsmEvent> = {}): FsmEvent {
+  return {
+    id: overrides.id ?? 'evt-1',
+    run_id: overrides.run_id ?? 'run-1',
+    kind: overrides.kind ?? 'state_entered',
+    producer_id: overrides.producer_id ?? 'engine',
+    payload: overrides.payload ?? {},
+    created_at: overrides.created_at ?? '2025-01-01T00:00:00Z',
+    seq: overrides.seq ?? 1,
+  };
+}
+
+function rowsByEventId(container: Element | HTMLElement): Map<string, Element> {
+  const out = new Map<string, Element>();
+  for (const li of Array.from(
+    container.querySelectorAll('li[data-event-id]'),
+  )) {
+    const id = li.getAttribute('data-event-id');
+    if (id) out.set(id, li);
+  }
+  return out;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('RunEventTimeline (freshness flash)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  test('initial render does not flash any of the seeded events', () => {
+    const events = [
+      makeEvent({ id: 'a' }),
+      makeEvent({ id: 'b', created_at: '2025-01-01T00:00:01Z' }),
+    ];
+    const { container } = render(<RunEventTimeline events={events} />);
+    const rows = rowsByEventId(container);
+    expect(rows.size).toBe(2);
+    for (const row of rows.values()) {
+      expect(row.getAttribute('data-fresh')).toBe('false');
+    }
+  });
+
+  test('a newly-prepended event row gets data-fresh="true"', () => {
+    const initial = [makeEvent({ id: 'a' })];
+    const { container, rerender } = render(
+      <RunEventTimeline events={initial} />,
+    );
+
+    const grown = [makeEvent({ id: 'b', seq: 2 }), ...initial];
+    act(() => {
+      rerender(<RunEventTimeline events={grown} />);
+    });
+
+    const rows = rowsByEventId(container);
+    expect(rows.get('b')?.getAttribute('data-fresh')).toBe('true');
+    expect(rows.get('a')?.getAttribute('data-fresh')).toBe('false');
+  });
+
+  test('the data-fresh attribute clears ~2 s after the event arrives', () => {
+    const initial = [makeEvent({ id: 'a' })];
+    const { container, rerender } = render(
+      <RunEventTimeline events={initial} />,
+    );
+
+    act(() => {
+      rerender(
+        <RunEventTimeline events={[makeEvent({ id: 'b', seq: 2 }), ...initial]} />,
+      );
+    });
+    expect(rowsByEventId(container).get('b')?.getAttribute('data-fresh')).toBe(
+      'true',
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    expect(rowsByEventId(container).get('b')?.getAttribute('data-fresh')).toBe(
+      'false',
+    );
+  });
+
+  test('entryIdFilter narrows the rendered events to matching ones', () => {
+    const events = [
+      makeEvent({ id: 'a', payload: { state_id: 'plan' } }),
+      makeEvent({
+        id: 'b',
+        payload: { state_id: 'execute' },
+        created_at: '2025-01-01T00:00:01Z',
+      }),
+      makeEvent({
+        id: 'c',
+        payload: { entry_id: 'plan' },
+        created_at: '2025-01-01T00:00:02Z',
+      }),
+    ];
+    const { container } = render(
+      <RunEventTimeline events={events} entryIdFilter="plan" />,
+    );
+    const rows = rowsByEventId(container);
+    expect(rows.has('a')).toBe(true);
+    expect(rows.has('c')).toBe(true);
+    expect(rows.has('b')).toBe(false);
+  });
+
+  test('empty list renders the EmptyState branch (no rows)', () => {
+    const { container, getByText } = render(
+      <RunEventTimeline events={[]} />,
+    );
+    expect(rowsByEventId(container).size).toBe(0);
+    expect(getByText(/No events yet/i)).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/runDetailRefresh.ts
+++ b/ui/src/lib/runDetailRefresh.ts
@@ -1,0 +1,63 @@
+/**
+ * Per-pane refresh nonces for the run-detail page.
+ *
+ * The single SSE subscription owned by ``runDetail.tsx`` dispatches
+ * incoming events to debounced refetchers. The route also bumps the
+ * per-pane nonces below so lazily-mounted panels (eg. AdminSheetBody's
+ * Drift / Signatures / Tool calls sections) can react to the same
+ * event burst without having to open their OWN ``EventStream`` (which
+ * would double-subscribe the connection limit and double the server's
+ * SSE fan-out work).
+ *
+ * Each section reads the nonce from a ``useSignal``-style accessor in
+ * its render body so dependency tracking is automatic. When the nonce
+ * changes, the section's ``useEffect`` re-runs and refetches the data.
+ *
+ * Why one nonce PER kind (and not one global "bump everything"):
+ *
+ *   - State-tree refetches are noisy on chatty runs; we do not want
+ *     them to invalidate the signatures section's render every time a
+ *     ``state_entered`` lands.
+ *   - The debouncers in ``runDetail.tsx`` already coalesce bursts per
+ *     kind, so the nonces likewise tick at most once per coalesced
+ *     burst — they are NOT bumped per raw SSE frame.
+ *
+ * Tests reset the signals by calling ``resetRunDetailRefresh()`` in a
+ * ``beforeEach`` so leaked state from a prior test cannot influence
+ * the next one.
+ */
+
+import { signal, type Signal } from '@preact/signals';
+
+export const stateTreeRefreshNonce: Signal<number> = signal(0);
+export const driftRefreshNonce: Signal<number> = signal(0);
+export const signaturesRefreshNonce: Signal<number> = signal(0);
+export const toolCallsRefreshNonce: Signal<number> = signal(0);
+
+/** Bump the state-tree refresh nonce. */
+export function bumpStateTreeRefresh(): void {
+  stateTreeRefreshNonce.value = stateTreeRefreshNonce.value + 1;
+}
+
+/** Bump the drift refresh nonce. */
+export function bumpDriftRefresh(): void {
+  driftRefreshNonce.value = driftRefreshNonce.value + 1;
+}
+
+/** Bump the commit-signatures refresh nonce. */
+export function bumpSignaturesRefresh(): void {
+  signaturesRefreshNonce.value = signaturesRefreshNonce.value + 1;
+}
+
+/** Bump the tool-calls refresh nonce. */
+export function bumpToolCallsRefresh(): void {
+  toolCallsRefreshNonce.value = toolCallsRefreshNonce.value + 1;
+}
+
+/** Reset every nonce to zero. Useful in test ``beforeEach`` hooks. */
+export function resetRunDetailRefresh(): void {
+  stateTreeRefreshNonce.value = 0;
+  driftRefreshNonce.value = 0;
+  signaturesRefreshNonce.value = 0;
+  toolCallsRefreshNonce.value = 0;
+}

--- a/ui/src/routes/runDetail.tsx
+++ b/ui/src/routes/runDetail.tsx
@@ -55,7 +55,7 @@
  */
 
 import type { JSX } from 'preact';
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useRoute } from 'preact-iso';
 
 import {
@@ -96,6 +96,13 @@ import {
   openEdgeSheet as openEdgeSheetOpener,
   openStateEntrySheet as openStateEntrySheetOpener,
 } from '../lib/runDetailSheets';
+import {
+  bumpDriftRefresh,
+  bumpSignaturesRefresh,
+  bumpStateTreeRefresh,
+  bumpToolCallsRefresh,
+} from '../lib/runDetailRefresh';
+import { useDebouncedRefetch } from '../lib/useDebouncedRefetch';
 import { EventStream } from '../lib/sse';
 import { AdminSheetBody } from './runDetail/AdminSheetBody';
 import { EdgeSheetBody } from './runDetail/EdgeSheetBody';
@@ -274,6 +281,9 @@ export function RunDetailRoute(): JSX.Element {
   // AdminSheet (which mounts lazily) sees a populated manifest the
   // first time the operator opens it. They are NOT rendered inline by
   // the route any more — that responsibility moved to AdminSheetBody.
+  // The setters are also fed by the PR 6 SSE-driven debounced
+  // refetchers below; the values themselves are intentionally not read
+  // here (AdminSheetBody owns the per-section fetch + render).
   const [, setToolCalls] = useState<ToolCall[]>([]);
   const [, setDrift] = useState<DriftSignalsResponse | null>(null);
   const [, setSignatures] = useState<CommitSignatureRecord[]>([]);
@@ -386,7 +396,106 @@ export function RunDetailRoute(): JSX.Element {
   }, [run?.manifest.fsm_spec_id]);
 
   // -----------------------------------------------------------------------
-  // SSE subscription — keeps the timeline live
+  // PR 6: SSE-driven debounced refetchers.
+  //
+  // The route owns the SINGLE EventStream subscription for the page so
+  // the server only fans out the run's events once. As each event lands
+  // we (a) prepend it to the timeline (handled below) and (b) dispatch
+  // a debounced refetch for the relevant data source — state tree on
+  // entry/exit/transition/inline events, drift on signal/pause events,
+  // signatures on commit verify/mismatch, tool-calls on tool_call
+  // events. The debouncer coalesces bursts so a chatty run does not
+  // hammer the API with one refetch per frame.
+  //
+  // The refetchers also bump per-kind refresh nonces (see
+  // ``runDetailRefresh.ts``) so lazily-mounted panels (eg. the Admin
+  // Sheet's Drift / Signatures / Tool calls sections) can react to the
+  // same burst without opening their own redundant EventStream.
+  // -----------------------------------------------------------------------
+
+  // Race guard — every refetch closure captures the event seq at
+  // trigger time and ignores its response if a newer event has since
+  // arrived. The check is a defence-in-depth measure: the debouncer's
+  // bounded latency already minimises overlap, but a slow API call can
+  // still resolve out of order relative to a fresh burst. ``lastEventSeq``
+  // is updated by the SSE handler each time a frame lands so the guard
+  // sees the most-recent seq when the API call resolves.
+  const lastEventSeqRef = useRef<number>(0);
+
+  const refetchStateTree = useDebouncedRefetch(() => {
+    if (!runId) return;
+    const seqAtTrigger = lastEventSeqRef.current;
+    return api
+      .getStateTree(runId)
+      .then((tree) => {
+        if (seqAtTrigger < lastEventSeqRef.current && lastEventSeqRef.current > 0) {
+          // A newer burst overtook us; a follow-up refetch is already
+          // queued or in-flight so dropping this response is safe.
+          return;
+        }
+        setStateTree(tree);
+        bumpStateTreeRefresh();
+      })
+      .catch(() => {
+        // Stay silent: a single failed refetch should not blank the
+        // tree. The next event tick will retry.
+      });
+  });
+
+  const refetchDrift = useDebouncedRefetch(() => {
+    if (!runId) return;
+    const seqAtTrigger = lastEventSeqRef.current;
+    return api
+      .listDriftSignals(runId)
+      .then((res) => {
+        if (seqAtTrigger < lastEventSeqRef.current && lastEventSeqRef.current > 0) {
+          return;
+        }
+        setDrift(res);
+        bumpDriftRefresh();
+      })
+      .catch(() => {
+        /* see refetchStateTree */
+      });
+  });
+
+  const refetchSignatures = useDebouncedRefetch(() => {
+    if (!runId) return;
+    const seqAtTrigger = lastEventSeqRef.current;
+    return api
+      .listCommitSignatures(runId, { page_size: 200 })
+      .then((page) => {
+        if (seqAtTrigger < lastEventSeqRef.current && lastEventSeqRef.current > 0) {
+          return;
+        }
+        setSignatures(page.items);
+        bumpSignaturesRefresh();
+      })
+      .catch(() => {
+        /* see refetchStateTree */
+      });
+  });
+
+  const refetchToolCalls = useDebouncedRefetch(() => {
+    if (!runId) return;
+    const seqAtTrigger = lastEventSeqRef.current;
+    return api
+      .listToolCalls({ run_id: runId, page_size: 50 })
+      .then((page) => {
+        if (seqAtTrigger < lastEventSeqRef.current && lastEventSeqRef.current > 0) {
+          return;
+        }
+        setToolCalls(page.items);
+        bumpToolCallsRefresh();
+      })
+      .catch(() => {
+        /* see refetchStateTree */
+      });
+  });
+
+  // -----------------------------------------------------------------------
+  // SSE subscription — keeps the timeline live and dispatches the
+  // debounced per-kind refetches above.
   // -----------------------------------------------------------------------
 
   useEffect(() => {
@@ -396,6 +505,36 @@ export function RunDetailRoute(): JSX.Element {
       filter_run_id: runId,
     });
     const unsubscribe = stream.on((event) => {
+      // Track the most-recent seq so each in-flight refetch's race
+      // guard sees the latest tick when it resolves.
+      if (event.seq != null && event.seq > lastEventSeqRef.current) {
+        lastEventSeqRef.current = event.seq;
+      }
+      // Dispatch debounced refetches BEFORE the prepend so a fast SSE
+      // burst still triggers exactly one refetch per kind per debounce
+      // window — the timeline prepend just rerenders the rows.
+      switch (event.kind) {
+        case 'state_entered':
+        case 'state_exited':
+        case 'state_faulted':
+        case 'transition_taken':
+        case 'inline_executed':
+          refetchStateTree.trigger();
+          break;
+        case 'drift_signal_recorded':
+        case 'drift_pause_triggered':
+          refetchDrift.trigger();
+          break;
+        case 'commit_signature_verified':
+        case 'commit_signature_mismatch':
+          refetchSignatures.trigger();
+          break;
+        case 'tool_call_observed':
+          refetchToolCalls.trigger();
+          break;
+        default:
+          break;
+      }
       // Prepend so newest renders at the top of the timeline; cap at 200
       // so the DOM stays bounded on chatty runs.
       setEvents((prev) => {
@@ -410,7 +549,7 @@ export function RunDetailRoute(): JSX.Element {
       unsubscribe();
       stream.close();
     };
-  }, [runId]);
+  }, [runId, refetchStateTree, refetchDrift, refetchSignatures, refetchToolCalls]);
 
   // -----------------------------------------------------------------------
   // Derived state

--- a/ui/src/routes/runDetail/__tests__/runDetail.test.tsx
+++ b/ui/src/routes/runDetail/__tests__/runDetail.test.tsx
@@ -21,9 +21,11 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { cleanup, render, waitFor } from '@testing-library/preact';
 
 import type {
+  Event as FsmEvent,
   RunDetail,
   StateNode,
 } from '../../../lib/api';
+import { resetRunDetailRefresh } from '../../../lib/runDetailRefresh';
 
 // --- Mocks --------------------------------------------------------------
 
@@ -34,13 +36,19 @@ vi.mock('preact-iso', () => ({
 }));
 
 // The SSE EventStream opens a real EventSource on construction; jsdom
-// doesn't ship one. Stub the module so the timeline mount doesn't
-// throw and the route's render path is exercised end-to-end.
+// doesn't ship one. Stub the module and capture the most-recent ``on``
+// handler so PR 6 tests can synthesise SSE frames into the route.
+const sseHandlers: Array<(e: FsmEvent) => void> = [];
+function emitSse(event: FsmEvent): void {
+  for (const h of sseHandlers) h(event);
+}
 vi.mock('../../../lib/sse', () => ({
   EventStream: class {
-    on(): () => void {
+    on(cb: (e: FsmEvent) => void): () => void {
+      sseHandlers.push(cb);
       return () => {
-        // no-op
+        const i = sseHandlers.indexOf(cb);
+        if (i >= 0) sseHandlers.splice(i, 1);
       };
     }
     close(): void {
@@ -133,6 +141,8 @@ function renderRoute() {
 describe('RunDetailRoute (PR 7 layout)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sseHandlers.length = 0;
+    resetRunDetailRefresh();
   });
 
   test('renders the 50/50 grid (graph | timeline) once data has loaded', async () => {
@@ -169,6 +179,131 @@ describe('RunDetailRoute (PR 7 layout)', () => {
       getByRole('button', { name: /Admin/i }),
     );
     expect(adminBtn).toBeInTheDocument();
+  });
+
+  test('SSE state-tree events dispatch a debounced refetch (PR 6)', async () => {
+    const { getByTestId } = renderRoute();
+    await waitFor(() => getByTestId('run-detail-grid'));
+
+    // Import the mock api so we can assert on call counts.
+    const { api } = await import('../../../lib/api');
+    const initialStateTreeCalls = (api.getStateTree as ReturnType<typeof vi.fn>)
+      .mock.calls.length;
+    const initialDriftCalls = (api.listDriftSignals as ReturnType<typeof vi.fn>)
+      .mock.calls.length;
+    const initialSigsCalls = (
+      api.listCommitSignatures as ReturnType<typeof vi.fn>
+    ).mock.calls.length;
+    const initialToolsCalls = (api.listToolCalls as ReturnType<typeof vi.fn>)
+      .mock.calls.length;
+
+    emitSse({
+      id: 'e1',
+      run_id: 'run-test-1',
+      kind: 'state_entered',
+      producer_id: 'engine',
+      payload: { state_id: 'plan' },
+      created_at: '2025-01-01T00:00:02Z',
+      seq: 10,
+    });
+
+    // useDebouncedRefetch waits 200ms; allow real timers to elapse.
+    await new Promise((r) => setTimeout(r, 350));
+
+    expect(
+      (api.getStateTree as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBeGreaterThan(initialStateTreeCalls);
+    // Other refetchers should NOT fire on a state_entered event.
+    expect(
+      (api.listDriftSignals as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(initialDriftCalls);
+    expect(
+      (api.listCommitSignatures as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(initialSigsCalls);
+    expect(
+      (api.listToolCalls as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(initialToolsCalls);
+  });
+
+  test('SSE drift / signatures / tool_call events route to their own refetchers (PR 6)', async () => {
+    const { getByTestId } = renderRoute();
+    await waitFor(() => getByTestId('run-detail-grid'));
+
+    const { api } = await import('../../../lib/api');
+    const before = {
+      drift: (api.listDriftSignals as ReturnType<typeof vi.fn>).mock.calls
+        .length,
+      sigs: (api.listCommitSignatures as ReturnType<typeof vi.fn>).mock.calls
+        .length,
+      tools: (api.listToolCalls as ReturnType<typeof vi.fn>).mock.calls.length,
+    };
+
+    emitSse({
+      id: 'e2',
+      run_id: 'run-test-1',
+      kind: 'drift_signal_recorded',
+      producer_id: 'engine',
+      payload: {},
+      created_at: '2025-01-01T00:00:03Z',
+      seq: 11,
+    });
+    emitSse({
+      id: 'e3',
+      run_id: 'run-test-1',
+      kind: 'commit_signature_verified',
+      producer_id: 'engine',
+      payload: {},
+      created_at: '2025-01-01T00:00:04Z',
+      seq: 12,
+    });
+    emitSse({
+      id: 'e4',
+      run_id: 'run-test-1',
+      kind: 'tool_call_observed',
+      producer_id: 'engine',
+      payload: {},
+      created_at: '2025-01-01T00:00:05Z',
+      seq: 13,
+    });
+
+    await new Promise((r) => setTimeout(r, 350));
+
+    expect(
+      (api.listDriftSignals as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBeGreaterThan(before.drift);
+    expect(
+      (api.listCommitSignatures as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBeGreaterThan(before.sigs);
+    expect(
+      (api.listToolCalls as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBeGreaterThan(before.tools);
+  });
+
+  test('a burst of state_entered events coalesces to a single refetch (PR 6 debouncer)', async () => {
+    const { getByTestId } = renderRoute();
+    await waitFor(() => getByTestId('run-detail-grid'));
+
+    const { api } = await import('../../../lib/api');
+    const before = (api.getStateTree as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+
+    for (let i = 0; i < 5; i++) {
+      emitSse({
+        id: `burst-${i}`,
+        run_id: 'run-test-1',
+        kind: 'state_entered',
+        producer_id: 'engine',
+        payload: {},
+        created_at: '2025-01-01T00:00:06Z',
+        seq: 20 + i,
+      });
+    }
+
+    await new Promise((r) => setTimeout(r, 350));
+    const after = (api.getStateTree as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+    // 5 frames → exactly 1 coalesced refetch.
+    expect(after - before).toBe(1);
   });
 
   test('legacy inline surfaces are not rendered (States tree, Admin Card, Tool Calls audit, per-node JsonViewer panels)', async () => {

--- a/ui/src/routes/runDetail/admin/DriftSection.tsx
+++ b/ui/src/routes/runDetail/admin/DriftSection.tsx
@@ -10,7 +10,7 @@
  */
 
 import type { JSX } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
 import {
   EmptyState,
@@ -18,6 +18,7 @@ import {
   Spinner,
 } from '../../../components';
 import { api, ApiError, type DriftSignalsResponse } from '../../../lib/api';
+import { driftRefreshNonce } from '../../../lib/runDetailRefresh';
 import { CollapsibleSection } from './CollapsibleSection';
 
 /** Visual gauge for a drift score in the ``[0, 1]`` band. */
@@ -63,12 +64,24 @@ export function DriftSection({ runId }: DriftSectionProps): JSX.Element {
   const [drift, setDrift] = useState<DriftSignalsResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState<boolean>(false);
+  // PR 6: re-fetch whenever the route's SSE handler bumps the drift
+  // nonce. Reading ``.value`` in the render body auto-subscribes so a
+  // dependency on it triggers the effect on every bump. We keep
+  // previously-loaded data on-screen across refetches so the panel
+  // does not flash a Spinner on every tick.
+  const nonce = driftRefreshNonce.value;
+  const lastRunIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    setDrift(null);
-    setError(null);
-    setLoaded(false);
+    // Only blank-and-spin on the FIRST fetch for a given runId. Nonce-
+    // driven refetches keep the previously-loaded data visible.
+    if (lastRunIdRef.current !== runId) {
+      setDrift(null);
+      setError(null);
+      setLoaded(false);
+      lastRunIdRef.current = runId;
+    }
     api
       .listDriftSignals(runId)
       .then((res) => {
@@ -84,7 +97,7 @@ export function DriftSection({ runId }: DriftSectionProps): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [runId]);
+  }, [runId, nonce]);
 
   const trailing = drift ? (
     <Pill variant="neutral" size="sm">

--- a/ui/src/routes/runDetail/admin/SignaturesSection.tsx
+++ b/ui/src/routes/runDetail/admin/SignaturesSection.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { JSX } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
 import {
   EmptyState,
@@ -20,6 +20,7 @@ import {
   ApiError,
   type CommitSignatureRecord,
 } from '../../../lib/api';
+import { signaturesRefreshNonce } from '../../../lib/runDetailRefresh';
 import { CollapsibleSection } from './CollapsibleSection';
 
 function shortHash(hash: string): string {
@@ -41,11 +42,19 @@ export function SignaturesSection({
 }: SignaturesSectionProps): JSX.Element {
   const [sigs, setSigs] = useState<CommitSignatureRecord[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // PR 6: SSE-driven refresh — refetch when the route bumps the
+  // signatures nonce, keeping the previously-loaded list visible
+  // across refetches so the panel does not flash empty on every tick.
+  const nonce = signaturesRefreshNonce.value;
+  const lastRunIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    setSigs(null);
-    setError(null);
+    if (lastRunIdRef.current !== runId) {
+      setSigs(null);
+      setError(null);
+      lastRunIdRef.current = runId;
+    }
     api
       .listCommitSignatures(runId, { page_size: 200 })
       .then((page) => {
@@ -59,7 +68,7 @@ export function SignaturesSection({
     return () => {
       cancelled = true;
     };
-  }, [runId]);
+  }, [runId, nonce]);
 
   const trailing = sigs ? (
     <Pill variant="neutral" size="sm">

--- a/ui/src/routes/runDetail/admin/ToolCallsSection.tsx
+++ b/ui/src/routes/runDetail/admin/ToolCallsSection.tsx
@@ -13,7 +13,7 @@
  */
 
 import type { JSX } from 'preact';
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import {
   EmptyState,
@@ -24,6 +24,7 @@ import {
   type FilterChip,
 } from '../../../components';
 import { api, ApiError, type ToolCall } from '../../../lib/api';
+import { toolCallsRefreshNonce } from '../../../lib/runDetailRefresh';
 import { CollapsibleSection } from './CollapsibleSection';
 
 function shortHash(hash: string): string {
@@ -48,11 +49,17 @@ export function ToolCallsSection({
   const [calls, setCalls] = useState<ToolCall[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  // PR 6: refetch on SSE-driven tool-calls nonce bumps.
+  const nonce = toolCallsRefreshNonce.value;
+  const lastRunIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    setCalls(null);
-    setError(null);
+    if (lastRunIdRef.current !== runId) {
+      setCalls(null);
+      setError(null);
+      lastRunIdRef.current = runId;
+    }
     api
       .listToolCalls({ run_id: runId, page_size: 100 })
       .then((page) => {
@@ -66,7 +73,7 @@ export function ToolCallsSection({
     return () => {
       cancelled = true;
     };
-  }, [runId]);
+  }, [runId, nonce]);
 
   const filtered = useMemo(() => {
     if (!calls) return [];

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -181,3 +181,29 @@ body {
     outline: 2px solid rgb(251 191 36);
   }
 }
+
+/* PR 6: RunEventTimeline freshness flash. SSE-driven prepends arrive at
+   the top of the tape; the row's ``data-fresh="true"`` attribute
+   triggers a brief amber background that fades out over ~2 s so the
+   operator's eye lands on the newly-arrived row without obscuring its
+   content. The CSS transition runs on a property that doesn't trigger
+   layout (background-color) so the flash is GPU-friendly even when
+   dozens of rows are flashing at once during a burst. */
+[data-fresh="true"] {
+  background: rgba(251, 191, 36, 0.18);
+  transition: background 1800ms ease-out 200ms;
+}
+
+.dark [data-fresh="true"] {
+  background: rgba(120, 53, 15, 0.35);
+}
+
+/* Reduced-motion fallback: no background fade — replace with a static
+   amber outline so the freshness affordance is still visible without
+   continuous animation. */
+@media (prefers-reduced-motion: reduce) {
+  [data-fresh="true"] {
+    background: none;
+    outline: 2px solid rgb(251 191 36);
+  }
+}


### PR DESCRIPTION
Resolves the missing PR 6 of the /runs/:id redesign cascade (was incorrectly blocked by a stale-worktree agent). Adds RunEventTimeline component with 2s amber freshness flash on newly-arrived events, plus per-event-kind debounced refetch dispatch so the graph state-tree, drift signals, commit signatures, and tool calls all update in real time without polling. Per plan in /Users/developer/.claude/plans/how-it-fits-toasty-gray.md PR 6/7.