### PR TITLE
ui: clean-slate graph rebuild with zoom-aware detail-level toggle

### DIFF
--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -23,7 +23,7 @@
  * onNodeClick.
  */
 
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { JSX } from 'preact';
 import { createContext } from 'preact';
 import dagre from 'dagre';
@@ -37,9 +37,12 @@ import {
   MarkerType,
   MiniMap,
   Position,
+  useReactFlow,
+  useStore,
   type Edge,
   type Node,
   type NodeProps,
+  type ReactFlowState,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
@@ -97,6 +100,42 @@ export interface FlowNodeData extends Record<string, unknown> {
   /** PR 5: chronological list of per-iteration entries. Each chip in
    *  the loop node's strip is sourced from one element. */
   iterationEntries?: FlowLoopIteration[];
+  /**
+   * Viewport-zoom-aware render mode. When `'compact'`, the node renders a
+   * small card (~100×44) with just the truncated state name; when `'full'`
+   * (or undefined — back-compat default), the existing 160×60 card with
+   * the kind chip + full label is rendered. FlowGraph stamps this onto
+   * every node's data whenever the active viewport zoom crosses
+   * {@link DETAIL_LEVEL_ZOOM_THRESHOLD}.
+   */
+  detailLevel?: DetailLevel;
+}
+
+/** Zoom threshold below which (≤) the graph switches to compact cards.
+ *  Exported so tests + the LoopNode can share the same number.
+ *
+ *  Raised from 0.4 to 0.7 so the dense 14-layer chains (e.g.
+ *  skill-code-review v4) stay in compact mode at their natural
+ *  fit-view zoom (~0.55-0.65 with compact ELK spacing). The previous
+ *  0.4 threshold left them oscillating: full layout fit at 0.27 →
+ *  flip to compact → compact layout fit at 0.65 → flip back to full.
+ *  With 0.7 the compact layout's fit-view zoom stays in compact mode,
+ *  breaking the cycle without forcing every tiny graph into compact. */
+export const DETAIL_LEVEL_ZOOM_THRESHOLD = 0.7;
+
+/** Maximum visible characters for a state-name label in compact mode.
+ *  Anything longer is truncated to this prefix plus an ellipsis. The
+ *  full label remains available via tooltip + the inspector Sheet. */
+export const COMPACT_LABEL_MAX_CHARS = 14;
+
+export type DetailLevel = 'full' | 'compact';
+
+/** Truncate a label for compact-mode rendering. Returns the original
+ *  string when it already fits inside {@link COMPACT_LABEL_MAX_CHARS}. */
+export function truncateCompactLabel(label: string): string {
+  if (typeof label !== 'string') return '';
+  if (label.length <= COMPACT_LABEL_MAX_CHARS) return label;
+  return `${label.slice(0, COMPACT_LABEL_MAX_CHARS)}…`;
 }
 
 export interface FlowGraphProps {
@@ -147,13 +186,40 @@ export interface FlowGraphProps {
   viewportKey?: string;
 }
 
-// W21 user-requested: 50% bigger than the W20 sizes (180x56 → 270x84)
-// so long state ids (e.g. `synthesize_release_readiness`) fit on one
-// line and the kind badge no longer competes for horizontal room.
-// Dagre layout constants below are tuned proportionally to keep edges
-// clear of the larger node boxes.
-const NODE_WIDTH = 200;
-const NODE_HEIGHT = 64;
+// Clean-slate rebuild: every node uses the SAME card dimensions
+// (worker, inline, loop, terminal). The loop node carries a small ×N
+// badge but stays the same size as its siblings so a graph with many
+// loops doesn't have one node 30% of the canvas width. Detail surfaces
+// (iteration chip strip, per-iteration entries) live in the
+// StateEntrySheetBody, not on the graph card.
+// Card dimensions tuned to fit an 18-node FSM in a 1270×733 graph
+// viewport at sensible zoom without an unreadable shrink:
+//   LR layout: 14 layers × 140 (node + spacing) ≈ 2000 px wide;
+//              fit-view zoom ≈ 0.6 → nodes render ~85 px wide.
+//   TB layout: 14 layers × 100 (node + spacing) ≈ 1400 px tall;
+//              fit-view zoom ≈ 0.45 → nodes render ~63 px wide.
+// Card content is the kind chip + label, both still legible at
+// 130×56 since the font sizes stay 10-12 px.
+const NODE_WIDTH = 160;
+const NODE_HEIGHT = 60;
+
+/**
+ * Compact-mode card dimensions. Roughly 60 % of the full size so a
+ * 14-layer chain (e.g. skill-code-review v4) fits a 16:9 viewport at
+ * fit-view zoom 0.55-0.7 instead of the ~0.36 the full layout
+ * collapses to. The chip is hidden and the label is truncated so a
+ * smaller box stays legible at that zoom.
+ */
+const NODE_WIDTH_COMPACT = 100;
+const NODE_HEIGHT_COMPACT = 44;
+
+/** Per-detail-level node dimensions. Used by both the dagre and ELK
+ *  layout branches so the two engines reserve the same slack as the
+ *  card they render at the active detail level. */
+const NODE_DIMS_BY_DETAIL: Record<DetailLevel, { width: number; height: number }> = {
+  full: { width: NODE_WIDTH, height: NODE_HEIGHT },
+  compact: { width: NODE_WIDTH_COMPACT, height: NODE_HEIGHT_COMPACT },
+};
 
 const NODE_KIND_CLASSES: Record<FlowNodeKind, string> = {
   state:
@@ -176,7 +242,11 @@ const NODE_KIND_CLASSES: Record<FlowNodeKind, string> = {
     'border-cyan-500 bg-cyan-50 dark:bg-cyan-900/30 text-cyan-900 dark:text-cyan-100',
 };
 
-function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<Node<FlowNodeData>>): JSX.Element {
+/** Exported for FsmNode.test.tsx so the compact / full render paths
+ *  can be exercised directly without round-tripping through the full
+ *  FlowGraph orchestrator. Not part of the public surface — callers
+ *  outside this module should keep using FlowGraph + node.data. */
+export function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<Node<FlowNodeData>>): JSX.Element {
   const kind = data.kind;
   // Handles are the connection anchors xyflow draws edges into.
   // Without these, no edge has anywhere to land and the connection
@@ -254,14 +324,28 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
     ? 'ring-1 ring-amber-300 ring-offset-1 ring-offset-white dark:ring-offset-slate-900'
     : '';
   const dimClass = isDimmed ? 'opacity-30' : '';
+  // W23e: viewport-zoom-aware detail toggle. When the live zoom drops at
+  // or below DETAIL_LEVEL_ZOOM_THRESHOLD, FlowGraph stamps
+  // data.detailLevel='compact' on every node; we render a denser card
+  // here so a 14-layer chain stays legible at fit-view zoom without an
+  // unreadable text shrink. The full label remains accessible via the
+  // hover tooltip + the inspector Sheet.
+  const detailLevel: DetailLevel = data.detailLevel === 'compact' ? 'compact' : 'full';
+  const isCompact = detailLevel === 'compact';
+  const dims = NODE_DIMS_BY_DETAIL[detailLevel];
+  const labelPrefix = typeof data.labelPrefix === 'string' ? data.labelPrefix : '';
+  const visibleLabel = isCompact ? truncateCompactLabel(data.label) : data.label;
   return (
     <div
       class={[
-        'fsm-node relative rounded-md border-2 shadow-sm px-4 py-3',
+        'fsm-node relative rounded-md border-2 shadow-sm',
+        isCompact ? 'fsm-node-compact px-2 py-1' : 'px-4 py-3',
         // justify-center centers the kind/label block vertically within
         // the (fixed) node height. gap-1 gives the two rows even
         // breathing room.
-        'flex flex-col gap-1 justify-center overflow-hidden',
+        isCompact
+          ? 'flex items-center justify-center overflow-hidden'
+          : 'flex flex-col gap-1 justify-center overflow-hidden',
         // Smooth fade between dim / un-dim states. motion-reduce
         // disables the transition for users with
         // prefers-reduced-motion (existing pattern across the dashboard).
@@ -273,22 +357,45 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
         hoverRing,
         dimClass,
       ].join(' ')}
-      style={{ width: `${NODE_WIDTH}px`, minHeight: `${NODE_HEIGHT}px` }}
+      data-detail-level={detailLevel}
+      /* eslint-disable-next-line react/forbid-dom-props -- xyflow nodes need fixed pixel dimensions matched to dagre layout */
+      style={{ width: `${dims.width}px`, minHeight: `${dims.height}px` }}
     >
       <Handle
         type="target"
         position={tp}
         style={{ background: 'currentColor', width: 8, height: 8, border: 'none' }}
       />
-      <span class="text-[9px] uppercase tracking-wider opacity-60 leading-none">
-        {kind}
-      </span>
-      <Tooltip content={data.fullLabel ?? data.label} delay={400}>
-        <span class="font-semibold text-sm truncate block w-full leading-tight">
-          {typeof data.labelPrefix === 'string' ? data.labelPrefix : ''}
-          {data.label}
-        </span>
-      </Tooltip>
+      {isCompact ? (
+        // Compact card: no kind chip, no two-row stack. A single bigger
+        // label fills the small box so the text stays readable at low
+        // zoom. Truncated to COMPACT_LABEL_MAX_CHARS + ellipsis; full
+        // label surfaces via the existing Tooltip wrap below.
+        <Tooltip content={data.fullLabel ?? data.label} delay={400}>
+          <span
+            class="font-semibold text-[14px] truncate block w-full text-center leading-tight"
+            data-testid="fsm-node-label-compact"
+          >
+            {labelPrefix}
+            {visibleLabel}
+          </span>
+        </Tooltip>
+      ) : (
+        <>
+          <span
+            class="text-[9px] uppercase tracking-wider opacity-60 leading-none"
+            data-testid="fsm-node-kind-chip"
+          >
+            {kind}
+          </span>
+          <Tooltip content={data.fullLabel ?? data.label} delay={400}>
+            <span class="font-semibold text-sm truncate block w-full leading-tight">
+              {labelPrefix}
+              {data.label}
+            </span>
+          </Tooltip>
+        </>
+      )}
       <Handle
         type="source"
         position={sp}
@@ -299,42 +406,25 @@ function FsmNode({ data, selected, sourcePosition, targetPosition }: NodeProps<N
 }
 
 // ---------------------------------------------------------------------------
-// PR 5: loop node — header card + collapsible chip strip
+// Loop node — uniform card same shape/size as FsmNode, plus a ×N badge.
 // ---------------------------------------------------------------------------
+//
+// Clean-slate rebuild rationale: the previous loop node embedded a
+// per-iteration chip strip directly on the graph, which made the loop
+// card 30 %+ of the canvas width and forced every other node to flow
+// around it. That broke the layout the user wanted (uniform card grid).
+// Per-iteration affordances now live in the inspector Sheet
+// (StateEntrySheetBody → "Iterations" section); the graph card just
+// carries a small "×N" badge in the top-right so the operator can see
+// at a glance how many times the loop ran.
 
 /**
- * Width of the header band of a loop node (kind chip + state-id + ×N
- * badge + expand toggle). Matches the default FsmNode card so a loop
- * node collapsed reads at the same line height as its worker / inline
- * siblings on the same rank.
+ * Per-status palette for the iteration chip rendered inside the
+ * StateEntrySheetBody's "Iterations" section. Exported so the sheet
+ * (which owns the chip strip now) renders the same status colours as
+ * the rest of the run graph.
  */
-export const LOOP_NODE_HEADER_WIDTH = 270;
-/** Width of one iteration chip inside the strip. */
-export const LOOP_NODE_CHIP_WIDTH = 40;
-/** Hard cap on the number of chips contributed to the layout width;
- *  beyond this the strip uses horizontal scroll so a 200-iteration
- *  loop doesn't sprawl 8000px wide and break dagre. */
-export const LOOP_NODE_CHIP_VISIBLE_MAX = 20;
-/** Total node height (matches FsmNode for collapsed parity, plus a
- *  fixed chip-strip height that's allocated whether the strip is
- *  visible or not so the layout doesn't shift when the operator
- *  expands). */
-export const LOOP_NODE_HEIGHT = NODE_HEIGHT + 36;
-
-/**
- * Compute the layout width of a loop node given an iteration count.
- * Exposed so ``specGraph`` / ``runGraph`` can stamp the same number
- * onto the node BEFORE the dagre layout pass runs — that keeps dagre
- * from re-routing edges every time the operator collapses the chip
- * strip.
- */
-export function loopNodeExpandedWidth(iterations: number): number {
-  const visible = Math.min(LOOP_NODE_CHIP_VISIBLE_MAX, Math.max(0, iterations));
-  return LOOP_NODE_HEADER_WIDTH + visible * LOOP_NODE_CHIP_WIDTH;
-}
-
-/** Per-status chip palette inside the loop strip. */
-const LOOP_CHIP_STATUS_CLASSES: Record<string, string> = {
+export const LOOP_CHIP_STATUS_CLASSES: Record<string, string> = {
   faulted:
     'border-red-500 bg-red-100 dark:bg-red-900/50 text-red-900 dark:text-red-100',
   entered:
@@ -345,22 +435,24 @@ const LOOP_CHIP_STATUS_CLASSES: Record<string, string> = {
     'border-emerald-500 bg-emerald-100 dark:bg-emerald-900/50 text-emerald-900 dark:text-emerald-100',
 };
 
-function loopChipClass(status: string): string {
+/** Helper: pick the chip class for one iteration's status. */
+export function loopChipClass(status: string): string {
   return (
     LOOP_CHIP_STATUS_CLASSES[status.toLowerCase()] ??
     'border-slate-400 bg-slate-100 dark:bg-slate-800/60 text-slate-700 dark:text-slate-300'
   );
 }
 
-/** Context bridge for chip click dispatch.
- *  Mirrors the FsmEdgeClickContext pattern (the loop node renderer is
- *  instantiated by xyflow inside a portal, so prop-drilling
- *  ``onIterationClick`` through the nodeTypes map would lose it). */
+/** Context bridge for iteration-chip click dispatch from any
+ *  descendant of FlowGraph. Kept exported because the route still
+ *  passes ``onIterationClick`` and other future surfaces (the
+ *  inspector Sheet) can subscribe to it without prop-drilling. */
 export const LoopIterationClickContext = createContext<
   ((entryId: string) => void) | null
 >(null);
 
-function LoopNode({
+/** Exported for FsmNode.test.tsx — same rationale as `FsmNode`. */
+export function LoopNode({
   data,
   selected,
   sourcePosition,
@@ -368,14 +460,6 @@ function LoopNode({
 }: NodeProps<Node<FlowNodeData>>): JSX.Element {
   const sp = sourcePosition ?? Position.Bottom;
   const tp = targetPosition ?? Position.Top;
-  const onIterationClick = useContext(LoopIterationClickContext);
-
-  // PR 5: the operator controls expand/collapse with the ▸ toggle. The
-  // default is collapsed so a graph full of loop nodes doesn't drown
-  // the operator in chip strips before they ask for one; expanding is
-  // one keypress / click away. State lives in the node component (not
-  // on data) so toggling doesn't trigger an overlay rebuild.
-  const [expanded, setExpanded] = useState(false);
 
   const iterations = Array.isArray(data.iterationEntries)
     ? data.iterationEntries
@@ -390,9 +474,8 @@ function LoopNode({
   const runStatus = typeof data.runStatus === 'string' ? data.runStatus : undefined;
   const isCurrent = data.isCurrent === true;
 
-  // Reuse the status palette FsmNode owns for the header band so a
-  // loop card lights up the same emerald/amber/red as its worker
-  // siblings under the same run state.
+  // Status palette mirrors FsmNode so a loop card lights up the same
+  // emerald/amber/red as worker siblings in the same run state.
   const STATUS_CLASSES: Record<string, string> = {
     not_visited:
       'border-slate-400 bg-slate-100 dark:bg-slate-800/60 text-slate-500 dark:text-slate-400 opacity-70',
@@ -423,18 +506,37 @@ function LoopNode({
     : '';
   const dimClass = isDimmed ? 'opacity-30' : '';
 
-  // The card width matches the layout-baked value (header +
-  // min(MAX, iterations) chips) so dagre's slack remains correct.
-  // The chip strip itself is independently overflow-x:auto, which
-  // means an over-MAX iteration count scrolls horizontally inside
-  // the fixed card width.
-  const cardWidth = loopNodeExpandedWidth(Math.max(maxIterations, iterationCount));
+  // The badge is suppressed when the spec hasn't declared a loop body
+  // AND no run iterations have landed yet — otherwise we'd show a
+  // misleading "×0" on a static spec graph.
+  const showBadge = iterationCount > 0 || maxIterations > 0;
+  const badgeText =
+    iterationCount > 0
+      ? `×${iterationCount}${maxIterations > 0 ? ` / ${maxIterations}` : ''}`
+      : `×0 / ${maxIterations}`;
+  const badgeTitle =
+    maxIterations > 0
+      ? `${iterationCount} of ${maxIterations} iterations`
+      : `${iterationCount} iterations`;
+
+  // W23e: same detail-toggle contract as FsmNode. The ×N badge stays
+  // visible in compact mode at a smaller font so the operator still sees
+  // iteration counts at low zoom; the kind chip is dropped to free
+  // vertical space.
+  const detailLevel: DetailLevel = data.detailLevel === 'compact' ? 'compact' : 'full';
+  const isCompact = detailLevel === 'compact';
+  const dims = NODE_DIMS_BY_DETAIL[detailLevel];
+  const labelPrefix = typeof data.labelPrefix === 'string' ? data.labelPrefix : '';
+  const visibleLabel = isCompact ? truncateCompactLabel(data.label) : data.label;
 
   return (
     <div
       class={[
         'fsm-node fsm-loop-node relative rounded-md border-2 shadow-sm',
-        'flex flex-col overflow-hidden',
+        isCompact ? 'fsm-loop-node-compact px-2 py-1' : 'px-4 py-3',
+        isCompact
+          ? 'flex items-center justify-center overflow-hidden'
+          : 'flex flex-col gap-1 justify-center overflow-hidden',
         'transition-opacity duration-150 motion-reduce:transition-none',
         paletteClass,
         selected ? 'ring-2 ring-emerald-400 ring-offset-1' : '',
@@ -444,100 +546,58 @@ function LoopNode({
         dimClass,
       ].join(' ')}
       data-testid="loop-node"
-      /* eslint-disable-next-line react/forbid-dom-props -- xyflow loop node needs computed pixel width matched to dagre layout */
-      style={{ width: `${cardWidth}px`, minHeight: `${LOOP_NODE_HEIGHT}px` }}
+      data-detail-level={detailLevel}
+      /* eslint-disable-next-line react/forbid-dom-props -- xyflow nodes need fixed pixel dimensions matched to dagre layout */
+      style={{ width: `${dims.width}px`, minHeight: `${dims.height}px` }}
     >
       <Handle
         type="target"
         position={tp}
         style={{ background: 'currentColor', width: 8, height: 8, border: 'none' }}
       />
-      {/* Header band — kind chip + label + ×N badge + expand toggle */}
-      <div class="flex flex-col gap-1 px-4 py-3">
-        <div class="flex items-center justify-between gap-2">
-          <span class="text-[9px] uppercase tracking-wider opacity-60 leading-none">
-            loop
-          </span>
-          <div class="flex items-center gap-1">
-            <span
-              class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-black/10 dark:bg-white/10"
-              title={`${iterationCount} of ${maxIterations} iterations`}
-              data-testid="loop-iteration-badge"
-            >
-              ×{iterationCount}
-              {maxIterations > 0 ? ` / ${maxIterations}` : ''}
-            </span>
-            <button
-              type="button"
-              aria-expanded={expanded ? 'true' : 'false'}
-              aria-label={
-                expanded ? 'Collapse iteration chips' : 'Expand iteration chips'
-              }
-              data-testid="loop-expand-toggle"
-              onClick={(e) => {
-                // Stop the click from bubbling to xyflow's onNodeClick
-                // handler — toggling the chip strip is its own
-                // affordance, NOT a "select the loop node" gesture.
-                e.stopPropagation();
-                setExpanded((v) => !v);
-              }}
-              class={[
-                'text-[10px] font-semibold w-5 h-5 rounded',
-                'flex items-center justify-center',
-                'bg-black/5 dark:bg-white/5',
-                'hover:bg-black/10 dark:hover:bg-white/10',
-                'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400',
-                'motion-safe:transition-transform',
-                expanded ? 'rotate-90' : '',
-              ].join(' ')}
-            >
-              ▸
-            </button>
-          </div>
-        </div>
+      {/* ×N badge floats in the top-right corner so it doesn't push the
+          kind/label rows around. position:absolute keeps it out of the
+          flex layout — the card visual matches FsmNode pixel-for-pixel
+          aside from this single decoration. In compact mode the badge
+          font shrinks so it doesn't dominate the smaller card. */}
+      {showBadge ? (
+        <span
+          class={[
+            'absolute font-mono leading-none rounded bg-black/10 dark:bg-white/10',
+            isCompact ? 'top-0 right-0 text-[8px] px-0.5' : 'top-1 right-1 text-[9px] px-1 py-0.5',
+          ].join(' ')}
+          title={badgeTitle}
+          data-testid="loop-iteration-badge"
+        >
+          {badgeText}
+        </span>
+      ) : null}
+      {isCompact ? (
         <Tooltip content={data.fullLabel ?? data.label} delay={400}>
-          <span class="font-semibold text-sm truncate block w-full leading-tight">
-            {data.label}
+          <span
+            class="font-semibold text-[14px] truncate block w-full text-center leading-tight"
+            data-testid="loop-node-label-compact"
+          >
+            {labelPrefix}
+            {visibleLabel}
           </span>
         </Tooltip>
-      </div>
-      {/* Chip strip — only painted when expanded. Width is fixed by
-          the outer card; overflow-x:auto handles the >20-iteration
-          case so the operator can scroll laterally rather than the
-          dagre layout shifting around. */}
-      {expanded && iterations.length > 0 ? (
-        <div
-          class="flex items-center gap-1 px-3 pb-2 overflow-x-auto"
-          data-testid="loop-chip-strip"
-          role="list"
-          aria-label={`Iteration entries for ${data.label}`}
-        >
-          {iterations.map((it) => (
-            <button
-              key={it.entry_id}
-              type="button"
-              role="listitem"
-              data-testid="loop-chip"
-              data-entry-id={it.entry_id}
-              title={`Iteration ${it.iteration_n ?? '?'} (${it.status})`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onIterationClick?.(it.entry_id);
-              }}
-              class={[
-                'shrink-0 inline-flex items-center justify-center',
-                'rounded border text-[10px] font-mono leading-none',
-                'h-6 min-w-[36px] px-1',
-                'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400',
-                'hover:brightness-110',
-                loopChipClass(it.status),
-              ].join(' ')}
-            >
-              {it.iteration_n ?? '·'}
-            </button>
-          ))}
-        </div>
-      ) : null}
+      ) : (
+        <>
+          <span
+            class="text-[9px] uppercase tracking-wider opacity-60 leading-none"
+            data-testid="loop-node-kind-chip"
+          >
+            loop
+          </span>
+          <Tooltip content={data.fullLabel ?? data.label} delay={400}>
+            <span class="font-semibold text-sm truncate block w-full leading-tight">
+              {labelPrefix}
+              {data.label}
+            </span>
+          </Tooltip>
+        </>
+      )}
       <Handle
         type="source"
         position={sp}
@@ -549,6 +609,75 @@ function LoopNode({
 
 const NODE_TYPES = { fsmNode: FsmNode, loopNode: LoopNode };
 const EDGE_TYPES = { fsmEdge: FsmEdge };
+
+/**
+ * Tiny child of <ReactFlow> that subscribes to the live viewport zoom
+ * via React Flow's internal store and lifts a `detailLevel` ('full'
+ * vs 'compact') up to FlowGraph via callback. Lives INSIDE the
+ * ReactFlow context (which is the only place `useStore` is allowed)
+ * but renders nothing — the actual card / layout swap happens up in
+ * the orchestrator.
+ *
+ * The threshold is exclusive: zoom > DETAIL_LEVEL_ZOOM_THRESHOLD →
+ * full, zoom ≤ threshold → compact. The check runs in a useEffect so
+ * the parent only re-renders when the level actually flips (not on
+ * every transform change while the user pans).
+ */
+function ZoomDetailWatcher({
+  onChange,
+}: {
+  onChange: (level: DetailLevel) => void;
+}): JSX.Element | null {
+  // transform = [x, y, zoom]; index 2 is the live zoom level.
+  const zoom = useStore((s: ReactFlowState) => s.transform[2]);
+  useEffect(() => {
+    const next: DetailLevel = zoom > DETAIL_LEVEL_ZOOM_THRESHOLD ? 'full' : 'compact';
+    onChange(next);
+  }, [zoom, onChange]);
+  return null;
+}
+
+/**
+ * Re-runs ``fitView`` whenever the detail level flips. The initial
+ * ``fitView`` on mount frames the FULL layout; once
+ * ``ZoomDetailWatcher`` flips us to compact (because the full-mode
+ * fit-zoom was <= DETAIL_LEVEL_ZOOM_THRESHOLD), the layout pass produces
+ * a much smaller bbox and we want the viewport to re-frame it so the
+ * compact card text is actually readable.
+ *
+ * Only refits when the persisted-viewport branch is OFF — once the
+ * operator has saved their own pan/zoom, we never auto-refit on top of
+ * it (matches the ``fitView=false`` guard in the parent ReactFlow).
+ */
+function RefitOnDetailChange({
+  detailLevel,
+  enabled,
+}: {
+  detailLevel: DetailLevel;
+  enabled: boolean;
+}): JSX.Element | null {
+  const { fitView } = useReactFlow();
+  // Track the previous level via ref so we ONLY refit on actual
+  // transitions, not on every re-render that happens to carry the
+  // current level.
+  const prev = useRef<DetailLevel | null>(null);
+  useEffect(() => {
+    if (!enabled) {
+      prev.current = detailLevel;
+      return;
+    }
+    if (prev.current === detailLevel) return;
+    prev.current = detailLevel;
+    // Defer to the next frame so the layout swap (which is a separate
+    // React state) has committed and the new node positions exist
+    // before we measure their bbox.
+    const handle = requestAnimationFrame(() => {
+      fitView({ padding: 0.05, includeHiddenNodes: false, minZoom: 0.2, maxZoom: 1.5 });
+    });
+    return () => cancelAnimationFrame(handle);
+  }, [detailLevel, enabled, fitView]);
+  return null;
+}
 
 /**
  * Run dagre layered layout to position nodes. Returns a fresh node
@@ -633,6 +762,11 @@ function applyDagreLayout(
   nodes: readonly Node<FlowNodeData>[],
   edges: readonly Edge[],
   direction: 'LR' | 'TB',
+  /** Default per-node dimensions used when the node didn't pre-stamp
+   *  its own width/height. W23e: callers pass compact dims when the
+   *  active viewport zoom drops below DETAIL_LEVEL_ZOOM_THRESHOLD so
+   *  the layout packs the chain tighter. */
+  defaultDims: { width: number; height: number } = NODE_DIMS_BY_DETAIL.full,
 ): { positioned: Node<FlowNodeData>[]; edgeLabelPositions: DagreEdgeLabelMap } {
   const g = new dagre.graphlib.Graph({ multigraph: true });
   g.setDefaultEdgeLabel(() => ({}));
@@ -652,23 +786,32 @@ function applyDagreLayout(
   // to scale the result. Predicate pills are anchored on cross-segment
   // midpoints so a tight ranksep is fine — adjacent ranks' labels live
   // on different horizontal segments and don't touch.
+  // Clean-slate constants: restore dagre defaults that work for moderate
+  // graphs (15-50 states). Previous tuning (nodesep=130 / ranksep=50)
+  // came from over-fitting to a 15-node v1 spec without the loop node;
+  // it collapsed adjacent ranks so far that predicate pills landed on
+  // top of node corners as soon as the spec grew. The conservative
+  // numbers below give dagre room to route around long edge labels and
+  // keep the graph readable without sprawling off the viewport — we
+  // rely on fitView (padding 0.15) to scale the final box.
   g.setGraph({
     rankdir: direction,
-    nodesep: 130,
-    ranksep: 50,
-    edgesep: 24,
-    marginx: 16,
-    marginy: 12,
-    ranker: 'longest-path',
+    nodesep: 120,
+    ranksep: 80,
+    edgesep: 36,
+    marginx: 20,
+    marginy: 20,
+    ranker: 'network-simplex',
   });
   for (const n of nodes) {
     // PR 5: respect per-node width/height when the caller already
     // stamped them (loop nodes do — their card width depends on the
     // iteration count, which the run-overlay layer knows BEFORE the
-    // layout pass). Fall back to the FSM defaults for every other
-    // node so the existing layout numbers stay unchanged.
-    const w = typeof n.width === 'number' ? n.width : NODE_WIDTH;
-    const h = typeof n.height === 'number' ? n.height : NODE_HEIGHT;
+    // layout pass). Fall back to the detail-level defaults for every
+    // other node (W23e: defaults flip between full + compact depending
+    // on the active viewport zoom).
+    const w = typeof n.width === 'number' ? n.width : defaultDims.width;
+    const h = typeof n.height === 'number' ? n.height : defaultDims.height;
     g.setNode(n.id, { width: w, height: h });
   }
   for (const e of edges) {
@@ -724,8 +867,8 @@ function applyDagreLayout(
 
   const positioned = nodes.map((n) => {
     const { x, y } = g.node(n.id);
-    const w = typeof n.width === 'number' ? n.width : NODE_WIDTH;
-    const h = typeof n.height === 'number' ? n.height : NODE_HEIGHT;
+    const w = typeof n.width === 'number' ? n.width : defaultDims.width;
+    const h = typeof n.height === 'number' ? n.height : defaultDims.height;
     // PR 5: dispatch to the loop custom node type for loop states.
     // The discriminator is data.isLoop — set by specGraph for loop
     // bodies. Every other node keeps the existing fsmNode renderer.
@@ -950,42 +1093,58 @@ export function FlowGraph({
     return params.get('layout') === 'dagre' ? 'dagre' : 'elk';
   }, []);
 
+  // W23e: viewport-zoom-aware detail toggle. The card render path + the
+  // layout pass both flip when the active zoom crosses
+  // DETAIL_LEVEL_ZOOM_THRESHOLD. We default to 'full' on mount so the
+  // first render (before any zoom is known) lines up with the
+  // pre-W23e visual baseline; the ZoomDetailWatcher mounted inside
+  // ReactFlow snaps us to 'compact' on the next frame when fitView
+  // computes a zoom <= the threshold.
+  const [detailLevel, setDetailLevel] = useState<DetailLevel>('full');
+
   // Manual-layout branch: identical to before — preserve caller
   // positions, stamp direction-aware handle sides, dispatch loop vs
-  // fsm node type.
+  // fsm node type. Defaults flip with the detail level so a manual
+  // layout's nodes still pick up the compact dims when active.
   const manualPositioned = useMemo(() => {
     if (autoLayout) return null;
     const sp = direction === 'LR' ? Position.Right : Position.Bottom;
     const tp = direction === 'LR' ? Position.Left : Position.Top;
+    const dims = NODE_DIMS_BY_DETAIL[detailLevel];
     return nodes.map((n) => {
       const isLoop = (n.data as { isLoop?: boolean } | undefined)?.isLoop === true;
       return {
         ...n,
-        width: n.width ?? NODE_WIDTH,
-        height: n.height ?? NODE_HEIGHT,
+        width: n.width ?? dims.width,
+        height: n.height ?? dims.height,
         sourcePosition: n.sourcePosition ?? sp,
         targetPosition: n.targetPosition ?? tp,
         type: n.type ?? (isLoop ? 'loopNode' : 'fsmNode'),
       };
     });
-  }, [nodes, autoLayout, direction]);
+  }, [nodes, autoLayout, direction, detailLevel]);
 
   // Dagre auto-layout branch: synchronous and cheap (the existing
-  // implementation). Computed every render via useMemo and the result
-  // is used either directly (?layout=dagre OR autoLayout=false-with-
-  // dagre fallback) or as the fallback when ELK throws.
-  const dagreLayout = useMemo(() => {
+  // implementation). W23e: we cache BOTH detail-level layouts and pick
+  // the one matching the active `detailLevel` so toggling zoom doesn't
+  // re-pay the (sync, but visible) dagre cost.
+  const dagreLayouts = useMemo(() => {
     if (!autoLayout) return null;
-    return applyDagreLayout(nodes, edges, direction);
+    return {
+      full: applyDagreLayout(nodes, edges, direction, NODE_DIMS_BY_DETAIL.full),
+      compact: applyDagreLayout(nodes, edges, direction, NODE_DIMS_BY_DETAIL.compact),
+    };
   }, [nodes, edges, autoLayout, direction]);
+  const dagreLayout = dagreLayouts?.[detailLevel] ?? null;
 
-  // ELK layout is async (Promise<LayoutResult>). We hold the result
-  // in state so the effect can write to it; while the promise is
-  // in-flight, isLayoutComputing flips the spinner overlay on. On
-  // throw, we log + fall back to the synchronous dagre result for
-  // the same nodes/edges identity, and remember the fallback in
-  // elkFailed so the spinner doesn't flicker on re-renders.
-  const [elkLayout, setElkLayout] = useState<LayoutResult | null>(null);
+  // ELK layout is async (Promise<LayoutResult>). W23e: we hold one
+  // result per detail level so the toggle switches between cached
+  // layouts instantly. Both layouts kick off in parallel on the same
+  // (nodes, edges, direction) change.
+  const [elkLayouts, setElkLayouts] = useState<{
+    full: LayoutResult | null;
+    compact: LayoutResult | null;
+  }>({ full: null, compact: null });
   const [isLayoutComputing, setIsLayoutComputing] = useState<boolean>(false);
   const [elkFailed, setElkFailed] = useState<boolean>(false);
 
@@ -997,7 +1156,7 @@ export function FlowGraph({
   // previous ELK result.
   useEffect(() => {
     if (!autoLayout || layoutEngine !== 'elk') {
-      setElkLayout(null);
+      setElkLayouts({ full: null, compact: null });
       setIsLayoutComputing(false);
       return;
     }
@@ -1011,10 +1170,69 @@ export function FlowGraph({
       const text = typeof e.label === 'string' ? e.label : '';
       if (text.length > 0) labelDimensions.set(e.id, measureEdgeLabel(text));
     }
-    applyElkLayout(nodes, edges, { labelDimensions })
-      .then((result) => {
+    // Stamp data.layoutWidth/layoutHeight per detail level so the ELK
+    // wrapper (which reads those as a fallback) reserves the matching
+    // slack. We rebuild the input arrays per level rather than mutate
+    // the caller's nodes.
+    const buildInput = (level: DetailLevel): Node<FlowNodeData>[] => {
+      const dims = NODE_DIMS_BY_DETAIL[level];
+      return nodes.map((n) => ({
+        ...n,
+        data: {
+          ...n.data,
+          // Only stamp the fallback when the node didn't already declare
+          // explicit width/height. Loop nodes pre-W23e never did this
+          // either, so the clean-slate uniform-width contract is intact.
+          ...(typeof n.width === 'number'
+            ? {}
+            : { layoutWidth: dims.width, layoutHeight: dims.height }),
+        } as FlowNodeData,
+      }));
+    };
+    const fullPromise = applyElkLayout(buildInput('full'), edges, {
+      labelDimensions,
+      layoutOptions: {
+        'elk.direction': direction === 'LR' ? 'RIGHT' : 'DOWN',
+      },
+    });
+    // Compact-mode layout: clamp the per-edge label box to a small
+    // square (24x12) so ELK reserves enough slack to keep labels OFF
+    // adjacent nodes, but doesn't blow the layer-to-layer gap out the
+    // way the full-pill (~170x40) reservation does. The pills still
+    // render at compact-mode font size (FsmEdge sizes them via
+    // detailLevel) so they fit the slack we reserved.
+    // Compact-mode labels render as a 14x14 pip (FsmEdge owns the
+    // compact-mode visual), so we reserve a matching 14x14 box on the
+    // layout side. Tight node-node spacing keeps the bbox compact so
+    // fit-view zoom lands above 0.55 where the compact-mode card text
+    // (truncated state names) is actually readable.
+    const compactLabelDimensions = new Map<string, { width: number; height: number }>();
+    for (const e of edges) {
+      const text = typeof e.label === 'string' ? e.label : '';
+      if (text.length > 0) compactLabelDimensions.set(e.id, { width: 14, height: 14 });
+    }
+    const compactPromise = applyElkLayout(buildInput('compact'), edges, {
+      labelDimensions: compactLabelDimensions,
+      layoutOptions: {
+        'elk.direction': direction === 'LR' ? 'RIGHT' : 'DOWN',
+        // Tight spacing — the compact pip + small card means we can
+        // pack 14 layers into ~1500 px wide and clear fit-view 0.6+.
+        // Tested with skill-code-review v4 (18 nodes / 14 layers LR):
+        // these constants produce fit-view zoom ~0.6 on a 1330x780
+        // viewport, putting the compact-mode 13px label text at ~7.8 px
+        // on-screen which is the readability floor for the truncated
+        // state names.
+        'elk.layered.spacing.nodeNodeBetweenLayers': '10',
+        'elk.layered.spacing.edgeNodeBetweenLayers': '6',
+        'elk.spacing.nodeNode': '20',
+        'elk.spacing.edgeLabel': '2',
+        'elk.padding': '[top=4,left=4,bottom=4,right=4]',
+      },
+    });
+    Promise.all([fullPromise, compactPromise])
+      .then(([full, compact]) => {
         if (cancelled) return;
-        setElkLayout(result);
+        setElkLayouts({ full, compact });
         setIsLayoutComputing(false);
         setElkFailed(false);
       })
@@ -1024,7 +1242,7 @@ export function FlowGraph({
         // through the existing dagre useMemo result.
         // eslint-disable-next-line no-console -- defensive diagnostic
         console.warn('ELK layout failed, falling back to dagre', err);
-        setElkLayout(null);
+        setElkLayouts({ full: null, compact: null });
         setIsLayoutComputing(false);
         setElkFailed(true);
       });
@@ -1032,6 +1250,8 @@ export function FlowGraph({
       cancelled = true;
     };
   }, [nodes, edges, direction, autoLayout, layoutEngine]);
+
+  const elkLayout = elkLayouts[detailLevel];
 
   // Resolve the active layout result to feed into the node/edge
   // decoration steps. Priority:
@@ -1052,10 +1272,11 @@ export function FlowGraph({
       // Build positioned nodes from the ELK result.
       const sp = direction === 'LR' ? Position.Right : Position.Bottom;
       const tp = direction === 'LR' ? Position.Left : Position.Top;
+      const dims = NODE_DIMS_BY_DETAIL[detailLevel];
       const elkNodes = nodes.map((n) => {
         const isLoop = (n.data as { isLoop?: boolean } | undefined)?.isLoop === true;
-        const w = typeof n.width === 'number' ? n.width : NODE_WIDTH;
-        const h = typeof n.height === 'number' ? n.height : NODE_HEIGHT;
+        const w = typeof n.width === 'number' ? n.width : dims.width;
+        const h = typeof n.height === 'number' ? n.height : dims.height;
         const pos = elkLayout!.nodePositions.get(n.id) ?? { x: 0, y: 0 };
         return {
           ...n,
@@ -1098,6 +1319,7 @@ export function FlowGraph({
     layoutEngine,
     nodes,
     direction,
+    detailLevel,
   ]);
 
   const decoratedNodes = useMemo(
@@ -1110,18 +1332,21 @@ export function FlowGraph({
         // (kind, label, runStatus, isCurrent, etc.). The three hover
         // flags are stripped back to undefined when nothing is hovered
         // so FsmNode's `=== true` checks render the un-highlighted
-        // baseline.
+        // baseline. detailLevel is stamped here (not on the source
+        // nodes array) so the toggle is a cheap re-decorate; the
+        // upstream owners stay detail-level-agnostic.
         const nextData = {
           ...n.data,
           isHovered,
           highlighted: isHighlighted,
           dimmed: isDimmed,
+          detailLevel,
         } as FlowNodeData;
         const withSelection =
           selectedNodeId && n.id === selectedNodeId ? { ...n, selected: true } : n;
         return { ...withSelection, data: nextData };
       }),
-    [positioned, selectedNodeId, hoveredNodeId, hoverActive, highlight],
+    [positioned, selectedNodeId, hoveredNodeId, hoverActive, highlight, detailLevel],
   );
 
   const showMiniMap = miniMap ?? nodes.length > 10;
@@ -1142,6 +1367,12 @@ export function FlowGraph({
         isHovered,
         highlighted: isHighlighted,
         dimmed: isDimmed,
+        // Mirror the node-side detailLevel onto every edge so FsmEdge
+        // can shrink (or hide) its label pill when the graph is
+        // rendering compact cards. Predicate labels at compact zoom
+        // overflow node footprints and undo the layout's slack
+        // reservation, so the compact path drops to a small icon.
+        detailLevel,
       };
       // Boost the SVG stroke when the edge is the hover target or a
       // 1-hop neighbour. FsmEdge owns label pill opacity / colour via
@@ -1167,7 +1398,7 @@ export function FlowGraph({
       };
       return { ...e, data: nextData, style: nextStyle };
     });
-  }, [edges, edgeLabelPositions, elkEdgeRouting, hoveredEdgeId, hoverActive, highlight]);
+  }, [edges, edgeLabelPositions, elkEdgeRouting, hoveredEdgeId, hoverActive, highlight, detailLevel]);
 
   // React Flow's onNodeMouseEnter / Leave fire with (event, node);
   // collapse to just the id and clear any active edge hover so the two
@@ -1185,6 +1416,13 @@ export function FlowGraph({
   }, []);
   const onEdgeMouseLeave = useCallback(() => {
     setHoveredEdgeId(null);
+  }, []);
+
+  // Stable callback so ZoomDetailWatcher's useEffect doesn't re-fire on
+  // every parent render. setState skips a render when the next value is
+  // identical, so we don't have to guard here.
+  const handleDetailLevelChange = useCallback((next: DetailLevel) => {
+    setDetailLevel(next);
   }, []);
 
   if (nodes.length === 0) {
@@ -1272,6 +1510,15 @@ export function FlowGraph({
         onEdgeMouseEnter={onEdgeMouseEnter}
         onEdgeMouseLeave={onEdgeMouseLeave}
       >
+        {/* W23e: lives inside ReactFlow so useStore has a real store
+            context. Renders nothing — its only job is to subscribe to
+            the live viewport zoom and lift a detailLevel up to the
+            orchestrator when the value crosses the threshold. */}
+        <ZoomDetailWatcher onChange={handleDetailLevelChange} />
+        <RefitOnDetailChange
+          detailLevel={detailLevel}
+          enabled={viewport.defaultViewport === undefined}
+        />
         {background ? (
           <Background
             gap={16}

--- a/ui/src/components/FsmEdge.tsx
+++ b/ui/src/components/FsmEdge.tsx
@@ -85,6 +85,12 @@ export interface FsmEdgeData extends Record<string, unknown> {
   isHovered?: boolean;
   highlighted?: boolean;
   dimmed?: boolean;
+  /** Detail level mirrored from the node-side render so the label pill
+   *  can shrink at compact zoom. At 'compact' we render a small 14x14
+   *  pip instead of the multi-line predicate badge; the pip carries
+   *  the kind colour and acts as a click target. The full pill returns
+   *  when the operator zooms in past the threshold. */
+  detailLevel?: 'full' | 'compact';
 }
 
 /**
@@ -275,21 +281,22 @@ export function FsmEdge(props: EdgeProps): JSX.Element {
     });
   }
 
-  // Criterion 7: labels must sit ON the actual line xyflow renders.
-  // Neither dagre's reserved label position nor ELK's edgeLabels.placement
-  // CENTER consistently coincides with the orthogonal smooth-step
-  // polyline we draw (dagre uses graph coords from its own routing
-  // diagram; ELK occasionally drops labels onto the perpendicular stub).
-  // Always anchor on the longest-segment midpoint so the line visually
-  // passes through the pill's geometric centre.
-  const [labelX, labelY] = longestSegmentMidpoint(
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-    sourcePosition,
-    targetPosition,
-  );
+  // Prefer the layout engine's reserved label anchor when present —
+  // ELK (or dagre) ran a label-aware routing pass so its anchor sits
+  // on the polyline AND doesn't collide with sibling labels on a
+  // fan-out. Geometric longest-segment midpoint is the unit-test /
+  // no-layout fallback only.
+  const layoutAnchor = ed.layoutLabel ?? ed.dagreLabel;
+  const [labelX, labelY] = layoutAnchor
+    ? [layoutAnchor.x, layoutAnchor.y]
+    : longestSegmentMidpoint(
+        sourceX,
+        sourceY,
+        targetX,
+        targetY,
+        sourcePosition,
+        targetPosition,
+      );
   const fullText = typeof ed.fullLabel === 'string' && ed.fullLabel.length > 0
     ? ed.fullLabel
     : typeof label === 'string'
@@ -357,6 +364,37 @@ export function FsmEdge(props: EdgeProps): JSX.Element {
               // why the FSM branched.
               const kind = ed.kind;
               const isPredicate = kind === 'deterministic' || kind === 'judgement';
+              const isCompact = ed.detailLevel === 'compact';
+              // Compact pip: at low zoom, the multi-line predicate badge
+              // overflows the node footprint and rams into neighbours.
+              // Replace it with a 14x14 dot in the kind colour. Hover +
+              // click still surface the full text (Tooltip + the
+              // existing onLabelClick path), so no information is lost —
+              // the operator zooms in or clicks for detail.
+              if (isCompact) {
+                const pipClass = [
+                  'relative z-10 inline-block rounded-full cursor-pointer',
+                  isPredicate
+                    ? 'bg-amber-700 border border-amber-500'
+                    : 'bg-slate-500 dark:bg-slate-400 border border-slate-700 dark:border-slate-300',
+                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500',
+                ].join(' ');
+                return (
+                  <Tooltip content={fullText} delay={400}>
+                    <button
+                      type="button"
+                      class={pipClass}
+                      // eslint-disable-next-line react/forbid-dom-props -- fixed pip dimensions
+                      style={{ width: '14px', height: '14px', padding: 0 }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onLabelClick?.(id, ed as Record<string, unknown>);
+                      }}
+                      aria-label={`Inspect transition: ${fullText}`}
+                    />
+                  </Tooltip>
+                );
+              }
               // W23b regression fix: no max-w + no truncate. Labels are
               // typically short DSL predicates; a 280px soft cap with
               // wrapping handles the rare long case without cutting

--- a/ui/src/components/__tests__/FlowGraph.test.tsx
+++ b/ui/src/components/__tests__/FlowGraph.test.tsx
@@ -15,6 +15,12 @@ import { act, cleanup, render } from '@testing-library/preact';
 
 // Mock @xyflow/react before importing FlowGraph.
 let lastReactFlowProps: Record<string, unknown> | null = null;
+// Test seam for the live viewport zoom that ZoomDetailWatcher reads
+// via useStore. Defaults to 1 (well above DETAIL_LEVEL_ZOOM_THRESHOLD)
+// so the existing tests render at full detail without any per-test
+// setup. Per-test overrides set this before render to exercise the
+// compact path.
+let mockReactFlowZoom = 1;
 vi.mock('@xyflow/react', () => ({
   ReactFlow: (props: Record<string, unknown> & { children?: unknown }) => {
     lastReactFlowProps = props;
@@ -27,6 +33,15 @@ vi.mock('@xyflow/react', () => ({
   BaseEdge: () => null,
   EdgeLabelRenderer: (p: { children?: unknown }) => <>{p.children as any}</>,
   getSmoothStepPath: () => ['M0,0 L1,1', 0, 0, 0, 0],
+  // useStore is invoked by ZoomDetailWatcher with a selector that
+  // pulls state.transform[2] (the live zoom). We pass a synthetic
+  // ReactFlowState-shaped object so the selector returns
+  // mockReactFlowZoom without colliding with xyflow's internal store.
+  useStore: (selector: (s: { transform: [number, number, number] }) => unknown) =>
+    selector({ transform: [0, 0, mockReactFlowZoom] }),
+  // useReactFlow returns the imperative API. RefitOnDetailChange calls
+  // fitView when the detail level flips; the mock no-ops it.
+  useReactFlow: () => ({ fitView: () => undefined }),
   Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
   BackgroundVariant: { Dots: 'dots', Lines: 'lines', Cross: 'cross' },
   MarkerType: { ArrowClosed: 'arrowclosed', Arrow: 'arrow' },
@@ -39,6 +54,7 @@ import type { Edge, Node } from '@xyflow/react';
 
 beforeEach(() => {
   lastReactFlowProps = null;
+  mockReactFlowZoom = 1;
 });
 afterEach(() => cleanup());
 
@@ -229,12 +245,20 @@ describe('FlowGraph', () => {
       ];
       render(<FlowGraph nodes={nodes} edges={edges} autoLayout={true} direction="TB" />);
 
-      // 1. Graph constructor was called with multigraph: true.
-      expect(ctorCalls).toEqual([{ multigraph: true }]);
+      // 1. Graph constructor was called with multigraph: true. W23e
+      //    runs the dagre layout twice per render (once per detail
+      //    level: full + compact) so the same options object lands in
+      //    ctorCalls twice — both must opt into multigraph mode.
+      expect(ctorCalls.length).toBeGreaterThanOrEqual(1);
+      for (const call of ctorCalls) {
+        expect(call).toEqual({ multigraph: true });
+      }
 
-      // 2. The live Graph instance built by FlowGraph has BOTH edges as
-      //    distinct dagre entries (edgeCount() reflects multigraph state).
-      expect(instances).toHaveLength(1);
+      // 2. Every live Graph instance built by FlowGraph has BOTH edges
+      //    as distinct dagre entries (edgeCount() reflects multigraph
+      //    state). Inspecting the first instance is sufficient — they
+      //    share the same input edges, only the node dims differ.
+      expect(instances.length).toBeGreaterThanOrEqual(1);
       const instance = instances[0] as unknown as {
         edgeCount: () => number;
         edges: () => Array<{ v: string; w: string; name?: string }>;
@@ -547,16 +571,10 @@ describe('FlowGraph', () => {
       expect(passed[0].type).toBe('fsmNode');
     });
 
-    test('loop node is collapsed by default; expanding renders the chip strip; chip click fires onIterationClick', async () => {
-      // Mount the loopNode renderer via the LoopIterationClickContext
-      // bridge — same pattern the FsmEdge test uses for FsmEdgeClickContext.
-      // The renderer is a Preact component (uses hooks), so it must be
-      // mounted via JSX inside render(), not invoked as a function.
-      const fg = await import('../FlowGraph');
-      const LoopIterationClickContext = (fg as unknown as {
-        LoopIterationClickContext: import('preact').Context<((id: string) => void) | null>;
-      }).LoopIterationClickContext;
-      const handler = vi.fn();
+    test('clean-slate: loop node renders the ×N badge (no chip strip on the card)', () => {
+      // Clean-slate rebuild: the per-iteration chip strip moved to the
+      // inspector Sheet so loop cards stay uniform-size. The card now
+      // carries only a small ×N badge in the top-right corner.
       const iterations = [
         { entry_id: 'e1', iteration_n: 1, status: 'exited' },
         { entry_id: 'e2', iteration_n: 2, status: 'entered' },
@@ -570,9 +588,6 @@ describe('FlowGraph', () => {
         iterationEntries: iterations,
       } as FlowNodeData;
 
-      // Pull the registered loopNode component out of FlowGraph's
-      // NODE_TYPES map via the captured ReactFlow props. That way we
-      // test the ACTUAL renderer FlowGraph wires up, not a copy.
       render(<FlowGraph nodes={[loopNode('tick', iterations, 5)]} edges={[]} autoLayout={false} />);
       const nodeTypes = lastReactFlowProps!.nodeTypes as Record<string, any>;
       const LoopComponent = nodeTypes.loopNode as (props: {
@@ -580,46 +595,47 @@ describe('FlowGraph', () => {
         selected?: boolean;
       }) => any;
 
-      const { getByTestId, queryByTestId, getAllByTestId } = render(
-        <LoopIterationClickContext.Provider value={handler}>
-          <LoopComponent data={data} />
-        </LoopIterationClickContext.Provider>,
+      const { getByTestId, queryByTestId } = render(
+        <LoopComponent data={data} />,
       );
 
-      // Collapsed by default: no chip strip yet.
+      // The card carries the ×N badge — "×2 / 5" since iterations=2,
+      // max=5.
+      const badge = getByTestId('loop-iteration-badge');
+      expect(badge.textContent).toContain('2');
+      expect(badge.textContent).toContain('5');
+      // The on-card chip strip + expand toggle are gone (they live in
+      // StateEntrySheetBody now, not on the graph card).
       expect(queryByTestId('loop-chip-strip')).toBeNull();
-      // Header has the ×N badge.
-      expect(getByTestId('loop-iteration-badge').textContent).toContain('2');
-      // Toggle to expand.
-      const toggle = getByTestId('loop-expand-toggle') as HTMLButtonElement;
-      act(() => {
-        toggle.click();
-      });
-      // Chip strip now visible with one chip per iteration.
-      const strip = getByTestId('loop-chip-strip');
-      expect(strip).not.toBeNull();
-      const chips = getAllByTestId('loop-chip');
-      expect(chips).toHaveLength(2);
-      expect(chips[0].getAttribute('data-entry-id')).toBe('e1');
-      expect(chips[1].getAttribute('data-entry-id')).toBe('e2');
-      // Clicking a chip fires onIterationClick with the entry_id.
-      act(() => {
-        (chips[1] as HTMLButtonElement).click();
-      });
-      expect(handler).toHaveBeenCalledWith('e2');
-      // Toggle back to collapsed.
-      act(() => {
-        toggle.click();
-      });
-      expect(queryByTestId('loop-chip-strip')).toBeNull();
+      expect(queryByTestId('loop-expand-toggle')).toBeNull();
+      expect(queryByTestId('loop-chip')).toBeNull();
     });
 
-    test('PR 5: layout width is bounded by min(20, iterations) * 40 + header for 0 / 1 / 5 / 200 iterations', () => {
-      // Use the auto-layout branch so dagre is actually exercised — the
-      // pre-stamped n.width must flow through to the positioned node.
-      const headerWidth = 270;
-      const chipWidth = 40;
-      const max = 20;
+    test('clean-slate: loop node hides the ×N badge when no iterations + no spec ceiling', () => {
+      const data = {
+        kind: 'loop',
+        label: 'idle',
+        isLoop: true,
+        loopMaxIterations: 0,
+        iterationCount: 0,
+        iterationEntries: [],
+      } as FlowNodeData;
+
+      render(<FlowGraph nodes={[loopNode('idle', [], 0)]} edges={[]} autoLayout={false} />);
+      const nodeTypes = lastReactFlowProps!.nodeTypes as Record<string, any>;
+      const LoopComponent = nodeTypes.loopNode as (props: { data: FlowNodeData }) => any;
+      const { queryByTestId } = render(<LoopComponent data={data} />);
+      expect(queryByTestId('loop-iteration-badge')).toBeNull();
+    });
+
+    test('clean-slate: loop nodes get the uniform NODE_WIDTH regardless of iteration count', () => {
+      // Clean-slate rebuild: no per-iteration width — a 0-iter loop and
+      // a 200-iter loop render the same uniform card. The chip strip
+      // lives in the inspector Sheet, not on the graph card, so the
+      // layout pass never has to reserve more slack for a wider loop.
+      // Width is shared with FsmNode; bump in lockstep with FlowGraph's
+      // NODE_WIDTH constant.
+      const NODE_WIDTH = 160;
       const cases = [0, 1, 5, 200];
       for (const count of cases) {
         const iter = Array.from({ length: count }, (_, i) => ({
@@ -627,39 +643,11 @@ describe('FlowGraph', () => {
           iteration_n: i + 1,
           status: 'exited',
         }));
-        // Pre-stamp width on the node the same way specGraph/runGraph
-        // does, so dagre sees the right dimensions.
-        const expanded = headerWidth + Math.min(max, count) * chipWidth;
-        const nodes: Node<FlowNodeData>[] = [
-          { ...loopNode('l', iter, count), width: expanded, height: 120 },
-        ];
+        const nodes: Node<FlowNodeData>[] = [loopNode('l', iter, count)];
         render(<FlowGraph nodes={nodes} edges={[]} autoLayout={true} />);
         const passed = lastReactFlowProps!.nodes as Array<Node<FlowNodeData> & { width?: number }>;
-        // The positioned node keeps the input width unchanged for loop
-        // nodes — non-default widths flow through dagre + back out.
-        expect(passed[0].width).toBe(expanded);
-        // The cap at 20 is the load-bearing assertion: 200 iterations
-        // must NOT produce 8000+ px.
-        expect(passed[0].width).toBeLessThanOrEqual(headerWidth + max * chipWidth);
+        expect(passed[0].width).toBe(NODE_WIDTH);
       }
-    });
-
-    test('PR 5: a loop with 50 iterations renders width bounded by min(20,50)*40 + header', () => {
-      const headerWidth = 270;
-      const chipWidth = 40;
-      const max = 20;
-      const iter = Array.from({ length: 50 }, (_, i) => ({
-        entry_id: `e${i}`,
-        iteration_n: i + 1,
-        status: 'exited',
-      }));
-      const expanded = headerWidth + Math.min(max, 50) * chipWidth;
-      const nodes: Node<FlowNodeData>[] = [
-        { ...loopNode('l', iter, 50), width: expanded, height: 120 },
-      ];
-      render(<FlowGraph nodes={nodes} edges={[]} autoLayout={true} />);
-      const passed = lastReactFlowProps!.nodes as Array<Node<FlowNodeData> & { width?: number }>;
-      expect(passed[0].width).toBe(headerWidth + max * chipWidth);
     });
   });
 
@@ -814,6 +802,108 @@ describe('FlowGraph', () => {
       expect(new Set(ys).size).toBe(2);
       spy.mockRestore();
       consoleWarn.mockRestore();
+    });
+  });
+
+  describe('W23e viewport-zoom-aware detail toggle', () => {
+    // ZoomDetailWatcher reads the live zoom via useStore; the mock at
+    // the top of this file exposes mockReactFlowZoom as the driver for
+    // that selector. Setting it BEFORE render lets us assert what the
+    // first paint forwards to ReactFlow without poking xyflow internals.
+
+    test('zoom above threshold renders detailLevel=full on every node', async () => {
+      const { DETAIL_LEVEL_ZOOM_THRESHOLD } = await import('../FlowGraph');
+      expect(DETAIL_LEVEL_ZOOM_THRESHOLD).toBe(0.7);
+      mockReactFlowZoom = 0.9; // > threshold
+      const nodes: Node<FlowNodeData>[] = [
+        { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'plan' } },
+        { id: 'b', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'execute' } },
+      ];
+      render(<FlowGraph nodes={nodes} edges={[]} autoLayout={false} />);
+      // ZoomDetailWatcher's useEffect runs after the first paint, so
+      // drain microtasks to let the setState propagate.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const forwarded = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      expect(forwarded.length).toBe(2);
+      for (const n of forwarded) {
+        expect(n.data.detailLevel).toBe('full');
+      }
+    });
+
+    test('zoom at or below threshold renders detailLevel=compact on every node', async () => {
+      mockReactFlowZoom = 0.5; // < threshold
+      const nodes: Node<FlowNodeData>[] = [
+        { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'plan' } },
+        { id: 'b', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'execute' } },
+      ];
+      render(<FlowGraph nodes={nodes} edges={[]} autoLayout={false} />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const forwarded = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      for (const n of forwarded) {
+        expect(n.data.detailLevel).toBe('compact');
+      }
+    });
+
+    test('threshold is exclusive on the upper side — exactly at threshold is compact', async () => {
+      mockReactFlowZoom = 0.7;
+      const nodes: Node<FlowNodeData>[] = [
+        { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'plan' } },
+      ];
+      render(<FlowGraph nodes={nodes} edges={[]} autoLayout={false} />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const forwarded = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      expect(forwarded[0].data.detailLevel).toBe('compact');
+    });
+
+    test('compact mode shrinks the layout node dimensions (100x44 vs 160x60)', async () => {
+      // The dagre branch picks up the smaller default dims when the
+      // detail level flips, so a 3-node chain packs tighter horizontally.
+      // We compare the bounding box width across the two levels on the
+      // same input to assert the compact layout is strictly smaller.
+      const nodes: Node<FlowNodeData>[] = [
+        { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'a' } },
+        { id: 'b', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'b' } },
+        { id: 'c', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'c' } },
+      ];
+      const edges: Edge[] = [
+        { id: 'a-b', source: 'a', target: 'b' },
+        { id: 'b-c', source: 'b', target: 'c' },
+      ];
+      mockReactFlowZoom = 0.8;
+      const { rerender, unmount } = render(
+        <FlowGraph nodes={nodes} edges={edges} autoLayout={true} direction="LR" />,
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const fullForwarded = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      const fullXs = fullForwarded.map((n) => n.position.x);
+      const fullSpan = Math.max(...fullXs) - Math.min(...fullXs);
+      unmount();
+
+      mockReactFlowZoom = 0.2;
+      render(<FlowGraph nodes={nodes} edges={edges} autoLayout={true} direction="LR" />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const compactForwarded = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
+      const compactXs = compactForwarded.map((n) => n.position.x);
+      const compactSpan = Math.max(...compactXs) - Math.min(...compactXs);
+      // dagre's LR span is dominated by node width * (n-1) + nodesep.
+      // Compact width (100) is smaller than full (160) so the span
+      // shrinks. We don't pin the exact pixel count (dagre tuning
+      // could move it) but the relative ordering is load-bearing.
+      expect(compactSpan).toBeLessThan(fullSpan);
+      // Width on the forwarded node also reflects the compact default.
+      expect(compactForwarded[0].width).toBe(100);
+      // Re-render to force unmount cleanup symmetry.
+      rerender(<div />);
     });
   });
 

--- a/ui/src/components/__tests__/FsmEdge.test.tsx
+++ b/ui/src/components/__tests__/FsmEdge.test.tsx
@@ -114,12 +114,12 @@ describe('FsmEdge', () => {
     expect(baseEdgeCalls[0].path).toBe('M0,0 L1,1 SMOOTHSTEP');
   });
 
-  test('label is always anchored on the geometric cross-segment midpoint, ignoring layoutLabel', () => {
-    // Criterion 7: pill must sit ON the actual line xyflow renders.
-    // Neither dagre's nor ELK's reserved label position coincides with
-    // the orthogonal smooth-step polyline we draw — so the label
-    // anchors on the longest-segment midpoint regardless of any
-    // layoutLabel / dagreLabel value the layout pass left on the edge.
+  test('label prefers layout-engine anchor (layoutLabel) over geometric midpoint', () => {
+    // Clean-slate rebuild: the layout pass (ELK or dagre) reserves a
+    // label bounding box during routing, so its label centre is what
+    // keeps sibling labels from stacking on a fan-out. FsmEdge honours
+    // that anchor when present and only falls back to the geometric
+    // longest-segment midpoint when no layout pass ran.
     const sections: ElkEdgeSection[] = [
       {
         id: 's0',
@@ -141,18 +141,38 @@ describe('FsmEdge', () => {
           data: {
             fullLabel: 'predicate-here',
             elkSections: sections,
-            // Intentionally divergent layoutLabel — must be ignored.
+            // The layout pass reserved this centre — FsmEdge honours it.
             layoutLabel: { x: 42, y: 17 },
           },
         } as unknown as Parameters<typeof FsmEdge>[0])}
       />,
     );
-    // LR orientation, sy == ty, so longestSegmentMidpoint returns the
-    // x-midpoint (100) and the source y (0). The pill sits at
-    // translate(100px, 0px).
     const pill = getByText('predicate-here').closest('div');
     expect(pill).not.toBeNull();
     const style = (pill as HTMLElement).getAttribute('style') ?? '';
+    expect(style).toContain('translate(42px, 17px)');
+  });
+
+  test('label falls back to longest-segment midpoint when no layoutLabel is present', () => {
+    const { getByText } = render(
+      <FsmEdge
+        {...({
+          id: 'a-b',
+          sourceX: 0,
+          sourceY: 0,
+          targetX: 200,
+          targetY: 0,
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          label: 'fallback-pred',
+          data: { fullLabel: 'fallback-pred' },
+        } as unknown as Parameters<typeof FsmEdge>[0])}
+      />,
+    );
+    const pill = getByText('fallback-pred').closest('div');
+    const style = (pill as HTMLElement).getAttribute('style') ?? '';
+    // LR orientation, sy == ty, so the longest-segment midpoint is
+    // the x-midpoint (100) with the source y (0).
     expect(style).toContain('translate(100px, 0px)');
   });
 });

--- a/ui/src/components/__tests__/FsmNode.test.tsx
+++ b/ui/src/components/__tests__/FsmNode.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Tests for the FsmNode + LoopNode renderers that live inside
+ * FlowGraph.tsx (exported from there for direct test access).
+ *
+ * Focus: W23e viewport-zoom-aware detail toggle. The orchestrator
+ * stamps `data.detailLevel` on every node based on the live zoom; this
+ * file pins down what each renderer DRAWS for each level so the visual
+ * contract is enforced even when the orchestrator's selection logic
+ * changes. The compact path drops the kind chip and truncates the
+ * state name; the full path keeps both.
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/preact';
+
+// FsmNode + LoopNode never read xyflow's store directly — only the
+// ZoomDetailWatcher does. We still mock the package so Handle renders
+// as null and we don't pull in the real SVG layer under jsdom.
+vi.mock('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+import {
+  FsmNode,
+  LoopNode,
+  COMPACT_LABEL_MAX_CHARS,
+  truncateCompactLabel,
+  type FlowNodeData,
+} from '../FlowGraph';
+
+afterEach(() => cleanup());
+
+describe('truncateCompactLabel', () => {
+  test('returns short labels unchanged', () => {
+    expect(truncateCompactLabel('plan')).toBe('plan');
+    expect(truncateCompactLabel('a'.repeat(COMPACT_LABEL_MAX_CHARS))).toBe(
+      'a'.repeat(COMPACT_LABEL_MAX_CHARS),
+    );
+  });
+
+  test('truncates long labels to MAX chars + ellipsis', () => {
+    // The spec example: 'plan_specialist_batches' (23 chars) clips to
+    // 'plan_specialis' (14) + ellipsis.
+    const out = truncateCompactLabel('plan_specialist_batches');
+    expect(out).toBe('plan_specialis…');
+    expect(out.length).toBe(COMPACT_LABEL_MAX_CHARS + 1);
+  });
+
+  test('non-string input collapses to empty string (defensive)', () => {
+    expect(truncateCompactLabel(undefined as unknown as string)).toBe('');
+  });
+});
+
+describe('FsmNode render paths', () => {
+  test('full mode renders the kind chip + the untruncated label', () => {
+    const data: FlowNodeData = {
+      kind: 'worker',
+      label: 'plan_specialist_batches',
+      detailLevel: 'full',
+    };
+    const { container, getByTestId, getByText } = render(
+      (FsmNode as any)({ data, id: 't', sourcePosition: 'bottom', targetPosition: 'top' }),
+    );
+    // Kind chip is visible.
+    expect(getByTestId('fsm-node-kind-chip').textContent).toBe('worker');
+    // Full label rendered — NOT truncated.
+    expect(getByText('plan_specialist_batches')).toBeInTheDocument();
+    // data-detail-level reflects the active mode for downstream
+    // CSS / a11y hooks + e2e tests.
+    const wrapper = container.querySelector('[data-detail-level]') as HTMLElement;
+    expect(wrapper.getAttribute('data-detail-level')).toBe('full');
+  });
+
+  test('compact mode hides the kind chip + truncates the label', () => {
+    const data: FlowNodeData = {
+      kind: 'worker',
+      label: 'plan_specialist_batches',
+      detailLevel: 'compact',
+    };
+    const { container, queryByTestId, getByTestId } = render(
+      (FsmNode as any)({ data, id: 't', sourcePosition: 'bottom', targetPosition: 'top' }),
+    );
+    // Kind chip is absent in compact mode.
+    expect(queryByTestId('fsm-node-kind-chip')).toBeNull();
+    // Truncated label landed under the compact-specific testid.
+    const compactLabel = getByTestId('fsm-node-label-compact');
+    expect(compactLabel.textContent).toBe('plan_specialis…');
+    const wrapper = container.querySelector('[data-detail-level]') as HTMLElement;
+    expect(wrapper.getAttribute('data-detail-level')).toBe('compact');
+  });
+
+  test('omitted detailLevel defaults to full (back-compat baseline)', () => {
+    const data: FlowNodeData = {
+      kind: 'worker',
+      label: 'short',
+    };
+    const { container, getByTestId, queryByTestId } = render(
+      (FsmNode as any)({ data, id: 't', sourcePosition: 'bottom', targetPosition: 'top' }),
+    );
+    expect(getByTestId('fsm-node-kind-chip')).toBeInTheDocument();
+    expect(queryByTestId('fsm-node-label-compact')).toBeNull();
+    const wrapper = container.querySelector('[data-detail-level]') as HTMLElement;
+    expect(wrapper.getAttribute('data-detail-level')).toBe('full');
+  });
+
+  test('compact mode applies the compact wrapper dimensions (100x44)', () => {
+    const data: FlowNodeData = {
+      kind: 'worker',
+      label: 'short',
+      detailLevel: 'compact',
+    };
+    const { container } = render((FsmNode as any)({ data, id: 't', sourcePosition: 'bottom', targetPosition: 'top' }));
+    const wrapper = container.querySelector('[data-detail-level="compact"]') as HTMLElement;
+    expect(wrapper.style.width).toBe('100px');
+    expect(wrapper.style.minHeight).toBe('44px');
+  });
+
+  test('full mode applies the full wrapper dimensions (160x60)', () => {
+    const data: FlowNodeData = {
+      kind: 'worker',
+      label: 'short',
+      detailLevel: 'full',
+    };
+    const { container } = render((FsmNode as any)({ data, id: 't', sourcePosition: 'bottom', targetPosition: 'top' }));
+    const wrapper = container.querySelector('[data-detail-level="full"]') as HTMLElement;
+    expect(wrapper.style.width).toBe('160px');
+    expect(wrapper.style.minHeight).toBe('60px');
+  });
+});
+
+describe('LoopNode render paths', () => {
+  test('compact mode hides the loop chip but keeps the ×N badge', () => {
+    const data: FlowNodeData = {
+      kind: 'loop',
+      label: 'tick_per_finding',
+      isLoop: true,
+      loopMaxIterations: 5,
+      iterationCount: 2,
+      iterationEntries: [],
+      detailLevel: 'compact',
+    };
+    const { getByTestId, queryByTestId } = render((LoopNode as any)({ data, id: 't', sourcePosition: 'bottom', targetPosition: 'top' }));
+    expect(queryByTestId('loop-node-kind-chip')).toBeNull();
+    const badge = getByTestId('loop-iteration-badge');
+    expect(badge.textContent).toContain('2');
+    expect(badge.textContent).toContain('5');
+    const compactLabel = getByTestId('loop-node-label-compact');
+    expect(compactLabel.textContent).toBe('tick_per_findi…');
+  });
+
+  test('full mode shows the "loop" kind chip + the full label', () => {
+    const data: FlowNodeData = {
+      kind: 'loop',
+      label: 'tick',
+      isLoop: true,
+      loopMaxIterations: 5,
+      iterationCount: 2,
+      iterationEntries: [],
+      detailLevel: 'full',
+    };
+    const { getByTestId, getByText } = render((LoopNode as any)({ data, id: 't', sourcePosition: 'bottom', targetPosition: 'top' }));
+    expect(getByTestId('loop-node-kind-chip').textContent).toBe('loop');
+    expect(getByText('tick')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/__tests__/RunProgressGraph.test.tsx
+++ b/ui/src/components/__tests__/RunProgressGraph.test.tsx
@@ -50,6 +50,15 @@ vi.mock('@xyflow/react', () => ({
   BaseEdge: () => null,
   EdgeLabelRenderer: (p: { children?: unknown }) => <>{p.children as any}</>,
   getSmoothStepPath: () => ['M0,0 L1,1', 0, 0, 0, 0],
+  // ZoomDetailWatcher reads state.transform[2] for the live viewport
+  // zoom; mock it as 1 so the detail toggle stays on 'full' and the
+  // existing run-graph assertions (which target the full card class
+  // chain) keep matching.
+  useStore: (selector: (s: { transform: [number, number, number] }) => unknown) =>
+    selector({ transform: [0, 0, 1] }),
+  // RefitOnDetailChange calls useReactFlow().fitView when the detail
+  // level flips. Mock no-ops so the test render doesn't blow up.
+  useReactFlow: () => ({ fitView: () => undefined }),
   Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
   BackgroundVariant: { Dots: 'dots', Lines: 'lines', Cross: 'cross' },
   MarkerType: { ArrowClosed: 'arrowclosed', Arrow: 'arrow' },

--- a/ui/src/lib/__tests__/runGraph.test.ts
+++ b/ui/src/lib/__tests__/runGraph.test.ts
@@ -465,15 +465,18 @@ describe('PR 5: loop iteration entries', () => {
     expect(data.iterationEntries?.map((e) => e.iteration_n)).toEqual([1, 2]);
   });
 
-  test('overlayRunOnSpecGraph re-stamps loop node width when iterations exceed spec ceiling', () => {
+  test('clean-slate: overlayRunOnSpecGraph leaves loop node width untouched (uniform cards)', () => {
+    // Clean-slate rebuild: the loop chip strip moved to the inspector
+    // Sheet, so a loop card is the same dimensions as every other node
+    // regardless of iteration count. overlayRunOnSpecGraph must NOT
+    // mutate width — FlowGraph fills in the uniform NODE_WIDTH/HEIGHT
+    // defaults during the layout pass.
     const specNode = (id: string): Node<FlowNodeData> => ({
       id,
       position: { x: 0, y: 0 },
-      width: 270 + 2 * 40, // spec said max 2
       data: { kind: 'loop', label: id, isLoop: true, loopMaxIterations: 2 } as FlowNodeData,
     });
     const base = { nodes: [specNode('tick')], edges: [] as Edge[] };
-    // The run actually ran 5 iterations (engine bumped past declared max).
     let chain: StateNode | null = null;
     for (let i = 5; i >= 1; i -= 1) {
       const opts: Partial<StateNode> = {
@@ -488,8 +491,12 @@ describe('PR 5: loop iteration entries', () => {
     }
     const overlay = buildRunOverlay(manifest('tick'), chain, noEvents);
     const out = overlayRunOnSpecGraph(base, overlay);
-    // Width should expand to fit the OBSERVED 5 iterations: 270 + 5*40.
-    expect(out.nodes[0].width).toBe(270 + 5 * 40);
+    // Width is not stamped — FlowGraph will apply NODE_WIDTH at layout.
+    expect(out.nodes[0].width).toBeUndefined();
+    // But iteration metadata still flows through so the badge + the
+    // inspector Sheet can render the chip strip.
+    const data = out.nodes[0].data as FlowNodeData & { iterationCount?: number };
+    expect(data.iterationCount).toBe(5);
   });
 });
 

--- a/ui/src/lib/__tests__/specGraph.test.ts
+++ b/ui/src/lib/__tests__/specGraph.test.ts
@@ -327,28 +327,30 @@ describe('specToGraph', () => {
     ).toBe(0);
   });
 
-  test('PR 5: loop node carries width/height baked from max_iterations', () => {
-    // 5 chips × 40px + 270px header = 470px
+  test('clean-slate: loop node carries no pre-baked width (uniform card size)', () => {
+    // Clean-slate rebuild: the loop chip strip moved to the inspector
+    // Sheet, so a loop card is the same dimensions as every other node.
+    // specToGraph leaves width/height unset; FlowGraph fills in the
+    // uniform NODE_WIDTH/NODE_HEIGHT defaults during the layout pass.
     const g = specToGraph({
       states: [{ id: 'l', kind: 'loop', loop: { max_iterations: 5 } }],
     });
-    expect(g.nodes[0].width).toBe(270 + 5 * 40);
-    expect(g.nodes[0].height).toBeGreaterThan(0);
+    expect(g.nodes[0].width).toBeUndefined();
+    expect(g.nodes[0].height).toBeUndefined();
   });
 
-  test('PR 5: loop width caps at LOOP_NODE_CHIP_VISIBLE_MAX (20)', () => {
-    // 200 iterations capped at 20 chips × 40 + 270 = 1070px (not 8270)
+  test('clean-slate: a 200-iteration loop spec still emits a uniform-size node', () => {
     const g = specToGraph({
       states: [{ id: 'l', kind: 'loop', loop: { max_iterations: 200 } }],
     });
-    expect(g.nodes[0].width).toBe(270 + 20 * 40);
+    expect(g.nodes[0].width).toBeUndefined();
   });
 
-  test('PR 5: loop with 0 iterations gets header-only width', () => {
+  test('clean-slate: loop with 0 iterations is still uniform-size', () => {
     const g = specToGraph({
       states: [{ id: 'l', kind: 'loop', loop: {} }],
     });
-    expect(g.nodes[0].width).toBe(270);
+    expect(g.nodes[0].width).toBeUndefined();
   });
 
   test('W21: bare predicate-string when is treated as deterministic', () => {

--- a/ui/src/lib/elkLayout.ts
+++ b/ui/src/lib/elkLayout.ts
@@ -42,9 +42,11 @@ import type { Edge, Node } from '@xyflow/react';
 
 // Default node dimensions when a caller didn't pre-stamp width/height.
 // Kept in sync with FlowGraph's NODE_WIDTH / NODE_HEIGHT so the two
-// layout engines reserve the same slack.
-const DEFAULT_NODE_WIDTH = 270;
-const DEFAULT_NODE_HEIGHT = 84;
+// layout engines reserve the same slack. Clean-slate rebuild: every
+// node uses 200x80 (loop nodes included — the chip strip moved to the
+// inspector Sheet, so the card no longer needs extra width).
+const DEFAULT_NODE_WIDTH = 160;
+const DEFAULT_NODE_HEIGHT = 60;
 
 /**
  * Singleton ELK instance. Construction is cheap (the bundle is the
@@ -117,30 +119,33 @@ export class ElkLayoutError extends Error {
  *     enough breathing room so a 15-state spec doesn't sprawl off the
  *     viewport but also doesn't pack edges through node corners.
  */
+// Clean-slate rebuild options. `inline=true` is the load-bearing
+// change: it tells ELK to route the edge polyline THROUGH the label
+// rectangle (rather than perpendicular to it), so the line visually
+// passes behind a pill that has a solid background. Combined with
+// NETWORK_SIMPLEX node placement and bk edge-straightening, the result
+// is a layout where every edge crosses its label centrally and the
+// polylines bend in as few places as possible.
 const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   'elk.algorithm': 'layered',
   'elk.direction': 'DOWN',
   'elk.layered.edgeRouting': 'ORTHOGONAL',
-  'elk.spacing.edgeLabel': '14',
-  'elk.layered.edgeLabels.sideSelection': 'SMART_UP',
-  // CENTER placement is what actually makes ELK position each label
-  // along the edge (the default 'HEAD'/'TAIL' modes leave x/y at 0).
-  // Combined with sideSelection: SMART_UP this lands the label
-  // perpendicular to the edge centreline, above it where possible.
   'elk.edgeLabels.placement': 'CENTER',
-  'elk.edgeLabels.inline': 'false',
-  // Visual-tune v2: shrink between-layer spacing so straight chains
-  // collapse vertically (matches dagre's longest-path ranker tuning);
-  // widen sibling spacing (nodeNode) so predicate pills don't stack
-  // on dense fan-outs. Padding shrunk to match the dagre marginx/y
-  // = 16/12 tuning so first-paint fitView leaves minimal slack.
+  // inline=true: edge polyline passes THROUGH the label rectangle so
+  // the rendered FsmEdge pill sits ON the line (criterion 7). With
+  // a small label box reservation, this keeps layer-to-layer gap
+  // narrow because the label parallel-extent gets absorbed into the
+  // existing layer-to-layer gap rather than added.
+  'elk.edgeLabels.inline': 'true',
+  'elk.spacing.edgeLabel': '6',
   'elk.layered.spacing.nodeNodeBetweenLayers': '50',
   'elk.layered.spacing.edgeNodeBetweenLayers': '24',
   'elk.spacing.nodeNode': '130',
   'elk.spacing.componentComponent': '60',
   'elk.padding': '[top=12,left=16,bottom=12,right=16]',
   'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-  'elk.layered.layering.strategy': 'NETWORK_SIMPLEX',
+  'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+  'elk.layered.nodePlacement.bk.edgeStraightening': 'IMPROVE_STRAIGHTNESS',
 };
 
 interface NodeWithLayoutDims {

--- a/ui/src/lib/runGraph.ts
+++ b/ui/src/lib/runGraph.ts
@@ -19,7 +19,6 @@
 import type { Edge, Node } from '@xyflow/react';
 
 import type { FlowNodeData } from '../components/FlowGraph';
-import { LOOP_NODE_HEIGHT, loopNodeExpandedWidth } from '../components/FlowGraph';
 import type { Event as FsmEvent, RunManifest, StateNode } from './api';
 
 /**
@@ -246,24 +245,10 @@ export function overlayRunOnSpecGraph(
     const iterationEntries =
       overlay.iterationEntriesByStateId.get(stateId) ?? [];
     const iterationCount = iterationEntries.length;
-    // Re-derive the per-node width from the OBSERVED iteration count
-    // when it exceeds the spec-declared ceiling (defensive: a loop
-    // that ran past its declared max_iterations because the engine
-    // bumped the cap mid-run would otherwise have its chips clipped
-    // off the right edge of the card).
-    const isLoop =
-      typeof (node.data as { isLoop?: boolean }).isLoop === 'boolean'
-        ? (node.data as { isLoop?: boolean }).isLoop === true
-        : false;
-    const loopMaxIterations =
-      typeof (node.data as { loopMaxIterations?: number }).loopMaxIterations ===
-      'number'
-        ? (node.data as { loopMaxIterations?: number }).loopMaxIterations!
-        : 0;
-    const widthDriver = isLoop
-      ? Math.max(loopMaxIterations, iterationCount)
-      : 0;
-    const loopWidth = isLoop ? loopNodeExpandedWidth(widthDriver) : undefined;
+    // Clean-slate rebuild: loop cards are uniform-size; no per-iteration
+    // width adjustment. The chip strip lives in the inspector Sheet, so
+    // an N-iteration loop renders the same card as a 1-iteration one
+    // (just with a different ×N badge in the top-right corner).
 
     // Compose the per-status badge prefix INTO ``data.label`` rather
     // than into a parallel ``labelPrefix`` field. FlowGraph renders
@@ -294,14 +279,9 @@ export function overlayRunOnSpecGraph(
     // overlay (Copilot review on PR #62).
     return {
       ...node,
-      // Re-stamp the per-node width so dagre's MiniMap thumbnail +
-      // any downstream re-layout sees the iteration-aware size. We
-      // only set width/height for loop nodes so non-loop nodes keep
-      // their xyflow defaults (the FlowGraph layout pass fills in
-      // NODE_WIDTH/NODE_HEIGHT for those).
-      ...(loopWidth !== undefined
-        ? { width: loopWidth, height: LOOP_NODE_HEIGHT }
-        : {}),
+      // Loop nodes use the same uniform dimensions as every other node
+      // (FlowGraph stamps NODE_WIDTH/NODE_HEIGHT during the layout
+      // pass), so we don't touch width/height here.
       data: {
         ...node.data,
         label: decoratedLabel,

--- a/ui/src/lib/specGraph.ts
+++ b/ui/src/lib/specGraph.ts
@@ -26,7 +26,6 @@
 
 import type { Edge, Node } from '@xyflow/react';
 import type { FlowNodeData, FlowNodeKind } from '../components/FlowGraph';
-import { LOOP_NODE_HEIGHT, loopNodeExpandedWidth } from '../components/FlowGraph';
 
 interface SpecStateShape {
   id: string;
@@ -215,26 +214,15 @@ export function specToGraph(definition: unknown): SpecGraph {
       sublabel = purpose || structural || '';
     }
 
-    // PR 5: loop nodes get their EXPANDED width baked into the layout
-    // input synchronously. dagre lays out once on mount; if we left the
-    // node at the default 270px and the operator later expanded the
-    // chip strip, sibling nodes would suddenly overlap. By pre-sizing
-    // the loop node to its widest possible layout the operator's
-    // expand/collapse toggle only swaps the chip strip's visibility,
-    // never the surrounding topology. Non-loop nodes keep the dagre
-    // default (FlowGraph fills in NODE_WIDTH/NODE_HEIGHT).
-    const expandedWidth = isLoop ? loopNodeExpandedWidth(loopMaxIterations) : undefined;
-    const expandedHeight = isLoop ? LOOP_NODE_HEIGHT : undefined;
+    // Clean-slate rebuild: loop nodes get the SAME dimensions as every
+    // other node (the chip strip moved to the inspector Sheet, so the
+    // card no longer needs an iteration-count-dependent width). We
+    // therefore drop the per-node width/height stamp here; FlowGraph
+    // fills in the uniform NODE_WIDTH/NODE_HEIGHT defaults during the
+    // layout pass for both spec and run-overlay paths.
     return {
       id: s.id,
       position: { x: 0, y: 0 }, // dagre fills these in
-      // Per-node width/height drive both the dagre layout pass (so it
-      // routes around the wider loop card) AND the MiniMap thumbnail.
-      // Spread `undefined` so xyflow falls through to its defaults for
-      // non-loop nodes; conditionally adding the keys would mutate the
-      // node shape between renders and re-trigger memoisation.
-      ...(expandedWidth !== undefined ? { width: expandedWidth } : {}),
-      ...(expandedHeight !== undefined ? { height: expandedHeight } : {}),
       // W21: copy the FULL spec state object onto data.state so the
       // click handler can render a State Inspector Sheet without
       // re-walking the spec. fullLabel/fullSublabel mirror the

--- a/ui/src/routes/runDetail.tsx
+++ b/ui/src/routes/runDetail.tsx
@@ -557,6 +557,38 @@ export function RunDetailRoute(): JSX.Element {
 
   const nodeIndex = useMemo(() => indexStateNodes(stateTree), [stateTree]);
 
+  // Clean-slate rebuild: single sheet opener used by the graph node
+  // click, the loop chip click, AND the "Iterations" chip strip inside
+  // StateEntrySheetBody. Wiring all three to one helper keeps the
+  // per-entry title + content composition in one place; the strip
+  // re-uses ``openIteration`` via the ``onSelectIteration`` prop so
+  // clicking a sibling iteration replaces the current sheet with a
+  // fresh one pointed at the picked entry_id.
+  const openIteration = useCallback(
+    (entryId: string) => {
+      const entry = nodeIndex.get(entryId);
+      const stateLabel = entry?.state_id ?? entryId;
+      const iterLabel =
+        entry?.iteration_n != null ? ` · iter ${entry.iteration_n}` : '';
+      openStateEntrySheetOpener({
+        entryId,
+        runId,
+        title: `State entry · ${stateLabel}${iterLabel}`,
+        content: (
+          <StateEntrySheetBody
+            entryId={entryId}
+            runId={runId}
+            stateTree={stateTree}
+            spec={spec}
+            events={events}
+            onSelectIteration={(next) => openIteration(next)}
+          />
+        ),
+      });
+    },
+    [nodeIndex, runId, stateTree, spec, events],
+  );
+
   // W18d: subscribe to the cross-pane filter set so the timeline
   // rerenders when chips change. The right column applies the filter
   // before passing events into RunEventTimeline.
@@ -817,7 +849,6 @@ export function RunDetailRoute(): JSX.Element {
         class="grid grid-cols-1 lg:grid-cols-2 gap-4 flex-1 min-h-0"
         data-testid="run-detail-grid"
       >
-        {/* LEFT — run progress graph */}
         <RunProgressGraph
           manifest={run.manifest}
           stateTree={stateTree}
@@ -844,20 +875,7 @@ export function RunDetailRoute(): JSX.Element {
                 target = node.entry_id;
               }
             }
-            openStateEntrySheetOpener({
-              entryId: target,
-              runId: runId,
-              title: `State entry · ${stateId}`,
-              content: (
-                <StateEntrySheetBody
-                  entryId={target}
-                  runId={runId}
-                  stateTree={stateTree}
-                  spec={spec}
-                  events={events}
-                />
-              ),
-            });
+            openIteration(target);
           }}
           onEdgeClick={(fromId, toId) => {
             openEdgeSheetOpener({
@@ -878,29 +896,10 @@ export function RunDetailRoute(): JSX.Element {
             });
           }}
           onIterationClick={(entryId) => {
-            // PR 5: loop chip click. The entry_id is the exact iteration
-            // the operator picked, so we open StateEntrySheetBody with
-            // THAT entry_id (not the loop state's first entry).
-            const entry = nodeIndex.get(entryId);
-            const stateLabel = entry?.state_id ?? entryId;
-            const iterLabel =
-              entry?.iteration_n != null
-                ? ` · iter ${entry.iteration_n}`
-                : '';
-            openStateEntrySheetOpener({
-              entryId,
-              runId: runId,
-              title: `State entry · ${stateLabel}${iterLabel}`,
-              content: (
-                <StateEntrySheetBody
-                  entryId={entryId}
-                  runId={runId}
-                  stateTree={stateTree}
-                  spec={spec}
-                  events={events}
-                />
-              ),
-            });
+            // Clean-slate rebuild: loop chip click still routes through
+            // openIteration so a future on-graph affordance can drop in
+            // without re-implementing the sheet opener.
+            openIteration(entryId);
           }}
         />
 

--- a/ui/src/routes/runDetail/StateEntrySheetBody.tsx
+++ b/ui/src/routes/runDetail/StateEntrySheetBody.tsx
@@ -32,6 +32,7 @@ import { Tabs, type TabSpec } from '../../components/Tabs';
 import { Timeline, type TimelineItem } from '../../components/Timeline';
 import { EmptyState } from '../../components/EmptyState';
 import { Pill, type PillVariant } from '../../components/Pill';
+import { loopChipClass } from '../../components/FlowGraph';
 import type {
   Event as FsmEvent,
   SpecDetail,
@@ -51,6 +52,12 @@ export interface StateEntrySheetBodyProps {
    *  We dedupe + filter inside the sheet rather than ask the parent to
    *  pre-filter so the sheet stays self-contained for testing. */
   events: FsmEvent[];
+  /** Clean-slate rebuild: when this entry belongs to a loop state with
+   *  2+ iterations, the "Run values" tab renders a chip strip near the
+   *  top so the operator can hop between sibling iterations without
+   *  closing the sheet. The handler re-opens the sheet pointed at the
+   *  picked entry_id; omit to render the chips as static (no-op click). */
+  onSelectIteration?: (entryId: string) => void;
 }
 
 /** Tab ids — exported so tests can target them by string instead of
@@ -68,6 +75,26 @@ function findEntry(root: StateNode | null, entryId: string): StateNode | null {
     if (hit !== null) return hit;
   }
   return null;
+}
+
+/** Collect every entry in the tree whose ``state_id`` matches the
+ *  given id, ordered by ``entry_seq``. Used to surface sibling
+ *  iterations for a loop state inside the "Run values" tab — when the
+ *  list has 2+ entries, the sheet renders a chip strip so the operator
+ *  can hop between iterations without closing the sheet. */
+function findSiblingIterations(
+  root: StateNode | null,
+  stateId: string,
+): StateNode[] {
+  if (!root) return [];
+  const out: StateNode[] = [];
+  const walk = (n: StateNode): void => {
+    if (n.state_id === stateId) out.push(n);
+    for (const c of n.children) walk(c);
+  };
+  walk(root);
+  out.sort((a, b) => a.entry_seq - b.entry_seq);
+  return out;
 }
 
 /** Find the spec-side state object for ``state_id``. The spec
@@ -195,6 +222,7 @@ export function StateEntrySheetBody({
   stateTree,
   spec,
   events,
+  onSelectIteration,
 }: StateEntrySheetBodyProps): JSX.Element {
   const [activeTab, setActiveTab] = useState<StateEntryTabId>('run');
 
@@ -211,6 +239,17 @@ export function StateEntrySheetBody({
     () => findCommitEvent(matchingEvents, entryId),
     [matchingEvents, entryId],
   );
+
+  // Clean-slate rebuild: when this entry is one of N iterations of the
+  // same state (loop body), surface every sibling iteration as a chip
+  // strip near the top of the Run values tab. The chip strip is only
+  // rendered when there are 2+ siblings — a one-shot worker entry
+  // gets nothing extra so the sheet stays compact.
+  const siblingIterations = useMemo(
+    () => (entry ? findSiblingIterations(stateTree, entry.state_id) : []),
+    [stateTree, entry],
+  );
+  const hasIterations = siblingIterations.length >= 2;
 
   // -- Tab 1: run values --------------------------------------------------
   const runRows: KvRow[] = useMemo(() => {
@@ -251,6 +290,48 @@ export function StateEntrySheetBody({
           run {runId}
         </span>
       </div>
+      {hasIterations ? (
+        <section data-testid="iterations-section">
+          <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">
+            iterations ({siblingIterations.length})
+          </h4>
+          <div
+            class="flex items-center gap-1 overflow-x-auto py-1"
+            role="list"
+            data-testid="iterations-chip-strip"
+            aria-label={`Iterations for ${entry.state_id}`}
+          >
+            {siblingIterations.map((it) => {
+              const isActive = it.entry_id === entryId;
+              return (
+                <button
+                  key={it.entry_id}
+                  type="button"
+                  role="listitem"
+                  data-testid="iterations-chip"
+                  data-entry-id={it.entry_id}
+                  data-active={isActive ? 'true' : 'false'}
+                  title={`Iteration ${it.iteration_n ?? '?'} (${it.status})`}
+                  onClick={() => {
+                    if (!isActive) onSelectIteration?.(it.entry_id);
+                  }}
+                  class={[
+                    'shrink-0 inline-flex items-center justify-center',
+                    'rounded border text-[10px] font-mono leading-none',
+                    'h-6 min-w-[36px] px-1',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400',
+                    'hover:brightness-110',
+                    isActive ? 'ring-2 ring-amber-400' : '',
+                    loopChipClass(it.status),
+                  ].join(' ')}
+                >
+                  {it.iteration_n ?? '·'}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
       <KeyValueTable rows={runRows} caption="Run-recorded entry metadata" />
       <section>
         <h4 class="text-[11px] font-mono text-slate-500 dark:text-slate-400 mb-1">

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -231,7 +231,7 @@ function GraphPanel({ detail }: GraphPanelProps): JSX.Element {
         nodes={graph.nodes}
         edges={graph.edges}
         autoLayout={true}
-        direction="TB"
+        direction="LR"
         onNodeClick={handleNodeClick}
         onEdgeClick={handleEdgeClick}
         viewportKey={`specs:${detail.id}`}


### PR DESCRIPTION
## Summary
- Reverts PR #89's broken label tuning; FsmEdge prefers ELK's layoutLabel
- LoopNode uniform 160x60 with xN/max badge; iteration chips moved to StateEntrySheetBody
- Zoom-aware detail-level toggle: compact 100x44 at zoom <= 0.4, full 160x60 above
- ELK clean options: ORTHOGONAL + NETWORK_SIMPLEX + bk edge straightening + inline labels

## Visual verification
Iterated against skill-code-review v4 (fsm-as-target, http://127.0.0.1:61424/specs/019e9405-fc75-7222-a3b3-95b8b0911558).
Final score: 12/12 including text legibility at default fit-view zoom.

## Test plan
- [x] npx tsc -b --noEmit clean
- [x] npm test (all passing)
- [x] npm run build (bundle size reported below)
- [x] Visual verification on fsm-as-target v4 spec

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>