### PR TITLE
fix(engine): render prompts per call, cache only the parsed template

### DIFF
--- a/ctxr/fsm/core/engine.py
+++ b/ctxr/fsm/core/engine.py
@@ -104,19 +104,16 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-# Cache of rendered prompt strings keyed by (spec.id, state.id, iteration?).
-# The cache exists so re-entering a state (or iterating a loop) does not
-# re-parse the same template. We key on the raw template text under the
-# (spec, state) tuple so a spec mutation that swaps the template body
-# automatically invalidates the cached entry. Loop bodies share their
-# loop state's id, so per-iteration env differences are reflected by
-# always recomputing the runtime context but only re-using the parsed
-# Jinja template; the renderer itself owns Jinja parsing reuse via its
-# SandboxedEnvironment cache, so this dict is a lightweight per-state
-# guard against re-walking the needs_rendering precheck or re-allocating
-# the PromptRenderer.
+# The shared, lazily-constructed prompt renderer. Template *parsing*
+# (the expensive part) is cached inside the renderer, keyed on the raw
+# template text, so re-entering a state or iterating a loop re-uses the
+# compiled Jinja template. The renderer is deliberately NOT a rendered-
+# string cache: the same template renders to different text for
+# different args / iteration_n, so every build_brief call renders afresh
+# against its own runtime context. Caching the rendered string here
+# would bleed one run's args into a later run's prompt and reuse
+# iteration 1's text for later iterations.
 _PROMPT_RENDERER: PromptRenderer | None = None
-_RENDER_CACHE: dict[tuple[str, str, str], str] = {}
 
 
 def _get_prompt_renderer() -> PromptRenderer:
@@ -147,34 +144,34 @@ def _maybe_render_prompt(
     if not needs_rendering(template):
         return worker
 
-    cache_key = (spec.id, state.id, template)
-    cached = _RENDER_CACHE.get(cache_key)
-    if cached is None:
-        renderer = _get_prompt_renderer()
-        context = PromptContext(
-            spec_slug=spec.id,
-            spec_version=spec.version,
-            state_id=state.id,
-            state_kind=state.kind.value,
-            response_schema=(
-                worker.response_schema.schema_
-                if worker.response_schema is not None
-                else None
-            ),
-            inputs_schema=(
-                worker.inputs_schema.schema_
-                if worker.inputs_schema is not None
-                else None
-            ),
-            allowed_tools=list(state.allowed_tools),
-            iteration_n=iteration_n,
-            args=dict(env),
-            metadata={},
-        )
-        cached = renderer.render(template, context)
-        _RENDER_CACHE[cache_key] = cached
+    # Render afresh on every call. The renderer caches the *parsed*
+    # template internally (keyed on the template text), so re-parsing is
+    # cheap, but the rendered output must reflect THIS call's env / args
+    # / iteration_n rather than a stale cached string.
+    renderer = _get_prompt_renderer()
+    context = PromptContext(
+        spec_slug=spec.id,
+        spec_version=spec.version,
+        state_id=state.id,
+        state_kind=state.kind.value,
+        response_schema=(
+            worker.response_schema.schema_
+            if worker.response_schema is not None
+            else None
+        ),
+        inputs_schema=(
+            worker.inputs_schema.schema_
+            if worker.inputs_schema is not None
+            else None
+        ),
+        allowed_tools=list(state.allowed_tools),
+        iteration_n=iteration_n,
+        args=dict(env),
+        metadata={},
+    )
+    rendered = renderer.render(template, context)
 
-    return worker.model_copy(update={"prompt_template": cached})
+    return worker.model_copy(update={"prompt_template": rendered})
 
 
 def _new_brief_id() -> uuid.UUID:

--- a/ctxr/fsm/core/prompts.py
+++ b/ctxr/fsm/core/prompts.py
@@ -38,7 +38,7 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
-from jinja2 import StrictUndefined, TemplateSyntaxError
+from jinja2 import StrictUndefined, Template, TemplateSyntaxError
 from jinja2.exceptions import UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from pydantic import BaseModel, ConfigDict, Field
@@ -289,6 +289,14 @@ class PromptRenderer:
         self._env.filters["fields_table"] = _filter_fields_table
         self._model_allowlist = tuple(model_allowlist)
         self._allow_model_import = allow_model_import
+        # Cache of PARSED templates keyed on the raw template text. We
+        # cache the compiled :class:`jinja2.Template` (the expensive part:
+        # lexing + parsing + bytecode compilation) and re-render it per
+        # call against the live context. Caching the *rendered string*
+        # would be a correctness bug: the same template renders to
+        # different text for different args / iteration_n, so a string
+        # cache would bleed one call's values into a later call.
+        self._template_cache: dict[str, Template] = {}
 
     # ------------------------------------------------------------------
     # Context construction
@@ -370,18 +378,27 @@ class PromptRenderer:
     def render(self, template: str, context: PromptContext) -> str:
         """Render ``template`` against ``context`` inside the sandbox.
 
+        The parsed :class:`jinja2.Template` is cached per raw template
+        text so re-entering a state (or iterating a loop) re-uses the
+        compiled template instead of re-parsing it. The *render* itself
+        always runs against the live ``context``, so distinct args /
+        iteration_n produce distinct output.
+
         Raises :class:`PromptRenderError` for Jinja syntax errors,
         unknown tokens (StrictUndefined), unsafe attribute access
         (sandbox), or model-resolution failures.
         """
 
-        try:
-            tmpl = self._env.from_string(template)
-        except TemplateSyntaxError as exc:
-            raise PromptRenderError(
-                f"prompt template has a Jinja syntax error: {exc.message}",
-                line=exc.lineno,
-            ) from exc
+        tmpl = self._template_cache.get(template)
+        if tmpl is None:
+            try:
+                tmpl = self._env.from_string(template)
+            except TemplateSyntaxError as exc:
+                raise PromptRenderError(
+                    f"prompt template has a Jinja syntax error: {exc.message}",
+                    line=exc.lineno,
+                ) from exc
+            self._template_cache[template] = tmpl
 
         jinja_context = self._build_jinja_context(context)
         try:

--- a/ctxr/fsm/core/prompts.py
+++ b/ctxr/fsm/core/prompts.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import importlib
 import json
+from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any
 
@@ -262,6 +263,12 @@ def _filter_fields_table(value: Any) -> str:
 # Renderer
 # ---------------------------------------------------------------------------
 
+#: Default upper bound on the parsed-template LRU. A single spec has a
+#: handful of templates; this caps a long-lived renderer (e.g. the MCP
+#: server reusing one instance across every spec/run) so the cache cannot
+#: grow without bound as new unique templates are rendered over time.
+DEFAULT_TEMPLATE_CACHE_SIZE = 512
+
 
 class PromptRenderer:
     """Sandboxed renderer for FSM worker prompt templates.
@@ -278,6 +285,7 @@ class PromptRenderer:
         *,
         model_allowlist: tuple[str, ...] = (),
         allow_model_import: bool = True,
+        template_cache_size: int = DEFAULT_TEMPLATE_CACHE_SIZE,
     ) -> None:
         self._env = SandboxedEnvironment(
             undefined=StrictUndefined,
@@ -296,7 +304,14 @@ class PromptRenderer:
         # would be a correctness bug: the same template renders to
         # different text for different args / iteration_n, so a string
         # cache would bleed one call's values into a later call.
-        self._template_cache: dict[str, Template] = {}
+        #
+        # The cache is a bounded LRU (OrderedDict ordered by last use): a
+        # long-lived renderer that sees an unbounded stream of unique
+        # templates evicts its least-recently-used entry instead of growing
+        # memory without end. A size <= 0 disables the bound (unbounded),
+        # which suits short-lived per-render instances.
+        self._template_cache: OrderedDict[str, Template] = OrderedDict()
+        self._template_cache_size = template_cache_size
 
     # ------------------------------------------------------------------
     # Context construction
@@ -399,6 +414,14 @@ class PromptRenderer:
                     line=exc.lineno,
                 ) from exc
             self._template_cache[template] = tmpl
+            if self._template_cache_size > 0:
+                # Evict the least-recently-used entry (front of the
+                # OrderedDict) while the cache exceeds its bound.
+                while len(self._template_cache) > self._template_cache_size:
+                    self._template_cache.popitem(last=False)
+        else:
+            # Cache hit: refresh recency so this entry is evicted last.
+            self._template_cache.move_to_end(template)
 
         jinja_context = self._build_jinja_context(context)
         try:

--- a/tests/unit/core/test_engine_jinja_render.py
+++ b/tests/unit/core/test_engine_jinja_render.py
@@ -96,14 +96,15 @@ def _spec_with_state(state: State) -> FsmSpec:
 
 
 @pytest.fixture(autouse=True)
-def _reset_render_cache() -> None:
-    """Clear the engine's module-level render cache between tests.
+def _reset_prompt_renderer() -> None:
+    """Reset the engine's module-level prompt renderer between tests.
 
-    The cache is keyed on (spec_id, state_id, template_text) so test
-    isolation is robust, but reusing identical (id, state, template)
-    triples across tests would otherwise leak rendered strings.
+    The renderer caches PARSED templates (keyed on template text), which
+    is correctness-neutral, but resetting the shared instance keeps each
+    test fully isolated and lets ``monkeypatch`` swaps of
+    ``PromptRenderer.render`` take effect on a fresh renderer.
     """
-    engine_mod._RENDER_CACHE.clear()
+    engine_mod._PROMPT_RENDERER = None
 
 
 # ---------------------------------------------------------------------------
@@ -315,6 +316,79 @@ def test_loop_worker_prompt_template_is_rendered() -> None:
 
     assert "Loop iteration 2 of state looping." in brief.loop.worker.prompt_template
     assert "{{" not in brief.loop.worker.prompt_template
+
+
+# ---------------------------------------------------------------------------
+# Render cache must NOT bleed args / iteration_n across calls (#93)
+# ---------------------------------------------------------------------------
+
+
+def test_args_from_run_a_do_not_appear_in_run_b_prompt() -> None:
+    # Regression for #93: the engine previously cached the *rendered*
+    # string keyed only on (spec.id, state.id, template), so the first
+    # run's args bled into every later run that re-entered the same state
+    # with the same template. Render afresh per call: run B's prompt must
+    # carry run B's arg, never run A's.
+    template = "Diff against {{ args.base_ref }}."
+    worker = Worker(
+        role="reviewer",
+        prompt_template=template,
+        inputs=["base_ref"],
+        response_schema=_response_schema(),
+    )
+    state = State(
+        id="qa",
+        worker=worker,
+        outputs=["verdict"],
+        transitions=[Transition(to="qa", when="always")],
+    )
+    spec = _spec_with_state(state)
+
+    brief_a = build_brief(spec, state, env={"base_ref": "alpha"}, run_id=uuid4())
+    brief_b = build_brief(spec, state, env={"base_ref": "bravo"}, run_id=uuid4())
+
+    assert brief_a.worker is not None
+    assert brief_b.worker is not None
+    assert brief_a.worker.prompt_template == "Diff against alpha."
+    # The bug would make this "Diff against alpha." (run A's arg reused).
+    assert brief_b.worker.prompt_template == "Diff against bravo."
+    assert "alpha" not in brief_b.worker.prompt_template
+
+
+def test_distinct_iteration_n_yields_distinct_text() -> None:
+    # Regression for #93: a loop body re-entered for iteration 2 must not
+    # reuse iteration 1's rendered text. The cache keyed on the loop
+    # state's id (shared across iterations) made every iteration reuse
+    # the first iteration's prompt.
+    template = "Loop iteration {{ iteration_n }} of state {{ state.id }}."
+    loop_worker = Worker(
+        role="iterator",
+        prompt_template=template,
+        inputs=["seed"],
+        response_schema=_loop_response_schema(),
+    )
+    loop = Loop(worker=loop_worker, max_iterations=5, done_field="done")
+    state = State(
+        id="looping",
+        loop=loop,
+        outputs=["done"],
+        transitions=[Transition(to="looping", when="always")],
+    )
+    spec = _spec_with_state(state)
+
+    brief_iter1 = build_brief(
+        spec, state, env={"seed": "x"}, run_id=uuid4(), iteration_n=1
+    )
+    brief_iter2 = build_brief(
+        spec, state, env={"seed": "x"}, run_id=uuid4(), iteration_n=2
+    )
+
+    assert brief_iter1.worker is not None
+    assert brief_iter2.worker is not None
+    assert brief_iter1.worker.prompt_template == "Loop iteration 1 of state looping."
+    # The bug would make this "Loop iteration 1 ..." (iter 1 text reused).
+    assert brief_iter2.worker.prompt_template == "Loop iteration 2 of state looping."
+    assert brief_iter1.worker.prompt_template != brief_iter2.worker.prompt_template
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_prompts.py
+++ b/tests/unit/core/test_prompts.py
@@ -294,3 +294,34 @@ def test_validate_attaches_state_id_on_failure() -> None:
     envelope = info.value.as_envelope()
     assert envelope["error"] == "prompt_template_invalid"
     assert envelope["state_id"] == "qa"
+
+
+# ---------------------------------------------------------------------------
+# Parsed-template cache: reuse the compiled template, render per context (#93)
+# ---------------------------------------------------------------------------
+
+
+def test_render_caches_parsed_template_but_renders_per_context() -> None:
+    # The renderer caches the PARSED template keyed on template text, so a
+    # second render of the same template reuses the compiled object rather
+    # than re-parsing. The rendered OUTPUT, however, must always reflect
+    # the live context: the same template renders different text for
+    # different args.
+    renderer = PromptRenderer()
+    template = "Iteration {{ iteration_n }} for {{ args.who }}."
+
+    first = renderer.render(
+        template,
+        PromptContext(iteration_n=1, args={"who": "alpha"}),
+    )
+    cached_template = renderer._template_cache[template]
+
+    second = renderer.render(
+        template,
+        PromptContext(iteration_n=2, args={"who": "bravo"}),
+    )
+
+    assert first == "Iteration 1 for alpha."
+    assert second == "Iteration 2 for bravo."
+    # Same compiled template object reused across both renders (no re-parse).
+    assert renderer._template_cache[template] is cached_template

--- a/tests/unit/core/test_prompts.py
+++ b/tests/unit/core/test_prompts.py
@@ -338,3 +338,35 @@ def test_render_caches_parsed_template_but_renders_per_context() -> None:
     # Compiled exactly once across both renders: the second render reused the
     # cached template instead of re-parsing.
     assert compile_calls == 1
+
+
+def test_template_cache_is_bounded_and_evicts_lru() -> None:
+    # A long-lived renderer that renders an unbounded stream of unique
+    # templates must not grow memory without end: the parsed-template cache
+    # is a bounded LRU that evicts its least-recently-used entry once full.
+    ctx = PromptContext()
+    renderer = PromptRenderer(template_cache_size=2)
+
+    renderer.render("a {{ iteration_n }}", ctx)  # cache: [a]
+    renderer.render("b {{ iteration_n }}", ctx)  # cache: [a, b]
+    # Touch "a" so "b" becomes the least-recently-used entry.
+    renderer.render("a {{ iteration_n }}", ctx)  # cache: [b, a]
+    # A third distinct template overflows the bound and evicts "b" (LRU),
+    # keeping the most-recently-used "a" and the new "c".
+    renderer.render("c {{ iteration_n }}", ctx)  # cache: [a, c]
+
+    cached = list(renderer._template_cache.keys())
+    assert len(cached) == 2
+    assert "b {{ iteration_n }}" not in cached
+    assert "a {{ iteration_n }}" in cached
+    assert "c {{ iteration_n }}" in cached
+
+
+def test_template_cache_size_zero_is_unbounded() -> None:
+    # A non-positive size disables the bound (suits short-lived per-render
+    # instances that never accumulate templates).
+    ctx = PromptContext()
+    renderer = PromptRenderer(template_cache_size=0)
+    for i in range(50):
+        renderer.render(f"t{i} {{{{ iteration_n }}}}", ctx)
+    assert len(renderer._template_cache) == 50

--- a/tests/unit/core/test_prompts.py
+++ b/tests/unit/core/test_prompts.py
@@ -302,20 +302,32 @@ def test_validate_attaches_state_id_on_failure() -> None:
 
 
 def test_render_caches_parsed_template_but_renders_per_context() -> None:
-    # The renderer caches the PARSED template keyed on template text, so a
-    # second render of the same template reuses the compiled object rather
-    # than re-parsing. The rendered OUTPUT, however, must always reflect
-    # the live context: the same template renders different text for
-    # different args.
+    # The renderer parses (compiles) a template only on the FIRST render of
+    # that template text and reuses the compiled object afterwards. The
+    # rendered OUTPUT, however, must always reflect the live context: the
+    # same template renders different text for different args.
+    #
+    # We assert the caching behavior by counting compile calls (the parse
+    # step is the single from_string entry point) rather than reaching into
+    # the private cache structure, so the test survives a cache refactor
+    # (e.g. switching to an LRU) as long as the public behavior holds.
     renderer = PromptRenderer()
     template = "Iteration {{ iteration_n }} for {{ args.who }}."
+
+    real_from_string = renderer._env.from_string
+    compile_calls = 0
+
+    def counting_from_string(source: str, *args: object, **kwargs: object) -> object:
+        nonlocal compile_calls
+        compile_calls += 1
+        return real_from_string(source, *args, **kwargs)
+
+    renderer._env.from_string = counting_from_string  # type: ignore[method-assign]
 
     first = renderer.render(
         template,
         PromptContext(iteration_n=1, args={"who": "alpha"}),
     )
-    cached_template = renderer._template_cache[template]
-
     second = renderer.render(
         template,
         PromptContext(iteration_n=2, args={"who": "bravo"}),
@@ -323,5 +335,6 @@ def test_render_caches_parsed_template_but_renders_per_context() -> None:
 
     assert first == "Iteration 1 for alpha."
     assert second == "Iteration 2 for bravo."
-    # Same compiled template object reused across both renders (no re-parse).
-    assert renderer._template_cache[template] is cached_template
+    # Compiled exactly once across both renders: the second render reused the
+    # cached template instead of re-parsing.
+    assert compile_calls == 1


### PR DESCRIPTION
## Summary

Fixes the prompt render cache that keyed only on (spec.id, state.id, template), so a rendered string was reused across runs and iterations (args from one run bled into a later run, iteration 1 text was reused for later iterations). Now caches only the parsed Template and renders per call with the actual env/args/iteration_n.

## Test plan

- Adds unit tests covering per-call rendering and the parsed-template cache (tests/unit/core/test_engine_jinja_render.py, tests/unit/core/test_prompts.py).
- ruff and mypy are clean locally (ruff check ctxr/ passes, mypy ctxr/fsm reports no issues).
- Full pytest runs in CI.
- Note: main itself is currently red on the "Lint (ruff + mypy)" and "Test (alembic + pytest)" matrix checks (py3.12 + py3.13) for two pre-existing reasons unrelated to this fix (the audit-strings W14i finding in ctxr/fsm/api/routes_ports.py, and a doctor alembic-revision-panel test). E2E and UI build stay green. This PR adds no new failing check.

Closes #93