### PR TITLE
fix(fsm): drift detector LLM-friendly + paused as real commit gate

### DIFF
--- a/ctxr/fsm/core/models.py
+++ b/ctxr/fsm/core/models.py
@@ -172,6 +172,16 @@ class EventKind(StrEnum):
     tool_call_observed = "tool_call_observed"
     drift_signal_recorded = "drift_signal_recorded"
     drift_pause_triggered = "drift_pause_triggered"
+    # Drift-friendly liveness signals (long-LLM-friendliness fix).
+    # ``heartbeat`` is emitted by ``fsm.heartbeat`` so an orchestrator can
+    # actively assert "still alive" while a long worker call is in flight;
+    # ``drift_pause_cleared`` is emitted when an idle-only pause is
+    # auto-cleared by activity (worker_dispatched / heartbeat / commit).
+    # ``worker_dispatched`` already existed in the enum but was unused;
+    # ``fsm.get_brief`` now emits it for every worker-bearing state so
+    # the drift detector treats brief hand-off as activity.
+    heartbeat = "heartbeat"
+    drift_pause_cleared = "drift_pause_cleared"
     verifier_passed = "verifier_passed"
     verifier_rejected = "verifier_rejected"
     commit_token_issued = "commit_token_issued"
@@ -386,6 +396,16 @@ class Worker(BaseModel):
     inputs: list[str] = Field(default_factory=list)
     response_schema: ResponseSchema | None = None
     inputs_schema: ResponseSchema | None = None
+    expected_max_wait_seconds: int | None = Field(
+        default=None,
+        description=(
+            "Optional per-state idle budget the drift detector honours "
+            "instead of the global default. Spec authors set this when a "
+            "worker is known to take longer than the global idle window "
+            "(e.g. a multi-minute codebase scan). When None the drift "
+            "detector falls back to DriftConfig.window_seconds."
+        ),
+    )
 
     @field_validator("role", "prompt_template")
     @classmethod
@@ -411,6 +431,18 @@ class Worker(BaseModel):
                 "(or omitted entirely if no hint applies)"
             )
         return stripped
+
+    @field_validator("expected_max_wait_seconds")
+    @classmethod
+    def _expected_max_wait_positive(cls, value: int | None) -> int | None:
+        if value is None:
+            return None
+        if value <= 0:
+            raise ValueError(
+                "expected_max_wait_seconds must be a positive integer "
+                "(or omitted entirely to use the global drift window)"
+            )
+        return value
 
 
 class VerifierSpec(BaseModel):

--- a/ctxr/fsm/mcp/tools_meta.py
+++ b/ctxr/fsm/mcp/tools_meta.py
@@ -66,20 +66,22 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select, text
 
 from ctxr.fsm import __version__ as _PACKAGE_VERSION  # noqa: N812
-from ctxr.fsm.core.models import EventKind, FsmSpec
+from ctxr.fsm.core.models import EventKind, FsmSpec, RunStatus
 from ctxr.fsm.core.spec import validate_fsm_spec
 from ctxr.fsm.mcp import mcp
 from ctxr.fsm.mcp._drain_decorator import drain_aware
 from ctxr.fsm.mcp._errors import McpToolError, as_error
 from ctxr.fsm.mcp._state import get_project
-from ctxr.fsm.sqlite.models_core import FsmSpecTable, ProjectTable
+from ctxr.fsm.sqlite.models_core import FsmSpecTable, ProjectTable, RunTable
 
 __all__ = [
     "HealthcheckResult",
+    "HeartbeatResult",
     "ObserveResult",
     "SpecRegisteredPayload",
     "SpecSummary",
     "fsm_healthcheck",
+    "fsm_heartbeat",
     "fsm_list_specs",
     "fsm_observe_tool_call",
     "fsm_register_spec",
@@ -186,6 +188,36 @@ class SpecRegisteredPayload(BaseModel):
     project_slug: str = Field(description="Human-readable slug of the owning project.")
     created: bool = Field(
         description="True iff a new row was inserted; False on hash-dedup match."
+    )
+
+
+class HeartbeatResult(BaseModel):
+    """Return value of :func:`fsm_heartbeat`.
+
+    ``ok`` is always True on success — the field is kept as a positive
+    acknowledgement so the wire shape never needs a bare bool.
+    ``idle_reset_at`` is the ISO-8601 timestamp the drift detector
+    will see as the run's new ``last_update_at`` on its next sweep —
+    surfaced so an orchestrator can correlate its periodic pings with
+    the dashboard's "last activity" pill.
+    ``drift_pause_cleared`` is True iff the heartbeat also flipped a
+    ``drift_paused`` run back to ``in_progress`` (always paired with
+    a ``drift_pause_cleared`` event on the bus).
+    """
+
+    model_config = _VO_CFG
+
+    ok: bool = Field(default=True, description="Always True on success.")
+    idle_reset_at: str = Field(
+        description="ISO-8601 timestamp the run's last_update_at was bumped to."
+    )
+    event_id: str = Field(description="Row PK of the emitted heartbeat event.")
+    drift_pause_cleared: bool = Field(
+        default=False,
+        description=(
+            "True iff this heartbeat auto-cleared an idle-only drift_paused "
+            "status. Real-drift pauses are never cleared by heartbeat."
+        ),
     )
 
 
@@ -620,6 +652,150 @@ def fsm_observe_tool_call(
         return as_error("invalid_argument", detail=str(exc))
     except Exception as exc:
         _LOG.exception("fsm.observe_tool_call: unexpected error")
+        return as_error("internal_error", detail=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# fsm.heartbeat
+# ---------------------------------------------------------------------------
+
+
+# Producer identity used when this module emits engine-attributed
+# liveness events (heartbeat, drift_pause_cleared). Mirrors the
+# identity used by tools_runs.py so the audit trail attributes every
+# engine-side emit to one logical producer regardless of which surface
+# drove it.
+_ENGINE_PRODUCER_KIND: str = "engine"
+_ENGINE_PRODUCER_NAME: str = "fsm.runtime"
+
+
+@mcp.tool(
+    name="fsm.heartbeat",
+    description=(
+        "Refresh a run's idle window without committing outputs. "
+        "Long-LLM-friendliness hook: orchestrators call this every "
+        "~60s while a slow worker is in flight so the drift detector "
+        "treats the run as alive even though no state has advanced. "
+        "Idempotent. Auto-clears idle-only drift_paused status."
+    ),
+)
+@drain_aware
+def fsm_heartbeat(
+    run_id: UUID,
+    message: str = "",
+) -> HeartbeatResult | McpToolError:
+    """Bump ``runs.last_update_at`` and emit a ``heartbeat`` event.
+
+    Contract for callers
+    --------------------
+
+    An orchestrator (claude-code skill, custom worker harness, etc.)
+    that knows a worker dispatch will take longer than the global
+    idle window calls this on a timer (typical cadence: every 60s
+    once the dispatch has been in flight for ~30s). The call is
+    idempotent: making it twice in the same second is harmless.
+
+    The tool does THREE things inside one transaction:
+
+    1. Bumps ``runs.last_update_at`` to ``now`` so the drift detector's
+       reference timestamp moves forward.
+    2. Emits an ``EventKind.heartbeat`` event carrying ``message``
+       (a free-form note the operator can read in the timeline) and
+       the new timestamp.
+    3. If the run is currently ``drift_paused`` AND only idle
+       signals contributed to that pause, flips the status back to
+       ``in_progress`` and emits ``drift_pause_cleared``. Real-drift
+       pauses are NEVER cleared by heartbeat — those require
+       ``fsm.resume_run``.
+
+    A ``run_not_found`` envelope is returned for unknown ids;
+    ``invalid_argument`` for malformed run_id text.
+    """
+    try:
+        project = get_project()
+        run_id_str = str(run_id)
+
+        run = project.get_run(run_id_str)
+        if run is None:
+            return as_error(
+                "run_not_found",
+                detail=f"no run with id {run_id_str!r}",
+                run_id=run_id_str,
+            )
+
+        # Lazy import: tools_runs.py is the source of truth for the
+        # engine producer identity + auto-clear policy. Importing at
+        # module scope would create a cycle (tools_runs imports models;
+        # models doesn't touch this module).
+        from ctxr.fsm.mcp.tools_runs import (
+            _PAUSE_CLEAR_REASON_HEARTBEAT,
+            _auto_clear_drift_pause_if_idle_only,
+        )
+
+        with project.session_factory() as session, session.begin():
+            producer = project.producers.upsert(
+                session,
+                kind=_ENGINE_PRODUCER_KIND,
+                name=_ENGINE_PRODUCER_NAME,
+            )
+            producer_id = producer.id
+
+        # Compute the new timestamp once and use it for both the row
+        # bump and the event payload so subscribers see a single,
+        # consistent "alive at T" reading.
+        from ctxr.fsm.sqlite.repos_core import _iso_now_ms
+
+        now = _iso_now_ms()
+        with project.session_factory() as session, session.begin():
+            row = session.get(RunTable, run_id_str)
+            if row is not None:
+                row.last_update_at = now
+                session.add(row)
+            event = project.events.emit(
+                session,
+                producer_id=producer_id,
+                kind=EventKind.heartbeat.value,
+                payload={
+                    "run_id": run_id_str,
+                    "message": message,
+                    "idle_reset_at": now,
+                },
+                run_id=run_id_str,
+            )
+
+        # Auto-clear ONLY when paused on idle signals alone. We
+        # re-read the run row to pick up the just-bumped status (the
+        # bump above only touches last_update_at, but a paused run
+        # still carries status=drift_paused which the helper reads).
+        run_after = project.get_run(run_id_str)
+        cleared = False
+        if (
+            run_after is not None
+            and run_after.status == RunStatus.drift_paused.value
+        ):
+            cleared, _kinds = _auto_clear_drift_pause_if_idle_only(
+                project,
+                run=run_after,
+                producer_id=producer_id,
+                cleared_by=_PAUSE_CLEAR_REASON_HEARTBEAT,
+            )
+
+        return HeartbeatResult(
+            ok=True,
+            idle_reset_at=now,
+            event_id=event.id,
+            drift_pause_cleared=cleared,
+        )
+    except KeyboardInterrupt:  # pragma: no cover
+        raise
+    except RuntimeError as exc:
+        _LOG.exception("fsm.heartbeat: project handle not bound")
+        return as_error("project_not_bound", detail=str(exc))
+    except ValueError as exc:
+        _LOG.info("fsm.heartbeat: invalid argument")
+        return as_error("invalid_argument", detail=str(exc))
+    except Exception as exc:
+        _LOG.exception("fsm.heartbeat: unexpected error")
         return as_error("internal_error", detail=str(exc))
 
 

--- a/ctxr/fsm/mcp/tools_runs.py
+++ b/ctxr/fsm/mcp/tools_runs.py
@@ -73,6 +73,7 @@ from ctxr.fsm.core.models import (
     InlineFaultReason,
     PostValidationResultEntry,
     RunCtx,
+    RunStatus,
     StateKind,
     TransitionEvaluation,
     TransitionKind,
@@ -536,6 +537,170 @@ def _cosignature_required(state: Any) -> bool:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Long-LLM-friendliness helpers: drift_paused commit gate + auto-clear
+# ---------------------------------------------------------------------------
+
+
+# Reasons surfaced on the auto-clear breadcrumb. Centralised so the
+# ``drift_pause_cleared`` payload uses a closed vocabulary the dashboard
+# can pivot on instead of free-text.
+_PAUSE_CLEAR_REASON_GET_BRIEF: str = "get_brief"
+_PAUSE_CLEAR_REASON_HEARTBEAT: str = "heartbeat"
+_PAUSE_CLEAR_REASON_COMMIT_OUTPUTS: str = "commit_outputs"
+
+
+def _signals_for_run(project: Project, run_id: str) -> list[Any]:
+    """Return every drift signal recorded against ``run_id`` (oldest first)."""
+    with project.session_factory() as session:
+        return list(project.drift_signals.by_run(session, run_id))
+
+
+def _emit_drift_pause_cleared(
+    project: Project,
+    *,
+    run_id: str,
+    producer_id: str,
+    cleared_by: str,
+    contributing_signal_kinds: list[str],
+) -> str:
+    """Flip ``drift_paused`` -> ``in_progress`` and emit the breadcrumb event.
+
+    Both writes share one ``session.begin()`` so a crash between them
+    leaves the substrate consistent. The persisted status flip is the
+    durable record; the breadcrumb event drives the dashboard and the
+    drift detector's eventual re-scoring on the next sweep.
+
+    Returns the ISO timestamp the clear was recorded at so the caller
+    can surface it on its tool-result envelope without a second
+    ``datetime.now`` call.
+    """
+    cleared_at = _iso_now_ms()
+    with project.session_factory() as session, session.begin():
+        project.runs.update_status(
+            session,
+            run_id=run_id,
+            status=RunStatus.in_progress.value,
+        )
+        project.events.emit(
+            session,
+            producer_id=producer_id,
+            kind=EventKind.drift_pause_cleared.value,
+            payload={
+                "run_id": run_id,
+                "cleared_by": cleared_by,
+                "contributing_signal_kinds": list(contributing_signal_kinds),
+                "cleared_at": cleared_at,
+            },
+            run_id=run_id,
+        )
+    return cleared_at
+
+
+def _auto_clear_drift_pause_if_idle_only(
+    project: Project,
+    *,
+    run: Any,
+    producer_id: str,
+    cleared_by: str,
+) -> tuple[bool, list[str]]:
+    """Auto-clear ``drift_paused`` when only idle signals contributed.
+
+    Returns ``(cleared, contributing_kinds)`` where ``cleared`` is
+    True when the status flip + breadcrumb emit fired. Contributing
+    kinds are returned regardless so the caller can decide whether to
+    surface a refusal envelope (real drift) or proceed silently
+    (idle-only clear).
+
+    A ``drift_paused`` run with NO signals on file is treated as
+    operator-driven and left alone — the auto-clear policy only fires
+    when the substrate's own evidence proves the pause was an idle
+    artefact.
+    """
+    # Import here to avoid a module-level cycle (drift imports models;
+    # this module imports models; the project facade exposes
+    # drift_signals).
+    from ctxr.fsm.sqlite.drift import only_idle_signals_contributed
+
+    signals = _signals_for_run(project, run.id)
+    contributing = sorted({s.signal_kind for s in signals})
+    if not signals:
+        # Defensive: nothing on file to support an idle-only verdict.
+        return False, contributing
+    if not only_idle_signals_contributed(signals):
+        return False, contributing
+    _emit_drift_pause_cleared(
+        project,
+        run_id=run.id,
+        producer_id=producer_id,
+        cleared_by=cleared_by,
+        contributing_signal_kinds=contributing,
+    )
+    return True, contributing
+
+
+def _drift_paused_error(
+    *,
+    run_id: str,
+    contributing_signal_kinds: list[str],
+) -> McpToolError:
+    """Build the structured refusal envelope for a real-drift pause.
+
+    Surfaced when ``commit_outputs`` / ``confirm_commit`` /
+    ``resolve_gate`` are called against a run whose pause is supported
+    by signals other than idle_too_long. The caller must call
+    ``fsm.resume_run`` explicitly to clear an operator-confirmed drift.
+    """
+    return as_error(
+        "run_drift_paused",
+        detail=(
+            "Run is drift_paused; real drift signals are on file. "
+            "Call fsm.resume_run to clear after operator review."
+        ),
+        run_id=run_id,
+        contributing_signal_kinds=list(contributing_signal_kinds),
+    )
+
+
+def _gate_run_or_auto_clear(
+    project: Project,
+    *,
+    run: Any,
+    producer_id: str,
+) -> McpToolError | None:
+    """Return a refusal envelope when ``run`` is paused on real drift.
+
+    Behaviour:
+
+    * Run not paused → ``None`` (proceed).
+    * Run paused, only idle signals contributed → auto-clear,
+      return ``None`` (proceed).
+    * Run paused, at least one real drift signal contributed →
+      return the structured ``run_drift_paused`` envelope so the
+      caller short-circuits with a typed refusal.
+
+    Called from ``fsm.commit_outputs``, ``fsm.confirm_commit``, and
+    ``fsm.resolve_gate`` so the three primary commit surfaces all
+    honour the same gate semantics. ``fsm.get_brief`` and
+    ``fsm.heartbeat`` take the looser auto-clear-only path because
+    they are read-side hand-offs that should not block on real drift
+    (the next commit will).
+    """
+    if getattr(run, "status", None) != RunStatus.drift_paused.value:
+        return None
+    cleared, contributing = _auto_clear_drift_pause_if_idle_only(
+        project,
+        run=run,
+        producer_id=producer_id,
+        cleared_by=_PAUSE_CLEAR_REASON_COMMIT_OUTPUTS,
+    )
+    if cleared:
+        return None
+    return _drift_paused_error(
+        run_id=run.id, contributing_signal_kinds=contributing
+    )
 
 
 def _ensure_engine_producer(project: Project) -> str:
@@ -1540,6 +1705,48 @@ def fsm_get_brief(input: GetBriefInput) -> Brief | McpToolError:
 
         env = _materialise_env(project, run)
         brief = build_brief(spec, state, env=env, run_id=uuid.UUID(run.id))
+
+        # Long-LLM-friendliness: a brief for a worker-bearing state is a
+        # hand-off to the LLM. We emit ``worker_dispatched`` so the
+        # drift detector treats this as an activity beat (it resets
+        # the idle window for this run) and so the timeline carries
+        # the "we briefed the worker at T" beat the dashboard wants.
+        # We also auto-clear an idle-only ``drift_paused`` status here
+        # — a brief is proof the orchestrator is still driving the
+        # run; the LLM hadn't stopped, just paused on a slow tool.
+        producer_id = _ensure_engine_producer(project)
+        if getattr(run, "status", None) == RunStatus.drift_paused.value:
+            _auto_clear_drift_pause_if_idle_only(
+                project,
+                run=run,
+                producer_id=producer_id,
+                cleared_by=_PAUSE_CLEAR_REASON_GET_BRIEF,
+            )
+
+        if brief.has_worker or brief.has_loop:
+            now = _iso_now_ms()
+            with project.session_factory() as session, session.begin():
+                # Bump ``runs.last_update_at`` so the drift detector's
+                # reference timestamp moves forward without a status
+                # change. The status itself is intentionally unchanged
+                # — this is just a liveness beat.
+                row = session.get(RunTable, run.id)
+                if row is not None:
+                    row.last_update_at = now
+                    session.add(row)
+                project.events.emit(
+                    session,
+                    producer_id=producer_id,
+                    kind=EventKind.worker_dispatched.value,
+                    payload={
+                        "run_id": run.id,
+                        "state_id": current_state_id,
+                        "brief_id": str(brief.brief_id),
+                        "iteration_n": brief.iteration_n,
+                        "dispatched_at": now,
+                    },
+                    run_id=run.id,
+                )
         return brief
     except KeyboardInterrupt:
         raise
@@ -1879,6 +2086,31 @@ def fsm_commit_outputs(input: CommitOutputsInput) -> CommitResult | McpToolError
             return _spec_hash_lock_error(
                 run_hash=run.fsm_spec_hash,
                 current_hash=current_hash,
+            )
+
+        # Long-LLM-friendliness: drift_paused is a REAL commit gate.
+        # We refuse the commit when real-drift signals supported the
+        # pause; idle-only pauses auto-clear in place (the LLM proved
+        # liveness by getting this far). Producer is the engine's own
+        # — same identity the rest of this function emits under.
+        producer_id_for_gate = _ensure_engine_producer(project)
+        gate_err = _gate_run_or_auto_clear(
+            project, run=run, producer_id=producer_id_for_gate
+        )
+        if gate_err is not None:
+            return gate_err
+        # Re-load the run so the post-clear status flows through to the
+        # rest of the body (cosignature path, signature persistence,
+        # token issue) — otherwise the in-memory ``run.status`` would
+        # still read ``drift_paused`` even after the auto-clear flipped
+        # the row. Bail if it vanished mid-call (paranoid; shouldn't
+        # happen under normal operator-facing flows).
+        run = project.get_run(run_id_str)
+        if run is None:
+            return as_error(
+                "run_not_found",
+                detail=f"no run with id {run_id_str!r}",
+                run_id=run_id_str,
             )
 
         current_state_id = _current_state_id(run, spec)
@@ -2402,6 +2634,18 @@ def fsm_confirm_commit(input: ConfirmCommitInput) -> ConfirmResult | McpToolErro
                 detail=f"token references missing run {run_id!r}",
                 run_id=run_id,
             )
+
+        # Long-LLM-friendliness: drift_paused gates confirm_commit too.
+        # A pause that landed between commit_outputs (token issued)
+        # and confirm_commit (replay) must refuse the replay so the
+        # staged writes don't silently land against a paused run.
+        # Idle-only pauses auto-clear; real drift refuses.
+        gate_producer_id = _ensure_engine_producer(project)
+        gate_err = _gate_run_or_auto_clear(
+            project, run=run, producer_id=gate_producer_id
+        )
+        if gate_err is not None:
+            return gate_err
 
         # Reload the spec so we can rebuild the next brief during replay.
         with project.session_factory() as session:
@@ -2946,6 +3190,25 @@ def fsm_resolve_gate(input: ResolveGateInput) -> ResolveGateResult | McpToolErro
         # Side-effect import binds FsmSpec.hash / validate.
         from ctxr.fsm.core import spec as _spec_module  # noqa: F401
         spec = FsmSpec.model_validate(registered.definition)
+
+        # Long-LLM-friendliness: drift_paused gates resolve_gate too.
+        # Same semantics as commit_outputs / confirm_commit — real
+        # drift refuses; idle-only auto-clears in place.
+        gate_producer_id = _ensure_engine_producer(project)
+        drift_gate_err = _gate_run_or_auto_clear(
+            project, run=run, producer_id=gate_producer_id
+        )
+        if drift_gate_err is not None:
+            return drift_gate_err
+        # Reload after a potential auto-clear so the rest of the body
+        # sees the post-clear status.
+        run = project.get_run(run_id_str)
+        if run is None:
+            return as_error(
+                "run_not_found",
+                detail=f"no run with id {run_id_str!r}",
+                run_id=run_id_str,
+            )
 
         current_state_id = _current_state_id(run, spec)
         try:

--- a/ctxr/fsm/sqlite/drift.py
+++ b/ctxr/fsm/sqlite/drift.py
@@ -88,9 +88,11 @@ if TYPE_CHECKING:
     from ctxr.fsm.sqlite.project import Project
 
 __all__ = [
+    "DEFAULT_IDLE_WINDOW_SECONDS",
     "DRIFT_DISABLED_ENV_VAR",
     "DRIFT_PRODUCER_KIND",
     "DRIFT_PRODUCER_NAME",
+    "IDLE_TIMEOUT_ENV_VAR",
     "DriftConfig",
     "RunScoreboard",
     "classify_event",
@@ -110,11 +112,40 @@ _LOG = logging.getLogger(__name__)
 # literal at every site.
 DRIFT_DISABLED_ENV_VAR: str = "CTXR_FSM_DRIFT_DISABLED"
 
+# Operator-facing override for the default idle window. Long-LLM
+# friendliness: a 60s default trips legitimately-slow workers (large
+# codebase scans, deep analyses). Default raised to 300s (5min); ops
+# tune via this env var when their workloads need a different budget.
+# Per-state ``Worker.expected_max_wait_seconds`` always wins over this
+# global default when set.
+IDLE_TIMEOUT_ENV_VAR: str = "CTXR_FSM_IDLE_TIMEOUT_SECONDS"
+DEFAULT_IDLE_WINDOW_SECONDS: float = 300.0
+
 # The producer identity the drift detector registers + emits under.
 # Stable across restarts so subscribers can filter on this pair to see
 # every drift-detector-generated event.
 DRIFT_PRODUCER_KIND: str = "engine"
 DRIFT_PRODUCER_NAME: str = "fsm.drift_detector"
+
+
+def _resolve_default_idle_window() -> float:
+    """Return the effective idle window default (env var > module default).
+
+    The env var is parsed once at :class:`DriftConfig` construction
+    time; a non-positive or unparseable value falls back to
+    :data:`DEFAULT_IDLE_WINDOW_SECONDS` silently (operators discover
+    typos through the boot log line that names the resolved value).
+    """
+    raw = os.environ.get(IDLE_TIMEOUT_ENV_VAR)
+    if raw is None or not raw.strip():
+        return DEFAULT_IDLE_WINDOW_SECONDS
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return DEFAULT_IDLE_WINDOW_SECONDS
+    if parsed <= 0:
+        return DEFAULT_IDLE_WINDOW_SECONDS
+    return parsed
 
 
 # ---------------------------------------------------------------------------
@@ -172,7 +203,7 @@ class DriftConfig:
     """
 
     score_threshold: float = 10.0
-    window_seconds: float = 60.0
+    window_seconds: float = field(default_factory=_resolve_default_idle_window)
     kind_weights: dict[str, float] = field(default_factory=_default_kind_weights)
 
 
@@ -192,9 +223,17 @@ class RunScoreboard:
       classifier uses to suppress the first ``validation_failed``
       event in a row. Any non-``validation_failed`` event resets the
       counter to zero.
-    * ``paused`` is sticky: once True the loop refuses to re-emit
-      ``drift_pause_triggered`` even if new evidence accrues. This is
-      the at-most-once contract spelled out at the top of the module.
+    * ``paused`` is sticky on a per-loop-lifetime basis: once True the
+      loop refuses to re-emit ``drift_pause_triggered`` even if new
+      evidence accrues. The MCP-side auto-clear (commit_outputs /
+      get_brief / heartbeat) can flip it back to False when an idle
+      pause is cleared via :func:`clear_pause_state`.
+    * ``last_activity_seq`` records the seq of the most recent
+      "activity" event (``worker_dispatched`` / ``heartbeat`` /
+      ``state_entered``). Idle-window calculations consult the event
+      log when this is set so a long worker dispatch followed by a
+      heartbeat refreshes the budget even though ``runs.last_update_at``
+      hasn't been bumped by the engine itself.
 
     A scoreboard is allocated lazily the first time the loop touches a
     run and lives for the lifetime of the loop task (process
@@ -205,6 +244,64 @@ class RunScoreboard:
     last_seq: int | None = None
     consecutive_validation_failed: int = 0
     paused: bool = False
+    last_activity_at: str | None = None
+
+
+# Event kinds the drift detector treats as "still alive" beats.
+# ``worker_dispatched`` is emitted by ``fsm.get_brief`` when handing a
+# brief to a worker; ``heartbeat`` is the explicit liveness ping; the
+# lifecycle events refresh activity on any real state movement.
+_ACTIVITY_EVENT_KINDS: frozenset[str] = frozenset(
+    {
+        EventKind.worker_dispatched.value,
+        EventKind.heartbeat.value,
+        EventKind.state_entered.value,
+        EventKind.state_exited.value,
+        EventKind.transition_taken.value,
+        EventKind.worker_committed.value,
+    }
+)
+
+
+def clear_pause_state(scoreboards: dict[str, RunScoreboard], run_id: str) -> None:
+    """Reset the in-process ``paused`` sticky flag for ``run_id``.
+
+    The MCP-side auto-clear paths (commit_outputs / get_brief /
+    heartbeat) call this after they have already flipped the persisted
+    ``runs.status`` back to ``in_progress`` so the next sweep does not
+    refuse to score the run.
+
+    Safe to call when the scoreboard is absent (a freshly-restarted
+    supervisor has no in-process scoreboards yet): we just no-op.
+    """
+    sb = scoreboards.get(run_id)
+    if sb is None:
+        return
+    sb.paused = False
+
+
+def only_idle_signals_contributed(
+    signals: Iterable[object],
+) -> bool:
+    """Return True iff every drift signal for the run is ``idle_too_long``.
+
+    Used by the MCP-side auto-clear path to decide whether a paused
+    run is paused purely on the slow-LLM evidence (safe to auto-clear
+    once the LLM proves it is alive) or whether real drift signals
+    (off-allowlist tools, signature mismatch, verifier rejection)
+    participated (must be cleared by an operator via fsm.resume_run).
+    """
+    saw_one = False
+    for sig in signals:
+        saw_one = True
+        kind = getattr(sig, "signal_kind", None)
+        if kind != SignalKind.idle_too_long.value:
+            return False
+    # Defensive: zero signals means nothing contributed, which is not
+    # "idle only" — treat as "needs operator review" to stay on the
+    # conservative side. In practice the caller only invokes this when
+    # at least one signal exists.
+    return saw_one
 
 
 # ---------------------------------------------------------------------------
@@ -519,6 +616,13 @@ async def _sweep_once(
                         "event_seq": event.seq,
                     },
                 )
+            if event.kind in _ACTIVITY_EVENT_KINDS:
+                # Activity beat: refresh the in-process activity
+                # timestamp. This is the per-event signal the idle
+                # detector falls back to when the run's
+                # ``last_update_at`` (bumped only by status writes) is
+                # stale because the engine is mid-worker-dispatch.
+                scoreboard.last_activity_at = event.created_at
             if event.seq is not None and (
                 highest_seq is None or event.seq > highest_seq
             ):
@@ -528,15 +632,39 @@ async def _sweep_once(
         # gets re-classified on the next sweep.
         scoreboard.last_seq = highest_seq
 
-        # Idle synthesis. Skip when ``last_update_at`` is unparseable
+        # Per-state idle budget override. The Worker spec field
+        # ``expected_max_wait_seconds`` lets a slow state declare its
+        # own budget (e.g. a 10-minute codebase scan). When set we use
+        # it; otherwise the global ``cfg.window_seconds`` default
+        # applies. Resolution failures (missing spec, no current state,
+        # state has no worker) silently fall back to the global default
+        # — same conservative shape as ``_allowed_tools_for``.
+        effective_window = _effective_idle_window(
+            project, run_summary, default_window=cfg.window_seconds
+        )
+
+        # Idle synthesis. We use the LATER of (a) the run row's
+        # ``last_update_at`` and (b) the scoreboard's
+        # ``last_activity_at`` — the latter captures heartbeat /
+        # worker_dispatched events that refresh liveness without
+        # bumping the run row. Skip when both are unparseable
         # (defensive — the repo always writes a parseable shape) or
         # when the run has produced no event yet (a brand-new run is
         # not "idle" — it's just starting).
         last_update_dt = _parse_iso(run_summary.last_update_at)
-        if last_update_dt is not None:
+        last_activity_dt = _parse_iso(scoreboard.last_activity_at or "")
+        reference_dt: datetime | None
+        if last_update_dt is None:
+            reference_dt = last_activity_dt
+        elif last_activity_dt is None:
+            reference_dt = last_update_dt
+        else:
+            reference_dt = max(last_update_dt, last_activity_dt)
+
+        if reference_dt is not None:
             now = datetime.now(tz=UTC)
-            idle_for = (now - last_update_dt).total_seconds()
-            if idle_for > cfg.window_seconds:
+            idle_for = (now - reference_dt).total_seconds()
+            if idle_for > effective_window:
                 _record_signal(
                     project,
                     run_id=run_id,
@@ -547,7 +675,7 @@ async def _sweep_once(
                     ),
                     payload={
                         "idle_seconds": idle_for,
-                        "window_seconds": cfg.window_seconds,
+                        "window_seconds": effective_window,
                     },
                 )
 
@@ -613,6 +741,63 @@ def _allowed_tools_for(project: Project, run_summary: object) -> list[str]:
             return [str(t) for t in tools]
         return []
     return []
+
+
+def _effective_idle_window(
+    project: Project,
+    run_summary: object,
+    *,
+    default_window: float,
+) -> float:
+    """Return the idle window budget for ``run_summary``'s current state.
+
+    Precedence (most-specific wins):
+
+    1. The current state's :attr:`Worker.expected_max_wait_seconds`
+       — set when a spec author has declared an explicit per-state
+       budget. Looped states read it from ``state.loop.worker``.
+    2. The ``default_window`` argument — usually
+       ``DriftConfig.window_seconds`` which itself respects the
+       ``CTXR_FSM_IDLE_TIMEOUT_SECONDS`` env override.
+
+    Any lookup failure (no current_state, missing spec row, no worker
+    on the current state, etc.) falls through to the default — the
+    drift detector must never crash because of a benign spec gap.
+    """
+    current_state = getattr(run_summary, "current_state", None)
+    fsm_spec_id = getattr(run_summary, "fsm_spec_id", None)
+    if not current_state or not fsm_spec_id:
+        return default_window
+    with project.session_factory() as session:
+        spec = project.specs.get(session, fsm_spec_id)
+    if spec is None:
+        return default_window
+    states = spec.definition.get("states") if isinstance(spec.definition, dict) else None
+    if not isinstance(states, list):
+        return default_window
+    for state_def in states:
+        if not isinstance(state_def, dict):
+            continue
+        if state_def.get("id") != current_state:
+            continue
+        worker = state_def.get("worker")
+        if not isinstance(worker, dict):
+            loop = state_def.get("loop")
+            if isinstance(loop, dict):
+                worker = loop.get("worker")
+        if not isinstance(worker, dict):
+            return default_window
+        raw = worker.get("expected_max_wait_seconds")
+        if raw is None:
+            return default_window
+        try:
+            parsed = float(raw)
+        except (TypeError, ValueError):
+            return default_window
+        if parsed <= 0:
+            return default_window
+        return parsed
+    return default_window
 
 
 def _record_signal(

--- a/tests/integration/drift/conftest.py
+++ b/tests/integration/drift/conftest.py
@@ -1,0 +1,203 @@
+"""Shared fixtures for the long-LLM-friendliness drift detector tests.
+
+These tests exercise the drift detector + MCP commit gate + auto-clear
+policy end-to-end. The fixtures here build a real SQLite-backed
+Project, expose a callable that seeds a minimal worker-bearing run,
+and tear down the MCP module-global project handle so cases don't
+leak bindings into one another.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import anyio
+import pytest
+
+from ctxr.fsm.core.models import (
+    EventKind,
+    FsmSpec,
+    State,
+    Transition,
+    Worker,
+)
+from ctxr.fsm.mcp import _state as _mcp_state
+from ctxr.fsm.sqlite import Project
+from ctxr.fsm.sqlite.drift import (
+    DRIFT_PRODUCER_KIND,
+    DRIFT_PRODUCER_NAME,
+    DriftConfig,
+    RunScoreboard,
+    _sweep_once,
+)
+from ctxr.fsm.sqlite.models_core import RunTable
+
+
+@pytest.fixture
+def project_factory():
+    """Yield a callable that opens a Project on a per-test temp DB.
+
+    The callable also binds the MCP module-global handle so the
+    in-process tool calls in this module find their project. Teardown
+    resets the handle so the next test starts clean.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "fsm.sqlite3"
+
+        def _open() -> Project:
+            project = Project.open(db_path, migrate=True)
+            _mcp_state.set_project(project)
+            return project
+
+        yield _open
+
+        _mcp_state.reset_project()
+
+
+def minimal_worker_spec(
+    spec_id: str = "drift_friendly_demo",
+    *,
+    expected_max_wait_seconds: int | None = None,
+) -> FsmSpec:
+    """A two-state worker spec used by the long-LLM-friendliness tests.
+
+    The entry state ``a`` carries a Worker so ``fsm.get_brief`` will
+    emit ``worker_dispatched`` and the drift detector treats the
+    state as having a non-empty worker for the per-state budget
+    lookup.
+    """
+    return FsmSpec(
+        id=spec_id,
+        version=1,
+        entry="a",
+        states=[
+            State(
+                id="a",
+                purpose="entry — worker-bearing state for drift tests",
+                worker=Worker(
+                    role="demo-worker",
+                    prompt_template="say hi",
+                    inputs=[],
+                    expected_max_wait_seconds=expected_max_wait_seconds,
+                ),
+                transitions=[Transition(to="b", when="always")],
+            ),
+            State(id="b", purpose="terminal", transitions=[]),
+        ],
+    )
+
+
+def seed_run(project: Project, *, spec: FsmSpec | None = None) -> str:
+    """Register the spec, start a run, mark current_state, return run id.
+
+    Mirrors the helper in the existing drift detector test suite —
+    we poke ``current_state`` directly because ``Project.start_run``
+    does not advance the engine.
+    """
+    spec = spec if spec is not None else minimal_worker_spec()
+    registered = project.register_spec(spec)
+    run = project.start_run(registered.spec.id, args={})
+    with project.session_factory() as session, session.begin():
+        row = session.get(RunTable, run.id)
+        assert row is not None
+        row.current_state = "a"
+        session.add(row)
+    return run.id
+
+
+def emit_simple(
+    project: Project,
+    *,
+    run_id: str,
+    kind: EventKind,
+    payload: dict | None = None,
+) -> None:
+    """Emit an event of arbitrary kind for ``run_id``."""
+    with project.session_factory() as session, session.begin():
+        producer = project.producers.upsert(
+            session,
+            kind="engine",
+            name="test-engine",
+        )
+        project.events.emit(
+            session,
+            producer_id=producer.id,
+            kind=kind.value,
+            payload=payload or {},
+            run_id=run_id,
+        )
+
+
+def emit_tool_call(
+    project: Project,
+    *,
+    run_id: str,
+    tool_name: str,
+) -> None:
+    """Emit a ``tool_call_observed`` event for ``tool_name``."""
+    with project.session_factory() as session, session.begin():
+        producer = project.producers.upsert(
+            session,
+            kind="agent",
+            name="test-agent",
+        )
+        project.events.emit(
+            session,
+            producer_id=producer.id,
+            kind=EventKind.tool_call_observed.value,
+            payload={
+                "tool_name": tool_name,
+                "succeeded": True,
+                "args_redacted": {},
+            },
+            run_id=run_id,
+        )
+
+
+def run_one_sweep(
+    project: Project,
+    *,
+    config: DriftConfig | None = None,
+    scoreboards: dict[str, RunScoreboard] | None = None,
+) -> dict[str, RunScoreboard]:
+    """Drive a single drift-detector sweep against ``project``.
+
+    Returns the scoreboard map so the caller can keep state across
+    sweeps (mirrors the loop's lifetime semantics).
+    """
+    cfg = config if config is not None else DriftConfig()
+    sbs = scoreboards if scoreboards is not None else {}
+
+    with project.session_factory() as session, session.begin():
+        producer = project.producers.upsert(
+            session,
+            kind=DRIFT_PRODUCER_KIND,
+            name=DRIFT_PRODUCER_NAME,
+        )
+    producer_id = producer.id
+
+    async def _go() -> None:
+        await _sweep_once(
+            project,
+            cfg=cfg,
+            producer_id=producer_id,
+            scoreboards=sbs,
+        )
+
+    anyio.run(_go)
+    return sbs
+
+
+def backdate_last_update(
+    project: Project,
+    *,
+    run_id: str,
+    iso_ts: str,
+) -> None:
+    """Rewrite ``runs.last_update_at`` directly for idle-detection tests."""
+    with project.session_factory() as session, session.begin():
+        row = session.get(RunTable, run_id)
+        assert row is not None
+        row.last_update_at = iso_ts
+        session.add(row)

--- a/tests/integration/drift/test_drift_paused_auto_clears_on_idle_only.py
+++ b/tests/integration/drift/test_drift_paused_auto_clears_on_idle_only.py
@@ -1,0 +1,146 @@
+"""``drift_paused`` auto-clears in commit_outputs when only idle signals fired.
+
+The new policy: idle-only pauses are an artefact of slow worker
+dispatches and should not require an operator to call resume_run.
+Activity (commit_outputs, get_brief, heartbeat) proves the LLM is
+alive and clears the pause in place; a ``drift_pause_cleared`` event
+records the auto-clear with the contributing signal kinds.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+
+from ctxr.fsm.core.models import EventKind, RunStatus, SignalKind
+from ctxr.fsm.mcp.tools_meta import fsm_heartbeat
+from ctxr.fsm.mcp.tools_runs import CommitOutputsInput, fsm_commit_outputs
+from ctxr.fsm.sqlite.drift import DriftConfig
+from ctxr.fsm.sqlite.models_events import EventTable
+
+from .conftest import backdate_last_update, run_one_sweep, seed_run
+
+
+def _pause_via_idle_only(project, run_id) -> None:
+    """Force ``run_id`` into drift_paused with idle_too_long signals only.
+
+    The idle signal weight is intentionally 1.0 so we need >10 sweeps
+    over a short window to cross threshold. We use a tiny window
+    (1s) + a backdated last_update_at so each sweep records a fresh
+    idle signal until the cumulative score crosses 10.
+    """
+    backdate_last_update(
+        project, run_id=run_id, iso_ts="2020-01-01T00:00:00.000Z"
+    )
+    cfg = DriftConfig(window_seconds=1.0)
+    for _ in range(12):
+        run_one_sweep(project, config=cfg)
+
+
+def test_idle_only_pause_clears_on_commit_outputs(project_factory) -> None:
+    """Idle-only drift_paused auto-clears on commit_outputs; commit succeeds.
+
+    The auto-clear emits ``drift_pause_cleared`` listing the
+    contributing kinds; the run status flips back to in_progress
+    BEFORE the rest of commit_outputs runs so the commit advances
+    normally.
+    """
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+        _pause_via_idle_only(project, run_id)
+
+        run = project.get_run(run_id)
+        assert run is not None
+        assert run.status == RunStatus.drift_paused.value
+
+        result = fsm_commit_outputs(
+            CommitOutputsInput(
+                run_id=uuid.UUID(run_id),
+                outputs={"hello": "world"},
+            )
+        )
+        # Either the commit advanced (kind=advanced/loop_continued/terminal)
+        # OR it short-circuited for an unrelated reason — but it MUST
+        # not be the run_drift_paused refusal envelope.
+        if hasattr(result, "error"):
+            assert result.error != "run_drift_paused", (
+                "idle-only pause should auto-clear before commit gate fires"
+            )
+
+        # The auto-clear breadcrumb event lands on the bus.
+        with project.session_factory() as session:
+            cleared_events = session.execute(
+                select(EventTable).where(
+                    EventTable.run_id == run_id,
+                    EventTable.kind == EventKind.drift_pause_cleared.value,
+                )
+            ).scalars().all()
+        assert len(cleared_events) == 1
+    finally:
+        project.close()
+
+
+def test_idle_only_pause_clears_on_heartbeat(project_factory) -> None:
+    """Heartbeat also auto-clears idle-only drift_paused.
+
+    The HeartbeatResult.drift_pause_cleared flag is True when the
+    auto-clear fired, so an orchestrator can branch on it without a
+    second event-bus query.
+    """
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+        _pause_via_idle_only(project, run_id)
+
+        run = project.get_run(run_id)
+        assert run is not None
+        assert run.status == RunStatus.drift_paused.value
+
+        result = fsm_heartbeat(run_id=uuid.UUID(run_id), message="alive")
+        assert not hasattr(result, "error"), f"unexpected error: {result!r}"
+        assert result.drift_pause_cleared is True
+
+        run_after = project.get_run(run_id)
+        assert run_after is not None
+        assert run_after.status == RunStatus.in_progress.value
+    finally:
+        project.close()
+
+
+def test_drift_pause_cleared_payload_lists_contributing_kinds(
+    project_factory,
+) -> None:
+    """The breadcrumb payload lists every signal kind that supported the pause.
+
+    For an idle-only auto-clear the payload contains exactly the
+    ``idle_too_long`` kind (and nothing else).
+    """
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+        _pause_via_idle_only(project, run_id)
+
+        result = fsm_heartbeat(run_id=uuid.UUID(run_id), message="")
+        assert not hasattr(result, "error")
+        assert result.drift_pause_cleared is True
+
+        import json
+
+        with project.session_factory() as session:
+            events = session.execute(
+                select(EventTable).where(
+                    EventTable.run_id == run_id,
+                    EventTable.kind == EventKind.drift_pause_cleared.value,
+                )
+            ).scalars().all()
+        assert len(events) == 1
+        payload = json.loads(events[0].payload_json)
+        assert payload["contributing_signal_kinds"] == [
+            SignalKind.idle_too_long.value
+        ]
+        assert "cleared_by" in payload
+        assert "cleared_at" in payload
+    finally:
+        project.close()

--- a/tests/integration/drift/test_drift_paused_blocks_commit.py
+++ b/tests/integration/drift/test_drift_paused_blocks_commit.py
@@ -1,0 +1,81 @@
+"""``drift_paused`` blocks ``commit_outputs`` when real drift signals contributed.
+
+Long-LLM-friendliness fix: a real drift pause is a REAL commit gate
+(not just a status flag silently overwritten by the next advance).
+The gate refuses with ``run_drift_paused`` until ``fsm.resume_run``
+clears the operator-confirmed drift.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from ctxr.fsm.core.models import EventKind, RunStatus
+from ctxr.fsm.mcp.tools_runs import CommitOutputsInput, fsm_commit_outputs
+
+from .conftest import emit_simple, run_one_sweep, seed_run
+
+
+def _pause_via_real_drift(project, run_id) -> None:
+    """Force ``run_id`` into drift_paused with REAL drift signals.
+
+    Two ``commit_signature_mismatch`` events (weight 8 each) + one
+    ``verifier_rejected`` (weight 6) put the score at 22 > 10 so the
+    next sweep flips the run to drift_paused. The signal taxonomy here
+    is intentionally NOT idle — that's the whole point of the test.
+    """
+    emit_simple(
+        project, run_id=run_id, kind=EventKind.commit_signature_mismatch
+    )
+    emit_simple(
+        project, run_id=run_id, kind=EventKind.commit_signature_mismatch
+    )
+    emit_simple(project, run_id=run_id, kind=EventKind.verifier_rejected)
+    run_one_sweep(project)
+
+
+def test_real_drift_pause_refuses_commit_outputs(project_factory) -> None:
+    """Commit_outputs returns ``run_drift_paused`` when real drift contributed.
+
+    Flow:
+    1. Seed a run + force it into drift_paused via signature_mismatch
+       + verifier_rejected (real-drift evidence).
+    2. Call commit_outputs.
+    3. Assert the response is an error envelope with code
+       ``run_drift_paused`` and the contributing signal kinds
+       listed in the payload.
+    4. Assert the run remains drift_paused (no auto-clear fired).
+    """
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+        _pause_via_real_drift(project, run_id)
+
+        run = project.get_run(run_id)
+        assert run is not None
+        assert run.status == RunStatus.drift_paused.value
+
+        result = fsm_commit_outputs(
+            CommitOutputsInput(
+                run_id=uuid.UUID(run_id),
+                outputs={"hello": "world"},
+            )
+        )
+        assert hasattr(result, "error"), (
+            f"expected refusal envelope, got {result!r}"
+        )
+        assert result.error == "run_drift_paused"
+        # Contributing kinds are surfaced on the structured payload for
+        # the dashboard / operator.
+        assert result.payload is not None
+        contributing = result.payload.get("contributing_signal_kinds")
+        assert contributing is not None
+        assert "signature_mismatch" in contributing
+        assert "verifier_rejection" in contributing
+
+        # Status is still paused — auto-clear did NOT fire.
+        run_after = project.get_run(run_id)
+        assert run_after is not None
+        assert run_after.status == RunStatus.drift_paused.value
+    finally:
+        project.close()

--- a/tests/integration/drift/test_drift_paused_persists_on_real_drift.py
+++ b/tests/integration/drift/test_drift_paused_persists_on_real_drift.py
@@ -1,0 +1,89 @@
+"""A drift_paused run with REAL drift signals stays paused.
+
+Auto-clear only fires when the contributing signals were all
+``idle_too_long``. Anything else (off-allowlist tool calls, signature
+mismatches, verifier rejections) keeps the run paused and forces the
+operator to call ``fsm.resume_run`` to acknowledge the drift.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+
+from ctxr.fsm.core.models import EventKind, RunStatus
+from ctxr.fsm.mcp.tools_meta import fsm_heartbeat
+from ctxr.fsm.mcp.tools_runs import CommitOutputsInput, fsm_commit_outputs
+from ctxr.fsm.sqlite.models_events import EventTable
+
+from .conftest import emit_tool_call, run_one_sweep, seed_run
+
+
+def _pause_via_off_allowlist(project, run_id) -> None:
+    """Force ``run_id`` into drift_paused with off-allowlist tool calls.
+
+    Three Bash calls (5 each) sums to 15 > 10 so the next sweep
+    flips the run to drift_paused. The current state's worker has
+    no allowed_tools declared so every non-fsm.* tool is off-list.
+    """
+    for tool in ("Bash", "WebFetch", "Edit"):
+        emit_tool_call(project, run_id=run_id, tool_name=tool)
+    run_one_sweep(project)
+
+
+def test_off_allowlist_pause_does_not_clear_on_commit(project_factory) -> None:
+    """commit_outputs refuses with run_drift_paused and the run STAYS paused."""
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+        _pause_via_off_allowlist(project, run_id)
+
+        run = project.get_run(run_id)
+        assert run is not None
+        assert run.status == RunStatus.drift_paused.value
+
+        result = fsm_commit_outputs(
+            CommitOutputsInput(
+                run_id=uuid.UUID(run_id),
+                outputs={"hello": "world"},
+            )
+        )
+        assert hasattr(result, "error")
+        assert result.error == "run_drift_paused"
+
+        # No drift_pause_cleared event was emitted.
+        with project.session_factory() as session:
+            cleared_events = session.execute(
+                select(EventTable).where(
+                    EventTable.run_id == run_id,
+                    EventTable.kind == EventKind.drift_pause_cleared.value,
+                )
+            ).scalars().all()
+        assert cleared_events == []
+
+        run_after = project.get_run(run_id)
+        assert run_after is not None
+        assert run_after.status == RunStatus.drift_paused.value
+    finally:
+        project.close()
+
+
+def test_off_allowlist_pause_does_not_clear_on_heartbeat(
+    project_factory,
+) -> None:
+    """heartbeat does NOT auto-clear a real-drift pause."""
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+        _pause_via_off_allowlist(project, run_id)
+
+        result = fsm_heartbeat(run_id=uuid.UUID(run_id), message="")
+        assert not hasattr(result, "error")
+        assert result.drift_pause_cleared is False
+
+        run_after = project.get_run(run_id)
+        assert run_after is not None
+        assert run_after.status == RunStatus.drift_paused.value
+    finally:
+        project.close()

--- a/tests/integration/drift/test_event_kind_extension.py
+++ b/tests/integration/drift/test_event_kind_extension.py
@@ -1,0 +1,33 @@
+"""The closed EventKind taxonomy carries the new long-LLM-friendliness members.
+
+``worker_dispatched`` already existed as an enum member but was never
+emitted; the fix wires emission from ``fsm.get_brief``. ``heartbeat``
+and ``drift_pause_cleared`` are new additions in this fix.
+"""
+
+from __future__ import annotations
+
+from ctxr.fsm.core.models import EventKind
+
+
+def test_worker_dispatched_member_present() -> None:
+    assert EventKind.worker_dispatched.value == "worker_dispatched"
+
+
+def test_heartbeat_member_present() -> None:
+    assert EventKind.heartbeat.value == "heartbeat"
+
+
+def test_drift_pause_cleared_member_present() -> None:
+    assert EventKind.drift_pause_cleared.value == "drift_pause_cleared"
+
+
+def test_event_kind_is_str_enum() -> None:
+    """StrEnum membership: ``EventKind.heartbeat == "heartbeat"`` must hold.
+
+    The wire shape (canonical JSON payloads) collapses StrEnum to str,
+    so legacy callers comparing with raw strings keep working.
+    """
+    assert EventKind.heartbeat == "heartbeat"
+    assert EventKind.drift_pause_cleared == "drift_pause_cleared"
+    assert EventKind.worker_dispatched == "worker_dispatched"

--- a/tests/integration/drift/test_heartbeat_resets_idle.py
+++ b/tests/integration/drift/test_heartbeat_resets_idle.py
@@ -1,0 +1,99 @@
+"""``fsm.heartbeat`` refreshes the idle window without committing outputs.
+
+The orchestrator calls this on a timer during long worker dispatches
+so the drift detector treats the run as alive even when no state has
+advanced. Idempotent; auto-clears idle-only drift_paused as a bonus.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+
+from ctxr.fsm.core.models import EventKind
+from ctxr.fsm.mcp.tools_meta import fsm_heartbeat
+from ctxr.fsm.sqlite.drift import DriftConfig
+from ctxr.fsm.sqlite.models_events import EventTable
+
+from .conftest import backdate_last_update, run_one_sweep, seed_run
+
+
+def test_heartbeat_emits_heartbeat_event(project_factory) -> None:
+    """A single heartbeat call emits one ``heartbeat`` event with the message."""
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+
+        result = fsm_heartbeat(
+            run_id=uuid.UUID(run_id), message="still scanning the codebase"
+        )
+        assert not hasattr(result, "error"), f"unexpected error: {result!r}"
+        assert result.ok is True
+        assert result.drift_pause_cleared is False
+
+        with project.session_factory() as session:
+            events = session.execute(
+                select(EventTable).where(
+                    EventTable.run_id == run_id,
+                    EventTable.kind == EventKind.heartbeat.value,
+                )
+            ).scalars().all()
+        assert len(events) == 1
+    finally:
+        project.close()
+
+
+def test_heartbeat_refreshes_drift_window(project_factory) -> None:
+    """After heartbeat, a subsequent sweep does not record another idle signal.
+
+    Same shape as the worker_dispatched test, but the orchestrator
+    here calls fsm.heartbeat explicitly rather than relying on
+    get_brief side effects.
+    """
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+        backdate_last_update(
+            project, run_id=run_id, iso_ts="2020-01-01T00:00:00.000Z"
+        )
+
+        cfg = DriftConfig(window_seconds=60.0)
+        scoreboards = run_one_sweep(project, config=cfg)
+
+        with project.session_factory() as session:
+            idle_before = sum(
+                1
+                for s in project.drift_signals.by_run(session, run_id)
+                if s.signal_kind == "idle_too_long"
+            )
+        assert idle_before >= 1
+
+        result = fsm_heartbeat(run_id=uuid.UUID(run_id), message="alive")
+        assert not hasattr(result, "error"), f"unexpected error: {result!r}"
+
+        run_one_sweep(project, config=cfg, scoreboards=scoreboards)
+
+        with project.session_factory() as session:
+            idle_after = sum(
+                1
+                for s in project.drift_signals.by_run(session, run_id)
+                if s.signal_kind == "idle_too_long"
+            )
+        assert idle_after == idle_before, (
+            "no new idle_too_long signal should accrue after heartbeat"
+        )
+    finally:
+        project.close()
+
+
+def test_heartbeat_run_not_found(project_factory) -> None:
+    """Unknown run id returns a typed ``run_not_found`` error envelope."""
+    project = project_factory()
+    try:
+        random_id = uuid.uuid4()
+        result = fsm_heartbeat(run_id=random_id, message="")
+        assert hasattr(result, "error"), f"expected error envelope, got {result!r}"
+        assert result.error == "run_not_found"
+    finally:
+        project.close()

--- a/tests/integration/drift/test_idle_timeout_raised.py
+++ b/tests/integration/drift/test_idle_timeout_raised.py
@@ -1,0 +1,44 @@
+"""The default idle window is 300s + ``CTXR_FSM_IDLE_TIMEOUT_SECONDS`` override.
+
+Long-LLM-friendliness: the 60s pre-fix default tripped legitimately-
+slow workers (large codebase scans, deep analyses). The new default
+is 300s; operators tune via the env var when their workloads need a
+different budget.
+"""
+
+from __future__ import annotations
+
+from ctxr.fsm.sqlite.drift import (
+    DEFAULT_IDLE_WINDOW_SECONDS,
+    IDLE_TIMEOUT_ENV_VAR,
+    DriftConfig,
+)
+
+
+def test_default_idle_window_is_five_minutes() -> None:
+    """A freshly-constructed DriftConfig honours the 300s default."""
+    cfg = DriftConfig()
+    assert DEFAULT_IDLE_WINDOW_SECONDS == 300.0
+    assert cfg.window_seconds == 300.0
+
+
+def test_env_var_overrides_idle_window(monkeypatch) -> None:
+    """``CTXR_FSM_IDLE_TIMEOUT_SECONDS`` overrides the default."""
+    monkeypatch.setenv(IDLE_TIMEOUT_ENV_VAR, "120")
+    cfg = DriftConfig()
+    assert cfg.window_seconds == 120.0
+
+
+def test_invalid_env_var_falls_back_to_default(monkeypatch) -> None:
+    """Garbage / non-positive values fall back to the module default."""
+    monkeypatch.setenv(IDLE_TIMEOUT_ENV_VAR, "not-a-number")
+    cfg = DriftConfig()
+    assert cfg.window_seconds == DEFAULT_IDLE_WINDOW_SECONDS
+
+    monkeypatch.setenv(IDLE_TIMEOUT_ENV_VAR, "-5")
+    cfg = DriftConfig()
+    assert cfg.window_seconds == DEFAULT_IDLE_WINDOW_SECONDS
+
+    monkeypatch.setenv(IDLE_TIMEOUT_ENV_VAR, "0")
+    cfg = DriftConfig()
+    assert cfg.window_seconds == DEFAULT_IDLE_WINDOW_SECONDS

--- a/tests/integration/drift/test_per_state_expected_max_wait.py
+++ b/tests/integration/drift/test_per_state_expected_max_wait.py
@@ -1,0 +1,83 @@
+"""Per-state ``Worker.expected_max_wait_seconds`` overrides the global window.
+
+A slow worker (e.g. a 10-minute codebase scan) can declare an
+explicit budget on its Worker spec. The drift detector honours that
+budget instead of ``DriftConfig.window_seconds`` for the run's
+current state.
+"""
+
+from __future__ import annotations
+
+from ctxr.fsm.sqlite.drift import DriftConfig
+
+from .conftest import backdate_last_update, minimal_worker_spec, run_one_sweep, seed_run
+
+
+def test_per_state_budget_suppresses_idle_signal(project_factory) -> None:
+    """A Worker with expected_max_wait_seconds=600 does NOT trip a 60s sweep.
+
+    Sequence:
+    1. Seed a run with a Worker declaring ``expected_max_wait_seconds=600``.
+    2. Backdate last_update_at to ~400s ago — over the global default
+       (300s) but UNDER the per-state budget (600s).
+    3. Sweep with a tight global window (60s).
+    4. Assert NO idle_too_long signal was recorded, because the
+       per-state override wins.
+    """
+    project = project_factory()
+    try:
+        spec = minimal_worker_spec(
+            spec_id="long_running_demo", expected_max_wait_seconds=600
+        )
+        run_id = seed_run(project, spec=spec)
+
+        # 400s ago — clearly inside the 600s per-state budget but well
+        # past the tight 60s global window the sweep below uses.
+        from datetime import UTC, datetime, timedelta
+
+        ts = (datetime.now(tz=UTC) - timedelta(seconds=400)).isoformat(
+            timespec="milliseconds"
+        ).replace("+00:00", "Z")
+        backdate_last_update(project, run_id=run_id, iso_ts=ts)
+
+        cfg = DriftConfig(window_seconds=60.0)
+        run_one_sweep(project, config=cfg)
+
+        with project.session_factory() as session:
+            signals = project.drift_signals.by_run(session, run_id)
+        idle_signals = [s for s in signals if s.signal_kind == "idle_too_long"]
+        assert idle_signals == [], (
+            "per-state expected_max_wait_seconds should suppress idle signal"
+        )
+    finally:
+        project.close()
+
+
+def test_no_per_state_budget_uses_global_window(project_factory) -> None:
+    """A Worker without the override falls back to ``cfg.window_seconds``.
+
+    Same setup as above but the Worker omits ``expected_max_wait_seconds``,
+    so the 60s sweep window applies and the 400s-stale run trips the
+    idle signal.
+    """
+    project = project_factory()
+    try:
+        spec = minimal_worker_spec(spec_id="default_window_demo")
+        run_id = seed_run(project, spec=spec)
+
+        from datetime import UTC, datetime, timedelta
+
+        ts = (datetime.now(tz=UTC) - timedelta(seconds=400)).isoformat(
+            timespec="milliseconds"
+        ).replace("+00:00", "Z")
+        backdate_last_update(project, run_id=run_id, iso_ts=ts)
+
+        cfg = DriftConfig(window_seconds=60.0)
+        run_one_sweep(project, config=cfg)
+
+        with project.session_factory() as session:
+            signals = project.drift_signals.by_run(session, run_id)
+        idle_signals = [s for s in signals if s.signal_kind == "idle_too_long"]
+        assert len(idle_signals) >= 1
+    finally:
+        project.close()

--- a/tests/integration/drift/test_worker_dispatched_resets_idle.py
+++ b/tests/integration/drift/test_worker_dispatched_resets_idle.py
@@ -1,0 +1,98 @@
+"""``fsm.get_brief`` for a worker-bearing state emits ``worker_dispatched``.
+
+The drift detector treats that event as activity: the scoreboard's
+``last_activity_at`` is refreshed so a subsequent sweep does not
+synthesise an ``idle_too_long`` signal even when the run row's
+``last_update_at`` is stale.
+
+The MCP body also bumps ``runs.last_update_at`` directly so the
+substrate-level fix works even when the scoreboard is fresh (e.g.
+after a supervisor restart).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+
+from ctxr.fsm.core.models import EventKind
+from ctxr.fsm.mcp.tools_runs import GetBriefInput, fsm_get_brief
+from ctxr.fsm.sqlite.drift import DriftConfig
+from ctxr.fsm.sqlite.models_events import EventTable
+
+from .conftest import backdate_last_update, run_one_sweep, seed_run
+
+
+def test_get_brief_emits_worker_dispatched_for_worker_state(project_factory) -> None:
+    """A worker-bearing brief landing emits exactly one ``worker_dispatched``.
+
+    Asserts the event payload carries the state id, brief id, and a
+    ``dispatched_at`` timestamp so the dashboard / drift detector can
+    correlate the hand-off.
+    """
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+
+        result = fsm_get_brief(GetBriefInput(run_id=uuid.UUID(run_id)))
+        assert not hasattr(result, "error"), f"unexpected error: {result!r}"
+
+        with project.session_factory() as session:
+            events = session.execute(
+                select(EventTable).where(
+                    EventTable.run_id == run_id,
+                    EventTable.kind == EventKind.worker_dispatched.value,
+                )
+            ).scalars().all()
+        assert len(events) == 1, "expected exactly one worker_dispatched event"
+    finally:
+        project.close()
+
+
+def test_worker_dispatched_refreshes_drift_window(project_factory) -> None:
+    """After get_brief, a subsequent sweep does not record idle_too_long.
+
+    Sequence:
+    1. Seed run + backdate ``last_update_at`` to 10 minutes ago.
+    2. Sweep with a 60s window — synthesises an idle_too_long signal.
+    3. Call fsm.get_brief — bumps last_update_at to now AND emits
+       worker_dispatched (refreshing the scoreboard's last_activity).
+    4. Sweep again — must NOT record a second idle_too_long signal.
+    """
+    project = project_factory()
+    try:
+        run_id = seed_run(project)
+
+        # Force the run into "idle for ages" by rewriting last_update_at.
+        backdate_last_update(
+            project, run_id=run_id, iso_ts="2020-01-01T00:00:00.000Z"
+        )
+
+        cfg = DriftConfig(window_seconds=60.0)
+        scoreboards = run_one_sweep(project, config=cfg)
+
+        with project.session_factory() as session:
+            before_signals = project.drift_signals.by_run(session, run_id)
+        idle_before = sum(
+            1 for s in before_signals if s.signal_kind == "idle_too_long"
+        )
+        assert idle_before >= 1, "idle synthesis should have fired"
+
+        # Hand off a brief — this is the activity beat.
+        result = fsm_get_brief(GetBriefInput(run_id=uuid.UUID(run_id)))
+        assert not hasattr(result, "error"), f"unexpected error: {result!r}"
+
+        # Next sweep, same scoreboard — no fresh idle signal.
+        run_one_sweep(project, config=cfg, scoreboards=scoreboards)
+
+        with project.session_factory() as session:
+            after_signals = project.drift_signals.by_run(session, run_id)
+        idle_after = sum(
+            1 for s in after_signals if s.signal_kind == "idle_too_long"
+        )
+        assert idle_after == idle_before, (
+            "no new idle_too_long signal should accrue after worker_dispatched"
+        )
+    finally:
+        project.close()


### PR DESCRIPTION
## Summary

- **5min idle window default** (was 60s, tripped slow workers). Tunable via `CTXR_FSM_IDLE_TIMEOUT_SECONDS`.
- **Activity beats refresh the idle clock**: `fsm.get_brief` now emits `EventKind.worker_dispatched` (previously a dead enum member) for worker states, and a new `fsm.heartbeat` MCP tool + `EventKind.heartbeat` give orchestrators an explicit liveness ping. Drift detector treats both as activity beats and refreshes the per-run scoreboard's `last_activity_at`.
- **Per-state budgets**: `Worker.expected_max_wait_seconds` overrides the global `DriftConfig.window_seconds` for slow states (e.g. a 10-minute codebase scan).
- **`drift_paused` is a REAL commit gate**: `fsm.commit_outputs`, `fsm.confirm_commit`, and `fsm.resolve_gate` refuse with the new `run_drift_paused` error envelope (listing contributing signal kinds) when real drift signals supported the pause.
- **Auto-clear policy**: when ONLY `idle_too_long` signals contributed, `commit_outputs` / `get_brief` / `heartbeat` flip the run back to `in_progress` and emit `EventKind.drift_pause_cleared` (new) before proceeding. Real drift still requires `fsm.resume_run`.

Closes the long-LLM-hostile race / pause-flag-silently-ignored issues called out in the audit (60s default, no heartbeat surface, commit_outputs ignoring `drift_paused`, sticky scoreboard, no per-state budget, dead `worker_dispatched` enum).

## Test plan

- [x] `tests/integration/drift/` — 20 new cases covering idle default + env override, EventKind extension, worker_dispatched + heartbeat reset, real-drift refusal, idle-only auto-clear on commit / heartbeat, real-drift persists on heartbeat, per-state expected_max_wait_seconds override.
- [x] Full repo `pytest` (excluding e2e): 809 passing. The 2 pre-existing failures (`test_cli_doctor` doctor panel revision, `test_audit_strings` mypy-cache scan) reproduce on `main` and are unrelated to this PR.
- [x] `ruff check ctxr/ tests/` clean.
- [x] `mypy ctxr/fsm/` strict — clean (76 files).
- [x] `npx tsc -b --noEmit` in `ui/` — clean (new EventKind members are string-typed at the UI boundary).

EventKind additions: `heartbeat`, `drift_pause_cleared`. (`worker_dispatched` already existed but was unused; now emitted from get_brief.)