### PR TITLE
ui: pin vertical orientation + clamp minZoom for legibility

### DIFF
--- a/ui/src/components/FlowGraph.tsx
+++ b/ui/src/components/FlowGraph.tsx
@@ -114,14 +114,14 @@ export interface FlowNodeData extends Record<string, unknown> {
 /** Zoom threshold below which (≤) the graph switches to compact cards.
  *  Exported so tests + the LoopNode can share the same number.
  *
- *  Raised from 0.4 to 0.7 so the dense 14-layer chains (e.g.
- *  skill-code-review v4) stay in compact mode at their natural
- *  fit-view zoom (~0.55-0.65 with compact ELK spacing). The previous
- *  0.4 threshold left them oscillating: full layout fit at 0.27 →
- *  flip to compact → compact layout fit at 0.65 → flip back to full.
- *  With 0.7 the compact layout's fit-view zoom stays in compact mode,
- *  breaking the cycle without forcing every tiny graph into compact. */
-export const DETAIL_LEVEL_ZOOM_THRESHOLD = 0.7;
+ *  Lowered back to 0.4 to pair with the React Flow ``minZoom={0.45}``
+ *  floor introduced alongside the vertical-orientation fix: at the new
+ *  minimum zoom the graph never settles in compact mode, so labels +
+ *  full-detail cards stay readable at the equilibrium fit-view zoom.
+ *  Compact mode now only kicks in for genuinely tiny zooms (the user
+ *  has to Cmd/Ctrl-wheel BELOW the floor, which means they've
+ *  explicitly requested the bird's-eye view). */
+export const DETAIL_LEVEL_ZOOM_THRESHOLD = 0.4;
 
 /** Maximum visible characters for a state-name label in compact mode.
  *  Anything longer is truncated to this prefix plus an ellipsis. The
@@ -151,8 +151,12 @@ export interface FlowGraphProps {
    * per-node position. Pass `false` if the caller has already assigned
    * positions (e.g. a saved manual layout) and wants them preserved. */
   autoLayout?: boolean;
-  /** Layout direction. Default 'TB' (top to bottom) — natural reading for
-   * FSMs, and fits a viewport-bounded panel better than LR for long chains. */
+  /** Layout direction. Pinned to 'TB' (top to bottom) — vertical
+   *  orientation is a product-level invariant for both the spec graph
+   *  and the run graph. The prop is preserved for back-compat callers
+   *  but its value is ignored: every render lays out top-to-bottom and
+   *  stamps Top/Bottom handle anchors. Future re-introduction of
+   *  horizontal layout would resurrect this enum. */
   direction?: 'LR' | 'TB';
   /** Click handler on a node (e.g. open the state-details Sheet). */
   onNodeClick?: (id: string, data: FlowNodeData) => void;
@@ -672,7 +676,10 @@ function RefitOnDetailChange({
     // React state) has committed and the new node positions exist
     // before we measure their bbox.
     const handle = requestAnimationFrame(() => {
-      fitView({ padding: 0.05, includeHiddenNodes: false, minZoom: 0.2, maxZoom: 1.5 });
+      // minZoom mirrors the floor pinned on the ReactFlow root so a
+      // detail-level flip never refits us BELOW the threshold (which
+      // would re-trigger the compact transition and oscillate).
+      fitView({ padding: 0.05, includeHiddenNodes: false, minZoom: 0.45, maxZoom: 1.5 });
     });
     return () => cancelAnimationFrame(handle);
   }, [detailLevel, enabled, fitView]);
@@ -1102,14 +1109,18 @@ export function FlowGraph({
   // computes a zoom <= the threshold.
   const [detailLevel, setDetailLevel] = useState<DetailLevel>('full');
 
-  // Manual-layout branch: identical to before — preserve caller
-  // positions, stamp direction-aware handle sides, dispatch loop vs
-  // fsm node type. Defaults flip with the detail level so a manual
-  // layout's nodes still pick up the compact dims when active.
+  // Manual-layout branch: preserve caller positions, stamp Top/Bottom
+  // handle sides (TB layout is now pinned regardless of the `direction`
+  // prop — see prop doc above), dispatch loop vs fsm node type.
+  // Defaults flip with the detail level so a manual layout's nodes
+  // still pick up the compact dims when active.
   const manualPositioned = useMemo(() => {
     if (autoLayout) return null;
-    const sp = direction === 'LR' ? Position.Right : Position.Bottom;
-    const tp = direction === 'LR' ? Position.Left : Position.Top;
+    // Vertical orientation invariant: source handle anchors at the
+    // bottom of the card, target handle at the top.
+    void direction; // referenced for back-compat callers; value ignored.
+    const sp = Position.Bottom;
+    const tp = Position.Top;
     const dims = NODE_DIMS_BY_DETAIL[detailLevel];
     return nodes.map((n) => {
       const isLoop = (n.data as { isLoop?: boolean } | undefined)?.isLoop === true;
@@ -1127,12 +1138,15 @@ export function FlowGraph({
   // Dagre auto-layout branch: synchronous and cheap (the existing
   // implementation). W23e: we cache BOTH detail-level layouts and pick
   // the one matching the active `detailLevel` so toggling zoom doesn't
-  // re-pay the (sync, but visible) dagre cost.
+  // re-pay the (sync, but visible) dagre cost. Direction is pinned to
+  // 'TB' regardless of the prop so the dagre fallback matches the ELK
+  // vertical-orientation invariant.
   const dagreLayouts = useMemo(() => {
     if (!autoLayout) return null;
+    void direction; // back-compat only; layout is TB.
     return {
-      full: applyDagreLayout(nodes, edges, direction, NODE_DIMS_BY_DETAIL.full),
-      compact: applyDagreLayout(nodes, edges, direction, NODE_DIMS_BY_DETAIL.compact),
+      full: applyDagreLayout(nodes, edges, 'TB', NODE_DIMS_BY_DETAIL.full),
+      compact: applyDagreLayout(nodes, edges, 'TB', NODE_DIMS_BY_DETAIL.compact),
     };
   }, [nodes, edges, autoLayout, direction]);
   const dagreLayout = dagreLayouts?.[detailLevel] ?? null;
@@ -1191,9 +1205,11 @@ export function FlowGraph({
     };
     const fullPromise = applyElkLayout(buildInput('full'), edges, {
       labelDimensions,
-      layoutOptions: {
-        'elk.direction': direction === 'LR' ? 'RIGHT' : 'DOWN',
-      },
+      // Direction is pinned to DOWN inside the ELK wrapper itself;
+      // omit it from the per-call override block. The ``direction``
+      // prop only governs handle anchor sides (Top/Bottom) at the
+      // React Flow layer.
+      layoutOptions: {},
     });
     // Compact-mode layout: clamp the per-edge label box to a small
     // square (24x12) so ELK reserves enough slack to keep labels OFF
@@ -1214,7 +1230,7 @@ export function FlowGraph({
     const compactPromise = applyElkLayout(buildInput('compact'), edges, {
       labelDimensions: compactLabelDimensions,
       layoutOptions: {
-        'elk.direction': direction === 'LR' ? 'RIGHT' : 'DOWN',
+        // Direction pinned to DOWN inside the ELK wrapper; omit here.
         // Tight spacing — the compact pip + small card means we can
         // pack 14 layers into ~1500 px wide and clear fit-view 0.6+.
         // Tested with skill-code-review v4 (18 nodes / 14 layers LR):
@@ -1269,9 +1285,12 @@ export function FlowGraph({
     const usingElk =
       layoutEngine === 'elk' && !elkFailed && elkLayout !== null;
     if (usingElk) {
-      // Build positioned nodes from the ELK result.
-      const sp = direction === 'LR' ? Position.Right : Position.Bottom;
-      const tp = direction === 'LR' ? Position.Left : Position.Top;
+      // Build positioned nodes from the ELK result. Vertical
+      // orientation invariant: source handle at the bottom, target at
+      // the top, matching the pinned 'elk.direction'='DOWN'.
+      void direction;
+      const sp = Position.Bottom;
+      const tp = Position.Top;
       const dims = NODE_DIMS_BY_DETAIL[detailLevel];
       const elkNodes = nodes.map((n) => {
         const isLoop = (n.data as { isLoop?: boolean } | undefined)?.isLoop === true;
@@ -1470,8 +1489,18 @@ export function FlowGraph({
         // the operator has zoomed/panned and the viewport is saved,
         // restoring it on remount beats re-framing the whole graph.
         fitView={viewport.defaultViewport === undefined}
-        fitViewOptions={{ padding: 0.05, includeHiddenNodes: false, minZoom: 0.2, maxZoom: 1.5 }}
-        minZoom={0.15}
+        // Min-zoom floor is 0.45 so the equilibrium fit-view zoom sits
+        // ABOVE DETAIL_LEVEL_ZOOM_THRESHOLD (0.4). Without this floor a
+        // tall TB chain (e.g. 14-layer skill-code-review v4) framed by
+        // fitView lands at ~0.55-0.65 zoom, then ZoomDetailWatcher flips
+        // detailLevel='compact' and the labels collapse to pips —
+        // perceptually "min zoom is too low". With minZoom=0.45 the
+        // fitView is clamped above the compact threshold and the graph
+        // renders at full detail by default; the operator pans (drag or
+        // wheel) to navigate a long chain. Cmd/Ctrl+wheel still zooms
+        // in to maxZoom=2 if they want detail.
+        fitViewOptions={{ padding: 0.05, includeHiddenNodes: false, minZoom: 0.45, maxZoom: 1.5 }}
+        minZoom={0.45}
         maxZoom={2}
         defaultViewport={viewport.defaultViewport}
         onMove={viewportKey ? viewport.onMove : undefined}

--- a/ui/src/components/__tests__/FlowGraph.test.tsx
+++ b/ui/src/components/__tests__/FlowGraph.test.tsx
@@ -83,17 +83,21 @@ describe('FlowGraph', () => {
       { id: 'a-b', source: 'a', target: 'b' },
       { id: 'b-c', source: 'b', target: 'c' },
     ];
+    // Direction is now pinned to TB regardless of the prop value. The
+    // legacy LR prop is preserved for back-compat but ignored — the
+    // chain stacks vertically, so the y-coordinates differ.
     render(<FlowGraph nodes={nodes} edges={edges} autoLayout={true} direction="LR" />);
     const positioned = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
-    // Dagre lays out in a chain; positions must differ across all three nodes.
-    const xs = positioned.map((n) => n.position.x);
-    const uniqueX = new Set(xs);
-    expect(uniqueX.size).toBe(3);
+    // TB layout: dagre stacks ranks vertically, so y differs across
+    // all three nodes.
+    const ys = positioned.map((n) => n.position.y);
+    const uniqueY = new Set(ys);
+    expect(uniqueY.size).toBe(3);
     // All nodes should be tagged with our custom node type.
     expect(positioned.every((n) => n.type === 'fsmNode')).toBe(true);
   });
 
-  test('autoLayout=false preserves caller positions but stamps direction-aware handle sides', () => {
+  test('autoLayout=false preserves caller positions and stamps TB handle sides regardless of direction prop', () => {
     const nodes: Node<FlowNodeData>[] = [
       { id: 'a', position: { x: 100, y: 200 }, data: { kind: 'state', label: 'a' } },
     ];
@@ -107,13 +111,15 @@ describe('FlowGraph', () => {
     expect(passedTB[0].targetPosition).toBe('top');
     expect(passedTB[0].type).toBe('fsmNode');
 
-    // Same nodes but LR direction → handles flip to right/left.
+    // direction="LR" is now ignored — vertical orientation is the
+    // product-level invariant for both the spec graph and the run
+    // graph, so the handles still stamp bottom/top.
     render(<FlowGraph nodes={nodes} edges={[]} autoLayout={false} direction="LR" />);
     const passedLR = lastReactFlowProps!.nodes as Array<
       Node<FlowNodeData> & { sourcePosition?: string; targetPosition?: string }
     >;
-    expect(passedLR[0].sourcePosition).toBe('right');
-    expect(passedLR[0].targetPosition).toBe('left');
+    expect(passedLR[0].sourcePosition).toBe('bottom');
+    expect(passedLR[0].targetPosition).toBe('top');
   });
 
   test('selectedNodeId decorates the matching node with selected=true', () => {
@@ -813,7 +819,11 @@ describe('FlowGraph', () => {
 
     test('zoom above threshold renders detailLevel=full on every node', async () => {
       const { DETAIL_LEVEL_ZOOM_THRESHOLD } = await import('../FlowGraph');
-      expect(DETAIL_LEVEL_ZOOM_THRESHOLD).toBe(0.7);
+      // Threshold lowered to 0.4 to pair with the React Flow
+      // minZoom=0.45 floor — the equilibrium fit-view zoom (clamped to
+      // 0.45) now sits ABOVE the threshold so full detail stays on by
+      // default. Compact mode only activates below 0.4.
+      expect(DETAIL_LEVEL_ZOOM_THRESHOLD).toBe(0.4);
       mockReactFlowZoom = 0.9; // > threshold
       const nodes: Node<FlowNodeData>[] = [
         { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'plan' } },
@@ -833,7 +843,7 @@ describe('FlowGraph', () => {
     });
 
     test('zoom at or below threshold renders detailLevel=compact on every node', async () => {
-      mockReactFlowZoom = 0.5; // < threshold
+      mockReactFlowZoom = 0.3; // < threshold (0.4)
       const nodes: Node<FlowNodeData>[] = [
         { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'plan' } },
         { id: 'b', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'execute' } },
@@ -849,7 +859,7 @@ describe('FlowGraph', () => {
     });
 
     test('threshold is exclusive on the upper side — exactly at threshold is compact', async () => {
-      mockReactFlowZoom = 0.7;
+      mockReactFlowZoom = 0.4;
       const nodes: Node<FlowNodeData>[] = [
         { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'plan' } },
       ];
@@ -863,9 +873,10 @@ describe('FlowGraph', () => {
 
     test('compact mode shrinks the layout node dimensions (100x44 vs 160x60)', async () => {
       // The dagre branch picks up the smaller default dims when the
-      // detail level flips, so a 3-node chain packs tighter horizontally.
-      // We compare the bounding box width across the two levels on the
-      // same input to assert the compact layout is strictly smaller.
+      // detail level flips, so a 3-node chain packs tighter vertically
+      // (layout is pinned to TB). We compare the bounding-box HEIGHT
+      // across the two levels on the same input to assert the compact
+      // layout is strictly smaller.
       const nodes: Node<FlowNodeData>[] = [
         { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'a' } },
         { id: 'b', position: { x: 0, y: 0 }, data: { kind: 'worker', label: 'b' } },
@@ -875,28 +886,31 @@ describe('FlowGraph', () => {
         { id: 'a-b', source: 'a', target: 'b' },
         { id: 'b-c', source: 'b', target: 'c' },
       ];
+      // Below DETAIL_LEVEL_ZOOM_THRESHOLD (0.4) the renderer flips to
+      // compact; above it stays full. Use values that straddle the
+      // threshold so the two renders genuinely pick different layouts.
       mockReactFlowZoom = 0.8;
       const { rerender, unmount } = render(
-        <FlowGraph nodes={nodes} edges={edges} autoLayout={true} direction="LR" />,
+        <FlowGraph nodes={nodes} edges={edges} autoLayout={true} />,
       );
       await act(async () => {
         await Promise.resolve();
       });
       const fullForwarded = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
-      const fullXs = fullForwarded.map((n) => n.position.x);
-      const fullSpan = Math.max(...fullXs) - Math.min(...fullXs);
+      const fullYs = fullForwarded.map((n) => n.position.y);
+      const fullSpan = Math.max(...fullYs) - Math.min(...fullYs);
       unmount();
 
       mockReactFlowZoom = 0.2;
-      render(<FlowGraph nodes={nodes} edges={edges} autoLayout={true} direction="LR" />);
+      render(<FlowGraph nodes={nodes} edges={edges} autoLayout={true} />);
       await act(async () => {
         await Promise.resolve();
       });
       const compactForwarded = lastReactFlowProps!.nodes as Node<FlowNodeData>[];
-      const compactXs = compactForwarded.map((n) => n.position.x);
-      const compactSpan = Math.max(...compactXs) - Math.min(...compactXs);
-      // dagre's LR span is dominated by node width * (n-1) + nodesep.
-      // Compact width (100) is smaller than full (160) so the span
+      const compactYs = compactForwarded.map((n) => n.position.y);
+      const compactSpan = Math.max(...compactYs) - Math.min(...compactYs);
+      // dagre's TB span is dominated by node height * (n-1) + ranksep.
+      // Compact height (44) is smaller than full (60) so the span
       // shrinks. We don't pin the exact pixel count (dagre tuning
       // could move it) but the relative ordering is load-bearing.
       expect(compactSpan).toBeLessThan(fullSpan);
@@ -905,6 +919,29 @@ describe('FlowGraph', () => {
       // Re-render to force unmount cleanup symmetry.
       rerender(<div />);
     });
+  });
+
+  test('ReactFlow receives minZoom=0.45 and maxZoom=2 so the equilibrium zoom never settles in compact mode', () => {
+    // The user reported "min zoom is too low" because the run graph's
+    // fit-view zoom landed in compact mode (labels collapsed to pips).
+    // The fix pins the React Flow minZoom floor ABOVE
+    // DETAIL_LEVEL_ZOOM_THRESHOLD so fit-view + compact mode never
+    // overlap by default. maxZoom is pinned at the React Flow default
+    // (2) so Cmd/Ctrl+wheel zoom-in stays useful.
+    const nodes: Node<FlowNodeData>[] = [
+      { id: 'a', position: { x: 0, y: 0 }, data: { kind: 'state', label: 'a' } },
+    ];
+    render(<FlowGraph nodes={nodes} edges={[]} autoLayout={false} />);
+    expect(lastReactFlowProps!.minZoom).toBe(0.45);
+    expect(lastReactFlowProps!.maxZoom).toBe(2);
+    // fitViewOptions are clamped to the same floor so the initial
+    // frame can't undershoot the minZoom prop.
+    const fvo = lastReactFlowProps!.fitViewOptions as {
+      minZoom?: number;
+      maxZoom?: number;
+    };
+    expect(fvo.minZoom).toBe(0.45);
+    expect(fvo.maxZoom).toBe(1.5);
   });
 
   test('default direction is TB (top-to-bottom) when not specified', () => {

--- a/ui/src/components/__tests__/RunProgressGraph.test.tsx
+++ b/ui/src/components/__tests__/RunProgressGraph.test.tsx
@@ -190,6 +190,53 @@ describe('RunProgressGraph — PR 4 additions', () => {
     expect(onEdgeClick).toHaveBeenCalledWith('plan', 'execute');
   });
 
+  test('the run graph inherits the minZoom=0.45 + maxZoom=2 floor from FlowGraph', async () => {
+    // The user's "can't zoom in / labels disappear" symptom was the
+    // run graph: fitView landed at a zoom in compact-mode territory,
+    // collapsing the per-edge predicate labels to a pip. Pinning the
+    // floor here makes the bug unreachable on the default mount.
+    render(
+      <RunProgressGraph
+        manifest={MANIFEST}
+        stateTree={STATE_TREE}
+        events={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(lastReactFlowProps).not.toBeNull();
+    });
+    expect(lastReactFlowProps!.minZoom).toBe(0.45);
+    expect(lastReactFlowProps!.maxZoom).toBe(2);
+  });
+
+  test('the run graph lays out vertically — source handles at the bottom, target handles at the top', async () => {
+    // Vertical-orientation invariant: the run graph (like the spec
+    // graph) must stack top-to-bottom regardless of which `direction`
+    // prop variant flows through FlowGraph. The handle anchors are
+    // the cheap, FlowGraph-internal observable: bottom = source, top
+    // = target on every node.
+    render(
+      <RunProgressGraph
+        manifest={MANIFEST}
+        stateTree={STATE_TREE}
+        events={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(lastReactFlowProps).not.toBeNull();
+      expect(
+        (lastReactFlowProps!.nodes as Array<{ id: string }>).length,
+      ).toBeGreaterThan(0);
+    });
+    const decorated = lastReactFlowProps!.nodes as Array<
+      { sourcePosition?: string; targetPosition?: string }
+    >;
+    for (const n of decorated) {
+      expect(n.sourcePosition).toBe('bottom');
+      expect(n.targetPosition).toBe('top');
+    }
+  });
+
   test('the current state node renders with the fsm-pulse-current animation class', async () => {
     const { container } = render(
       <RunProgressGraph

--- a/ui/src/lib/__tests__/elkLayout.test.ts
+++ b/ui/src/lib/__tests__/elkLayout.test.ts
@@ -171,6 +171,29 @@ describe('applyElkLayout', () => {
     ).toBe(false);
   });
 
+  test('direction is pinned to DOWN — caller cannot override to RIGHT', async () => {
+    // Vertical orientation is a product-level invariant for both the
+    // spec graph and the run graph. Even if a caller passes
+    // 'elk.direction': 'RIGHT' in layoutOptions (back-compat surface
+    // pre-fix), the wrapper forces DOWN so the layout always renders
+    // top-to-bottom. Assertion strategy: lay out a tiny chain with a
+    // RIGHT override; the source must be ABOVE the target (positive
+    // y delta), not LEFT of it (positive x delta).
+    const nodes: Node[] = [makeNode('a', 200, 80), makeNode('b', 200, 80)];
+    const edges: Edge[] = [{ id: 'a-b', source: 'a', target: 'b' }];
+    const result = await applyElkLayout(nodes, edges, {
+      layoutOptions: { 'elk.direction': 'RIGHT' },
+    });
+    const aPos = result.nodePositions.get('a')!;
+    const bPos = result.nodePositions.get('b')!;
+    // DOWN: b is below a (yB > yA), x positions align.
+    expect(bPos.y).toBeGreaterThan(aPos.y);
+    // x alignment: the two cards stack vertically, so |xB - xA| is
+    // small (well under one card width) — much smaller than the
+    // y-delta which carries a full card + ranksep.
+    expect(Math.abs(bPos.x - aPos.x)).toBeLessThan(bPos.y - aPos.y);
+  });
+
   test('label dimensions round-trip: reserved space matches the request', async () => {
     // Single edge with a known label dimension. After layout, the
     // returned label centre should land inside the graph bounding

--- a/ui/src/lib/elkLayout.ts
+++ b/ui/src/lib/elkLayout.ts
@@ -198,7 +198,15 @@ export async function applyElkLayout(
   opts: ApplyElkLayoutOptions = {},
 ): Promise<LayoutResult> {
   const labelDimensions = opts.labelDimensions ?? new Map();
-  const layoutOptions = { ...DEFAULT_LAYOUT_OPTIONS, ...(opts.layoutOptions ?? {}) };
+  // Direction is pinned to DOWN (top-to-bottom) regardless of caller
+  // overrides — vertical orientation is a product-level invariant for
+  // both the spec graph and the run graph. Callers can still override
+  // every OTHER ELK option, but 'elk.direction' is forced.
+  const layoutOptions: LayoutOptions = {
+    ...DEFAULT_LAYOUT_OPTIONS,
+    ...(opts.layoutOptions ?? {}),
+    'elk.direction': 'DOWN',
+  };
 
   // Build the ELK input graph. Each React Flow node becomes an ElkNode
   // child of the synthetic root; each edge becomes an ElkExtendedEdge

--- a/ui/src/routes/specDetail.tsx
+++ b/ui/src/routes/specDetail.tsx
@@ -231,7 +231,7 @@ function GraphPanel({ detail }: GraphPanelProps): JSX.Element {
         nodes={graph.nodes}
         edges={graph.edges}
         autoLayout={true}
-        direction="LR"
+        direction="TB"
         onNodeClick={handleNodeClick}
         onEdgeClick={handleEdgeClick}
         viewportKey={`specs:${detail.id}`}


### PR DESCRIPTION
## Summary
- ELK direction = DOWN for spec + run graphs; dagre rankdir=TB for parity (vertical-always)
- React Flow minZoom = 0.45 (above compact threshold), maxZoom = 2.0; labels stay readable at every reachable zoom level

## User-reported bugs fixed
1. Spec graph was rendering horizontal; requirement was vertical
2. Run graph allowed zoom-out below the compact threshold, collapsing labels to dot pips and apparently breaking zoom-in

## Test plan
- [x] npx tsc -b --noEmit clean
- [x] npm test passing
- [x] Visual verification on http://127.0.0.1:61424/specs/...3fba6945ba4e (vertical, labels legible)
- [x] Visual verification on http://127.0.0.1:61424/runs/019e9407-... (vertical preserved, minZoom enforced, can still zoom in to 2.0)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>