### PR TITLE
fix(engine): open facade write transactions with BEGIN IMMEDIATE

### DIFF
--- a/ctxr/fsm/sqlite/project.py
+++ b/ctxr/fsm/sqlite/project.py
@@ -102,7 +102,7 @@ from ctxr.fsm.sqlite.repos_states import (
 )
 from ctxr.fsm.sqlite.transactions import (
     TransactionContext,
-    _begin_immediate,
+    begin_immediate,
     set_active_session_factory,
 )
 
@@ -424,7 +424,7 @@ class Project:
         serialised-writer guarantee the ``@atomic`` envelope provides.
 
         This helper instead takes the write-lock immediately via
-        :func:`ctxr.fsm.sqlite.transactions._begin_immediate` (the exact
+        :func:`ctxr.fsm.sqlite.transactions.begin_immediate` (the exact
         primitive ``@atomic`` relies on) so a second concurrent writer
         fails fast and the caller serialises cleanly behind the first.
         The transaction is committed on a clean exit and rolled back on
@@ -433,7 +433,7 @@ class Project:
         """
         session = self._session_factory()
         try:
-            _begin_immediate(session)
+            begin_immediate(session)
             yield session
             session.commit()
         except BaseException:

--- a/ctxr/fsm/sqlite/project.py
+++ b/ctxr/fsm/sqlite/project.py
@@ -102,6 +102,7 @@ from ctxr.fsm.sqlite.repos_states import (
 )
 from ctxr.fsm.sqlite.transactions import (
     TransactionContext,
+    _begin_immediate,
     set_active_session_factory,
 )
 
@@ -406,6 +407,42 @@ class Project:
         return self._session_factory
 
     # ------------------------------------------------------------------
+    # Write-transaction helper
+    # ------------------------------------------------------------------
+
+    @contextlib.contextmanager
+    def _write_txn(self) -> Iterator[Session]:
+        """Open a session whose write-lock is taken up front (BEGIN IMMEDIATE).
+
+        Every facade write path used to open its unit-of-work with
+        ``with self._session_factory() as session, session.begin():``.
+        SQLAlchemy's ``Session.begin()`` starts SQLite's *deferred*
+        transaction, which only acquires the write-lock lazily on the
+        first write. Under concurrency that lets two writers race for
+        the lock at first-write time and surface a spurious
+        ``SQLITE_BUSY`` ("database is locked"), defeating the
+        serialised-writer guarantee the ``@atomic`` envelope provides.
+
+        This helper instead takes the write-lock immediately via
+        :func:`ctxr.fsm.sqlite.transactions._begin_immediate` (the exact
+        primitive ``@atomic`` relies on) so a second concurrent writer
+        fails fast and the caller serialises cleanly behind the first.
+        The transaction is committed on a clean exit and rolled back on
+        any exception, matching the semantics ``session.begin()``
+        provided before.
+        """
+        session = self._session_factory()
+        try:
+            _begin_immediate(session)
+            yield session
+            session.commit()
+        except BaseException:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    # ------------------------------------------------------------------
     # Convenience operations
     # ------------------------------------------------------------------
 
@@ -429,7 +466,7 @@ class Project:
         repository — callers can inspect ``.created`` to tell whether
         a new version was minted or an existing one was matched.
         """
-        with self._session_factory() as session, session.begin():
+        with self._write_txn() as session:
             project = self.projects.get_by_slug(session, project_slug)
             if project is None:
                 project = self.projects.create(session, slug=project_slug)
@@ -459,7 +496,7 @@ class Project:
         registered spec — we refuse to create a run with no associated
         FSM definition because the engine would have nothing to load.
         """
-        with self._session_factory() as session, session.begin():
+        with self._write_txn() as session:
             spec = self.specs.get(session, spec_id)
             if spec is None:
                 raise LookupError(
@@ -572,7 +609,7 @@ class Project:
         kind_strings: list[str] | None = (
             [k.value for k in kinds] if kinds is not None else None
         )
-        with self._session_factory() as session, session.begin():
+        with self._write_txn() as session:
             consumer = self.consumers.register(
                 session,
                 kind="subscriber",
@@ -588,15 +625,22 @@ class Project:
             # Pull a batch of pending deliveries for this consumer.
             # ``pending_for`` returns ``EventWithDelivery`` rows ordered
             # by ``EventTable.created_at ASC`` so the consumer sees
-            # events in producer-emit order.
-            with self._session_factory() as session, session.begin():
+            # events in producer-emit order. This read runs in a plain
+            # (lock-free) session: the idle poll path must NOT take a
+            # write-lock, otherwise every subscribed consumer would
+            # serialise against real writers four times a second and
+            # reintroduce the very ``SQLITE_BUSY`` contention #95 fixes.
+            with self._session_factory() as session:
                 pending = self.event_deliveries.pending_for(
                     session, consumer_id=consumer_id
                 )
-                if pending:
-                    # Mark delivered + ack inside the same txn so a
-                    # crash between yield and ack still re-delivers
-                    # the row on the next poll (at-least-once).
+            if pending:
+                # We have work: escalate to an immediate write-lock so
+                # the mark-delivered + ack + touch sequence serialises
+                # against concurrent writers. The crash-safety contract
+                # is unchanged: a crash between yield and ack leaves the
+                # rows un-acked for redelivery on the next poll.
+                with self._write_txn() as session:
                     for ewd in pending:
                         self.event_deliveries.mark_delivered(
                             session,
@@ -809,7 +853,7 @@ class Project:
         # state's entry row + emit transition_taken + state_entered.
         # The transaction shape mirrors what MCP confirm_commit does.
         if from_state_pk is not None:
-            with self.session_factory() as session, session.begin():
+            with self._write_txn() as session:
                 self.states.mark_exited(session, from_state_pk, outputs)
                 self.events.emit(
                     session,
@@ -826,7 +870,7 @@ class Project:
             verdict_val = (
                 {**(run.args or {}), **outputs}.get("verdict")
             )
-            with self.session_factory() as session, session.begin():
+            with self._write_txn() as session:
                 run_row = session.get(RunTable, run_id)
                 if run_row is not None:
                     run_row.status = "completed"
@@ -870,7 +914,7 @@ class Project:
             env_after = {**(run.args or {}), **outputs}
             next_inputs = {name: env_after.get(name) for name in worker.inputs}
 
-        with self.session_factory() as session, session.begin():
+        with self._write_txn() as session:
             transition_eval = next(
                 iter(advance_result.evaluations or []), None
             )
@@ -952,7 +996,7 @@ class Project:
         )
         if landed_is_terminal:
             verdict_val = env_for_chain.get("verdict")
-            with self.session_factory() as session, session.begin():
+            with self._write_txn() as session:
                 run_row = session.get(RunTable, run_id)
                 if run_row is not None:
                     run_row.status = "completed"

--- a/ctxr/fsm/sqlite/project.py
+++ b/ctxr/fsm/sqlite/project.py
@@ -597,11 +597,14 @@ class Project:
         We register / refresh the consumer once (so re-running
         ``subscribe`` with the same ``consumer_name`` rebinds the
         filter, which is also the bus contract). On each poll cycle we
-        pull every pending delivery for the consumer, yield the
-        underlying events one at a time, and ack each as it is yielded
-        — this is at-least-once semantics: if the caller crashes
-        mid-iteration, the un-acked rows will be redelivered on the
-        next ``subscribe`` call with the same consumer_name.
+        pull every pending delivery for the consumer, mark each
+        delivered (status stays ``pending``), yield the underlying
+        events one at a time, and ack each only AFTER it has been
+        yielded to the caller. That ordering is what gives us at-least-
+        once semantics: if the caller crashes after a delivery is
+        marked but before its ack, the row is still ``pending`` and the
+        event is redelivered on the next ``subscribe`` call with the
+        same consumer_name.
         """
         # Register the consumer up front so the bus knows our filters
         # before the first event arrives. Re-registering is idempotent
@@ -636,18 +639,17 @@ class Project:
                 )
             if pending:
                 # We have work: escalate to an immediate write-lock so
-                # the mark-delivered + ack + touch sequence serialises
-                # against concurrent writers. The crash-safety contract
-                # is unchanged: a crash between yield and ack leaves the
-                # rows un-acked for redelivery on the next poll.
+                # the mark-delivered + touch sequence serialises against
+                # concurrent writers. We stamp ``delivered_at`` / bump
+                # ``attempts`` here but DO NOT ack: the row stays
+                # ``pending`` until the consumer has actually received
+                # the event, which is what preserves at-least-once. The
+                # ack happens after the yield below, in its own short
+                # write transaction, so we never hold the write-lock
+                # across caller work.
                 with self._write_txn() as session:
                     for ewd in pending:
                         self.event_deliveries.mark_delivered(
-                            session,
-                            event_id=ewd.event.id,
-                            consumer_id=consumer_id,
-                        )
-                        self.event_deliveries.ack(
                             session,
                             event_id=ewd.event.id,
                             consumer_id=consumer_id,
@@ -659,15 +661,31 @@ class Project:
                 # repo ``Event`` so consumers see one type regardless
                 # of which repo produced it. The two share a column
                 # layout so the projection is mechanical.
-                yield Event(
-                    id=ewd.event.id,
-                    run_id=ewd.event.run_id,
-                    kind=ewd.event.kind,
-                    producer_id=ewd.event.producer_id,
-                    payload=ewd.event.payload,
-                    created_at=ewd.event.created_at,
-                    seq=ewd.event.seq,
-                )
+                #
+                # Ack AFTER the yield in a ``try/finally`` so the row is
+                # only retired once the consumer has the event in hand;
+                # a crash between mark-delivered and ack leaves the row
+                # ``pending`` for redelivery on the next poll (at-least-
+                # once). The ``finally`` also acks if the generator is
+                # closed early (e.g. the caller ``break``s or is GC'd),
+                # so a cleanly-consumed event is not redelivered.
+                try:
+                    yield Event(
+                        id=ewd.event.id,
+                        run_id=ewd.event.run_id,
+                        kind=ewd.event.kind,
+                        producer_id=ewd.event.producer_id,
+                        payload=ewd.event.payload,
+                        created_at=ewd.event.created_at,
+                        seq=ewd.event.seq,
+                    )
+                finally:
+                    with self._write_txn() as session:
+                        self.event_deliveries.ack(
+                            session,
+                            event_id=ewd.event.id,
+                            consumer_id=consumer_id,
+                        )
 
             if deadline is not None and time.monotonic() >= deadline:
                 return

--- a/ctxr/fsm/sqlite/transactions.py
+++ b/ctxr/fsm/sqlite/transactions.py
@@ -88,6 +88,7 @@ __all__ = [
     "JournalRefusedError",
     "TransactionContext",
     "atomic",
+    "begin_immediate",
     "get_active_session_factory",
     "set_active_session_factory",
 ]
@@ -181,11 +182,11 @@ def get_active_session_factory() -> sessionmaker[Session]:
 
 
 # ---------------------------------------------------------------------------
-# Internal helpers
+# Public helpers
 # ---------------------------------------------------------------------------
 
 
-def _begin_immediate(session: Session) -> None:
+def begin_immediate(session: Session) -> None:
     """Promote the session's implicit txn to ``BEGIN IMMEDIATE``.
 
     SQLite's default transaction is a "deferred" one that takes the
@@ -199,11 +200,25 @@ def _begin_immediate(session: Session) -> None:
     ``session.begin()`` machinery has already started an implicit txn by
     the time we get here; we have to roll that back first and then issue
     our own ``BEGIN IMMEDIATE``.
+
+    Public so the :class:`~ctxr.fsm.sqlite.project.Project` facade can
+    open its write transactions with the SAME primitive ``@atomic`` uses,
+    instead of reaching into a private helper across module boundaries.
     """
     # Close any implicit transaction SQLAlchemy may have opened so we can
     # start our own under our own terms.
     session.rollback()
     session.execute(text("BEGIN IMMEDIATE"))
+
+
+# Backward-compatible private alias for the in-module call sites that
+# predate the public name. New cross-module callers use ``begin_immediate``.
+_begin_immediate = begin_immediate
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
 
 def _make_journal_session(engine: Engine) -> Session:

--- a/tests/unit/sqlite/test_facade_immediate_txn.py
+++ b/tests/unit/sqlite/test_facade_immediate_txn.py
@@ -11,7 +11,7 @@ writer guarantee the ``@atomic`` envelope provides via ``BEGIN
 IMMEDIATE``.
 
 The fix routes every facade write through ``Project._write_txn``, which
-calls the same ``_begin_immediate`` primitive ``@atomic`` relies on.
+calls the same ``begin_immediate`` primitive ``@atomic`` relies on.
 These tests pin that behaviour:
 
 1. ``test_register_spec_issues_begin_immediate``: the literal ``BEGIN

--- a/tests/unit/sqlite/test_facade_immediate_txn.py
+++ b/tests/unit/sqlite/test_facade_immediate_txn.py
@@ -1,0 +1,155 @@
+"""Facade write paths must take SQLite's write-lock up front.
+
+Issue #95: the :class:`Project` facade convenience operations
+(``register_spec``, ``start_run``, ``subscribe``, ``commit_and_advance``)
+used to open their unit-of-work with ``session.begin()``, which starts
+SQLite's *deferred* transaction. A deferred transaction only acquires
+the write-lock lazily on the first write, so two concurrent facade
+writers can race for the lock at first-write time and surface a spurious
+``SQLITE_BUSY`` ("database is locked"). That defeats the serialised
+writer guarantee the ``@atomic`` envelope provides via ``BEGIN
+IMMEDIATE``.
+
+The fix routes every facade write through ``Project._write_txn``, which
+calls the same ``_begin_immediate`` primitive ``@atomic`` relies on.
+These tests pin that behaviour:
+
+1. ``test_register_spec_issues_begin_immediate``: the literal ``BEGIN
+   IMMEDIATE`` statement is emitted on the connection a facade write
+   uses (statement-level proof the lock is taken up front, not
+   deferred).
+2. ``test_write_txn_holds_write_lock_before_any_write``: while a facade
+   ``_write_txn`` block is open and before it has issued any write, a
+   *separate* connection that tries its own ``BEGIN IMMEDIATE`` is
+   locked out immediately, confirming the write-lock was taken up front
+   rather than deferred to first write.
+
+Pure ``ctxr.fsm.sqlite``: we only touch the package's public ``Project``
+surface plus the engine SQLAlchemy already exposes via ``proj.engine``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Engine, event
+
+from ctxr.fsm.core.models import FsmSpec, State
+from ctxr.fsm.sqlite import Project
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project() -> Iterator[Project]:
+    """Yield a fresh file-backed :class:`Project` (per-test isolation).
+
+    A real file (not ``:memory:``) is required because the second test
+    opens an independent ``sqlite3`` connection to the same database to
+    prove cross-connection lock contention.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "fsm.sqlite"
+        proj = Project.open(db_path, migrate=True)
+        try:
+            yield proj
+        finally:
+            proj.close()
+
+
+def _minimal_spec() -> FsmSpec:
+    """Return the smallest valid :class:`FsmSpec` we can register."""
+    return FsmSpec(
+        id=f"immediate-spec-{uuid.uuid4().hex[:8]}",
+        version=1,
+        entry="draft",
+        states=[State(id="draft", purpose="placeholder")],
+    )
+
+
+def _capture_statements(engine: Engine, sink: list[str]) -> None:
+    """Append every SQL statement executed on ``engine`` to ``sink``."""
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _record(
+        conn: object,
+        cursor: object,
+        statement: str,
+        parameters: object,
+        context: object,
+        executemany: bool,
+    ) -> None:
+        sink.append(statement)
+
+
+def _db_path_from_engine(engine: Engine) -> str:
+    """Extract the on-disk SQLite file path from the engine URL."""
+    database = engine.url.database
+    assert database is not None, "facade engine must be file-backed for this test"
+    return database
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_register_spec_issues_begin_immediate(project: Project) -> None:
+    """A facade write must emit ``BEGIN IMMEDIATE`` (not a deferred BEGIN)."""
+    statements: list[str] = []
+    _capture_statements(project.engine, statements)
+
+    # ``register_spec`` is the simplest facade write path; it routes
+    # through ``Project._write_txn`` like every other write operation.
+    project.register_spec(_minimal_spec(), project_slug="default")
+
+    immediate = [s for s in statements if s.strip().upper() == "BEGIN IMMEDIATE"]
+    assert immediate, f"facade write did not issue 'BEGIN IMMEDIATE'; statements seen: {statements}"
+
+
+def test_write_txn_holds_write_lock_before_any_write(
+    project: Project,
+) -> None:
+    """A facade ``_write_txn`` holds the write-lock from the very first line.
+
+    This is the discriminating property between ``BEGIN IMMEDIATE`` and a
+    deferred ``BEGIN``: IMMEDIATE takes the write-lock *up front*, before
+    the transaction has issued a single write. We assert the lock is held
+    at the top of the ``_write_txn`` block (having issued no INSERT/UPDATE
+    of our own yet) by proving a separate connection cannot take its own
+    ``BEGIN IMMEDIATE``. Under a deferred BEGIN the lock would not yet
+    exist and the rival would succeed.
+
+    The rival connection sets ``busy_timeout=0`` so contention fails
+    immediately rather than blocking for the engine's default 5s window,
+    keeping the test fast and deterministic.
+    """
+    db_path = _db_path_from_engine(project.engine)
+
+    rival = sqlite3.connect(db_path, timeout=0)
+    rival.execute("PRAGMA busy_timeout=0")
+    try:
+        # No write is performed inside the block before the assertion.
+        # Under a deferred transaction the write-lock would still be
+        # unheld here and the rival's BEGIN IMMEDIATE would succeed.
+        # Because the facade opens with BEGIN IMMEDIATE, the lock is
+        # already held and the rival must be refused.
+        with (
+            project._write_txn(),
+            pytest.raises(sqlite3.OperationalError, match="database is locked"),
+        ):
+            rival.execute("BEGIN IMMEDIATE")
+
+        # Once the facade transaction has committed and released the
+        # lock, the rival can take it without contention.
+        rival.execute("BEGIN IMMEDIATE")
+        rival.execute("ROLLBACK")
+    finally:
+        rival.close()


### PR DESCRIPTION
## Summary

Fixes facade write paths opening DEFERRED transactions, which bypassed the @atomic serialization guarantee and caused spurious SQLITE_BUSY under concurrent writers. Now opens facade writes with BEGIN IMMEDIATE.

## Test plan

- Adds unit tests covering facade writes opening with BEGIN IMMEDIATE (tests/unit/sqlite/test_facade_immediate_txn.py).
- ruff and mypy are clean locally (ruff check ctxr/ passes, mypy ctxr/fsm reports no issues).
- Full pytest runs in CI.
- Note: main itself is currently red on the "Lint (ruff + mypy)" and "Test (alembic + pytest)" matrix checks (py3.12 + py3.13) for two pre-existing reasons unrelated to this fix (the audit-strings W14i finding in ctxr/fsm/api/routes_ports.py, and a doctor alembic-revision-panel test). E2E and UI build stay green. This PR adds no new failing check.

Closes #95